### PR TITLE
Rewrite rank 0 elemwise ops and push scalar constants into elemwise

### DIFF
--- a/pytensor/_version.py
+++ b/pytensor/_version.py
@@ -92,7 +92,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
                 env=env,
                 stdout=subprocess.PIPE,
                 stderr=(subprocess.PIPE if hide_stderr else None),
-                **popen_kwargs
+                **popen_kwargs,
             )
             break
         except OSError:

--- a/pytensor/compile/mode.py
+++ b/pytensor/compile/mode.py
@@ -250,6 +250,11 @@ optdb.register("specialize", EquilibriumDB(), "fast_run", "fast_compile", positi
 # misc special cases for speed that break canonicalization
 optdb.register("uncanonicalize", EquilibriumDB(), "fast_run", position=3)
 
+# Turn tensor operations to scalar operations where possible.
+# This is currently marked as numba-only, but this could be changed
+# in the future.
+optdb.register("scalarize", EquilibriumDB(), "numba_only", position=3.1)
+
 # misc special cases for speed that are dependent on the device.
 optdb.register(
     "specialize_device", EquilibriumDB(), "fast_compile", "fast_run", position=48.6
@@ -459,20 +464,42 @@ class Mode:
 # FunctionMaker, the Mode will be taken from this dictionary using the
 # string as the key
 # Use VM_linker to allow lazy evaluation by default.
-FAST_COMPILE = Mode(VMLinker(use_cloop=False, c_thunks=False), "fast_compile")
+FAST_COMPILE = Mode(
+    VMLinker(use_cloop=False, c_thunks=False),
+    RewriteDatabaseQuery(
+        include=["fast_compile"],
+        exclude=["numba_only"],
+    ),
+)
 if config.cxx:
-    FAST_RUN = Mode("cvm", "fast_run")
+    FAST_RUN = Mode(
+        "cvm",
+        RewriteDatabaseQuery(
+            include=["fast_run"],
+            exclude=["numba_only"],
+        ),
+    )
 else:
-    FAST_RUN = Mode("vm", "fast_run")
+    FAST_RUN = Mode(
+        "vm",
+        RewriteDatabaseQuery(
+            include=["fast_run"],
+            exclude=["numba_only"],
+        ),
+    )
 
 JAX = Mode(
     JAXLinker(),
-    RewriteDatabaseQuery(include=["fast_run", "jax"], exclude=["cxx_only", "BlasOpt"]),
+    RewriteDatabaseQuery(
+        include=["fast_run", "jax"],
+        exclude=["cxx_only", "BlasOpt", "numba_only"],
+    ),
 )
+
 NUMBA = Mode(
     NumbaLinker(),
     RewriteDatabaseQuery(
-        include=["fast_run", "fast_run_numba", "fast_compile_numba"],
+        include=["fast_run", "numba_only"],
         exclude=["cxx_only", "BlasOpt"],
     ),
 )

--- a/pytensor/compile/mode.py
+++ b/pytensor/compile/mode.py
@@ -255,6 +255,16 @@ optdb.register(
     "specialize_device", EquilibriumDB(), "fast_compile", "fast_run", position=48.6
 )  # must be after gpu stuff at 48.5
 
+# Must be before add_destroy_handler
+optdb.register(
+    "elemwise_fusion",
+    SequenceDB(),
+    "fast_run",
+    "fusion",
+    "local_elemwise_fusion",
+    position=49,
+)
+
 # especially constant merge
 optdb.register("merge2", MergeOptimizer(), "fast_run", "merge", position=49)
 
@@ -453,7 +463,10 @@ JAX = Mode(
 )
 NUMBA = Mode(
     NumbaLinker(),
-    RewriteDatabaseQuery(include=["fast_run"], exclude=["cxx_only", "BlasOpt"]),
+    RewriteDatabaseQuery(
+        include=["fast_run", "fast_run_numba", "fast_compile_numba"],
+        exclude=["cxx_only", "BlasOpt"],
+    ),
 )
 
 

--- a/pytensor/compile/mode.py
+++ b/pytensor/compile/mode.py
@@ -262,7 +262,15 @@ optdb.register(
     "fast_run",
     "fusion",
     "local_elemwise_fusion",
-    position=49,
+    position=48.7,
+)
+
+optdb.register(
+    "post_fusion",
+    EquilibriumDB(),
+    "fast_run",
+    "fast_compile",
+    position=48.8,
 )
 
 # especially constant merge

--- a/pytensor/tensor/rewriting/elemwise.py
+++ b/pytensor/tensor/rewriting/elemwise.py
@@ -411,7 +411,6 @@ def push_elemwise_constants(fgraph, node):
     contained scalar op.
     """
     op = node.op
-
     if not isinstance(op, Elemwise):
         return False
 
@@ -465,7 +464,7 @@ def push_elemwise_constants(fgraph, node):
     )
 
 
-compile.optdb["specialize"].register(
+compile.optdb["post_fusion"].register(
     "push_elemwise_constants",
     push_elemwise_constants,
     "fast_run_numba",

--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -8,6 +8,7 @@ import numpy as np
 
 import pytensor.scalar.basic as aes
 import pytensor.scalar.math as aes_math
+from pytensor import compile
 from pytensor.graph.basic import Constant, Variable
 from pytensor.graph.rewriting.basic import (
     NodeRewriter,
@@ -91,7 +92,7 @@ from pytensor.tensor.rewriting.basic import (
     register_uncanonicalize,
     register_useless,
 )
-from pytensor.tensor.rewriting.elemwise import FusionOptimizer, fuse_seqopt
+from pytensor.tensor.rewriting.elemwise import FusionOptimizer
 from pytensor.tensor.shape import Shape, Shape_i
 from pytensor.tensor.subtensor import Subtensor
 from pytensor.tensor.type import (
@@ -2922,7 +2923,7 @@ def local_add_mul_fusion(fgraph, node):
         return [output]
 
 
-fuse_seqopt.register(
+compile.optdb["elemwise_fusion"].register(
     "local_add_mul_fusion",
     FusionOptimizer(local_add_mul_fusion),
     "fast_run",

--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -469,7 +469,6 @@ def local_subtensor_lift(fgraph, node):
             return [rbcast_subt_x]
 
 
-@register_canonicalize
 @register_specialize
 @node_rewriter([Subtensor])
 def local_subtensor_merge(fgraph, node):

--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -469,7 +469,8 @@ def local_subtensor_lift(fgraph, node):
             return [rbcast_subt_x]
 
 
-@register_specialize
+@register_stabilize("cxx_only")
+@register_canonicalize("cxx_only")
 @node_rewriter([Subtensor])
 def local_subtensor_merge(fgraph, node):
     """

--- a/tests/link/numba/test_scan.py
+++ b/tests/link/numba/test_scan.py
@@ -10,7 +10,6 @@ from pytensor.scan.basic import scan
 from pytensor.scan.op import Scan
 from pytensor.scan.utils import until
 from pytensor.tensor import log, vector
-from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.random.utils import RandomStream
 from tests import unittest_tools as utt
 from tests.link.numba.test_basic import compare_numba_and_py
@@ -437,8 +436,4 @@ def test_inner_graph_optimized():
         node for node in f.maker.fgraph.apply_nodes if isinstance(node.op, Scan)
     ]
     inner_scan_nodes = scan_node.op.fgraph.apply_nodes
-    assert len(inner_scan_nodes) == 1
-    (inner_scan_node,) = scan_node.op.fgraph.apply_nodes
-    assert isinstance(inner_scan_node.op, Elemwise) and isinstance(
-        inner_scan_node.op.scalar_op, Log1p
-    )
+    assert any(isinstance(node.op, Log1p) for node in inner_scan_nodes)


### PR DESCRIPTION
A bit more groundwork for the #92, to remove some cases where elemwise ops are not actually needed.

This adds two rewrites:

- `local_elemwise_lift_scalars` is meant to remove Elemwise ops that do not actually vectorize anything because all inputs are rank 0 tensors, and replaces them by a `TensorFromScalar(Composite)`. I put this into the "specialize" phase, because I think it interacts badly with stabilization rewrites (that come before the specialize phase). I'm not really sure I like the way this works yet. It seems that currently most rewrites assume that during canonicalization we always deal with elemwise ops instead of scalar ops. And many rewrites then only apply to those. So for instance if we avoid all elemwise ops and only use scalars, even basic rewrites are not applied at all:
  ```python
  x = pytensor.scalar.ScalarVariable(pytensor.scalar.ScalarType("float64"), None)
  out = pytensor.scalar.log(pytensor.scalar.as_scalar(1) + x)
  pytensor.dprint(out)
  ```
  is not rewritten to use log1p:

  ```python
  func = pytensor.function([x], out, mode="NUMBA")
  pytensor.dprint(func)
  # log [id A] 1
  # |add [id B] 0
  #   |ScalarConstant{1} [id C]
  #   |<float64> [id D]
  ```
  because those rewrites only target tensor log and add ops, not the scalar versions.
  So if we put this new rewrite in `canonicalize` (where I think it maybe should belong?) it would break a lot of other rewrites that assume that everything is wrapped in an elemwise.
  I wonder if we can change the pattern rewriter so that it figures this out automatically and also applies rewrites to matching scalar ops? I think this would give us quite a bit more flexibility, because then we can change things to scalar ops, which should usually compile and execute faster.

- `push_elemwise_constants` I made it so this rewrite only applies to numba (see below), and is applied after Elemwise fusion. We often have Ops that use scalar constants in an elemwise, but those constants are provided as rank 0 inputs to the Elemwise ops and then broadcasted, when they could just be ScalarConstants in the inner Composite op. So we rewrite
  ```python
    Elemwise{Composite{(i0 + (i1 * i2))}} [id A] 0
     |TensorConstant{(1,) of 1.0} [id B]
     |TensorConstant{(1,) of 2.0} [id C]
     |x [id D]
  ```
  to 
  ```python
  Elemwise{Composite{(1.0 + (2.0 * i0))}} [id A] 0
   |x [id B]
  ```
  I ran into segfaults when I tried this with the c backend, so this only applies to numba for now.
- I also made some small changes to the rewrites: Previously the elemwise fusion db was created in a different file than all the other basic rewrite dbs (mode.py), so I moved that to the others to make it more consistent. I then also created a new rewrite phase `post_fusion` that is executed right after the elemwise_fusion rewrites, that currently only contains `push_elemwise_constants`.

*Update*
- I also removed `local_subtensor_merge` from the `canonicalize` pass. This is supposed to simplify chained `Subtensor` ops, but I'm not sure we really should have this rewrite be so aggressive. There are cases where I'd say it is making things more complicated instead of simpler, which was especially apparent in combination with `local_elemwise_lift_scalars`. For instance it would end up rewriting this:
  ```python
  x = pt.dvector("x")
  a = x.shape[0]
  b = x[0:][:a]
  pytensor.dprint([a, b])
  func = pytensor.function([x], b, mode="NUMBA")
  ```
  into
  ```python
  DeepCopyOp [id A] 5
   |Subtensor{int64:int64:int8} [id B] 4
     |x [id C]
     |Switch [id D] 3
     | |LE [id E] 2
     | | |ScalarFromTensor [id F] 1
     | | | |Shape_i{0} [id G] 0
     | | |   |x [id C]
     | | |ScalarConstant{0} [id H]
     | |ScalarConstant{0} [id H]
     | |ScalarConstant{0} [id I]
     |ScalarFromTensor [id F] 1
     |ScalarConstant{1} [id J]
  ```
  while without it pytensor would notice that `b` is just `x`. Maybe we should change this rewrite so that it only does something if it knows statically if `start` and `end` are non-negative? (And I guess this also suggests we could use a rewrite that teaches graphs that shapes are non-negative (or they should just return an unsigned int?))

*Update*
A bit more motivation for this:
I think the numba backend at least can really profit from turning more things into scalar ops. Both for compile time and run time. This clashes a bit with what theano thinks of as the "canonical form", where pretty much everything is a tensor.
Maybe a nice compromise between this might be to leave the canonicalize and specialize phases exactly as they are, so that the tensor form stays the canonical way of representing everything, and all the rewrites in those phases work with that.
But at some stage later (not sure exactly when...) we could add a stage (possibly numba specific) that tries to turns as much as possible into scalars. So elemwise ops, shape_i, sum and a bunch of others could be rewritten to return scalars.

The reason I think scalars are better if possible in numba is that tensors produce a lot of code, which slows down compilation, adds lots of allocations and makes the code in general much less transparent for llvm, which I think leads to lots of missed optimizations there.

I benchmarked a small radon model for this a bit, and in that model for instance we spend about 5% of the time in allocation code. That might not sound like too much, but I think this is way to much for comfort, given that most of the cost of those allocations in terms of missed optimizations, cache misses, ref counting etc will be hidden.

After the rewrites here I see a lot of code like this in logp graphs:
```python
Sum{acc_dtype=float64} [id A] '__logp' 120
 |MakeVector{dtype='float64'} [id B] 114
   |TensorFromScalar [id C] 'intercept_logprob' 73
   | |sub [id D] 66
   |   |mul [id E] 59
   |   | |ScalarConstant{-0.5} [id F]
   |   | |sqr [id G] 47
   |   |   |mul [id H] 32
   |   |     |ScalarConstant{0.1} [id I]
   |   |     |ScalarFromTensor [id J] 23
   |   |       |Reshape{0} [id K] 14
   |   |         |Subtensor{int64:int64:} [id L] 6
   |   |         | |__joined_variables [id M]
   |   |         | |ScalarConstant{0} [id N]
   |   |         | |ScalarConstant{1} [id O]
   |   |         |TensorConstant{[]} [id P]
   |   |ScalarConstant{3.2215236261987186} [id Q]
   |Sum{acc_dtype=float64} [id R] 30
   | |Elemwise{Composite{((-0.5 * sqr(i0)) - 0.9189385332046727)}} [id S] 'county_raw_logprob' 21
   |   |SpecifyShape [id T] 13
   |     |Subtensor{int64:int64:} [id U] 5
   |     | |__joined_variables [id M]
   |     | |ScalarConstant{1} [id O]
   |     | |ScalarConstant{86} [id V]
   |     |TensorConstant{85} [id W]
   |TensorFromScalar [id X] 'county_sd_log___logprob' 82
   | |add [id Y] 77
   |   |Switch [id Z] 72
   |   | |GE [id BA] 45
...
```
There is quite a bit of potential now to rewrite this further: Sum of make vector for instance shoudl just be the sum of the elements. But those sums can easily be represented as a scalar `add` node for instance, so that we never have to allocate those tensors.

So why do I think that rank 0 tensors are something to avoid in numba? Take this addition for instance:

```python
import numba
from numba import types
import numpy as np

@numba.njit("float64(float64, float64)", no_cpython_wrapper=True)
def add_scalar(x, y):
    return x + y

ty_rank0 = types.Array(numba.float64, 0, "C")

@numba.njit(ty_rank0(ty_rank0, ty_rank0), no_cpython_wrapper=True)
def add_tensor(x, y):
    return np.asarray(x + y)
```

The first is compiled to this:

<details>

```llvm
; ModuleID = 'add_scalar'
source_filename = "<string>"
target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
target triple = "x86_64-unknown-linux-gnu"

@_ZN08NumbaEnv8__main__10add_scalarB3v14B42c8tJTIcFHzwl2ILiXkcBV0KBSmNGHkyiCKJEEwA_3dEdd = common local_unnamed_addr global i8* null

; Function Attrs: nofree norecurse nounwind writeonly
define i32 @_ZN8__main__10add_scalarB3v14B42c8tJTIcFHzwl2ILiXkcBV0KBSmNGHkyiCKJEEwA_3dEdd(double* noalias nocapture %retptr, { i8*, i32, i8* }** noalias nocapture readnone %excinfo, double %arg.x, double %arg.y) local_unnamed_addr #0 {
entry:
  %.6 = fadd double %arg.x, %arg.y
  store double %.6, double* %retptr, align 8
  ret i32 0
}

; Function Attrs: nofree norecurse nounwind writeonly
define double @cfunc._ZN8__main__10add_scalarB3v14B42c8tJTIcFHzwl2ILiXkcBV0KBSmNGHkyiCKJEEwA_3dEdd(double %.1, double %.2) local_unnamed_addr #0 {
entry:
  %.4 = alloca double, align 8
  store double 0.000000e+00, double* %.4, align 8
  %.8 = call i32 @_ZN8__main__10add_scalarB3v14B42c8tJTIcFHzwl2ILiXkcBV0KBSmNGHkyiCKJEEwA_3dEdd(double* nonnull %.4, { i8*, i32, i8* }** undef, double %.1, double %.2) #2
  %.18 = load double, double* %.4, align 8
  ret double %.18
}

; Function Attrs: nounwind
declare void @llvm.stackprotector(i8*, i8**) #1

attributes #0 = { nofree norecurse nounwind writeonly }
attributes #1 = { nounwind }
attributes #2 = { noinline }
```

</details>

The addition is turned into a single `fadd` instruction that is *really* easy to reason about for llvm:
```
  %.6 = fadd double %arg.x, %arg.y
```

In contrast the second look like this (after optimization):

<details>

```llvm
; ModuleID = 'add_tensor'
source_filename = "<string>"
target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
target triple = "x86_64-unknown-linux-gnu"

@_ZN08NumbaEnv8__main__10add_tensorB3v13B42c8tJTIcFHzwl2ILiXkcBV0KBSmNGHkyiCKJEEwA_3dE5ArrayIdLi0E1C7mutable7alignedE5ArrayIdLi0E1C7mutable7alignedE = common local_unnamed_addr global i8* null
@".const.<numba.core.cpu.CPUContext object at 0x7f44de3b8640>" = internal constant [53 x i8] c"<numba.core.cpu.CPUContext object at 0x7f44de3b8640>\00"
@PyExc_SystemError = external global i8
@".const.unknown error when calling native function" = internal constant [43 x i8] c"unknown error when calling native function\00"
@_ZN08NumbaEnv5numba2np9arraymath10np_asarray12_3clocals_3e4implB2v7B42c8tJTIcFHzwl2ILiXkcBV0KBSmNGHkyiCKJEEwA_3dEd27omitted_28default_3dNone_29 = common local_unnamed_addr global i8* null
@_ZN08NumbaEnv5numba2np8arrayobj13impl_np_array12_3clocals_3e4implB2v3B42c8tJTIcFHzwl2ILiXkcBV0KBSmNGHkyiCKJEEwA_3dEd18dtype_28float64_29 = common local_unnamed_addr global i8* null
@_ZN08NumbaEnv5numba2np8arrayobj15_call_allocatorB2v4B44c8tJTC_2fWQA9wW1DkAz0Pj1skAdT4gkkUlYBZmgA_3dEN29typeref_5b_3cclass_20_27numba4core5types8npytypes14Array_27_3e_5dExj = common local_unnamed_addr global i8* null
@_ZN08NumbaEnv5numba2np8arrayobj18_ol_array_allocate12_3clocals_3e4implB2v5B42c8tJTIcFHzwl2ILiXkcBV0KBSmNGHkyiCKJEEwA_3dEN29typeref_5b_3cclass_20_27numba4core5types8npytypes14Array_27_3e_5dExj = common local_unnamed_addr global i8* null
@.const.picklebuf.139933779134528 = internal constant { i8*, i32, i8* } { i8* getelementptr inbounds ([86 x i8], [86 x i8]* @.const.pickledata.139933779134528, i32 0, i32 0), i32 86, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @.const.pickledata.139933779134528.sha1, i32 0, i32 0) }
@.const.pickledata.139933779134528 = internal constant [86 x i8] c"\80\04\95K\00\00\00\00\00\00\00\8C\08builtins\94\8C\0BMemoryError\94\93\94\8C'Allocation failed (probably too large).\94\85\94N\87\94."
@.const.pickledata.139933779134528.sha1 = internal constant [20 x i8] c"\BA(\9D\81\F0\\p \F3G|\15sH\04\DFe\AB\E2\09"

define i32 @_ZN8__main__10add_tensorB3v13B42c8tJTIcFHzwl2ILiXkcBV0KBSmNGHkyiCKJEEwA_3dE5ArrayIdLi0E1C7mutable7alignedE5ArrayIdLi0E1C7mutable7alignedE({ i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] }* noalias nocapture %retptr, { i8*, i32, i8* }** noalias nocapture %excinfo, i8* nocapture readnone %arg.x.0, i8* nocapture readnone %arg.x.1, i64 %arg.x.2, i64 %arg.x.3, double* nocapture readonly %arg.x.4, i8* nocapture readnone %arg.y.0, i8* nocapture readnone %arg.y.1, i64 %arg.y.2, i64 %arg.y.3, double* nocapture readonly %arg.y.4) local_unnamed_addr {
entry:
  %.43.le = load double, double* %arg.x.4, align 8
  %.45.le = load double, double* %arg.y.4, align 8
  %.7.i.i.i.i = tail call i8* @NRT_MemInfo_alloc_aligned(i64 8, i32 32), !noalias !0
  %.8.i.i.i.i = icmp eq i8* %.7.i.i.i.i, null
  br i1 %.8.i.i.i.i, label %afterloop.if, label %afterloop.endif, !prof !13

afterloop.if:                                     ; preds = %entry
  store { i8*, i32, i8* }* @.const.picklebuf.139933779134528, { i8*, i32, i8* }** %excinfo, align 8
  ret i32 1, !ret_is_raise !14

afterloop.endif:                                  ; preds = %entry
  %.46.le = fadd double %.43.le, %.45.le
  %.5.i.i.i = getelementptr i8, i8* %.7.i.i.i.i, i64 24
  %0 = bitcast i8* %.5.i.i.i to double**
  %.6.i2.i.i = load double*, double** %0, align 8, !noalias !15
  store double %.46.le, double* %.6.i2.i.i, align 8, !noalias !15
  %1 = ptrtoint i8* %.7.i.i.i.i to i64
  %2 = ptrtoint double* %.6.i2.i.i to i64
  %3 = bitcast { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] }* %retptr to i64*
  store i64 %1, i64* %3, align 8
  %retptr.repack2 = getelementptr inbounds { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] }, { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] }* %retptr, i64 0, i32 1
  %4 = bitcast i8** %retptr.repack2 to <2 x i64>*
  store <2 x i64> <i64 0, i64 1>, <2 x i64>* %4, align 8
  %retptr.repack6 = getelementptr inbounds { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] }, { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] }* %retptr, i64 0, i32 3
  store i64 8, i64* %retptr.repack6, align 8
  %retptr.repack8 = getelementptr inbounds { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] }, { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] }* %retptr, i64 0, i32 4
  %5 = bitcast double** %retptr.repack8 to i64*
  store i64 %2, i64* %5, align 8
  ret i32 0
}

define { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] } @cfunc._ZN8__main__10add_tensorB3v13B42c8tJTIcFHzwl2ILiXkcBV0KBSmNGHkyiCKJEEwA_3dE5ArrayIdLi0E1C7mutable7alignedE5ArrayIdLi0E1C7mutable7alignedE({ i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] } %.1, { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] } %.2) local_unnamed_addr {
entry:
  %.4 = alloca { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] }, align 8
  %.fca.0.gep1 = bitcast { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] }* %.4 to i8**
  %.fca.1.gep = getelementptr inbounds { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] }, { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] }* %.4, i64 0, i32 1
  %.fca.2.gep = getelementptr inbounds { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] }, { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] }* %.4, i64 0, i32 2
  %.fca.3.gep = getelementptr inbounds { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] }, { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] }* %.4, i64 0, i32 3
  %.fca.4.gep = getelementptr inbounds { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] }, { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] }* %.4, i64 0, i32 4
  %excinfo = alloca { i8*, i32, i8* }*, align 8
  %0 = bitcast { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] }* %.4 to i8*
  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 dereferenceable(40) %0, i8 0, i64 40, i1 false)
  store { i8*, i32, i8* }* null, { i8*, i32, i8* }** %excinfo, align 8
  %extracted.meminfo = extractvalue { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] } %.1, 0
  %extracted.parent = extractvalue { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] } %.1, 1
  %extracted.nitems = extractvalue { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] } %.1, 2
  %extracted.itemsize = extractvalue { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] } %.1, 3
  %extracted.data = extractvalue { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] } %.1, 4
  %extracted.meminfo.1 = extractvalue { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] } %.2, 0
  %extracted.parent.1 = extractvalue { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] } %.2, 1
  %extracted.nitems.1 = extractvalue { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] } %.2, 2
  %extracted.itemsize.1 = extractvalue { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] } %.2, 3
  %extracted.data.1 = extractvalue { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] } %.2, 4
  %.8 = call i32 @_ZN8__main__10add_tensorB3v13B42c8tJTIcFHzwl2ILiXkcBV0KBSmNGHkyiCKJEEwA_3dE5ArrayIdLi0E1C7mutable7alignedE5ArrayIdLi0E1C7mutable7alignedE({ i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] }* nonnull %.4, { i8*, i32, i8* }** nonnull %excinfo, i8* %extracted.meminfo, i8* %extracted.parent, i64 %extracted.nitems, i64 %extracted.itemsize, double* %extracted.data, i8* %extracted.meminfo.1, i8* %extracted.parent.1, i64 %extracted.nitems.1, i64 %extracted.itemsize.1, double* %extracted.data.1) #2
  %.9 = load { i8*, i32, i8* }*, { i8*, i32, i8* }** %excinfo, align 8
  %.10.not = icmp eq i32 %.8, 0
  %.18.fca.0.load = load i8*, i8** %.fca.0.gep1, align 8
  %.18.fca.1.load = load i8*, i8** %.fca.1.gep, align 8
  %.18.fca.2.load = load i64, i64* %.fca.2.gep, align 8
  %.18.fca.3.load = load i64, i64* %.fca.3.gep, align 8
  %.18.fca.4.load = load double*, double** %.fca.4.gep, align 8
  %.27 = alloca i32, align 4
  store i32 0, i32* %.27, align 4
  br i1 %.10.not, label %entry.endif, label %entry.if, !prof !16

entry.if:                                         ; preds = %entry
  %.16 = icmp sgt i32 %.8, 0
  call void @numba_gil_ensure(i32* nonnull %.27)
  br i1 %.16, label %entry.if.if, label %entry.if.endif.endif.endif

entry.endif:                                      ; preds = %entry, %.30
  %.18.fca.0.insert = insertvalue { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] } undef, i8* %.18.fca.0.load, 0
  %.18.fca.1.insert = insertvalue { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] } %.18.fca.0.insert, i8* %.18.fca.1.load, 1
  %.18.fca.2.insert = insertvalue { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] } %.18.fca.1.insert, i64 %.18.fca.2.load, 2
  %.18.fca.3.insert = insertvalue { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] } %.18.fca.2.insert, i64 %.18.fca.3.load, 3
  %.18.fca.4.insert = insertvalue { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] } %.18.fca.3.insert, double* %.18.fca.4.load, 4
  ret { i8*, i8*, i64, i64, double*, [0 x i64], [0 x i64] } %.18.fca.4.insert

.30:                                              ; preds = %entry.if.if, %entry.if.if.if, %entry.if.endif.endif.endif
  %.52 = call i8* @PyUnicode_FromString(i8* getelementptr inbounds ([53 x i8], [53 x i8]* @".const.<numba.core.cpu.CPUContext object at 0x7f44de3b8640>", i64 0, i64 0))
  call void @PyErr_WriteUnraisable(i8* %.52)
  call void @Py_DecRef(i8* %.52)
  call void @numba_gil_release(i32* nonnull %.27)
  br label %entry.endif

entry.if.if:                                      ; preds = %entry.if
  call void @PyErr_Clear()
  %.33 = load { i8*, i32, i8* }, { i8*, i32, i8* }* %.9, align 8
  %.34 = extractvalue { i8*, i32, i8* } %.33, 0
  %.36 = extractvalue { i8*, i32, i8* } %.33, 1
  %.38 = extractvalue { i8*, i32, i8* } %.33, 2
  %.39 = call i8* @numba_unpickle(i8* %.34, i32 %.36, i8* %.38)
  %.40.not = icmp eq i8* %.39, null
  br i1 %.40.not, label %.30, label %entry.if.if.if, !prof !13

entry.if.if.if:                                   ; preds = %entry.if.if
  call void @numba_do_raise(i8* nonnull %.39)
  br label %.30

entry.if.endif.endif.endif:                       ; preds = %entry.if
  call void @PyErr_SetString(i8* nonnull @PyExc_SystemError, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @".const.unknown error when calling native function", i64 0, i64 0))
  br label %.30
}

declare void @numba_gil_ensure(i32*) local_unnamed_addr

declare i8* @PyUnicode_FromString(i8*) local_unnamed_addr

declare void @PyErr_WriteUnraisable(i8*) local_unnamed_addr

declare void @Py_DecRef(i8*) local_unnamed_addr

declare void @numba_gil_release(i32*) local_unnamed_addr

declare void @PyErr_Clear() local_unnamed_addr

declare i8* @numba_unpickle(i8*, i32, i8*) local_unnamed_addr

declare void @numba_do_raise(i8*) local_unnamed_addr

declare void @PyErr_SetString(i8*, i8*) local_unnamed_addr

declare noalias i8* @NRT_MemInfo_alloc_aligned(i64, i32) local_unnamed_addr

; Function Attrs: argmemonly nounwind willreturn writeonly
declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #0

; Function Attrs: nounwind
declare void @llvm.stackprotector(i8*, i8**) #1

attributes #0 = { argmemonly nounwind willreturn writeonly }
attributes #1 = { nounwind }
attributes #2 = { noinline }

!0 = !{!1, !3, !4, !6, !7, !9, !10, !12}
!1 = distinct !{!1, !2, !"_ZN5numba2np8arrayobj18_ol_array_allocate12_3clocals_3e4implB2v5B42c8tJTIcFHzwl2ILiXkcBV0KBSmNGHkyiCKJEEwA_3dEN29typeref_5b_3cclass_20_27numba4core5types8npytypes14Array_27_3e_5dExj: %retptr"}
!2 = distinct !{!2, !"_ZN5numba2np8arrayobj18_ol_array_allocate12_3clocals_3e4implB2v5B42c8tJTIcFHzwl2ILiXkcBV0KBSmNGHkyiCKJEEwA_3dEN29typeref_5b_3cclass_20_27numba4core5types8npytypes14Array_27_3e_5dExj"}
!3 = distinct !{!3, !2, !"_ZN5numba2np8arrayobj18_ol_array_allocate12_3clocals_3e4implB2v5B42c8tJTIcFHzwl2ILiXkcBV0KBSmNGHkyiCKJEEwA_3dEN29typeref_5b_3cclass_20_27numba4core5types8npytypes14Array_27_3e_5dExj: %excinfo"}
!4 = distinct !{!4, !5, !"_ZN5numba2np8arrayobj15_call_allocatorB2v4B44c8tJTC_2fWQA9wW1DkAz0Pj1skAdT4gkkUlYBZmgA_3dEN29typeref_5b_3cclass_20_27numba4core5types8npytypes14Array_27_3e_5dExj: %retptr"}
!5 = distinct !{!5, !"_ZN5numba2np8arrayobj15_call_allocatorB2v4B44c8tJTC_2fWQA9wW1DkAz0Pj1skAdT4gkkUlYBZmgA_3dEN29typeref_5b_3cclass_20_27numba4core5types8npytypes14Array_27_3e_5dExj"}
!6 = distinct !{!6, !5, !"_ZN5numba2np8arrayobj15_call_allocatorB2v4B44c8tJTC_2fWQA9wW1DkAz0Pj1skAdT4gkkUlYBZmgA_3dEN29typeref_5b_3cclass_20_27numba4core5types8npytypes14Array_27_3e_5dExj: %excinfo"}
!7 = distinct !{!7, !8, !"_ZN5numba2np8arrayobj13impl_np_array12_3clocals_3e4implB2v3B42c8tJTIcFHzwl2ILiXkcBV0KBSmNGHkyiCKJEEwA_3dEd18dtype_28float64_29: %retptr"}
!8 = distinct !{!8, !"_ZN5numba2np8arrayobj13impl_np_array12_3clocals_3e4implB2v3B42c8tJTIcFHzwl2ILiXkcBV0KBSmNGHkyiCKJEEwA_3dEd18dtype_28float64_29"}
!9 = distinct !{!9, !8, !"_ZN5numba2np8arrayobj13impl_np_array12_3clocals_3e4implB2v3B42c8tJTIcFHzwl2ILiXkcBV0KBSmNGHkyiCKJEEwA_3dEd18dtype_28float64_29: %excinfo"}
!10 = distinct !{!10, !11, !"_ZN5numba2np9arraymath10np_asarray12_3clocals_3e4implB2v7B42c8tJTIcFHzwl2ILiXkcBV0KBSmNGHkyiCKJEEwA_3dEd27omitted_28default_3dNone_29: %retptr"}
!11 = distinct !{!11, !"_ZN5numba2np9arraymath10np_asarray12_3clocals_3e4implB2v7B42c8tJTIcFHzwl2ILiXkcBV0KBSmNGHkyiCKJEEwA_3dEd27omitted_28default_3dNone_29"}
!12 = distinct !{!12, !11, !"_ZN5numba2np9arraymath10np_asarray12_3clocals_3e4implB2v7B42c8tJTIcFHzwl2ILiXkcBV0KBSmNGHkyiCKJEEwA_3dEd27omitted_28default_3dNone_29: %excinfo"}
!13 = !{!"branch_weights", i32 1, i32 99}
!14 = !{i1 true}
!15 = !{!7, !9, !10, !12}
!16 = !{!"branch_weights", i32 99, i32 1}
```

</details>

Including a call to `@NRT_MemInfo_alloc_aligned(i64 8, i32 32)`, which allocates, and sets up refcounting. But `llvm` doesn't know what this function is doing, so it's presence prevents a lot of optimizations. For instance if we do something like this:

```python
@numba.njit(types.void(types.float64), no_cpython_wrapper=True)
def useless_asarray(x):
    np.asarray(x)
```

where we just call `np.asarray`, but never use it in any way, it still can't optimize that away.