### PR TITLE
Static broadcast

### DIFF
--- a/pytensor/sparse/basic.py
+++ b/pytensor/sparse/basic.py
@@ -954,7 +954,7 @@ class DenseFromSparse(Op):
 
     """
 
-    __props__ = ()
+    __props__ = ("sparse_grad",)
 
     def __init__(self, structured=True):
         self.sparse_grad = structured

--- a/pytensor/sparse/rewriting.py
+++ b/pytensor/sparse/rewriting.py
@@ -1099,13 +1099,13 @@ class CSMGradC(_NoPythonCOp):
 csm_grad_c = CSMGradC()
 
 
-@node_rewriter([csm_grad(None)])
+@node_rewriter([csm_grad()])
 def local_csm_grad_c(fgraph, node):
     """
     csm_grad(None) -> csm_grad_c
 
     """
-    if node.op == csm_grad(None):
+    if node.op == csm_grad():
         return [csm_grad_c(*node.inputs)]
     return False
 

--- a/pytensor/sparse/type.py
+++ b/pytensor/sparse/type.py
@@ -73,7 +73,10 @@ class SparseTensorType(TensorType, HasDataType):
     ):
         if shape is None and broadcastable is None:
             shape = (None, None)
-
+        if broadcastable is None:
+            broadcastable = (False, False)
+        if broadcastable != (False, False):
+            raise ValueError("Broadcasting sparse types is not yet implemented")
         if format not in self.format_cls:
             raise ValueError(
                 f'unsupported format "{format}" not in list',
@@ -95,7 +98,9 @@ class SparseTensorType(TensorType, HasDataType):
             dtype = self.dtype
         if shape is None:
             shape = self.shape
-        return type(self)(format, dtype, shape=shape, **kwargs)
+        return type(self)(
+            format, dtype, shape=shape, broadcastable=broadcastable, **kwargs
+        )
 
     def filter(self, value, strict=False, allow_downcast=None):
         if isinstance(value, Variable):

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -396,7 +396,7 @@ def get_scalar_constant_value(
                         for i in v.owner.inputs
                     ]
                     ret = [[None]]
-                    v.owner.op.perform(v.owner, const, ret)
+                    v.owner.op.scalar_op.perform(v.owner, const, ret)
                     return np.asarray(ret[0][0].copy())
             elif (
                 isinstance(v.owner.op, pytensor.tensor.subtensor.Subtensor)

--- a/pytensor/tensor/blas.py
+++ b/pytensor/tensor/blas.py
@@ -137,6 +137,7 @@ try:
 except ImportError:
     pass
 
+from functools import reduce
 from typing import Tuple
 
 import pytensor.scalar
@@ -639,10 +640,8 @@ class GemmRelated(COp):
         {PyErr_SetString(PyExc_NotImplementedError, "type(b) is not double or float"); %(fail)s;}
         """
 
-    # broadcast_xy = None
-
     check_dims = """
-        if (Nx[0] !=1 && Nz[0] != 1 && Nx[0] != Nz[0])
+        if (Nx[0] != Nz[0])
         {
             PyErr_Format(PyExc_ValueError,
                 "Shape mismatch: x has %%ld rows but z has %%ld rows",
@@ -656,7 +655,7 @@ class GemmRelated(COp):
                 (long int)Nx[1], (long int)Nx[0], (long int)Ny[0], (long int)Ny[1]);
             %(fail)s;
         }
-        if (Ny[1] != 1 && Nz[1]!= 1 && Ny[1] != Nz[1])
+        if (Ny[1] != Nz[1])
         {
             PyErr_Format(PyExc_ValueError,
                 "Shape mismatch: y has %%ld cols but z has %%ld cols",
@@ -842,14 +841,14 @@ class GemmRelated(COp):
         else:
             setup_z_Nz_Sz = self.setup_z_Nz_Sz
 
-        return "".join(
+        return reduce(
+            str.__add__,
             (
                 self.declare_NS,
                 self.check_xyz_rank2,
                 setup_z_Nz_Sz,
                 self.check_xyz_double_or_float,
                 self.check_ab_double_or_float,
-                self.broadcast_xy,
                 self.check_dims,
                 self.check_strides,
                 self.encode_strides_in_unit,
@@ -862,7 +861,8 @@ class GemmRelated(COp):
                 self.case_double_ab_constants,
                 self.case_double_gemm,
                 self.end_switch_typenum,
-            )
+            ),
+            "",
         )
 
     def build_gemm_version(self):
@@ -992,11 +992,6 @@ class Gemm(GemmRelated):
             z.itemset(z * a + b * np.dot(x, y))
             zout[0] = z
         else:
-            # Broadcast Z if needed
-            if (x.shape[0] > z.shape[0]) or (y.shape[1] > z.shape[1]):
-                z = np.broadcast_to(
-                    z, (max(x.shape[0], z.shape[0]), max(y.shape[1], z.shape[1]))
-                ).copy()
             if b == 0.0:
                 if a == 1.0:
                     z[:] = np.dot(x, y)
@@ -1017,135 +1012,88 @@ class Gemm(GemmRelated):
             zout[0] = z
 
     def infer_shape(self, fgraph, node, input_shapes):
-        z_shape, _, x_shape, y_shape, _ = input_shapes
-        return [
-            (
-                pytensor.scalar.scalar_maximum(z_shape[0], x_shape[0]),
-                pytensor.scalar.scalar_maximum(z_shape[1], y_shape[1]),
-            )
-        ]
+        return [input_shapes[0]]
 
     setup_z_Nz_Sz_inplace = """
