### PR TITLE
Misc RandomVariable improvements

### DIFF
--- a/pytensor/tensor/elemwise.py
+++ b/pytensor/tensor/elemwise.py
@@ -173,6 +173,7 @@ class DimShuffle(ExternalCOp):
         # List of dimensions of the output that are broadcastable and were not
         # in the original input
         self.augment = sorted([i for i, x in enumerate(new_order) if x == "x"])
+        self.drop = drop
 
         if self.inplace:
             self.view_map = {0: [0]}

--- a/pytensor/tensor/random/basic.py
+++ b/pytensor/tensor/random/basic.py
@@ -1990,11 +1990,12 @@ class ChoiceRV(RandomVariable):
         raise NotImplementedError()
 
     def _infer_shape(self, size, dist_params, param_shapes=None):
-        (a, p, _) = dist_params
-
+        a, p, _ = dist_params
         if isinstance(p.type, pytensor.tensor.type_other.NoneTypeT):
+            param_shapes = param_shapes[:1] if param_shapes is not None else None
             shape = super()._infer_shape(size, (a,), param_shapes)
         else:
+            param_shapes = param_shapes[:2] if param_shapes is not None else None
             shape = super()._infer_shape(size, (a, p), param_shapes)
 
         return shape

--- a/pytensor/tensor/random/op.py
+++ b/pytensor/tensor/random/op.py
@@ -192,6 +192,19 @@ class RandomVariable(Op):
         size_len = get_vector_length(size)
 
         if size_len > 0:
+
+            # Fail early when size is incompatible with parameters
+            for i, (param, param_ndim_supp) in enumerate(
+                zip(dist_params, self.ndims_params)
+            ):
+                param_batched_dims = getattr(param, "ndim", 0) - param_ndim_supp
+                if param_batched_dims > size_len:
+                    raise ValueError(
+                        f"Size length is incompatible with batched dimensions of parameter {i} {param}:\n"
+                        f"len(size) = {size_len}, len(batched dims {param}) = {param_batched_dims}. "
+                        f"Size length must be 0 or >= {param_batched_dims}"
+                    )
+
             if self.ndim_supp == 0:
                 return size
             else:

--- a/pytensor/tensor/random/utils.py
+++ b/pytensor/tensor/random/utils.py
@@ -134,7 +134,7 @@ def normalize_size_param(
             "Parameter size must be None, an integer, or a sequence with integers."
         )
     else:
-        size = cast(as_tensor_variable(size, ndim=1), "int64")
+        size = cast(as_tensor_variable(size, ndim=1, dtype="int64"), "int64")
 
         if not isinstance(size, Constant):
             # This should help ensure that the length of non-constant `size`s

--- a/tests/tensor/random/test_basic.py
+++ b/tests/tensor/random/test_basic.py
@@ -1390,6 +1390,19 @@ def test_choice_samples():
     compare_sample_values(choice, at.as_tensor_variable([1, 2, 3]), 2, replace=True)
 
 
+def test_choice_infer_shape():
+    node = choice([0, 1]).owner
+    res = node.op._infer_shape((), node.inputs[3:], None)
+    assert tuple(res.eval()) == ()
+
+    node = choice([0, 1]).owner
+    # The param_shape of a NoneConst is None, during shape_inference
+    res = node.op._infer_shape(
+        (), node.inputs[3:], (node.inputs[3].shape, None, node.inputs[5].shape)
+    )
+    assert tuple(res.eval()) == ()
+
+
 def test_permutation_samples():
     compare_sample_values(
         permutation,

--- a/tests/tensor/random/test_op.py
+++ b/tests/tensor/random/test_op.py
@@ -217,3 +217,17 @@ def test_random_maker_ops_no_seed():
     z = function(inputs=[], outputs=[default_rng()])()
     aes_res = z[0]
     assert isinstance(aes_res, np.random.Generator)
+
+
+def test_RandomVariable_incompatible_size():
+    rv_op = RandomVariable("normal", 0, [0, 0], config.floatX, inplace=True)
+    with pytest.raises(
+        ValueError, match="Size length is incompatible with batched dimensions"
+    ):
+        rv_op(np.zeros((1, 3)), 1, size=(3,))
+
+    rv_op = RandomVariable("dirichlet", 0, [1], config.floatX, inplace=True)
+    with pytest.raises(
+        ValueError, match="Size length is incompatible with batched dimensions"
+    ):
+        rv_op(np.zeros((2, 4, 3)), 1, size=(4,))

--- a/tests/tensor/random/test_op.py
+++ b/tests/tensor/random/test_op.py
@@ -148,6 +148,9 @@ def test_RandomVariable_bcast():
     res = rv(0, 1, size=at.as_tensor(1, dtype=np.int64))
     assert res.broadcastable == (True,)
 
+    res = rv(0, 1, size=(at.as_tensor(1, dtype=np.int32), s3))
+    assert res.broadcastable == (True, False)
+
 
 def test_RandomVariable_bcast_specify_shape():
     rv = RandomVariable("normal", 0, [0, 0], config.floatX, inplace=True)

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -794,7 +794,7 @@ class TestAlloc:
         assert np.array_equal(res, np.full((2, 3), 3, dtype="int64"))
 
 
-def test_infer_broadcastable():
+def test_infer_shape():
     with pytest.raises(TypeError, match="^Shapes must be scalar integers.*"):
         infer_static_shape([constant(1.0)])
 


### PR DESCRIPTION
This PR improves a couple of edge issues related to RandomVariable static shape inference, and simplifies and extends the `local_dimshuffle_rv_lift rewrite`. 

Allowing the rewrite to apply in more cases increases the range of graphs we can infer the logprob in PyMC: https://github.com/pymc-devs/pymc/blob/a0d6ba079eac2f044ed40cc5747f1079d99f9f16/pymc/logprob/tensor.py#L288-L290

Closes #60 and makes progress related to #49
