### PR TITLE
Remove some inline arguments and make some njit functions global

### DIFF
--- a/tests/link/numba/test_basic.py
+++ b/tests/link/numba/test_basic.py
@@ -149,9 +149,18 @@ def eval_python_only(fn_inputs, fn_outputs, inputs, mode=numba_mode):
         else:
             return wrap
 
+    def py_global_numba_func(func):
+        if hasattr(func, "py_func"):
+            return func.py_func
+        return func
+
     mocks = [
         mock.patch("numba.njit", njit_noop),
         mock.patch("numba.vectorize", vectorize_noop),
+        mock.patch(
+            "pytensor.link.numba.dispatch.basic.global_numba_func",
+            py_global_numba_func,
+        ),
         mock.patch(
             "pytensor.link.numba.dispatch.basic.tuple_setitem", py_tuple_setitem
         ),


### PR DESCRIPTION
This allows numba to reuse previous typing and compilation
results if the same function is reused, which then also
leads to smaller llvm modules.

For the tests to continue to work we have to return
those global functions through a wrapper (`basic.global_numba_func`)
so that the tests are still able to disable compilation.

Also remove some inline="always" arguments that don't seem
to be helpful.