### PR TITLE
Match error message in function graph tests

### DIFF
--- a/tests/graph/test_fg.py
+++ b/tests/graph/test_fg.py
@@ -42,17 +42,23 @@ class TestFunctionGraph:
         var1 = op1()
         var2 = op2()
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="'Variable' object is not iterable"):
             FunctionGraph(var1, [var2])
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="'Variable' object is not reversible"):
             FunctionGraph([var1], var2)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match=(
+                "One of the provided inputs is the output of an already existing node. "
+                "If that is okay, either discard that input's owner or use graph.clone."
+            ),
+        ):
             var3 = op1(var1)
             FunctionGraph([var3], [var2], clone=False)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="No outputs specified"):
             var3 = op1(var1)
             FunctionGraph([var3], clone=False)
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

### Motivation for these changes
Function graph tests did not have clear error messages to check

### Implementation details
Added `match=...` to existing `pytest.raises`

### Checklist
+ [x] Explain motivation and implementation 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- ...

## Docs / Maintenance
- ...
