### PR TITLE
Implement Scalar Scan (as dummy Op)

### DIFF
--- a/pytensor/scalar/scan.py
+++ b/pytensor/scalar/scan.py
@@ -1,0 +1,23 @@
+from pytensor.scalar.basic import ScalarOp, same_out
+
+
+class ScalarScanOp(ScalarOp):
+    """Dummy Scalar Op that encapsulates a scalar scan operation.
+
+    This Op is never supposed to be evaluated. It can safely be converted
+    to an Elemwise which is rewritten into a Scan node during compilation.
+
+    TODO: FINISH DOCSTRINGS
+    TODO: ABC for fn property
+    """
+
+    def __init__(self, output_types_preference=None, **kwargs):
+        if output_types_preference is None:
+
+            def output_types_preference(*types):
+                return tuple(same_out(type)[0] for type in types[: self.nout])
+
+        super().__init__(output_types_preference=output_types_preference, **kwargs)
+
+    def impl(self, *args, **kwargs):
+        raise RuntimeError("Scalar Scan Ops should never be evaluated!")

--- a/pytensor/tensor/elemwise.py
+++ b/pytensor/tensor/elemwise.py
@@ -638,6 +638,9 @@ class Elemwise(OpenMPOp):
                 return DimShuffle((), ["x"] * nd)(res)
 
             new_r = Elemwise(node.op, {})(*[transform(ipt) for ipt in node.inputs])
+            if isinstance(new_r, (list, tuple)):
+                # Scalar Op with multiple outputs
+                new_r = new_r[r.owner.outputs.index(r)]
             return new_r
 
         ret = []


### PR DESCRIPTION
Alternative to #283 

Closes #83 

The idea here is to implement a specialized kind of looping operation that can be treated as an Elemwise. I create a dummy scalar Op, whose Elemwise version is then converted to a scan by a rewrite.

As a test case I made use of the Scalar Scans in the gradient of gammaincc. Performance is now 20-30x better than before when running the new benchmark test, even though the two branches are now always computed. Further improvements could be achieved with a lazy switch, but that is not really the goal of this PR.

PS: It shouldn't be so hard to write a scan without accumulation