### PR TITLE
Allow autogeneration of release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+# This file has been mostly taken verbatim from https://github.com/pymc-devs/pymc/blob/main/.github/release.yml
+#
+# This file contains configuration for the automatic generation of release notes in GitHub.
+# It's not perfect, but it makes it a little less laborious to write informative release notes.
+# Also see https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  exclude:
+    labels:
+      - no releasenotes
+  categories:
+    - title: Major Changes 🛠
+      labels:
+        - major
+    - title: New Features & Bugfixes 🎉
+      labels:
+        - bug
+        - enhancements
+        - feature-request
+    - title: Docs & Maintenance 🔧
+      labels:
+        - docs
+        - installation
+        - maintenance
+        - pre-commit
+        - tests
+        - "*"

--- a/README.rst
+++ b/README.rst
@@ -114,10 +114,10 @@ Contributing
 We welcome bug reports and fixes and improvements to the documentation.
 
 For more information on contributing, please see the
-`contributing guide <https://github.com/pymc-devs/pytensor/CONTRIBUTING.md>`.
+`contributing guide <https://github.com/pymc-devs/pytensor/CONTRIBUTING.md>`__.
 
 A good place to start contributing is by looking through the issues
-`here <https://github.com/pymc-devs/pytensor/issues`.
+`here <https://github.com/pymc-devs/pytensor/issues>`__.
 
 
 .. |Project Name| replace:: PyTensor


### PR DESCRIPTION
Closes #26.

This PR adds the capability of autogenerating release notes akin to the [one PyMC has](https://github.com/pymc-devs/pymc/blob/main/.github/release.yml). The first commit fixes some minor link display issue in the README.

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [x] There is an informative high-level description of the changes.
+ [x] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [x] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [x] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [x] There are tests covering the changes introduced in the PR.

Don't worry, your PR doesn't need to be in perfect order to submit it.  As development progresses and/or reviewers request changes, you can always [rewrite the history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) of your feature/PR branches.

If your PR is an ongoing effort and you would like to involve us in the process, simply make it a [draft PR](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