-        // Needs broadcasting
-        if (PyArray_DIMS(%(_z)s)[0] < Nx[0] || PyArray_DIMS(%(_z)s)[1] < Ny[1]){
-
-            npy_intp dims[2];
-            dims[0] = (PyArray_DIMS(%(_z)s)[0] >= Nx[0]) ? PyArray_DIMS(%(_z)s)[0] : Nx[0];
-            dims[1] = (PyArray_DIMS(%(_z)s)[1] >= Ny[1]) ? PyArray_DIMS(%(_z)s)[1] : Ny[1];
-
-            // Check if we need to allocate new array
-            if((NULL == %(_zout)s)
-                || (PyArray_DIMS(%(_zout)s)[0] != dims[0])
-                || (PyArray_DIMS(%(_zout)s)[1] != dims[1]))
+        if (%(_zout)s != %(_z)s)
+        {
+            if (%(_zout)s)
             {
-                // fprintf(stderr, "Gemm Allocating z output array with shape (%%i %%i)\\n", dims[0], dims[1]);
-                Py_XDECREF(%(_zout)s);
-                %(_zout)s = (PyArrayObject*)PyArray_SimpleNew(2, dims, PyArray_TYPE(%(_z)s));
+                Py_DECREF(%(_zout)s);
             }
-
-            // fprintf(stderr, "Gemm Broadcasting Z into shape (%%i %%i)\\n", dims[0], dims[1]);
-            if(PyArray_CopyInto(%(_zout)s, %(_z)s) == -1)
-            {
-                %(fail)s;
-            }
-
-        } else {
-            if (%(_zout)s != %(_z)s)
-            {
-                Py_XDECREF(%(_zout)s);
-                %(_zout)s = %(_z)s;
-                Py_INCREF(%(_zout)s);
-            }
+            %(_zout)s = %(_z)s;
+            Py_INCREF(%(_zout)s);
         }
-
-        Nz = PyArray_DIMS(%(_zout)s);
-        Sz = PyArray_STRIDES(%(_zout)s);
+        Nz = PyArray_DIMS(%(_z)s);
+        Sz = PyArray_STRIDES(%(_z)s);
         """
 
     setup_z_Nz_Sz_outplace = """
-        npy_intp dims[2];
-        dims[0] = (PyArray_DIMS(%(_z)s)[0] >= Nx[0]) ? PyArray_DIMS(%(_z)s)[0] : Nx[0];
-        dims[1] = (PyArray_DIMS(%(_z)s)[1] >= Ny[1]) ? PyArray_DIMS(%(_z)s)[1] : Ny[1];
-
-        // Check if we need to allocate new array
         if ((NULL == %(_zout)s)
-            || (PyArray_DIMS(%(_zout)s)[0] != dims[0])
-            || (PyArray_DIMS(%(_zout)s)[1] != dims[1]))
+            || (PyArray_DIMS(%(_zout)s)[0] != PyArray_DIMS(%(_z)s)[0])
+            || (PyArray_DIMS(%(_zout)s)[1] != PyArray_DIMS(%(_z)s)[1])
+            || (PyArray_STRIDES(%(_zout)s)[0] <= 0)
+            || (PyArray_STRIDES(%(_zout)s)[1] <= 0)
+            || (PyArray_STRIDES(%(_zout)s)[0] MOD type_size)
+            || (PyArray_STRIDES(%(_zout)s)[1] MOD type_size)
+            || ((PyArray_STRIDES(%(_zout)s)[0] != type_size)
+                && (PyArray_STRIDES(%(_zout)s)[1] != type_size)))
         {
             Py_XDECREF(%(_zout)s);
-            %(_zout)s = (PyArrayObject*)PyArray_SimpleNew(2, dims, PyArray_TYPE(%(_z)s));
-            // fprintf(stderr, "Gemm Allocating z output array with shape (%%i %%i)\\n", dims[0], dims[1]);
+            npy_intp dims[2];
+            dims[0] = PyArray_DIMS(%(_z)s)[0];
+            dims[1] = PyArray_DIMS(%(_z)s)[1];
+            %(_zout)s = (PyArrayObject*)PyArray_SimpleNew(2, dims,
+                                                          PyArray_TYPE(%(_z)s));
+            //fprintf(stderr, "Gemm Allocating %%i %%i\\n", dims[0], dims[1]);
             if(!%(_zout)s) {
                 PyErr_SetString(PyExc_MemoryError,
                                 "failed to alloc gemm_no_inplace output");
                 %(fail)s
             }
         }
