### PR TITLE
🔄 From Aesara: 1362: "Add `HalfNormalRV` JAX implementation"

### DIFF
--- a/pytensor/link/jax/dispatch/random.py
+++ b/pytensor/link/jax/dispatch/random.py
@@ -262,11 +262,7 @@ def jax_sample_fn_halfnormal(op):
             loc,
             scale,
         ) = parameters
-        sample = (
-            loc
-            + jax.numpy.abs(jax.random.normal(sampling_key, size, dtype))
-            * scale
-        )
+        sample = loc + jax.numpy.abs(jax.random.normal(sampling_key, size, dtype) * scale
         rng["jax_state"] = rng_key
         return (rng, sample)
 

--- a/pytensor/link/jax/dispatch/random.py
+++ b/pytensor/link/jax/dispatch/random.py
@@ -258,10 +258,7 @@ def jax_sample_fn_halfnormal(op):
     def sample_fn(rng, size, dtype, *parameters):
         rng_key = rng["jax_state"]
         rng_key, sampling_key = jax.random.split(rng_key, 2)
-        (
-            loc,
-            scale,
-        ) = parameters
+        loc, scale = parameters
         sample = loc + jax.numpy.abs(jax.random.normal(sampling_key, size, dtype) * scale
         rng["jax_state"] = rng_key
         return (rng, sample)

--- a/pytensor/link/jax/dispatch/random.py
+++ b/pytensor/link/jax/dispatch/random.py
@@ -259,7 +259,7 @@ def jax_sample_fn_halfnormal(op):
         rng_key = rng["jax_state"]
         rng_key, sampling_key = jax.random.split(rng_key, 2)
         loc, scale = parameters
-        sample = loc + jax.numpy.abs(jax.random.normal(sampling_key, size, dtype) * scale
+        sample = loc + jax.numpy.abs(jax.random.normal(sampling_key, size, dtype)) * scale
         rng["jax_state"] = rng_key
         return (rng, sample)
 

--- a/pytensor/link/jax/dispatch/random.py
+++ b/pytensor/link/jax/dispatch/random.py
@@ -259,7 +259,9 @@ def jax_sample_fn_halfnormal(op):
         rng_key = rng["jax_state"]
         rng_key, sampling_key = jax.random.split(rng_key, 2)
         loc, scale = parameters
-        sample = loc + jax.numpy.abs(jax.random.normal(sampling_key, size, dtype)) * scale
+        sample = (
+            loc + jax.numpy.abs(jax.random.normal(sampling_key, size, dtype)) * scale
+        )
         rng["jax_state"] = rng_key
         return (rng, sample)
 

--- a/pytensor/link/jax/dispatch/random.py
+++ b/pytensor/link/jax/dispatch/random.py
@@ -264,7 +264,7 @@ def jax_sample_fn_halfnormal(op):
         ) = parameters
         sample = (
             loc
-            + jax.random.truncated_normal(sampling_key, 0.0, jax.numpy.inf, size, dtype)
+            + jax.numpy.abs(jax.random.normal(sampling_key, size, dtype))
             * scale
         )
         rng["jax_state"] = rng_key

--- a/pytensor/link/jax/dispatch/random.py
+++ b/pytensor/link/jax/dispatch/random.py
@@ -251,6 +251,28 @@ def jax_sample_fn_t(op):
     return sample_fn
 
 
+@jax_sample_fn.register(aer.HalfNormalRV)
+def jax_sample_fn_halfnormal(op):
+    """JAX implementation of `HalfNormalRV`."""
+
+    def sample_fn(rng, size, dtype, *parameters):
+        rng_key = rng["jax_state"]
+        rng_key, sampling_key = jax.random.split(rng_key, 2)
+        (
+            loc,
+            scale,
+        ) = parameters
+        sample = (
+            loc
+            + jax.random.truncated_normal(sampling_key, 0.0, jax.numpy.inf, size, dtype)
+            * scale
+        )
+        rng["jax_state"] = rng_key
+        return (rng, sample)
+
+    return sample_fn
+
+
 @jax_sample_fn.register(aer.ChoiceRV)
 def jax_funcify_choice(op):
     """JAX implementation of `ChoiceRV`."""

--- a/tests/link/jax/test_random.py
+++ b/tests/link/jax/test_random.py
@@ -280,6 +280,22 @@ def test_random_updates(rng_ctor):
             "uniform",
             lambda *args: args,
         ),
+        (
+            aer.halfnormal,
+            [
+                set_test_value(
+                    at.dvector(),
+                    np.array([-1.0, 2.0], dtype=np.float64),
+                ),
+                set_test_value(
+                    at.dscalar(),
+                    np.array(1000.0, dtype=np.float64),
+                ),
+            ],
+            (2,),
+            "halfnorm",
+            lambda *args: args,
+        ),
     ],
 )
 def test_random_RandomVariable(rv_op, dist_params, base_size, cdf_name, params_conv):


### PR DESCRIPTION
Downstreaming https://github.com/aesara-devs/aesara/pull/1362. PR port done by downstream_pr.sh script.