### PR TITLE
Improve numba DimShuffle compile time

### DIFF
--- a/pytensor/link/numba/dispatch/elemwise.py
+++ b/pytensor/link/numba/dispatch/elemwise.py
@@ -554,7 +554,7 @@ def numba_funcify_DimShuffle(op, **kwargs):
 
     shape_template = (1,) * ndim_new_shape
 
-    # When `len(shuffle) == 0`, the `shuffle_shape[j]` expression above is
+    # When `len(shuffle) == 0`, the `shuffle_shape[j]` expression below
     # is typed as `getitem(Tuple(), int)`, which has no implementation
     # (since getting an item from an empty sequence doesn't make sense).
     # To avoid this compile-time error, we omit the expression altogether.


### PR DESCRIPTION
Compile time for DimShuffle ops is pretty long:

```python
import pytensor
import pytensor.tensor as pt
import numpy as np
import numba

z = pt.dscalar("z")
out = z[None, None]
z_val = np.array(0.1)

%%time
func = pytensor.function([z], out, mode="NUMBA")
func(z_val)


# Before
CPU times: user 1.6 s, sys: 23.5 ms, total: 1.62 s
Wall time: 1.62 s

# After
CPU times: user 661 ms, sys: 36.1 ms, total: 697 ms
Wall time: 697 ms
```

Still ways to go, and unfortunately it doesn't seem to have as big an impact on the compile times for larger models as I hoped, but it is a start...

Going forward I think we should try to find more ops like this, where individually the compile time is large, and try some other things:
- Do we really need to ask for O3 optimization all the time? I guess O2 might be enough for most cases
- We recreate the numba functions all the time, which means that llvm will potentially see functions multiple times, and will also have to optimize those multiple times. Could we move a lot of njit functions out of the dispatch function? I think this also prevents numba caching from working properly.
- There are a lot of inline="always" functions still around. Maybe we want to get rid of at least some of those?