-
-        // fprintf(stderr, "Gemm Broadcasting Z into shape (%%i %%i)\\n", dims[0], dims[1]);
-        if(PyArray_CopyInto(%(_zout)s, %(_z)s) == -1)
-        {
-            %(fail)s
-        }
-
         Nz = PyArray_DIMS(%(_zout)s);
         Sz = PyArray_STRIDES(%(_zout)s);
+
+        if (PyArray_DESCR(%(_zout)s)->type_num == NPY_FLOAT)
+        {
+            float * zoutdata = (float*)PyArray_DATA(%(_zout)s);
+            int zoi = Sz[0] / sizeof(float);
+            int zoj = Sz[1] / sizeof(float);
+            const float * zdata = (float*)PyArray_DATA(%(_z)s);
+            int zi = PyArray_STRIDES(%(_z)s)[0]/sizeof(float);
+            int zj = PyArray_STRIDES(%(_z)s)[1]/sizeof(float);
+            for (int i = 0; i < Nz[0]; ++i)
+            {
+                for (int j = 0; j < Nz[1]; ++j)
+                {
+                    zoutdata[zoi*i + zoj*j] = zdata[zi*i + zj*j];
+                }
+            }
+        }
+        else if (PyArray_DESCR(%(_zout)s)->type_num == NPY_DOUBLE)
+        {
+            double * zoutdata = (double*) PyArray_DATA(%(_zout)s);
+            int zoi = Sz[0] / sizeof(double);
+            int zoj = Sz[1] / sizeof(double);
+            const double * zdata = (double*)PyArray_DATA(%(_z)s);
+            int zi = PyArray_STRIDES(%(_z)s)[0]/sizeof(double);
+            int zj = PyArray_STRIDES(%(_z)s)[1]/sizeof(double);
+            for (int i = 0; i < Nz[0]; ++i)
+            {
+                for (int j = 0; j < Nz[1]; ++j)
+                {
+                    zoutdata[zoi*i + zoj*j] = zdata[zi*i + zj*j];
+                }
+            }
+        }
+        else
+        {
+            PyErr_SetString(PyExc_AssertionError,
+                            "neither float nor double dtype");
+            %(fail)s
+        }
         """
-
-    broadcast_xy = """
-        // Broadcast X if needed
-        if (Nz[0] > Nx[0])
-        {
-            npy_intp dims[2];
-            dims[0] = Nz[0];
-            dims[1] = Nx[1];
-            // fprintf(stderr, "Gemm Broadcasting X into shape (%%i %%i)\\n", dims[0], dims[1]);
-            PyArrayObject *x_new = (PyArrayObject*)PyArray_SimpleNew(2, dims, PyArray_TYPE(%(_x)s));
-            if(!x_new) {
-                PyErr_SetString(PyExc_MemoryError,
-                                "failed to alloc gemm_inplace input");
-                %(fail)s
-            }
-
-            if(PyArray_MoveInto(x_new, %(_x)s) == -1)
-            {
-                %(fail)s
-            }
-
-            Py_DECREF(%(_x)s);
-            %(_x)s = x_new;
-
-            Nx = PyArray_DIMS(%(_x)s);
-            Sx = PyArray_STRIDES(%(_x)s);
-        }
-
-        // Broadcast Y if needed
-        if (Nz[1] > Ny[1])
-        {
-            npy_intp dims[2];
-            dims[0] = Ny[0];
-            dims[1] = Nz[1];
-            // fprintf(stderr, "Gemm Broadcasting Y into shape (%%i %%i)\\n", dims[0], dims[1]);
-            PyArrayObject *y_new = (PyArrayObject*)PyArray_SimpleNew(2, dims, PyArray_TYPE(%(_x)s));
-            if(!y_new) {
-                PyErr_SetString(PyExc_MemoryError,
-                                "failed to alloc gemm_inplace input");
-                %(fail)s
-            }
-
-            if(PyArray_MoveInto(y_new, %(_y)s) == -1)
-            {
-                %(fail)s
-            }
-
-            Py_DECREF(%(_y)s);
-            %(_y)s = y_new;
-
-            Ny = PyArray_DIMS(%(_y)s);
-            Sy = PyArray_STRIDES(%(_y)s);
-        }
-
-    """
 
     case_float_ab_constants = """
         #define REAL float
