### PR TITLE
Fix automatic release notes label reference

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -13,7 +13,7 @@ changelog:
         - major
     - title: New Features 🎉
       labels:
-        - enhancements
+        - enhancement
         - feature request
     - title: Bugfixes 🪲
       labels:


### PR DESCRIPTION
Oops... would be nice if github would error when labels don't exist