### PR TITLE
Optimize Scan inner graph when compiling to Numba

### DIFF
--- a/pytensor/link/numba/dispatch/scan.py
+++ b/pytensor/link/numba/dispatch/scan.py
@@ -47,6 +47,13 @@ def array0d_range(x):
 
 @numba_funcify.register(Scan)
 def numba_funcify_Scan(op, node, **kwargs):
+    # Apply inner rewrites
+    # TODO: Not sure this is the right place to do this, should we have a rewrite that
+    #  explicitly triggers the optimization of the inner graphs of Scan?
+    #  The C-code deffers it to the make_thunk phase
+    rewriter = op.mode_instance.optimizer
+    rewriter(op.fgraph)
+
     scan_inner_func = numba_basic.numba_njit(numba_funcify(op.fgraph))
 
     outer_in_names_to_vars = {


### PR DESCRIPTION
Partially solves #20 for the NUMBA backend. I did not change or test JAX because that's currently completely broken.