@@ -1179,7 +1127,7 @@ class Gemm(GemmRelated):
     def c_code_cache_version(self):
         gv = self.build_gemm_version()
         if gv:
-            return (7,) + gv
+            return (8,) + gv
         else:
             return gv
 
@@ -1253,6 +1201,7 @@ def _beta_L_plus_alpha_M(fgraph, beta, L, alpha, M, recurse_flip=True):
     if M.owner and M.owner.op == _dot22:
         Ml, Mr = M.owner.inputs
         rval = [gemm_no_inplace(L, alpha, Ml, Mr, beta)]
+        # print 'GEMM 0', rval, beta, L, alpha, M
         return rval, M
 
     # it also might be the case that there is a dimshuffle between the +
@@ -1719,7 +1668,6 @@ class Dot22(GemmRelated):
         Sz = PyArray_STRIDES(%(_zout)s);
 
         """
-    broadcast_xy = ""
     check_ab_double_or_float = ""
     case_float_ab_constants = """
                 float a = 1.0;
@@ -2003,7 +1951,6 @@ class Dot22Scalar(GemmRelated):
         return [[input_shapes[0][0], input_shapes[1][1]]]
 
     setup_z_Nz_Sz = Dot22.setup_z_Nz_Sz
-    broadcast_xy = ""
 
     check_ab_double_or_float = """
         if ((PyArray_DESCR(%(_a)s)->type_num != NPY_DOUBLE)

--- a/pytensor/tensor/var.py
+++ b/pytensor/tensor/var.py
@@ -1018,7 +1018,7 @@ class TensorConstant(TensorVariable, Constant[_TensorTypeType]):
             )
 
         # We want all the shape information from `data`
-        new_type = type.clone(shape=data_shape)
+        new_type = type.clone(shape=data_shape, broadcastable=type.broadcastable)
 
         assert not any(s is None for s in new_type.shape)
 

--- a/tests/sparse/test_basic.py
+++ b/tests/sparse/test_basic.py
@@ -1093,21 +1093,23 @@ class TestConversion:
         s = SparseFromDense(format)(x)
         s_m = -s
         d = dense_from_sparse(s_m)
+        pytensor.grad(None, x, known_grads={d: d.type()})
         c = d.sum()
         g = pytensor.grad(c, x)
         f = pytensor.function([x], [s, g])
         f(np.array(0, dtype=config.floatX, ndmin=ndim))
         f(np.array(7, dtype=config.floatX, ndmin=ndim))
 
-    def test_format_ndim(self):
-        for format in "csc", "csr":
-            for ndim in 0, 1, 2:
-                self.check_format_ndim(format, ndim)
+    @pytest.mark.parametrize("format", ["csc", "csr"])
+    @pytest.mark.parametrize("ndim", [0, 1, 2])
+    def test_format_ndim(self, format, ndim):
+        self.check_format_ndim(format, ndim)
 
-            with pytest.raises(TypeError):
-                self.check_format_ndim(format, 3)
-            with pytest.raises(TypeError):
-                self.check_format_ndim(format, 4)
+    @pytest.mark.parametrize("format", ["csc", "csr"])
+    @pytest.mark.parametrize("ndim", [3, 4])
+    def test_format_ndim_raises(self, format, ndim):
+        with pytest.raises(TypeError):
+            self.check_format_ndim(format, ndim)
 
 
 class TestCsmProperties:

--- a/tests/tensor/rewriting/test_basic.py
+++ b/tests/tensor/rewriting/test_basic.py
@@ -1693,8 +1693,12 @@ class TestLocalElemwiseAlloc:
         ],
     )
     def test_basic(self, expr, x_shape, y_shape):
-        x = at.tensor(dtype="int64", shape=(None,) * len(x_shape), name="x")
-        y = at.tensor(dtype="int64", shape=(None,) * len(y_shape), name="y")
+        x = at.tensor(
+            dtype="int64", broadcastable=tuple(s == 1 for s in x_shape), name="x"
+        )
+        y = at.tensor(
+            dtype="int64", broadcastable=tuple(s == 1 for s in y_shape), name="y"
+        )
         z = expr(x, y)
 
         z_opt = pytensor.function(

--- a/tests/tensor/rewriting/test_shape.py
+++ b/tests/tensor/rewriting/test_shape.py
@@ -417,35 +417,78 @@ class TestSameShape:
         fgraph.attach_feature(shape_feature)
         assert shape_feature.same_shape(x, o)
 
-    def test_no_static_shapes(self):
+    @pytest.mark.parametrize(
+        "setup",
+        [
+            ("x", "o"),
+            pytest.param(("x", "y"), marks=pytest.mark.xfail(reason="Not implemented")),
+            pytest.param(("y", "o"), marks=pytest.mark.xfail(reason="Not implemented")),
+        ],
+        ids=lambda case: "{}.0=={}.0".format(*case),
+    )
+    def test_no_static_shapes(self, setup):
+        """All the shapes are actually equal and shape inference
+        should handle all the comparisons
+        """
+        _1, _2 = setup
         x = vector()
         y = vector()
         o = x + y
         fgraph = FunctionGraph([x, y], [o], clone=False)
         shape_feature = ShapeFeature()
         fgraph.attach_feature(shape_feature)
-        # We no longer assume that `x` has the same shape as `y` simply because
-        # neither has static shape information.  Instead, when there is no
-        # static shape information is available, we assume that `x` and/or `y`
-        # could have shapes `(1,)` and/or `(n,)`, where `n != 1`, or any
-        # combination of the two.
-        assert not shape_feature.same_shape(x, o)
-        # The following case isn't implemented
-        assert not shape_feature.same_shape(y, o)
+        # We assume that `x` has the same shape as `y` simply because
+        # neither broadcast. Same is for `o`
+        variables = dict(x=x, y=y, o=o)
+        assert shape_feature.same_shape(variables[_1], variables[_2], 0, 0)
 
     @pytest.mark.parametrize(
-        "y_dim_0",
-        [2, pytest.param(None, marks=pytest.mark.xfail(reason="Not implemented"))],
+        "setup",
+        [
+            # it has to be that verbose since
+            # specific combinations are impossible
+            # to infer so far due to limitations of
+            # the shape inference
+            (2, "x", "o", 0),
+            (2, "y", "o", 0),
+            (2, "x", "y", 0),
+            (2, "x", "o", 1),
+            pytest.param(
+                (2, "y", "o", 1), marks=pytest.mark.xfail(reason="Not implemented")
+            ),
+            pytest.param(
+                (2, "x", "y", 1), marks=pytest.mark.xfail(reason="Not implemented")
+            ),
+            (None, "x", "o", 0),
+            pytest.param(
+                (None, "y", "o", 0), marks=pytest.mark.xfail(reason="Not implemented")
+            ),
+            pytest.param(
+                (None, "x", "y", 0), marks=pytest.mark.xfail(reason="Not implemented")
+            ),
+            (None, "x", "o", 1),
+            pytest.param(
+                (None, "y", "o", 1), marks=pytest.mark.xfail(reason="Not implemented")
+            ),
+            pytest.param(
+                (None, "x", "y", 1), marks=pytest.mark.xfail(reason="Not implemented")
+            ),
+        ],
+        ids=lambda case: "{1}.{3}=={2}.{3}|ydim={0}".format(*case),
     )
-    def test_vector_dim(self, y_dim_0):
+    def test_vector_dim(self, setup):
+        """All the shapes are actually equal and shape inference
+        should handle all the comparisons
+        """
+        y_dim_0, _1, _2, dim = setup
         x = at.tensor(dtype="floatX", shape=(2, None))
         y = at.tensor(dtype="floatX", shape=(y_dim_0, None))
         o = x + y
         fgraph = FunctionGraph([x, y], [o], clone=False)
         shape_feature = ShapeFeature()
         fgraph.attach_feature(shape_feature)
-        assert shape_feature.same_shape(x, o, 0, 0)
-        assert not shape_feature.same_shape(x, o, 1, 1)
+        variables = dict(x=x, y=y, o=o)
+        assert shape_feature.same_shape(variables[_1], variables[_2], dim, dim)
 
     def test_vector_dim_err(self):
         x = vector()

--- a/tests/tensor/test_blas.py
+++ b/tests/tensor/test_blas.py
@@ -1,6 +1,5 @@
 from copy import copy
 from itertools import product
-from random import shuffle
 
 import numpy as np
 import pytest
@@ -68,7 +67,6 @@ from pytensor.tensor.type import (
     matrix,
     row,
     scalar,
-    scalars,
     tensor,
     tensor3,
     tensor4,
@@ -1042,41 +1040,6 @@ def test_inplace1():
     # pytensor.printing.debugprint(f)
     # it doesn't work inplace because we didn't mark Z as mutable input
     assert [n.op for n in f.maker.fgraph.apply_nodes] == [gemm_no_inplace]
-
-
-@pytest.mark.parametrize("linker", ("py", "cvm"))
-@pytest.mark.parametrize("inplace", (False, True))
-def test_gemm_broadcasting(inplace, linker):
-    a, b = scalars("a", "b")
-    z, x, y = matrices("z", "x", "y")
-
-    mode = Mode(linker=linker)
-    if inplace:
-        out = gemm_inplace(z, a, x, y, b)
-        f = pytensor.function([z, x, y, a, b], out, accept_inplace=True, mode=mode)
-        assert [node.op for node in f.maker.fgraph.toposort()] == [gemm_inplace]
-    else:
-        out = gemm_no_inplace(z, a, x, y, b)
-        f = pytensor.function([z, x, y, a, b], out, mode=mode)
-        assert [node.op for node in f.maker.fgraph.toposort()] == [gemm_no_inplace]
-
-    shapes_z = [(5, 3), (1, 3), (5, 1), (1, 1)]
-    shapes_x = [(5, 4), (1, 4)]
-    shapes_y = [(4, 3), (4, 1)]
-
-    rng = np.random.default_rng()
-    shuffle(shapes_z)
-    shuffle(shapes_x)
-    shuffle(shapes_y)
-    for shape_z, shape_x, shape_y in product(shapes_z, shapes_x, shapes_y):
-        z_v = rng.random(size=shape_z).astype(config.floatX)
-        x_v = rng.random(size=shape_x).astype(config.floatX)
-        y_v = rng.random(size=shape_y).astype(config.floatX)
-        # We have to copy for the inplace case
-        z_v_np = z_v.copy()
-        np.testing.assert_allclose(
-            f(z_v, x_v, y_v, 1, 1), z_v_np + np.dot(x_v, y_v), atol=2e-6
-        )
 
 
 def test_dot22():
@@ -2509,40 +2472,6 @@ class TestInferShape(unittest_tools.InferShapeTester):
                 np.asarray(0.5, dtype=config.floatX),
                 rng.random((2, 4)).astype(config.floatX),
                 np.asarray(0.5, dtype=config.floatX),
-            ],
-            Gemm,
-        )
-
-    def test_gemm_broadcast(self):
-        rng = np.random.default_rng(unittest_tools.fetch_seed())
-        x, y, z = matrices("xyz")
-        a = scalar("a")
-        b = scalar("b")
-
-        # Broadcast Z
-        self._compile_and_check(
-            [x, y, a, z, b],
-            [gemm(z, a, x, y, b)],
-            [
-                rng.random((2, 3)).astype(config.floatX),
-                rng.random((3, 4)).astype(config.floatX),
-                np.asarray(0.5, dtype=config.floatX),
-                rng.random((1, 4)).astype(config.floatX),
-                np.asarray(0.5, dtype=config.floatX),
-            ],
-            Gemm,
-        )
-
-        # Broadcast dot(X, Y)
-        self._compile_and_check(
-            [x, y, a, z, b],
-            [gemm(z, a, x, y, b)],
-            [
-                rng.random((1, 3)).astype(config.floatX),
-                rng.random((3, 4)).astype(config.floatX),
-                np.asarray(0.5, dtype=config.floatX),
-                rng.random((5, 4)).astype(config.floatX),
-                np.asarray(1, dtype=config.floatX),
             ],
             Gemm,
         )

--- a/tests/tensor/test_shape.py
+++ b/tests/tensor/test_shape.py
@@ -19,7 +19,6 @@ from pytensor.tensor.shape import (
     Shape_i,
     SpecifyShape,
     Unbroadcast,
-    _specify_shape,
     reshape,
     shape,
     shape_i,
@@ -350,13 +349,13 @@ class TestSpecifyShape(utt.InferShapeTester):
             specify_shape([[1, 2, 3], [4, 5, 6]], (2.2, 3))
 
         with pytest.raises(TypeError, match="must be integer types"):
-            _specify_shape([[1, 2, 3], [4, 5, 6]], *(2.2, 3))
+            SpecifyShape([False, False])([[1, 2, 3], [4, 5, 6]], *(2.2, 3))
 
         with pytest.raises(ValueError, match="will never match"):
             specify_shape(matrix(), [4])
 
         with pytest.raises(ValueError, match="will never match"):
-            _specify_shape(matrix(), *[4])
+            SpecifyShape([False, False])(matrix(), *[4])
 
         with pytest.raises(ValueError, match="must have fixed dimensions"):
             specify_shape(matrix(), vector(dtype="int32"))

--- a/tests/tensor/test_type.py
+++ b/tests/tensor/test_type.py
@@ -329,14 +329,12 @@ def test_fixed_shape_convert_variable():
     assert res.type.shape == (3, 2)
 
 
-def test_deprecated_kwargs():
-    with pytest.warns(DeprecationWarning, match=".*broadcastable.*"):
-        res = TensorType("float64", broadcastable=(True, False))
+def test_broadcastable_kwargs():
+    res = TensorType("float64", broadcastable=(True, False))
 
     assert res.shape == (1, None)
 
-    with pytest.warns(DeprecationWarning, match=".*broadcastable.*"):
-        new_res = res.clone(broadcastable=(False, True))
+    new_res = res.clone(broadcastable=(False, True))
 
     assert new_res.shape == (None, 1)
 
@@ -355,12 +353,9 @@ def test_tensor_creator_helper():
     assert res.type == TensorType(dtype="int64", shape=(5, None))
     assert res.name == "custom"
 
-    with pytest.warns(
-        DeprecationWarning, match="The `broadcastable` keyword is deprecated"
-    ):
-        res = tensor(dtype="int64", broadcastable=(True, False), name="custom")
-        assert res.type == TensorType("int64", shape=(1, None))
-        assert res.name == "custom"
+    res = tensor(dtype="int64", broadcastable=(True, False), name="custom")
+    assert res.type == TensorType("int64", shape=(1, None))
+    assert res.name == "custom"
 
 
 @pytest.mark.parametrize("dtype", ("floatX", "float64", bool, np.int64))


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

### Motivation for these changes
Dynamic broadcasting creates tremendous graph obfuscations. While in forward pass it is not visible, the backward pass should always check if the broadcasting had happened or not. It may sound simple, but still creates 2^n if else statements. Originally, theano had static broadcasting and the same we get in this PR

Related Issues and PRs
* https://github.com/aesara-devs/aesara/issues/1089
* https://github.com/aesara-devs/aesara/issues/335
* https://github.com/aesara-devs/aesara/pull/336
* https://github.com/aesara-devs/aesara/pull/928
* https://github.com/aesara-devs/aesara/pull/915
* https://github.com/aesara-devs/aesara/pull/986
* https://github.com/aesara-devs/aesara/pull/1253
* https://github.com/aesara-devs/aesara/pull/1102

### Implementation details
* Removed deprecations of broadcasting in TensorType
* Changed tests to check cases against static broadcasting
* Brought back shape inference for multioutput elemwise ops


### Checklist
+ [ ] Explain motivation and implementation 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [ ] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇


## Major / Breaking Changes
- ...

## New features
- ...

## Bugfixes
- ...

## Documentation
- ...

## Maintenance
- ...

