### PR TITLE
extend is_in_ancestors

### DIFF
--- a/pytensor/graph/basic.py
+++ b/pytensor/graph/basic.py
@@ -1617,15 +1617,15 @@ def list_of_nodes(
     )
 
 
-def is_in_ancestors(l_apply: Apply, f_node: Apply) -> bool:
-    """Determine if `f_node` is in the graph given by `l_apply`.
+def is_in_ancestors(l_apply: Apply, f_applys: Collection[Apply]) -> bool:
+    """Determine if `f_applys` is in the graph given by `l_apply`.
 
     Parameters
     ----------
-    l_apply : Apply
-        The node to walk.
-    f_apply : Apply
-        The node to find in `l_apply`.
+    l_apply : Collection[Apply]
+        Nodes to walk.
+    f_applys : Collection[Apply]
+        Nodes to find in `l_applys`.
 
     Returns
     -------
@@ -1634,13 +1634,14 @@ def is_in_ancestors(l_apply: Apply, f_node: Apply) -> bool:
     """
     computed = set()
     todo = [l_apply]
+    wanted = set(f_applys)
     while todo:
         cur = todo.pop()
         if cur.outputs[0] in computed:
             continue
         if all(i in computed or i.owner is None for i in cur.inputs):
             computed.update(cur.outputs)
-            if cur is f_node:
+            if cur in wanted:
                 return True
         else:
             todo.append(cur)

--- a/pytensor/ifelse.py
+++ b/pytensor/ifelse.py
@@ -604,7 +604,7 @@ class CondMerge(GraphRewriter):
         merging_node = cond_nodes[0]
         for proposal in cond_nodes[1:]:
             if proposal.inputs[0] == merging_node.inputs[0] and not is_in_ancestors(
-                proposal, merging_node
+                proposal, [merging_node]
             ):
                 # Create a list of replacements for proposal
                 mn_ts = merging_node.inputs[1:][: merging_node.op.n_outs]
@@ -703,8 +703,8 @@ def cond_merge_random_op(fgraph, main_node):
     for proposal in cond_nodes[1:]:
         if (
             proposal.inputs[0] == merging_node.inputs[0]
-            and not is_in_ancestors(proposal, merging_node)
-            and not is_in_ancestors(merging_node, proposal)
+            and not is_in_ancestors(proposal, [merging_node])
+            and not is_in_ancestors(merging_node, [proposal])
         ):
             # Create a list of replacements for proposal
             mn_ts = merging_node.inputs[1:][: merging_node.op.n_outs]

--- a/pytensor/scan/rewriting.py
+++ b/pytensor/scan/rewriting.py
@@ -1642,7 +1642,7 @@ def save_mem_new_scan(fgraph, node):
                     old_new += [(o, new_outs[nw_pos])]
             # Check if the new outputs depend on the old scan node
             old_scan_is_used = [
-                is_in_ancestors(new.owner, node) for old, new in old_new
+                is_in_ancestors(new.owner, [node]) for old, new in old_new
             ]
             if any(old_scan_is_used):
                 return False
@@ -1877,7 +1877,7 @@ class ScanMerge(GraphRewriter):
 
         # Check to see if it is an input of a different node
         for nd in set_nodes:
-            if is_in_ancestors(node, nd) or is_in_ancestors(nd, node):
+            if is_in_ancestors(node, [nd]) or is_in_ancestors(nd, [node]):
                 return False
 
         if not node.op.info.as_while:

--- a/tests/graph/test_basic.py
+++ b/tests/graph/test_basic.py
@@ -508,8 +508,11 @@ def test_is_in_ancestors():
     o1.name = "o1"
     o2 = MyOp(r3, o1)
     o2.name = "o2"
+    o3 = MyOp(r2, o1)
+    o3.name = "o3"
 
-    assert is_in_ancestors(o2.owner, o1.owner)
+    assert is_in_ancestors(o2.owner, [o1.owner])
+    assert not is_in_ancestors(o3.owner, [o2.owner])
 
 
 @pytest.mark.xfail(reason="Not implemented")


### PR DESCRIPTION
Extending a utility function to check for many candidate ancestors at one pass

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [x] There is an informative high-level description of the changes.
+ [x] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [x] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [x] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [x] There are tests covering the changes introduced in the PR.

Don't worry, your PR doesn't need to be in perfect order to submit it.  As development progresses and/or reviewers request changes, you can always [rewrite the history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) of your feature/PR branches.

If your PR is an ongoing effort and you would like to involve us in the process, simply make it a [draft PR](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
