### PR TITLE
Compute static shape types in outputs of `Join`

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -17,6 +17,7 @@
 # sys.path.append(os.path.abspath('some/directory'))
 
 import os
+import sys
 import pytensor
 
 # General configuration
@@ -60,7 +61,7 @@ version = pytensor.__version__
 if os.environ.get("READTHEDOCS", False):
     rtd_version = os.environ.get("READTHEDOCS_VERSION", "")
     if rtd_version.lower() == "stable":
-        version = pymc.__version__.split("+")[0]
+        version = pytensor.__version__.split("+")[0]
     elif rtd_version.lower() == "latest":
         version = "dev"
     else:

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -3,13 +3,13 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.7
+  - python=3.9
   - gcc_linux-64
   - gxx_linux-64
   - numpy
   - scipy
   - six
-  - sphinx>=5.1.0
+  - sphinx>=5.1.0,<6
   - mock
   - pillow
   - pip

--- a/environment.yml
+++ b/environment.yml
@@ -32,7 +32,7 @@ dependencies:
   - pytest-xdist
   - pytest-benchmark
   # For building docs
-  - sphinx>=5.1.0
+  - sphinx>=5.1.0,<6
   - sphinx_rtd_theme
   - pygments
   - pydot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,8 +89,7 @@ tests = [
     "pytest-benchmark",
 ]
 rtd = [
-    "sphinx>=1.3.0",
-    "sphinx_rtd_theme",
+    "sphinx>=5.1.0,<6",
     "pygments",
     "pydot",
     "pydot2",

--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -1194,7 +1194,6 @@ def local_IncSubtensor_serialize(fgraph, node):
             tip = new_add
             for mi in movable_inputs:
                 assert o_type.is_super(tip.type)
-                assert mi.owner.inputs[0].type.is_super(tip.type)
                 tip = mi.owner.op(tip, *mi.owner.inputs[1:])
                 # Copy over stacktrace from outputs of the original
                 # "movable" operation to the new operation.

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -1909,6 +1909,21 @@ class TestJoinAndSplit:
         with pytest.raises(TypeError, match="same number of dimensions"):
             self.join_op(0, v, m)
 
+    def test_static_shape_inference(self):
+        a = at.tensor(dtype="int8", shape=(2, 3))
+        b = at.tensor(dtype="int8", shape=(2, 5))
+        assert at.join(1, a, b).type.shape == (2, 8)
+        assert at.join(-1, a, b).type.shape == (2, 8)
+
+        # Check early informative errors from static shape info
+        with pytest.raises(ValueError, match="must match exactly"):
+            at.join(0, at.ones((2, 3)), at.ones((2, 5)))
+
+        # Check partial inference
+        d = at.tensor(dtype="int8", shape=(2, None))
+        assert at.join(1, a, b, d).type.shape == (2, None)
+        return
+
     def test_split_0elem(self):
         rng = np.random.default_rng(seed=utt.fetch_seed())
         m = self.shared(rng.random((4, 6)).astype(self.floatX))


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

### Motivation for these changes
Making static shapes propagate through `Join`s such as `pt.concatenate`.

Closes #163

### Implementation details
The previous double-`for` implementation was rather tricky to refactor, which is why I went with a simple matrix-based approach.

The first commit makes the corresponding tests and their output easier to read.

### Checklist
+ [x] Explain motivation and implementation 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇


## New features
- `Join` now propagate static shape information more reliably.

## Maintenance
- Docs build was updated to Python 3.9