### PR TITLE
Stop using deprecated generated_jit

### DIFF
--- a/pytensor/link/numba/dispatch/basic.py
+++ b/pytensor/link/numba/dispatch/basic.py
@@ -168,8 +168,12 @@ def enable_slice_boxing():
 enable_slice_boxing()
 
 
-@numba.generated_jit(nopython=True)
 def to_scalar(x):
+    raise NotImplementedError()
+
+
+@numba.extending.overload(to_scalar)
+def impl_to_scalar(x):
     if isinstance(x, (numba.types.Number, numba.types.Boolean)):
         return lambda x: x
     elif isinstance(x, numba.types.Array):


### PR DESCRIPTION
Numba is deprecating `generated_jit` in favor of `overload`.