### PR TITLE
Implement new Loop and Scan operators

### DIFF
--- a/pytensor/graph/fg.py
+++ b/pytensor/graph/fg.py
@@ -1053,6 +1053,10 @@ class FrozenFunctionGraph(AbstractFunctionGraph):
     def __deepcopy__(self, memo):
         return self
 
+    def clone(self, *args, **kwargs) -> "FrozenFunctionGraph":
+        # Immutable: cloning to guard against mutation is a no-op.
+        return self
+
     def toposort(self) -> tuple[Apply, ...]:
         return self._toposort
 
@@ -1099,7 +1103,7 @@ class FrozenFunctionGraph(AbstractFunctionGraph):
                 [o.type() for o in node.outputs],
             )
             memo.update(zip(node.outputs, new_node.outputs))
-        return [memo[out] for out in self.outputs]
+        return [out if isinstance(out, Constant) else memo[out] for out in self.outputs]
 
     def unfreeze(self) -> "FunctionGraph":
         """Return a mutable FunctionGraph with fresh mutable Apply nodes."""

--- a/pytensor/link/numba/dispatch/scan.py
+++ b/pytensor/link/numba/dispatch/scan.py
@@ -5,9 +5,14 @@ import numpy as np
 from numba import types
 from numba.extending import overload
 
-from pytensor.compile.aliasing import add_supervisor_to_fgraph, insert_deepcopy
+from pytensor.compile.aliasing import (
+    add_supervisor_to_fgraph,
+    alias_root,
+    insert_deepcopy,
+)
 from pytensor.compile.io import In, Out
 from pytensor.compile.mode import NUMBA, get_mode
+from pytensor.graph.basic import Constant
 from pytensor.link.numba.cache import compile_numba_function_src
 from pytensor.link.numba.dispatch import basic as numba_basic
 from pytensor.link.numba.dispatch.basic import (
@@ -104,7 +109,14 @@ def numba_funcify_Scan(op: Scan, node, **kwargs):
         accept_inplace=True,
     )
     rewriter(fgraph)
-    untraced_sit_sot_inner_outputs = set(op.inner_untraced_sit_sot_outs(fgraph.outputs))
+    # Constant-rooted outputs must not be borrowed, so that `insert_deepcopy`
+    # protects them. Otherwise the generated while loop would rebind the state
+    # storage to a numba-frozen (readonly) global array, which segfaults.
+    untraced_sit_sot_inner_outputs = {
+        out
+        for out in op.inner_untraced_sit_sot_outs(fgraph.outputs)
+        if not isinstance(alias_root(out), Constant)
+    }
     output_specs = [
         Out(x, borrow=x in untraced_sit_sot_inner_outputs) for x in fgraph.outputs
     ]

--- a/pytensor/loop/__init__.py
+++ b/pytensor/loop/__init__.py
@@ -1,0 +1,1 @@
+from pytensor.loop.api import InnerShiftedArg, ShiftedArg, loop, shift

--- a/pytensor/loop/api.py
+++ b/pytensor/loop/api.py
@@ -1,0 +1,367 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+from functools import reduce
+from typing import Any
+
+import numpy as np
+
+from pytensor.graph import FunctionGraph, Variable
+from pytensor.graph.basic import Constant
+from pytensor.graph.replace import graph_replace
+from pytensor.graph.traversal import truncated_graph_inputs
+from pytensor.loop.op import Scan
+from pytensor.tensor import as_tensor, constant, invert, minimum
+from pytensor.tensor.variable import TensorVariable
+
+
+@dataclass(frozen=True)
+class ShiftedArg:
+    x: Any
+    by: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class InnerShiftedArg:
+    x: Any
+    by: tuple[int, ...]
+    readonly: bool
+    update: Variable | None = None
+
+    def push(self, x: Variable) -> "InnerShiftedArg":
+        if self.readonly:
+            raise ValueError(
+                "Cannot push to a read-only ShiftedArg (xs shifts cannot be updated)"
+            )
+        if self.update is not None:
+            raise ValueError("ShiftedArg can only have a value pushed once")
+        return type(self)(x=self.x, by=self.by, update=x, readonly=self.readonly)
+
+    def __getitem__(self, idx):
+        if -len(self.by) <= idx < len(self.by):
+            return self.x[idx]
+        else:
+            raise IndexError()
+
+    def __len__(self):
+        return len(self.by)
+
+
+def shift(x: Any, by: int | Sequence[int] = -1):
+    by = (by,) if isinstance(by, int) else tuple(by)
+    if by != tuple(sorted(by)):
+        raise ValueError(f"by entries must be sorted, got {by}")
+    if min(by) < 0 and max(by) >= 0:
+        raise ValueError(
+            f"by cannot contain both negative and non-negative entries, got {by}"
+        )
+    # TODO: If shape is known statically, validate the input is as big as the min/max taps
+    return ShiftedArg(x, by=by)
+
+
+def flatten_tree(x, subsume_none: bool = False) -> tuple[tuple, Any]:
+    def recurse(e, spec):
+        match e:
+            case tuple() | list():
+                e_spec = []
+                for e_i in e:
+                    yield from recurse(e_i, e_spec)
+                if isinstance(e, tuple):
+                    e_spec = tuple(e_spec)
+                spec.append(e_spec)
+            case None if subsume_none:
+                spec.append(None)
+            case x:
+                spec.append("x")
+                yield x
+
+    spec: list[Any] = []
+    flat_inputs = tuple(recurse(x, spec=spec))
+    return flat_inputs, spec[0]
+
+
+def unflatten_tree(x, spec):
+    def recurse(x_iter, spec):
+        match spec:
+            case "x":
+                return next(x_iter)
+            case None:
+                return None
+            case tuple():
+                return tuple(recurse(x_iter, e_spec) for e_spec in spec)
+            case list():
+                return [recurse(x_iter, e_spec) for e_spec in spec]
+            case _:
+                raise ValueError(f"Unrecognized spec: {spec}")
+
+    iter_x = iter(x)
+    res = recurse(iter_x, spec=spec)
+    # Check we consumed the whole iterable
+    try:
+        next(iter_x)
+    except StopIteration:
+        return res
+    else:
+        raise ValueError(f"x {x} has more entries than expected from the spec: {spec}")
+
+
+def loop(f, init, xs=None, length=None):
+    """Repeatedly apply ``f`` to a carried state, optionally iterating over sequences.
+
+    Roughly equivalent to::
+
+        def loop(f, init, xs, length):
+            carry = init
+            ys = []
+            for x in zip(*xs):  # or range(length)
+                carry, y, *break_cond = f(carry, x)
+                ys.append(y)
+                if break_cond and break_cond[0]:
+                    break
+            return carry, stack(ys)
+
+    Parameters
+    ----------
+    f
+        Function from ``(carry, x)`` to ``(carry, y)`` or ``(carry, y, break_cond)``.
+        ``carry`` and ``x`` have the tree structures of ``init`` and ``xs``.
+        When ``break_cond`` is returned and evaluates to True, the loop stops
+        after the current step.
+    init
+        Tree of initial states. Entries can be variables of any type (states
+        that are not tensors, like RandomGenerators, can be carried but not traced),
+        ``shift(x, by=[-k, ..., -1])`` for states with multiple taps (where ``x``
+        stacks the ``k`` initial values along a new leading dimension), or None
+        for no carry.
+    xs
+        Tree of sequences to iterate over, scalar-indexed along their leading
+        dimension. Entries can be tensor variables or ``shift(x, by=[0, ..., k])``
+        for reading multiple positions per step.
+    length
+        Number of steps. Required when there are no ``xs``, otherwise the minimum
+        of the sequence lengths (adjusted for shifts) and ``length`` is used.
+
+    Returns
+    -------
+    (final, ys)
+        Trees with the structures of ``init`` and of the ``y`` returned by ``f``,
+        holding the final states and the stacked per-step outputs.
+    """
+    init_flat, init_tree = flatten_tree(init, subsume_none=True)
+    init_flat = [
+        leaf if isinstance(leaf, Variable | ShiftedArg) else as_tensor(leaf)
+        for leaf in init_flat
+    ]
+
+    xs_flat, xs_tree = flatten_tree(xs, subsume_none=True)
+    xs_flat = [
+        leaf if isinstance(leaf, Variable | ShiftedArg) else as_tensor(leaf)
+        for leaf in xs_flat
+    ]
+
+    idx0 = constant(np.array(0, dtype="int64"), name="idx")
+    symbolic_idx = idx0.type(name="idx")
+
+    # Create the inner inputs of the carry. Shifted entries become chains of
+    # states covering every position in the tap window, of which only the
+    # requested taps are exposed to `f`
+    state_dummies: list[Variable] = []  # All inner state inputs, except idx
+    carry_entries = []  # (kind, first_slot, n_states) per init leaf
+    init_flat_inner = []
+    for leaf in init_flat:
+        if isinstance(leaf, ShiftedArg):
+            if max(leaf.by) >= 0:
+                raise ValueError(f"Init shifts must be negative, got by={leaf.by}")
+            if not isinstance(leaf.x, TensorVariable) or leaf.x.type.ndim < 1:
+                raise ValueError(
+                    "Shifted init must be a tensor stacking the initial values along a new leading dimension"
+                )
+            n_chain = -min(leaf.by)
+            elem_type = leaf.x.type.clone(shape=leaf.x.type.shape[1:])
+            chain_dummies = [elem_type() for _ in range(n_chain)]
+            carry_entries.append(("chain", len(state_dummies), n_chain))
+            state_dummies.extend(chain_dummies)
+            init_flat_inner.append(
+                InnerShiftedArg(
+                    x=[chain_dummies[n_chain + k] for k in leaf.by],
+                    by=leaf.by,
+                    readonly=False,
+                )
+            )
+        else:
+            carry_entries.append(("plain", len(state_dummies), 1))
+            dummy = leaf.type()
+            state_dummies.append(dummy)
+            init_flat_inner.append(dummy)
+
+    # Create the inner inputs of the sequences: reads of the (outer) sequences
+    # at the current iteration index. The sequences themselves become implicit
+    # constants of the loop
+    xs_flat_inner = []
+    for leaf in xs_flat:
+        if isinstance(leaf, ShiftedArg):
+            if min(leaf.by) < 0:
+                raise ValueError(
+                    f"Sequence shifts must be non-negative, got by={leaf.by}"
+                )
+            xs_flat_inner.append(
+                InnerShiftedArg(
+                    x=[
+                        leaf.x[symbolic_idx + k if k else symbolic_idx] for k in leaf.by
+                    ],
+                    by=leaf.by,
+                    readonly=True,
+                )
+            )
+        elif isinstance(leaf, TensorVariable):
+            xs_flat_inner.append(leaf[symbolic_idx])
+        else:
+            raise ValueError(f"xs must be TensorVariables, got {leaf}")
+
+    res = f(
+        unflatten_tree(init_flat_inner, init_tree),
+        unflatten_tree(xs_flat_inner, xs_tree),
+    )
+    match res:
+        case (update_inner, ys_inner):
+            break_cond_inner = None
+        case (update_inner, ys_inner, break_cond_inner):
+            pass
+        case _:
+            raise ValueError("loop f must return a tuple with 2 or 3 outputs")
+
+    # Validate the updates and collect the next states, expanding the chains
+    update_flat, update_tree = flatten_tree(update_inner, subsume_none=True)
+    if update_tree != init_tree:
+        raise ValueError(
+            "The update (first output of f) does not match the structure of init "
+            f"(first input of f), expected: {init_tree}, got: {update_tree}"
+        )
+    next_states: list[Variable] = []
+    for (kind, slot, n_states), update in zip(carry_entries, update_flat):
+        if kind == "chain":
+            if not isinstance(update, InnerShiftedArg) or update.update is None:
+                raise ValueError(f"No update pushed for shifted argument {update}")
+            next_states.extend(state_dummies[slot + 1 : slot + n_states])
+            next_states.append(update.update)
+        else:
+            if isinstance(update, InnerShiftedArg):
+                raise ValueError(
+                    f"Shifted update returned for a non-shifted init {update}"
+                )
+            next_states.append(update)
+
+    # Per-step outputs. An output that coincides with a carry's update reuses
+    # that carry's trace; the rest become nit-sot outputs of the Scan, which need
+    # no initial value and are not fed back.
+    ys_flat, ys_tree = flatten_tree(ys_inner, subsume_none=True)
+    ys_entries = []  # ("carry", state pos) or ("output", output pos)
+    output_values = []
+    for y in ys_flat:
+        if not isinstance(y, TensorVariable):
+            raise TypeError(
+                f"ys outputs must be TensorVariables, got {y} of type {type(y)}. "
+                "Non-traceable types like RNG states should be carried in init, not returned as ys."
+            )
+        if any(y is next_state for next_state in next_states):
+            pos = next(i for i, n in enumerate(next_states) if n is y)
+            ys_entries.append(("carry", pos))
+        else:
+            ys_entries.append(("output", len(output_values)))
+            output_values.append(y)
+
+    if break_cond_inner is None:
+        while_cond = as_tensor(np.array(True))
+    else:
+        if getattr(break_cond_inner.type, "dtype", None) != "bool":
+            raise TypeError(
+                f"break_cond must be a boolean scalar, got {break_cond_inner}"
+            )
+        while_cond = invert(break_cond_inner)
+
+    # Number of steps: minimum of the sequence lengths and the requested length
+    lengths = []
+    for leaf in xs_flat:
+        if isinstance(leaf, ShiftedArg):
+            lengths.append(leaf.x.shape[0] - max(leaf.by))
+        else:
+            lengths.append(leaf.shape[0])
+    if length is not None:
+        lengths.append(as_tensor(length))
+    if not lengths:
+        raise ValueError("length must be provided when there are no xs")
+    n_steps = reduce(minimum, lengths)
+
+    # Assemble the initial values, in the order of the state dummies
+    init_values = []
+    for (kind, _, n_states_entry), leaf in zip(carry_entries, init_flat):
+        if kind == "chain":
+            init_values.extend(leaf.x[j] for j in range(n_states_entry))
+        else:
+            init_values.append(leaf)
+
+    fgraph_inputs = [symbolic_idx, *state_dummies]
+    fgraph_outputs = [while_cond, symbolic_idx + 1, *next_states, *output_values]
+
+    # The remaining inputs of the loop (including the sequences read by their
+    # index) are loop-invariant constants. They cannot be used directly as
+    # inputs of the inner function graph, so they are replaced by dummies
+    outer_constants = [
+        leaf.x if isinstance(leaf, ShiftedArg) else leaf for leaf in xs_flat
+    ]
+    outer_constants.extend(
+        inp
+        for inp in truncated_graph_inputs(
+            fgraph_outputs, ancestors_to_include=fgraph_inputs + outer_constants
+        )
+        if not isinstance(inp, Constant)
+        and inp not in fgraph_inputs
+        and inp not in outer_constants
+    )
+    inner_constants = [c.type() for c in outer_constants]
+    if outer_constants:
+        fgraph_outputs = graph_replace(
+            fgraph_outputs,
+            dict(zip(outer_constants, inner_constants)),
+            strict=False,
+        )
+
+    # State shapes are loop-invariant, but shape inference may type the updated
+    # states more weakly than the initial states. Coerce them back when needed
+    while_cond_out, next_idx, *carries_and_outputs = fgraph_outputs
+    next_states = carries_and_outputs[: len(state_dummies)]
+    output_values = carries_and_outputs[len(state_dummies) :]
+    next_states = [
+        next_state
+        if dummy.type.is_super(next_state.type)
+        else dummy.type.filter_variable(next_state)
+        for dummy, next_state in zip(state_dummies, next_states)
+    ]
+
+    update_fg = FunctionGraph(
+        inputs=[symbolic_idx, *state_dummies, *inner_constants],
+        outputs=[while_cond_out, next_idx, *next_states, *output_values],
+    )
+
+    n_carries = 1 + len(state_dummies)
+    scan_op = Scan(
+        update_fg=update_fg, sequences=range(len(xs_flat)), n_carries=n_carries
+    )
+    scan_outs = scan_op(n_steps, idx0, *init_values, *outer_constants)
+    # Output layout: carry finals, carry traces, output traces; idx is dropped.
+    finals = scan_outs[1:n_carries]
+    carry_traces = scan_outs[n_carries + 1 : 2 * n_carries]
+    output_traces = scan_outs[2 * n_carries :]
+
+    # The final value of a shifted carry is its most recent state
+    final_leaves = [
+        finals[slot + n_states_entry - 1] for (_, slot, n_states_entry) in carry_entries
+    ]
+    ys_leaves = [
+        carry_traces[pos] if kind == "carry" else output_traces[pos]
+        for kind, pos in ys_entries
+    ]
+
+    return (
+        unflatten_tree(final_leaves, init_tree),
+        unflatten_tree(ys_leaves, ys_tree),
+    )

--- a/pytensor/loop/basic.py
+++ b/pytensor/loop/basic.py
@@ -1,0 +1,237 @@
+import functools
+
+import numpy as np
+
+from pytensor.basic import as_symbolic
+from pytensor.graph import FunctionGraph, Variable
+from pytensor.graph.basic import Constant
+from pytensor.graph.replace import graph_replace
+from pytensor.graph.traversal import truncated_graph_inputs
+from pytensor.loop.op import Scan
+from pytensor.scan.utils import until
+from pytensor.tensor import as_tensor, constant, minimum
+
+
+def scan(
+    fn,
+    init_states=None,
+    sequences=None,
+    non_sequences=None,
+    n_steps=None,
+    go_backwards=False,
+) -> Variable | list[Variable]:
+    if sequences is None and n_steps is None:
+        raise ValueError("Must provide n_steps when scanning without sequences")
+
+    if init_states is None:
+        init_states = []
+    else:
+        if not isinstance(init_states, (tuple, list)):
+            init_states = [init_states]
+        init_states = [as_symbolic(i) if i is not None else None for i in init_states]
+
+    if sequences is None:
+        sequences = []
+    else:
+        if not isinstance(sequences, (tuple, list)):
+            sequences = [sequences]
+        sequences = [as_tensor(s) for s in sequences]
+
+    if sequences:
+        leading_dims = [seq.shape[0] for seq in sequences]
+        shortest_dim = functools.reduce(minimum, leading_dims)
+        if n_steps is None:
+            n_steps = shortest_dim
+        else:
+            n_steps = minimum(n_steps, shortest_dim)
+
+    if non_sequences is None:
+        non_sequences = []
+    else:
+        if not isinstance(non_sequences, (tuple, list)):
+            non_sequences = [non_sequences]
+        non_sequences = [as_symbolic(n) for n in non_sequences]
+
+    # Create dummy inputs for the init state. The user function should not
+    # draw any relationship with the outer initial states, since these are only
+    # valid in the first iteration
+    inner_states = [i.type() if i is not None else None for i in init_states]
+
+    # Create subsequence inputs for the inner function
+    idx = constant(0, dtype="int64", name="idx")
+    symbolic_idx = idx.type(name="idx")
+    subsequences = [s[symbolic_idx] for s in sequences]
+
+    # Call user function to retrieve inner outputs. We use the same order as the old Scan,
+    # although inner_states + subsequences + non_sequences seems more intuitive,
+    # since subsequences are just a fancy non_sequence
+    # We don't pass the non-carried outputs [init is None] to the inner function
+    fn_inputs = (
+        subsequences + [i for i in inner_states if i is not None] + non_sequences
+    )
+    fn_outputs = fn(*fn_inputs)
+    if not isinstance(fn_outputs, (tuple, list)):
+        fn_outputs = [fn_outputs]
+    next_states = [out for out in fn_outputs if not isinstance(out, until)]
+
+    if len(next_states) > len(init_states):
+        if not init_states:
+            init_states = [None] * len(next_states)
+            inner_states = init_states
+        else:
+            raise ValueError(
+                "Please provide None as `init` for any output that is not carried over (i.e. it behaves like a map) "
+            )
+
+    # Partition the inner outputs into carries (with an init, fed back) and
+    # map-like outputs (init is None): the latter become nit-sot outputs of the
+    # Scan, with no input and no initial value.
+    carry_prev_states = []  # outer init value per carry
+    carry_inner_states = []  # inner input dummy per carry
+    carry_next_states = []  # inner next value per carry
+    output_values = []  # inner nit-sot output value per map output
+    output_entries = []  # ("carry", pos) or ("output", pos), in fn-output order
+    for init_state, inner_state, next_state in zip(
+        init_states, inner_states, next_states
+    ):
+        if init_state is None:
+            output_entries.append(("output", len(output_values)))
+            output_values.append(next_state)
+        else:
+            # State shapes are loop-invariant, but shape inference may type the
+            # updated state more weakly than the init; coerce it back when needed.
+            if not inner_state.type.is_super(next_state.type):
+                next_state = inner_state.type.filter_variable(next_state)
+            output_entries.append(("carry", len(carry_next_states)))
+            carry_prev_states.append(init_state)
+            carry_inner_states.append(inner_state)
+            carry_next_states.append(next_state)
+
+    # Flip until to while condition
+    while_condition = [~out.condition for out in fn_outputs if isinstance(out, until)]
+    if not while_condition:
+        while_condition = [as_tensor(np.array(True))]
+    if len(while_condition) > 1:
+        raise ValueError("Only one until condition can be returned")
+
+    fgraph_inputs = [symbolic_idx, *carry_inner_states, *sequences, *non_sequences]
+    fgraph_outputs = [
+        *while_condition,
+        symbolic_idx + 1,
+        *carry_next_states,
+        *output_values,
+    ]
+
+    all_fgraph_inputs = truncated_graph_inputs(
+        fgraph_outputs, ancestors_to_include=fgraph_inputs
+    )
+    extra_fgraph_inputs = [
+        inp
+        for inp in all_fgraph_inputs
+        if (not isinstance(inp, Constant) and inp not in fgraph_inputs)
+    ]
+
+    # The outer constants (which may include shared variables) cannot be used
+    # directly as inputs of the inner function graph. Replace them by dummies.
+    outer_constants = [*sequences, *non_sequences, *extra_fgraph_inputs]
+    inner_constants = [c.type() for c in outer_constants]
+    if outer_constants:
+        fgraph_outputs = graph_replace(
+            fgraph_outputs,
+            dict(zip(outer_constants, inner_constants)),
+            strict=False,
+        )
+    update_fg = FunctionGraph(
+        inputs=[symbolic_idx, *carry_inner_states, *inner_constants],
+        outputs=fgraph_outputs,
+    )
+
+    n_carries = 1 + len(carry_inner_states)
+    scan_op = Scan(
+        update_fg=update_fg, sequences=range(len(sequences)), n_carries=n_carries
+    )
+    scan_outs = scan_op(
+        n_steps,
+        idx,
+        *carry_prev_states,
+        *sequences,
+        *non_sequences,
+        *extra_fgraph_inputs,
+    )
+    assert isinstance(scan_outs, list)
+    # Output layout: carry finals, carry traces, output traces; the idx is dropped.
+    carry_traces = scan_outs[n_carries + 1 : 2 * n_carries]
+    output_traces = scan_outs[2 * n_carries :]
+    traces = [
+        carry_traces[pos] if kind == "carry" else output_traces[pos]
+        for kind, pos in output_entries
+    ]
+    if len(traces) == 1:
+        return traces[0]
+    return traces
+
+
+def map(
+    fn,
+    sequences,
+    non_sequences=None,
+    go_backwards=False,
+):
+    traces = scan(
+        fn=fn,
+        sequences=sequences,
+        non_sequences=non_sequences,
+        go_backwards=go_backwards,
+    )
+    return traces
+
+
+def reduce(
+    fn,
+    init_states,
+    sequences,
+    non_sequences=None,
+    go_backwards=False,
+):
+    traces = scan(
+        fn=fn,
+        init_states=init_states,
+        sequences=sequences,
+        non_sequences=non_sequences,
+        go_backwards=go_backwards,
+    )
+    if not isinstance(traces, list):
+        return traces[-1]
+    return [trace[-1] for trace in traces]
+
+
+def filter(
+    fn,
+    sequences,
+    non_sequences=None,
+    go_backwards=False,
+):
+    if not isinstance(sequences, (tuple, list)):
+        sequences = [sequences]
+
+    masks = scan(
+        fn=fn,
+        sequences=sequences,
+        non_sequences=non_sequences,
+        go_backwards=go_backwards,
+    )
+
+    if not isinstance(masks, list):
+        masks = [masks] * len(sequences)
+    elif len(masks) != len(sequences):
+        raise ValueError(
+            "filter fn must return one variable or len(sequences), but it returned {len(masks)}"
+        )
+    if not all(mask.dtype == "bool" for mask in masks):
+        raise TypeError("The output of filter fn should be a boolean variable")
+
+    filtered_sequences = [seq[mask] for seq, mask in zip(sequences, masks)]
+
+    if len(filtered_sequences) == 1:
+        return filtered_sequences[0]
+    return filtered_sequences

--- a/pytensor/loop/op.py
+++ b/pytensor/loop/op.py
@@ -1,0 +1,976 @@
+from collections.abc import Sequence
+
+import numpy as np
+
+from pytensor import In, Out, config
+from pytensor.compile import function, optdb
+from pytensor.compile.ops import view_op
+from pytensor.gradient import (
+    DisconnectedType,
+    NullType,
+    _is_zero,
+    grad_undefined,
+    pullback,
+)
+from pytensor.graph import Apply, FunctionGraph, Op, Type, Variable, node_rewriter
+from pytensor.graph.replace import graph_replace
+from pytensor.graph.rewriting.basic import in2out
+from pytensor.graph.traversal import ancestors
+from pytensor.scan.op import Scan as LegacyScan
+from pytensor.scan.op import ScanInfo
+from pytensor.scan.utils import expand_empty
+from pytensor.tensor import (
+    add,
+    as_tensor,
+    concatenate,
+    get_scalar_constant_value,
+    invert,
+    shape_padleft,
+    zeros_like,
+)
+from pytensor.tensor.basic import ScalarFromTensor
+from pytensor.tensor.exceptions import NotScalarConstantError
+from pytensor.tensor.shape import Shape_i
+from pytensor.tensor.subtensor import (
+    AdvancedIncSubtensor,
+    AdvancedIncSubtensor1,
+    IncSubtensor,
+    Subtensor,
+    get_idx_list,
+)
+from pytensor.tensor.type import (
+    DenseTensorType,
+    TensorType,
+    continuous_dtypes,
+    integer_dtypes,
+)
+from pytensor.tensor.type_other import NoneTypeT
+from pytensor.typed_list import GetItem, TypedListType
+
+
+def validate_loop_update_types(update, n_carries=None):
+    assert update.outputs[0].type.dtype == "bool"
+    # Only the carries are fed back into inputs; trailing outputs (nit-sots) have
+    # no corresponding input.
+    next_carries = (
+        update.outputs[1:] if n_carries is None else update.outputs[1 : 1 + n_carries]
+    )
+    for i, (input_state, output_state) in enumerate(zip(update.inputs, next_carries)):
+        # Outputs may be more specific than the inputs (e.g. have static shapes
+        # the inputs lack), since they are fed back into them across iterations
+        if not input_state.type.is_super(output_state.type):
+            raise TypeError(
+                f"The {i}-th input and output states of the inner loop function have incompatible types: "
+                f"{input_state.type} vs {output_state.type}."
+            )
+
+
+def _scalar_constant(var):
+    try:
+        return int(get_scalar_constant_value(var, only_process_constants=True))
+    except NotScalarConstantError:
+        return None
+
+
+def match_sequence_read(client, position, state_inputs):
+    """Return (idx_state, tap) when the client is a `c[idx + tap]` read.
+
+    Negative taps don't match: they would wrap around the sequence,
+    which legacy Scan sequences cannot represent.
+    """
+    if client == "output" or not isinstance(client.op, Subtensor) or position != 0:
+        return None
+    indices = get_idx_list(client.inputs, client.op.idx_list)
+    if len(indices) != 1:
+        return None
+    [index] = indices
+    if (
+        isinstance(index, Variable)
+        and index.owner is not None
+        and isinstance(index.owner.op, ScalarFromTensor)
+    ):
+        index = index.owner.inputs[0]
+    if index in state_inputs:
+        return index, 0
+    if (
+        isinstance(index, Variable)
+        and index.owner is not None
+        and index.owner.op == add
+        and len(index.owner.inputs) == 2
+    ):
+        left, right = index.owner.inputs
+        if (
+            left in state_inputs
+            and (tap := _scalar_constant(right)) is not None
+            and tap >= 0
+        ):
+            return left, tap
+        if (
+            right in state_inputs
+            and (tap := _scalar_constant(left)) is not None
+            and tap >= 0
+        ):
+            return right, tap
+    return None
+
+
+def verify_sequence_reads(update_fg, n_states, sequences):
+    """Verify which of the declared constants are only read along an index state.
+
+    A constant `c` behaves as a sequence when its only uses are `c[idx + k]`
+    reads, for constant offsets `k >= 0`, where `idx` is a state that advances
+    by one in every iteration. Candidates that don't conform are simply not
+    recorded: they behave as plain constants, which is always valid. The
+    recorded reads only enable optimizations in the gradient and the lowering.
+
+    Returns the verified read offsets per constant, and the position of the
+    index state.
+    """
+    if not sequences:
+        return {}, None
+
+    state_inputs = set(update_fg.inputs[:n_states])
+
+    def advances_by_one(some_state):
+        next_state = update_fg.outputs[1 + update_fg.inputs.index(some_state)]
+        return (
+            next_state.owner is not None
+            and next_state.owner.op == add
+            and len(next_state.owner.inputs) == 2
+            and any(inp is some_state for inp in next_state.owner.inputs)
+            and any(
+                inp is not some_state and _scalar_constant(inp) == 1
+                for inp in next_state.owner.inputs
+            )
+        )
+
+    idx_state = None
+    sequence_reads = {}
+    for j in sequences:
+        const = update_fg.inputs[n_states + j]
+        taps = set()
+        for client, position in update_fg.clients[const]:
+            read = match_sequence_read(client, position, state_inputs)
+            if read is None:
+                taps = None
+                break
+            read_idx, tap = read
+            if read_idx is not idx_state and (
+                idx_state is not None or not advances_by_one(read_idx)
+            ):
+                taps = None
+                break
+            idx_state = read_idx
+            taps.add(tap)
+        if taps:
+            sequence_reads[j] = tuple(sorted(taps))
+
+    idx_state_pos = update_fg.inputs.index(idx_state) if sequence_reads else None
+    return sequence_reads, idx_state_pos
+
+
+def peel_last_step_cotangent(trace_cotangent):
+    """Extract g from trace cotangents of the form `inc_subtensor(zeros, g, -1)`.
+
+    This is the cotangent produced when the cost is only connected to the last
+    step of a trace (e.g. `cost = fn(trace[-1])`). Instead of streaming a one-hot
+    sequence of cotangents through the backward Scan, g can seed its initial
+    state cotangent directly.
+    """
+    node = trace_cotangent.owner
+    if node is None or not isinstance(node.op, IncSubtensor):
+        return None
+    if len(node.op.idx_list) != 1:
+        return None
+    zeros, g, *index_inputs = node.inputs
+    if _is_zero(zeros) != "yes":
+        return None
+    [index] = get_idx_list([zeros, *index_inputs], node.op.idx_list)
+    try:
+        if get_scalar_constant_value(index) != -1:
+            return None
+    except NotScalarConstantError:
+        return None
+    return g
+
+
+def accumulate_grad(acc, contribution):
+    """Accumulate a per-step gradient contribution into the running accumulator.
+
+    The pullback computes constant contributions as IncSubtensor chains rooted
+    in a zeros array. Grafting the accumulator as the root of the chain avoids
+    adding two arrays (one of which has the size of the whole gradient) in
+    every iteration of the backward Scan.
+    """
+    chain = []
+    root = contribution
+    while (
+        root.owner is not None
+        and isinstance(
+            root.owner.op,
+            IncSubtensor | AdvancedIncSubtensor | AdvancedIncSubtensor1,
+        )
+        and not root.owner.op.set_instead_of_inc
+    ):
+        chain.append(root.owner)
+        root = root.owner.inputs[0]
+
+    if root is contribution:
+        if _is_zero(contribution) == "yes":
+            return acc
+        return acc + contribution
+
+    # The graft is only valid if the zeros root is not also used in the
+    # increment values or indices of the chain
+    other_chain_inputs = [inp for node in chain for inp in node.inputs[1:]]
+    if _is_zero(root) == "yes" and root not in ancestors(other_chain_inputs):
+        return graph_replace([contribution], {root: acc})[0]
+    return acc + contribution
+
+
+def compile_update_fn(fgraph):
+    """Compile the inner update function graph of a Scan Op."""
+    wrapped_inputs = [In(x, borrow=True) for x in fgraph.inputs]
+    wrapped_outputs = [Out(x, borrow=False) for x in fgraph.outputs]
+
+    # TODO: Figure this out
+    # The numba linker cannot pass non-tensor types (TypedList, RandomGenerator)
+    # as arguments of the compiled update function
+    if all(
+        isinstance(var.type, DenseTensorType)
+        for var in (*fgraph.inputs, *fgraph.outputs[1:])
+    ):
+        mode = "FAST_RUN"
+    else:
+        mode = "CVM"
+
+    return function(
+        wrapped_inputs,
+        wrapped_outputs,
+        mode=mode,
+        accept_inplace=False,
+        on_unused_input="ignore",
+    )
+
+
+class Scan(Op):
+    """Represent a scan.
+
+    This Op can be thought of as a loop that collects intermediate steps
+
+    Roughly equivalent to
+    ```
+    def scan(fn, initial_states, constants, max_iters):
+        traces = [[] * len(initial_states)]
+        states = initial_states
+        for i in range(max_iters):
+            resume, states = fn(*states, *constants)
+            for trace, state in zip(traces, states):
+                trace.append(state)
+            if not resume:
+                break
+        return states, traces
+    ```
+    Tensor state traces are collected as tensors with a new leading dimension,
+    other types (e.g. RandomGenerator) are collected in TypedLists.
+
+    During compilation this Op is lowered to the legacy Scan Op. Non-tensor
+    states (e.g. RandomGenerators) can be carried but not traced.
+    """
+
+    def __init__(
+        self,
+        update_fg: FunctionGraph,  # (*carries, *consts) -> (bool, *next_carries, *outputs)
+        sequences: Sequence[int] = (),
+        n_carries: int | None = None,
+    ):
+        """
+        Parameters
+        ----------
+        update_fg
+            Inner function graph mapping (*carries, *constants) to
+            (continue_flag, *next_carries, *outputs). Carries are fed back into
+            the next iteration; trailing outputs are collected per step (nit-sot)
+            without being fed back.
+        sequences
+            Indices of constants that are only read elementwise along an index
+            state (`const[idx + k]`). This is validated, and recorded in
+            `sequence_reads`/`idx_state` for the gradient and lowering to exploit.
+        n_carries
+            Number of carried states; the remaining inner outputs are nit-sot
+            outputs. Defaults to every inner output being a carry.
+        """
+        n_inner_outputs = len(update_fg.outputs) - 1
+        if n_carries is None:
+            n_carries = n_inner_outputs
+        validate_loop_update_types(update_fg, n_carries)
+
+        # `state_types`/`n_states` refer to the carries throughout.
+        self.n_states = n_carries
+        self.state_types = [out.type for out in update_fg.outputs[1 : 1 + n_carries]]
+        self.output_types = [out.type for out in update_fg.outputs[1 + n_carries :]]
+        self.n_outputs = len(self.output_types)
+        self.sequence_reads, self.idx_state = verify_sequence_reads(
+            update_fg, self.n_states, tuple(sequences)
+        )
+        # Both carries and outputs are collected into traces.
+        self.trace_types: list[Type] = []
+        for traced_type in (*self.state_types, *self.output_types):
+            # TODO: Accommodate SparseTensors and Scalars
+            if isinstance(traced_type, DenseTensorType):
+                self.trace_types.append(
+                    DenseTensorType(
+                        shape=(None, *traced_type.shape), dtype=traced_type.dtype
+                    )
+                )
+            else:
+                self.trace_types.append(TypedListType(traced_type))
+
+        self.constant_types = [inp.type for inp in update_fg.inputs[self.n_states :]]
+        self.n_constants = len(self.constant_types)
+
+        # Stored immutable: the inner graph is frozen between construction and
+        # lowering, so the sequence-read analysis stays exact and the Op is
+        # hashable (structurally identical Scans can be merged).
+        self.update_fg = update_fg.freeze()
+
+        # It's more conservative to assume the Op has a while condition
+        self.has_while_condition = True
+        try:
+            self.has_while_condition = not get_scalar_constant_value(
+                update_fg.outputs[0]
+            )
+        except NotScalarConstantError:
+            pass
+
+    def __eq__(self, other):
+        if self is other:
+            return True
+        if type(self) is not type(other):
+            return False
+        return (
+            self.update_fg == other.update_fg
+            and self.n_states == other.n_states
+            and self.sequence_reads == other.sequence_reads
+        )
+
+    def __hash__(self):
+        return hash(
+            (
+                type(self),
+                self.update_fg,
+                self.n_states,
+                tuple(sorted(self.sequence_reads.items())),
+            )
+        )
+
+    def make_node(self, max_iters, *inputs):
+        assert len(inputs) == self.n_states + self.n_constants
+
+        max_iters = as_tensor(max_iters)
+        if max_iters.type.dtype != "int64":
+            if max_iters.type.dtype not in integer_dtypes:
+                raise TypeError(
+                    f"max_iters must be an integer scalar, got {max_iters.type}"
+                )
+            max_iters = max_iters.astype("int64")
+        max_iters = TensorType(dtype="int64", shape=()).filter_variable(max_iters)
+
+        states = inputs[: self.n_states]
+        states = [
+            inp_type.filter_variable(inp)
+            for inp_type, inp in zip(self.state_types, states)
+        ]
+
+        constants = inputs[self.n_states :]
+        constants = [
+            inp_type.filter_variable(inp)
+            for inp_type, inp in zip(self.constant_types, constants)
+        ]
+
+        # If there is no while condition, `max_iters` exclusively defines the number of iterations
+        # If this value is constant, we can get static type shapes for the leading dimensions of traces
+        trace_types = self.trace_types
+        if not self.has_while_condition:
+            try:
+                n_iters = int(get_scalar_constant_value(max_iters))
+            except NotScalarConstantError:
+                pass
+            else:
+                trace_types = []
+                for trace_type in self.trace_types:
+                    if isinstance(trace_type, DenseTensorType):
+                        trace_types.append(
+                            DenseTensorType(
+                                dtype=trace_type.dtype,
+                                shape=(n_iters, *trace_type.shape[1:]),
+                            )
+                        )
+                    else:
+                        trace_types.append(trace_type)
+
+        return Apply(
+            self,
+            [max_iters, *states, *constants],
+            [output_type() for output_type in self.state_types + trace_types],
+        )
+
+    def infer_shape(self, fgraph, node, input_shapes):
+        # If there is a while condition, `max_iters` provides only the upper bound for the number of iterations
+        if self.has_while_condition:
+            # find the first non-None trace
+            trace_out = next(
+                trace
+                for trace in node.outputs[self.n_states :]
+                if not isinstance(trace.type, NoneTypeT)
+            )
+            n_iters = Shape_i(0)(trace_out)
+        else:
+            n_iters = node.inputs[0]  # max_iters
+
+        carry_shapes = input_shapes[1 : self.n_states + 1]
+        carry_trace_shapes = [
+            (n_iters, *carry_shape) if carry_shape is not None else None
+            for carry_shape in carry_shapes
+        ]
+        # Outputs (nit-sots) have no input to take a per-step shape from; rely on
+        # the static type shape when fully known, otherwise leave it unknown.
+        output_trace_shapes = []
+        for output_trace in node.outputs[2 * self.n_states :]:
+            trailing = output_trace.type.shape[1:]
+            if any(dim is None for dim in trailing):
+                output_trace_shapes.append(None)
+            else:
+                output_trace_shapes.append((n_iters, *trailing))
+        return carry_shapes + carry_trace_shapes + output_trace_shapes
+
+    def do_constant_folding(self, fgraph, node):
+        return False
+
+    @property
+    def fn(self):
+        """Lazily compile the inner update function graph.
+
+        Only used when the Op was not lowered away during compilation
+        (e.g. in unoptimized modes).
+        """
+        if getattr(self, "_fn", None) is None:
+            self._fn = compile_update_fn(self.update_fg.unfreeze())
+        return self._fn
+
+    def perform(self, node, inputs, output_storage):
+        update_fn = self.fn
+
+        max_iters = inputs[0]
+        carries = list(inputs[1 : 1 + self.n_states])
+        constants = inputs[1 + self.n_states :]
+        # The inner function returns the next carries followed by the outputs;
+        # both are traced, but only the carries are fed back.
+        traces = [[] for _ in range(self.n_states + self.n_outputs)]
+        for _ in range(max_iters):
+            resume, *next_values = update_fn(*carries, *constants)
+            for trace, value in zip(traces, next_values):
+                trace.append(value)
+            carries = next_values[: self.n_states]
+            if not resume:
+                break
+
+        for i, carry in enumerate(carries):
+            output_storage[i][0] = carry
+        for i, (trace, trace_type) in enumerate(zip(traces, self.trace_types)):
+            if isinstance(trace_type, DenseTensorType):
+                if trace:
+                    trace = np.stack(trace)
+                else:
+                    # No iterations ran: carries keep their input per-step shape;
+                    # outputs fall back to their static (possibly partial) shape.
+                    if i < self.n_states:
+                        per_step_shape = np.shape(inputs[1 + i])
+                    else:
+                        per_step_shape = tuple(
+                            dim if dim is not None else 0
+                            for dim in trace_type.shape[1:]
+                        )
+                    trace = np.empty((0, *per_step_shape), dtype=trace_type.dtype)
+            output_storage[self.n_states + i][0] = trace
+
+    @staticmethod
+    def _input_grad_kind(var) -> str:
+        """Classify the gradient an input is entitled to.
+
+        "grad": continuous tensors, a proper gradient is computed.
+        "zeros": discrete tensors, which are structurally connected to the
+        outputs, and by convention receive zero gradients.
+        "undefined": non-tensor continuous inputs, for which gradients are not
+        implemented.
+        "disconnected": other types (RandomGenerator, TypedList, ...) through
+        which gradients cannot flow.
+        """
+        if isinstance(var.type, DenseTensorType):
+            return "grad" if var.type.dtype in continuous_dtypes else "zeros"
+        if getattr(var.type, "dtype", None) in continuous_dtypes:
+            return "undefined"
+        return "disconnected"
+
+    def connection_pattern(self, node):
+        n_outputs = len(node.outputs)
+        connected_inputs = [False]  # max_iters
+        connected_inputs += [
+            self._input_grad_kind(inp) != "disconnected" for inp in node.inputs[1:]
+        ]
+        return [[connected] * n_outputs for connected in connected_inputs]
+
+    def pullback(self, inputs, outputs, cotangents):
+        """Compute the gradient of a Scan as another Scan that iterates backwards over the traces.
+
+        At the backward step corresponding to forward step t, the cotangent of the t-th
+        states (the running cotangent plus the contribution of the respective trace entries)
+        is pulled back through the update function evaluated at the inputs of forward step t.
+        This yields the cotangents of the (t-1)-th states, and the contributions of the
+        constants, which are accumulated across iterations.
+
+        After the backward Scan, the running state cotangents correspond to the gradients
+        with respect to the initial states, and the accumulated contributions to the
+        gradients with respect to the constants.
+        """
+        # Avoid circular import
+        from pytensor.loop.basic import scan
+
+        max_iters = inputs[0]
+        init_states = inputs[1 : 1 + self.n_states]
+        constants = inputs[1 + self.n_states :]
+        traces = outputs[self.n_states :]
+        final_state_grads = cotangents[: self.n_states]
+        trace_grads = cotangents[self.n_states :]
+
+        def is_connected(g) -> bool:
+            return not isinstance(g.type, DisconnectedType)
+
+        disconnected = DisconnectedType()
+
+        def default_grad(input_pos, var):
+            """Gradient for inputs the backward Scan does not compute, consistent with connection_pattern."""
+            kind = self._input_grad_kind(var)
+            if kind == "grad":
+                return var.zeros_like()
+            if kind == "zeros":
+                return var.zeros_like(dtype=config.floatX)
+            if kind == "undefined":
+                return grad_undefined(
+                    self,
+                    input_pos,
+                    var,
+                    f"Gradient of Scan not implemented for inputs of type {var.type}",
+                )
+            return disconnected()
+
+        if any(isinstance(g.type, NullType) for g in cotangents if is_connected(g)):
+            null = NullType("Gradient of Scan output is undefined")
+            return [disconnected()] + [
+                null()
+                if self._input_grad_kind(var) != "disconnected"
+                else disconnected()
+                for var in (*init_states, *constants)
+            ]
+
+        diff_state_idxs = [
+            i for i, s in enumerate(init_states) if self._input_grad_kind(s) == "grad"
+        ]
+        diff_const_idxs = [
+            j for j, c in enumerate(constants) if self._input_grad_kind(c) == "grad"
+        ]
+        dense_state_idxs = [
+            i for i, s in enumerate(init_states) if isinstance(s.type, DenseTensorType)
+        ]
+        # Differentiable outputs (nit-sots) with a connected trace cotangent. They
+        # feed cotangent sequences into the backward Scan but, unlike carries, are
+        # not threaded as backward states.
+        diff_output_idxs = [
+            k
+            for k, out_type in enumerate(self.output_types)
+            if isinstance(out_type, DenseTensorType)
+            and out_type.dtype in continuous_dtypes
+            and is_connected(trace_grads[self.n_states + k])
+        ]
+
+        # A gradient is only computable if there is something differentiable to
+        # pull a connected cotangent through (a carry or an output) and something
+        # to seed the backward Scan with (a carry or a constant).
+        if (
+            not (diff_state_idxs or diff_output_idxs)
+            or not (diff_state_idxs or diff_const_idxs)
+            or not any(is_connected(g) for g in cotangents)
+        ):
+            return [disconnected()] + [
+                default_grad(pos, var)
+                for pos, var in enumerate((*init_states, *constants), start=1)
+            ]
+
+        # When the cost is only connected to the last step of a trace, fold the
+        # cotangent into the initial state cotangent of the backward Scan,
+        # instead of streaming a one-hot sequence of cotangents through it
+        final_state_grads = list(final_state_grads)
+        trace_grads = list(trace_grads)
+        for i in diff_state_idxs:
+            if not is_connected(trace_grads[i]):
+                continue
+            last_step_cotangent = peel_last_step_cotangent(trace_grads[i])
+            if last_step_cotangent is not None:
+                if is_connected(final_state_grads[i]):
+                    final_state_grads[i] = final_state_grads[i] + last_step_cotangent
+                else:
+                    final_state_grads[i] = last_step_cotangent
+                trace_grads[i] = disconnected()
+
+        # If there is a while condition, the trace length tells how many iterations were actually run
+        if self.has_while_condition:
+            dense_trace = next(
+                traces[i]
+                for i in (
+                    *dense_state_idxs,
+                    *(self.n_states + k for k in diff_output_idxs),
+                )
+            )
+            n_iters = dense_trace.shape[0]
+        else:
+            n_iters = max_iters
+
+        # Create the pullback (vector-Jacobian product) graph of the update function,
+        # with dummy variables for the state cotangents
+        update_fg = self.update_fg.unfreeze()
+        inner_prev_states = update_fg.inputs[: self.n_states]
+        inner_constants = update_fg.inputs[self.n_states :]
+        inner_next_states = update_fg.outputs[1:]
+
+        state_cotangents = [inner_next_states[i].type() for i in diff_state_idxs]
+        output_cotangents = [
+            inner_next_states[self.n_states + k].type() for k in diff_output_idxs
+        ]
+        # The next states/outputs are wrapped in ViewOps so that no entry of `f` is
+        # an ancestor of (or the same variable as) another. Otherwise the cotangents
+        # seeded at the nested entry would override the gradient flowing into it.
+        vjps = pullback(
+            f=(
+                [view_op(inner_next_states[i]) for i in diff_state_idxs]
+                + [
+                    view_op(inner_next_states[self.n_states + k])
+                    for k in diff_output_idxs
+                ]
+            ),
+            wrt=(
+                [inner_prev_states[i] for i in diff_state_idxs]
+                + [inner_constants[j] for j in diff_const_idxs]
+            ),
+            cotangents=state_cotangents + output_cotangents,
+            disconnected_inputs="ignore",
+            return_disconnected="zero",
+        )
+        non_dense_inner_states = [
+            s for i, s in enumerate(inner_prev_states) if i not in dense_state_idxs
+        ]
+
+        # The inputs of forward step t are the states of step t-1: the initial states
+        # followed by all trace entries but the last, reversed for the backward iteration
+        prev_state_seqs = [
+            concatenate([init_states[i][None], traces[i][:-1]])[::-1]
+            for i in dense_state_idxs
+        ]
+        traced_grad_idxs = [i for i in diff_state_idxs if is_connected(trace_grads[i])]
+        trace_grad_seqs = [trace_grads[i][::-1] for i in traced_grad_idxs]
+        output_grad_seqs = [
+            trace_grads[self.n_states + k][::-1] for k in diff_output_idxs
+        ]
+
+        init_lambdas = [
+            self.state_types[i].filter_variable(
+                final_state_grads[i]
+                if is_connected(final_state_grads[i])
+                else zeros_like(init_states[i])
+            )
+            for i in diff_state_idxs
+        ]
+        init_accs = [zeros_like(constants[j]) for j in diff_const_idxs]
+
+        n_prev = len(dense_state_idxs)
+        n_traced = len(traced_grad_idxs)
+        n_outs = len(diff_output_idxs)
+        n_lambdas = len(diff_state_idxs)
+
+        def backward_step(*args):
+            prev_state_elems = args[:n_prev]
+            trace_grad_elems = args[n_prev : n_prev + n_traced]
+            output_grad_elems = args[n_prev + n_traced : n_prev + n_traced + n_outs]
+            base = n_prev + n_traced + n_outs
+            lambdas = args[base : base + n_lambdas]
+            accs = args[base + n_lambdas : -len(constants) or None]
+            outer_constants = args[len(args) - len(constants) :]
+
+            total_lambdas = list(lambdas)
+            for k, i in enumerate(diff_state_idxs):
+                if i in traced_grad_idxs:
+                    total_lambdas[k] = (
+                        total_lambdas[k] + trace_grad_elems[traced_grad_idxs.index(i)]
+                    )
+
+            replace = dict(
+                zip(
+                    (inner_prev_states[i] for i in dense_state_idxs),
+                    prev_state_elems,
+                )
+            )
+            replace.update(zip(inner_constants, outer_constants))
+            replace.update(zip(state_cotangents, total_lambdas))
+            replace.update(zip(output_cotangents, output_grad_elems))
+            results = graph_replace(vjps, replace, strict=False)
+
+            if set(non_dense_inner_states) & set(ancestors(results)):
+                raise NotImplementedError(
+                    "Gradient of Scan requires the values of non-tensor states, which are not traced"
+                )
+
+            new_lambdas = [
+                self.state_types[i].filter_variable(r)
+                for i, r in zip(diff_state_idxs, results[:n_lambdas])
+            ]
+            new_accs = [
+                self.constant_types[j].filter_variable(accumulate_grad(acc, r))
+                for j, acc, r in zip(diff_const_idxs, accs, results[n_lambdas:])
+            ]
+            return [*new_lambdas, *new_accs]
+
+        backward_outs = scan(
+            backward_step,
+            init_states=[*init_lambdas, *init_accs],
+            sequences=[*prev_state_seqs, *trace_grad_seqs, *output_grad_seqs],
+            non_sequences=list(constants),
+            n_steps=n_iters,
+        )
+        if not isinstance(backward_outs, list):
+            backward_outs = [backward_outs]
+        final_lambdas = [trace[-1] for trace in backward_outs[:n_lambdas]]
+        final_accs = [trace[-1] for trace in backward_outs[n_lambdas:]]
+
+        input_grads = [disconnected()]  # max_iters
+        for i, init_state in enumerate(init_states):
+            if i in diff_state_idxs:
+                input_grads.append(final_lambdas[diff_state_idxs.index(i)])
+            else:
+                input_grads.append(default_grad(1 + i, init_state))
+        for j, constant_inp in enumerate(constants):
+            if j in diff_const_idxs:
+                input_grads.append(final_accs[diff_const_idxs.index(j)])
+            else:
+                input_grads.append(default_grad(1 + self.n_states + j, constant_inp))
+        return input_grads
+
+
+@node_rewriter([Scan])
+def scan_to_legacy_scan(fgraph, node):
+    """Lower a Scan Op into the legacy Scan Op.
+
+    Verified sequence constants are mapped to legacy sequences (one per read
+    offset), and the index state is elided when feeding those reads was its
+    only job. Tensor states whose traces are used are mapped to sit-sots, all
+    other states to untraced sit-sots, and the remaining constants to
+    non-sequences. This gives access to the legacy rewrites (pushouts, merging,
+    inplace) and backend dispatches. Untraced states need no buffers at all,
+    and their inner updates are allowed to operate inplace.
+
+    Traces of non-tensor states (TypedList) cannot be represented in the legacy
+    Scan, so tracing such a state is not supported.
+    """
+    op: Scan = node.op  # type: ignore
+
+    max_iters = node.inputs[0]
+    init_states = node.inputs[1 : 1 + op.n_states]
+    constants = node.inputs[1 + op.n_states :]
+    old_finals = node.outputs[: op.n_states]
+    old_traces = node.outputs[op.n_states :]
+
+    traced_idxs = []
+    untraced_idxs = []
+    for i, state_type in enumerate(op.state_types):
+        if fgraph.clients[old_traces[i]]:
+            if not isinstance(state_type, DenseTensorType):
+                raise NotImplementedError(
+                    "Non-tensor states (e.g. RandomGenerators) can be carried "
+                    "but not traced: their trace cannot be represented in the legacy Scan."
+                )
+            traced_idxs.append(i)
+        else:
+            untraced_idxs.append(i)
+
+    # Outputs (nit-sots) are emitted only when their trace is used.
+    output_traces = old_traces[op.n_states :]
+    used_output_idxs = [
+        k for k in range(op.n_outputs) if fgraph.clients[output_traces[k]]
+    ]
+
+    update_fg = op.update_fg.unfreeze()
+    inner_states = update_fg.inputs[: op.n_states]
+    inner_constants = update_fg.inputs[op.n_states :]
+    inner_cond, *inner_next_states = update_fg.outputs
+
+    # The sequence reads align with the legacy sequence slices only when the
+    # index starts at zero
+    sequence_reads = op.sequence_reads
+    idx_pos = op.idx_state
+    if sequence_reads and (
+        _scalar_constant(node.inputs[1 + idx_pos]) != 0
+        or not isinstance(init_states[idx_pos].type, DenseTensorType)
+    ):
+        sequence_reads = {}
+
+    # Replace the sequence reads by legacy sequence inputs (one per read offset),
+    # with the outer sequences sliced so that all offsets align at each step
+    inner_seqs = []
+    outer_seqs = []
+    read_replacements = {}
+    state_input_set = set(inner_states)
+    for j, taps in sequence_reads.items():
+        inner_const = inner_constants[j]
+        outer_const = constants[j]
+        max_tap = max(taps)
+        elem_by_tap = {}
+        for tap in taps:
+            elem = inner_const.type.clone(shape=inner_const.type.shape[1:])()
+            elem_by_tap[tap] = elem
+            inner_seqs.append(elem)
+            if tap == max_tap == 0:
+                outer_seqs.append(outer_const)
+            elif tap == max_tap:
+                outer_seqs.append(outer_const[tap:])
+            else:
+                outer_seqs.append(outer_const[tap : tap - max_tap])
+        for client, position in update_fg.clients[inner_const]:
+            read = match_sequence_read(client, position, state_input_set)
+            assert read is not None  # Verified at op construction
+            read_replacements[client.outputs[0]] = elem_by_tap[read[1]]
+    if read_replacements:
+        inner_cond, *inner_next_states = graph_replace(
+            [inner_cond, *inner_next_states], read_replacements, strict=False
+        )
+
+    # Drop the index state when its only remaining job was feeding the reads
+    if (
+        sequence_reads
+        and not fgraph.clients[old_finals[idx_pos]]
+        and not fgraph.clients[old_traces[idx_pos]]
+        and inner_states[idx_pos]
+        not in set(
+            ancestors(
+                [
+                    inner_cond,
+                    *(s for i, s in enumerate(inner_next_states) if i != idx_pos),
+                ]
+            )
+        )
+    ):
+        untraced_idxs = [i for i in untraced_idxs if i != idx_pos]
+
+    remaining_const_idxs = [j for j in range(op.n_constants) if j not in sequence_reads]
+
+    inner_inputs = [
+        *inner_seqs,
+        *(inner_states[i] for i in traced_idxs),
+        *(inner_states[i] for i in untraced_idxs),
+        *(inner_constants[j] for j in remaining_const_idxs),
+    ]
+    inner_outputs = [
+        *(inner_next_states[i] for i in traced_idxs),
+        *(inner_next_states[op.n_states + k] for k in used_output_idxs),
+        *(inner_next_states[i] for i in untraced_idxs),
+    ]
+    if op.has_while_condition:
+        # The legacy Scan stops when the condition output is True
+        inner_outputs.append(invert(inner_cond))
+
+    info = ScanInfo(
+        n_seqs=len(inner_seqs),
+        mit_mot_in_slices=(),
+        mit_mot_out_slices=(),
+        mit_sot_in_slices=(),
+        sit_sot_in_slices=((-1,),) * len(traced_idxs),
+        n_nit_sot=len(used_output_idxs),
+        n_untraced_sit_sot=len(untraced_idxs),
+        n_non_seqs=len(remaining_const_idxs),
+        as_while=op.has_while_condition,
+    )
+    legacy_op = LegacyScan(inner_inputs, inner_outputs, info, strict=True)
+
+    outer_inputs = [
+        max_iters,
+        *outer_seqs,
+        *(expand_empty(shape_padleft(init_states[i]), max_iters) for i in traced_idxs),
+        *(init_states[i] for i in untraced_idxs),
+        *(max_iters for _ in used_output_idxs),  # nit-sot buffer lengths
+        *(constants[j] for j in remaining_const_idxs),
+    ]
+    new_outs = legacy_op(*outer_inputs, return_list=True)
+    n_traced = len(traced_idxs)
+    n_nit = len(used_output_idxs)
+    buffers = new_outs[:n_traced]
+    nit_outs = new_outs[n_traced : n_traced + n_nit]
+    untraced_outs = new_outs[n_traced + n_nit :]
+
+    # The legacy outputs lose the static length information of the trace types,
+    # so the replacements must be filtered back into the original types
+    replacements = {}
+    for i, buffer in zip(traced_idxs, buffers):
+        replacements[old_finals[i]] = old_finals[i].type.filter_variable(buffer[-1])
+        replacements[old_traces[i]] = old_traces[i].type.filter_variable(buffer[1:])
+    # nit-sot buffers are the output traces directly (no leading init row)
+    for k, nit_out in zip(used_output_idxs, nit_outs):
+        replacements[output_traces[k]] = output_traces[k].type.filter_variable(nit_out)
+    for i, untraced_out in zip(untraced_idxs, untraced_outs):
+        replacements[old_finals[i]] = untraced_out
+    return replacements
+
+
+# Must run before the legacy scan rewrites (scan_eqopt1 at 0.05),
+# so that pushouts, buffer shortening and merging can be applied
+optdb.register(
+    "scan_to_legacy_scan",
+    in2out(scan_to_legacy_scan),
+    "fast_compile",
+    "fast_run",
+    "scan",
+    position=0.02,
+)
+
+
+@node_rewriter([Scan])
+def scan_view_last_state(fgraph, node):
+    """Replace trace[-1] by the last state output of a Scan node"""
+    replacements = {}
+    for final_state, trace in zip(
+        node.outputs[: node.op.n_states], node.outputs[node.op.n_states :]
+    ):
+        clients = fgraph.clients[trace]
+        for client, _ in clients:
+            if client == "output":
+                continue
+            if isinstance(client.op, (Subtensor, GetItem)):
+                if isinstance(client.op, Subtensor):
+                    idxs = get_idx_list(client.inputs, client.op.idx_list)
+                    if len(idxs) == 1:
+                        idx = idxs[0]
+                else:
+                    idx = client.inputs[1]
+                try:
+                    last_index = get_scalar_constant_value(idx) == -1
+                except NotScalarConstantError:
+                    continue
+                if last_index:
+                    replacements[client.default_output()] = final_state
+    return replacements
+
+
+# Must run before the lowering rewrites
+optdb.register(
+    "scan_view_last_state",
+    in2out(scan_view_last_state),
+    "fast_compile",
+    "fast_run",
+    position=0.01,
+)

--- a/pytensor/loop/op.py
+++ b/pytensor/loop/op.py
@@ -24,6 +24,7 @@ from pytensor.tensor import (
     as_tensor,
     concatenate,
     get_scalar_constant_value,
+    inc_subtensor,
     invert,
     shape_padleft,
     zeros_like,
@@ -593,6 +594,23 @@ class Scan(Op):
             and is_connected(trace_grads[self.n_states + k])
         ]
 
+        # Sequence constants (verified const[idx + k] reads) build their gradient
+        # from per-tap backward traces placed once after the Scan, instead of a
+        # per-step inc_subtensor accumulator. Only valid when the index starts at
+        # 0 (so forward step t reads position t + k); otherwise the constant falls
+        # back to the accumulator path.
+        idx_pos = self.idx_state
+        seq_eligible = (
+            bool(self.sequence_reads)
+            and idx_pos is not None
+            and isinstance(init_states[idx_pos].type, DenseTensorType)
+            and _scalar_constant(init_states[idx_pos]) == 0
+        )
+        diff_seq_idxs = [
+            j for j in diff_const_idxs if seq_eligible and j in self.sequence_reads
+        ]
+        diff_acc_idxs = [j for j in diff_const_idxs if j not in diff_seq_idxs]
+
         # A gradient is only computable if there is something differentiable to
         # pull a connected cotangent through (a carry or an output) and something
         # to seed the backward Scan with (a carry or a constant).
@@ -642,6 +660,16 @@ class Scan(Op):
         inner_constants = update_fg.inputs[self.n_states :]
         inner_next_states = update_fg.outputs[1:]
 
+        # Locate the inner read variables const[idx + k] of the sequence constants;
+        # the backward Scan traces their cotangents (one trace per read).
+        seq_state_inputs = set(inner_prev_states)
+        seq_reads_info = []  # (const_idx, tap, inner_read_var)
+        for j in diff_seq_idxs:
+            for client, position in update_fg.clients[inner_constants[j]]:
+                read = match_sequence_read(client, position, seq_state_inputs)
+                assert read is not None  # Verified at op construction
+                seq_reads_info.append((j, read[1], client.outputs[0]))
+
         state_cotangents = [inner_next_states[i].type() for i in diff_state_idxs]
         output_cotangents = [
             inner_next_states[self.n_states + k].type() for k in diff_output_idxs
@@ -659,7 +687,8 @@ class Scan(Op):
             ),
             wrt=(
                 [inner_prev_states[i] for i in diff_state_idxs]
-                + [inner_constants[j] for j in diff_const_idxs]
+                + [inner_constants[j] for j in diff_acc_idxs]
+                + [read_var for (_j, _tap, read_var) in seq_reads_info]
             ),
             cotangents=state_cotangents + output_cotangents,
             disconnected_inputs="ignore",
@@ -689,12 +718,14 @@ class Scan(Op):
             )
             for i in diff_state_idxs
         ]
-        init_accs = [zeros_like(constants[j]) for j in diff_const_idxs]
+        init_accs = [zeros_like(constants[j]) for j in diff_acc_idxs]
 
         n_prev = len(dense_state_idxs)
         n_traced = len(traced_grad_idxs)
         n_outs = len(diff_output_idxs)
         n_lambdas = len(diff_state_idxs)
+        n_acc = len(diff_acc_idxs)
+        n_reads = len(seq_reads_info)
 
         def backward_step(*args):
             prev_state_elems = args[:n_prev]
@@ -702,7 +733,7 @@ class Scan(Op):
             output_grad_elems = args[n_prev + n_traced : n_prev + n_traced + n_outs]
             base = n_prev + n_traced + n_outs
             lambdas = args[base : base + n_lambdas]
-            accs = args[base + n_lambdas : -len(constants) or None]
+            accs = args[base + n_lambdas : base + n_lambdas + n_acc]
             outer_constants = args[len(args) - len(constants) :]
 
             total_lambdas = list(lambdas)
@@ -734,13 +765,23 @@ class Scan(Op):
             ]
             new_accs = [
                 self.constant_types[j].filter_variable(accumulate_grad(acc, r))
-                for j, acc, r in zip(diff_const_idxs, accs, results[n_lambdas:])
+                for j, acc, r in zip(
+                    diff_acc_idxs, accs, results[n_lambdas : n_lambdas + n_acc]
+                )
             ]
-            return [*new_lambdas, *new_accs]
+            # Per-step cotangents of the sequence reads, traced (not accumulated)
+            read_cotangents = [
+                read_var.type.filter_variable(r)
+                for (_j, _tap, read_var), r in zip(
+                    seq_reads_info, results[n_lambdas + n_acc :]
+                )
+            ]
+            return [*new_lambdas, *new_accs, *read_cotangents]
 
         backward_outs = scan(
             backward_step,
-            init_states=[*init_lambdas, *init_accs],
+            # `None` inits make the read cotangents nit-sot outputs (traced, not fed back)
+            init_states=[*init_lambdas, *init_accs, *([None] * n_reads)],
             sequences=[*prev_state_seqs, *trace_grad_seqs, *output_grad_seqs],
             non_sequences=list(constants),
             n_steps=n_iters,
@@ -748,7 +789,16 @@ class Scan(Op):
         if not isinstance(backward_outs, list):
             backward_outs = [backward_outs]
         final_lambdas = [trace[-1] for trace in backward_outs[:n_lambdas]]
-        final_accs = [trace[-1] for trace in backward_outs[n_lambdas:]]
+        final_accs = [
+            trace[-1] for trace in backward_outs[n_lambdas : n_lambdas + n_acc]
+        ]
+        read_traces = backward_outs[n_lambdas + n_acc :]
+
+        # A sequence gradient is its per-tap cotangent traces (reversed back to
+        # forward order) placed at the slice each tap read, summed over taps.
+        seq_grads = {j: zeros_like(constants[j]) for j in diff_seq_idxs}
+        for (j, tap, _read_var), trace in zip(seq_reads_info, read_traces):
+            seq_grads[j] = inc_subtensor(seq_grads[j][tap : tap + n_iters], trace[::-1])
 
         input_grads = [disconnected()]  # max_iters
         for i, init_state in enumerate(init_states):
@@ -757,8 +807,10 @@ class Scan(Op):
             else:
                 input_grads.append(default_grad(1 + i, init_state))
         for j, constant_inp in enumerate(constants):
-            if j in diff_const_idxs:
-                input_grads.append(final_accs[diff_const_idxs.index(j)])
+            if j in diff_seq_idxs:
+                input_grads.append(self.constant_types[j].filter_variable(seq_grads[j]))
+            elif j in diff_acc_idxs:
+                input_grads.append(final_accs[diff_acc_idxs.index(j)])
             else:
                 input_grads.append(default_grad(1 + self.n_states + j, constant_inp))
         return input_grads

--- a/pytensor/typed_list/basic.py
+++ b/pytensor/typed_list/basic.py
@@ -17,6 +17,11 @@ class _typed_list_py_operators:
             "Cannot call len(TypedList). Use `.length()` method instead for the symbolic equivalent."
         )
 
+    def __bool__(self):
+        # Truthiness of TypedLists cannot depend on length,
+        # just like truthiness of TensorVariables does not depend on size or contents
+        return True
+
     def __getitem__(self, index):
         return getitem(self, index)
 
@@ -655,3 +660,18 @@ Notes
 All PyTensor variables must have the same type.
 
 """
+
+
+class MakeEmptyList(Op):
+    __props__ = ()
+
+    def make_node(self, ttype):
+        tl = TypedListType(ttype)()
+        return Apply(self, [], [tl])
+
+    def perform(self, node, inputs, outputs):
+        (out,) = outputs
+        out[0] = []
+
+
+make_empty_list = MakeEmptyList()

--- a/tests/graph/test_fg.py
+++ b/tests/graph/test_fg.py
@@ -8,7 +8,7 @@ from pytensor.graph.basic import NominalVariable
 from pytensor.graph.fg import FrozenFunctionGraph, FunctionGraph, Output
 from pytensor.graph.utils import MissingInputError
 from pytensor.printing import debugprint
-from pytensor.scalar.basic import ScalarConstant, add, float64, mul
+from pytensor.scalar.basic import ScalarConstant, add, constant, float64, mul
 from pytensor.tensor import reshape, stack, vector
 from tests.graph.utils import (
     MyConstant,
@@ -947,6 +947,25 @@ class TestFrozenFunctionGraph:
 
         assert ffg == refrozen
         assert hash(ffg) == hash(refrozen)
+
+    def test_bind_constant_output(self):
+        # An output fed directly as a Constant (e.g. a constant while condition)
+        # is never a node input, so bind/unfreeze must reuse it as-is rather than
+        # fail to find it in the substitution memo.
+        x = float64("x")
+        const = constant(1.0)
+        ffg = FunctionGraph([x], [const, add(x, x)]).freeze()
+
+        bound_const = ffg.bind([float64("z")])[0]
+        assert bound_const is ffg.outputs[0]
+        assert isinstance(bound_const, ScalarConstant) and bound_const.data == 1.0
+        assert ffg == ffg.unfreeze().freeze()
+
+    def test_clone_returns_self(self):
+        x = float64("x")
+        ffg = FunctionGraph([x], [add(x, x)]).freeze()
+        assert ffg.clone() is ffg
+        assert ffg.clone(check_integrity=False) is ffg
 
     def test_value_dependent_output_type_collision(self):
         """Output types are part of the interning key.

--- a/tests/link/numba/test_scan.py
+++ b/tests/link/numba/test_scan.py
@@ -521,3 +521,44 @@ def test_grad_until_and_truncate_sequence_taps():
 
 def test_aliased_inner_outputs():
     ScanCompatibilityTests.check_aliased_inner_outputs(static_shape=True, mode="NUMBA")
+
+
+def test_untraced_sit_sot_constant_update():
+    """Regression test for a segfault when an untraced sit-sot state that is
+    read by the inner function has a constant update. The generated while loop
+    would rebind the state storage to a numba-frozen (readonly) global array."""
+    from pytensor.scan.op import Scan, ScanInfo
+
+    idx = pt.lscalar("idx")
+    lam = pt.dscalar("lam")
+    acc = pt.dvector("acc")
+    gvec = pt.dvector("gvec")
+
+    info = ScanInfo(
+        n_seqs=0,
+        mit_mot_in_slices=(),
+        mit_mot_out_slices=(),
+        mit_sot_in_slices=(),
+        sit_sot_in_slices=(),
+        n_untraced_sit_sot=3,
+        n_nit_sot=0,
+        n_non_seqs=1,
+        as_while=False,
+    )
+    scan_op = Scan(
+        [idx, lam, acc, gvec],
+        [
+            idx + 1,
+            pt.constant(0.0, dtype="float64"),
+            pt.inc_subtensor(acc[idx], gvec[idx] * 2 + lam),
+        ],
+        info,
+    )
+    n_steps = pt.iscalar("n_steps")
+    outs = scan_op(n_steps, pt.lscalar(), pt.dscalar(), pt.dvector(), pt.dvector())
+
+    compare_numba_and_py(
+        outs[0].owner.inputs,
+        outs,
+        [np.int32(3), np.int64(0), np.float64(1.0), np.zeros(5), np.arange(5.0)],
+    )

--- a/tests/loop/test_api.py
+++ b/tests/loop/test_api.py
@@ -1,0 +1,403 @@
+import numpy as np
+import pytest
+
+import pytensor
+import pytensor.tensor as pt
+from pytensor import grad
+from pytensor.loop import InnerShiftedArg, loop, shift
+from pytensor.scan.op import Scan as LegacyScan
+from pytensor.tensor.random.type import RandomGeneratorType
+
+
+def test_simple_carry():
+    x = pt.scalar("x")
+    init = x
+
+    def f(carry, x):
+        x_t = carry
+        return x_t * 2, None
+
+    out, _ = loop(
+        f,
+        init=init,
+        length=5,
+    )
+
+    np.testing.assert_allclose(out.eval({x: 2}), 2**6)
+
+
+def test_structured_carry():
+    x0 = pt.scalar("x0")
+    init = ((x0,), x0 * 2)
+
+    def f(carry, _):
+        ((x_t,), y_t) = carry
+        return ((x_t * 2,), y_t * 2), None
+
+    ((x_final,), y_final), _ = loop(
+        f,
+        init=init,
+        length=5,
+    )
+
+    np.testing.assert_allclose(x_final.eval({x0: 2}), 2**6)
+    np.testing.assert_allclose(y_final.eval({x0: 2}), 2**7)
+
+
+def test_simple_xs():
+    x0 = pt.scalar("x0")
+    beta = pt.vector("beta", shape=(5,))
+    xs = beta
+
+    def f(x_t, beta_t):
+        return x_t * beta_t, None
+
+    x_final, _ = loop(f, init=x0, xs=xs)
+
+    np.testing.assert_allclose(
+        x_final.eval({x0: 2, beta: [2, 1, 2, 1, 2]}),
+        2**4,
+    )
+
+
+def test_structured_xs():
+    x0 = pt.scalar("x0")
+    beta = pt.vector("beta", shape=(5,))
+    xs = (beta, (3 - beta,))
+
+    def f(x_t, x):
+        beta_t, (complement_beta_t,) = x
+        return x_t * beta_t * complement_beta_t, None
+
+    x_final, _ = loop(f, init=x0, xs=xs)
+
+    np.testing.assert_allclose(
+        x_final.eval({x0: 2, beta: [2, 1, 2, 1, 2]}),
+        2**6,
+    )
+
+
+def test_simple_ys():
+    xs = pt.vector("beta", shape=(5,))
+
+    def f(_, x_t):
+        return None, x_t * 2
+
+    _, ys = loop(
+        f,
+        init=None,
+        xs=xs,
+    )
+
+    xs_test = np.arange(
+        5,
+    )
+    np.testing.assert_allclose(ys.eval({xs: xs_test}), xs_test * 2)
+
+
+def test_structured_ys():
+    xs = pt.vector("x", shape=(5,))
+
+    def f(_, x_t):
+        return None, (x_t * 2, ((x_t * 3,),))
+
+    _, (ys, ((zs,),)) = loop(
+        f,
+        init=None,
+        xs=xs,
+    )
+
+    xs_test = np.arange(
+        5,
+    )
+    np.testing.assert_allclose(ys.eval({xs: xs_test}), xs_test * 2)
+    np.testing.assert_allclose(zs.eval({xs: xs_test}), xs_test * 3)
+
+
+def test_shifted_carry():
+    x0 = pt.tensor("x0", shape=(2,))
+    init = shift(x0, by=[-2, -1])
+
+    def f(carry, xs):
+        assert isinstance(carry, InnerShiftedArg)
+        xtm2, xtm1 = carry
+        return carry.push(xtm2 * xtm1), None
+
+    x_final, _ = loop(
+        f,
+        init=init,
+        length=3,
+    )
+    np.testing.assert_allclose(x_final.eval({x0: [1, 2]}), 8)
+
+
+def test_shifted_xs():
+    x0 = pt.scalar("x0")
+    seq = pt.vector("seq", shape=(5,))
+    xs = shift(seq, by=[0, 1])
+
+    def f(carry, xs):
+        assert isinstance(xs, InnerShiftedArg)
+        xt, xtp1 = xs
+        return carry + xt * xtp1, None
+
+    x_final, _ = loop(
+        f,
+        init=x0,
+        xs=xs,
+    )
+
+    seq_val = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    # n_steps = 5 - 1 = 4 (due to tap offset)
+    # step 0: 0 + 1*2 = 2
+    # step 1: 2 + 2*3 = 8
+    # step 2: 8 + 3*4 = 20
+    # step 3: 20 + 4*5 = 40
+    np.testing.assert_allclose(x_final.eval({x0: 0, seq: seq_val}), 40)
+
+
+def test_shifted_xs_push_raises():
+    seq = pt.vector("seq", shape=(5,))
+    xs = shift(seq, by=[0, 1])
+
+    def f(carry, xs):
+        xs.push(xs[0] + xs[1])
+        return carry, None
+
+    with pytest.raises(ValueError, match="read-only"):
+        loop(f, init=pt.scalar("x"), xs=xs)
+
+
+def test_single_shift_carry():
+    x0 = pt.tensor("x0", shape=(1,))
+    init = shift(x0, by=-1)
+
+    def f(carry, _):
+        assert isinstance(carry, InnerShiftedArg)
+        (xtm1,) = carry
+        return carry.push(xtm1 * 2), None
+
+    x_final, _ = loop(f, init=init, length=5)
+    # x0=[3] → 6 → 12 → 24 → 48 → 96
+    np.testing.assert_allclose(x_final.eval({x0: [3]}), 96)
+
+
+def test_single_shift_xs():
+    seq = pt.vector("seq", shape=(5,))
+    xs = shift(seq, by=1)
+
+    def f(_, xs):
+        assert isinstance(xs, InnerShiftedArg)
+        (xtp1,) = xs
+        return None, xtp1 * 2
+
+    _, ys = loop(f, init=None, xs=xs)
+
+    seq_val = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    # n_steps = 4 (seq[1:] has length 4)
+    # ys = [2*2, 3*2, 4*2, 5*2] = [4, 6, 8, 10]
+    np.testing.assert_allclose(ys.eval({seq: seq_val}), [4, 6, 8, 10])
+
+
+def test_rng_carry():
+    rng_init = RandomGeneratorType()("rng")
+
+    def f(carry, _):
+        rng = carry
+        next_rng, sample = pt.random.normal(rng=rng).owner.outputs
+        return next_rng, sample
+
+    final_rng, samples = loop(f, init=rng_init, length=5)
+
+    fn = pytensor.function([rng_init], [samples, final_rng])
+
+    rng0 = np.random.default_rng(42)
+    result1, rng1 = fn(rng0)
+    assert result1.shape == (5,)
+    assert not np.all(result1 == result1[0])
+
+    # Same input RNG yields same results
+    result2, _ = fn(rng0)
+    np.testing.assert_array_equal(result1, result2)
+
+    # Updated RNG yields fresh samples
+    result3, _ = fn(rng1)
+    assert not np.array_equal(result1, result3)
+
+
+def test_rng_ys_trace_fails():
+    rng_init = RandomGeneratorType()("rng")
+
+    def f(carry, _):
+        rng = carry
+        next_rng, _sample = pt.random.normal(rng=rng).owner.outputs
+        return next_rng, next_rng  # Trying to trace the RNG state as ys
+
+    with pytest.raises(TypeError, match="ys outputs must be TensorVariables"):
+        loop(f, init=rng_init, length=5)
+
+
+def test_mixed_carry_and_xs():
+    # Traced carry (TensorVariable)
+    x0 = pt.scalar("x0")
+    # Untraced carry (RNG)
+    rng_init = RandomGeneratorType()("rng")
+    # Shifted carry (mit_sot)
+    y0 = pt.tensor("y0", shape=(2,))
+    y_shifted = shift(y0, by=[-2, -1])
+
+    # Regular xs + shifted xs
+    seq = pt.vector("seq", shape=(6,))
+    seq_shifted = shift(seq, by=[0, 1])
+
+    init = (x0, rng_init, y_shifted)
+
+    def f(carry, xs):
+        x, rng, y_carry = carry
+        xt, xtp1 = xs
+
+        next_rng, noise = pt.random.normal(rng=rng).owner.outputs
+        ytm2, ytm1 = y_carry
+        new_y = ytm2 + ytm1
+
+        return (x + xt + noise, next_rng, y_carry.push(new_y)), xt * xtp1
+
+    (x_final, final_rng, y_final), products = loop(f, init=init, xs=seq_shifted)
+
+    fn = pytensor.function(
+        [x0, rng_init, y0, seq], [x_final, final_rng, y_final, products]
+    )
+    seq_val = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    rng0 = np.random.default_rng(42)
+    x_final_val1, rng1, y_final_val, products_val = fn(0.0, rng0, [1.0, 1.0], seq_val)
+
+    # n_steps = 5 (shift (0,1) on seq of length 6)
+    # products: [1*2, 2*3, 3*4, 4*5, 5*6]
+    np.testing.assert_allclose(products_val, [2, 6, 12, 20, 30])
+
+    # y: fibonacci-like from [1, 1]
+    # step 0: 1+1=2, step 1: 1+2=3, step 2: 2+3=5, step 3: 3+5=8, step 4: 5+8=13
+    np.testing.assert_allclose(y_final_val, 13)
+
+    # Same input RNG yields same results
+    x_final_val2, _, _, _ = fn(0.0, rng0, [1.0, 1.0], seq_val)
+    np.testing.assert_array_equal(x_final_val1, x_final_val2)
+
+    # Updated RNG yields fresh samples (x_final includes noise, so it should differ)
+    x_final_val3, _, _, _ = fn(0.0, rng1, [1.0, 1.0], seq_val)
+    assert not np.array_equal(x_final_val1, x_final_val3)
+
+
+def test_loop_grad():
+
+    # Through the carry
+    x0 = pt.scalar("x0")
+    final, _ = loop(lambda c, _: (c * 2, None), init=x0, length=5)
+    np.testing.assert_allclose(grad(final, x0).eval({x0: 1.0}), 32.0)
+
+    # Through ys that alias the carry update, wrt init, sequence and closure constant
+    # in a linear recurrence: y_t = y_{t-1} * c + x_t
+    xs = pt.vector("xs")
+    c = pt.scalar("c")
+
+    def step(acc, x):
+        new = acc * c + x
+        return new, new
+
+    _, ys = loop(step, init=x0, xs=xs)
+    cost = ys.sum()
+    test_point = {x0: 0.5, xs: np.array([1.0, 2.0, 3.0]), c: 2.0}
+    gx0, gxs, gc = grad(cost, [x0, xs, c])
+    np.testing.assert_allclose(gx0.eval(test_point), 14.0)
+    np.testing.assert_allclose(gxs.eval(test_point), [7.0, 3.0, 1.0])
+    np.testing.assert_allclose(gc.eval(test_point), 15.5)
+
+
+def test_loop_shifted_carry_grad():
+
+    y0 = pt.tensor("y0", shape=(2,))
+
+    # Fibonacci-like: with y0 = [a, b] the 4th step is 3a + 5b
+    def fib(carry, _):
+        ytm2, ytm1 = carry
+        return carry.push(ytm2 + ytm1), None
+
+    final, _ = loop(fib, init=shift(y0, by=[-2, -1]), length=4)
+    np.testing.assert_allclose(grad(final, y0).eval({y0: [1.0, 1.0]}), [3.0, 5.0])
+
+    # Nonlinear taps: x_t = x_{t-2} * x_{t-1}; the 3rd step is a**2 * b**3
+    def prodstep(carry, _):
+        xtm2, xtm1 = carry
+        return carry.push(xtm2 * xtm1), None
+
+    final, _ = loop(prodstep, init=shift(y0, by=[-2, -1]), length=3)
+    g = grad(final, y0)
+    # d/da = 2ab**3, d/db = 3 a**2 b**2 at a=1, b=2
+    np.testing.assert_allclose(g.eval({y0: [1.0, 2.0]}), [16.0, 12.0])
+
+
+def test_sequence_reads_recorded():
+    x0 = pt.scalar("x0")
+    seq = pt.vector("seq", shape=(6,))
+
+    final, _ = loop(
+        lambda c, x: (c + x[0] * x[1], None), init=x0, xs=shift(seq, by=[0, 2])
+    )
+    op = final.owner.op
+    assert op.sequence_reads == {0: (0, 2)}
+    assert op.idx_state == 0
+
+    # A sequence that is also used whole (through the closure) is kept as a
+    # plain constant
+    final, _ = loop(lambda c, x: (c + x + seq.sum(), None), init=x0, xs=seq)
+    op = final.owner.op
+    assert op.sequence_reads == {}
+    assert op.idx_state is None
+
+
+def test_loop_shifted_xs_grad():
+    # final = x0 + sum_t seq[t] * seq[t+1], so
+    # d final / d seq[j] = seq[j-1] + seq[j+1] (at the boundaries only one term)
+    x0 = pt.scalar("x0")
+    seq = pt.vector("seq", shape=(5,))
+
+    def f(carry, x):
+        xt, xtp1 = x
+        return carry + xt * xtp1, None
+
+    final, _ = loop(f, init=x0, xs=shift(seq, by=[0, 1]))
+    g = grad(final, seq)
+    np.testing.assert_allclose(
+        g.eval({x0: 0.0, seq: np.array([1.0, 2.0, 3.0, 4.0, 5.0])}),
+        [2.0, 1.0 + 3.0, 2.0 + 4.0, 3.0 + 5.0, 4.0],
+    )
+
+
+def test_sequence_lowering():
+    xs = pt.vector("xs")
+    x0 = pt.scalar("x0")
+
+    # Same structure the legacy constructor produces: a native sequence,
+    # no index state, and no non-sequences
+    final, _ = loop(lambda c, x: (c * 0.9 + x, None), init=x0, xs=xs)
+    fn = pytensor.function([x0, xs], final)
+    [scan_node] = (
+        node for node in fn.maker.fgraph.apply_nodes if isinstance(node.op, LegacyScan)
+    )
+    info = scan_node.op.info
+    assert info.n_seqs == 1
+    assert info.n_non_seqs == 0
+    assert info.n_sit_sot + info.n_untraced_sit_sot == 1
+
+    # Multi-tap sequence reads become one sequence per offset
+    # (taps interacting with the carry, so that pushout cannot fuse them)
+    final, _ = loop(
+        lambda c, x: (c * x[0] + x[1], None), init=x0, xs=shift(xs, by=[0, 1])
+    )
+    fn = pytensor.function([x0, xs], final)
+    [scan_node] = (
+        node for node in fn.maker.fgraph.apply_nodes if isinstance(node.op, LegacyScan)
+    )
+    info = scan_node.op.info
+    assert info.n_seqs == 2
+    assert info.n_non_seqs == 0

--- a/tests/loop/test_api.py
+++ b/tests/loop/test_api.py
@@ -401,3 +401,23 @@ def test_sequence_lowering():
     info = scan_node.op.info
     assert info.n_seqs == 2
     assert info.n_non_seqs == 0
+
+
+def test_sequence_grad_is_traced():
+    # The gradient wrt a sequence is built from one nit-sot trace per tap of the
+    # backward Scan, not a per-step inc_subtensor accumulator. Differentiating a
+    # carry final (no forward nit-sot) leaves the per-tap cotangents as the only
+    # nit-sots in the graph.
+    x = pt.vector("x")
+    x0 = pt.scalar("x0")
+    final, _ = loop(
+        lambda c, xt: (c + xt[0] * xt[1], None), init=x0, xs=shift(x, by=[0, 1])
+    )
+    fn = pytensor.function([x, x0], pytensor.grad(final, x))
+
+    scans = [n for n in fn.maker.fgraph.apply_nodes if isinstance(n.op, LegacyScan)]
+    assert sum(n.op.info.n_nit_sot for n in scans) == 2  # one cotangent trace per tap
+
+    # final = x0 + sum_t x[t]*x[t+1]; d/dx[k] = x[k-1] + x[k+1]
+    xv = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    np.testing.assert_allclose(fn(xv, 0.0), [2.0, 4.0, 6.0, 8.0, 4.0])

--- a/tests/loop/test_basic.py
+++ b/tests/loop/test_basic.py
@@ -1,0 +1,224 @@
+import numpy as np
+
+import pytensor
+from pytensor import config, function, grad, shared
+from pytensor.graph.traversal import ancestors
+from pytensor.loop.basic import filter, map, reduce, scan
+from pytensor.scan import until
+from pytensor.tensor import arange, eq, scalar, vector, zeros
+from pytensor.tensor.random import normal
+from pytensor.tensor.subtensor import IncSubtensor
+
+
+def test_scan_with_sequences():
+    xs = vector("xs")
+    ys = vector("ys")
+    zs = scan(
+        fn=lambda x, y: x * y,
+        sequences=[xs, ys],
+    )
+    pytensor.dprint(ys, print_type=True)
+    np.testing.assert_almost_equal(
+        zs.eval(
+            {
+                xs: np.arange(10, dtype=config.floatX),
+                ys: np.arange(10, dtype=config.floatX),
+            }
+        ),
+        np.arange(10) ** 2,
+    )
+
+
+def test_scan_with_carried_and_non_carried_states():
+    x = scalar("x")
+    [ys1, ys2] = scan(
+        fn=lambda xtm1: (xtm1 + 1, (xtm1 + 1) * 2),
+        init_states=[x, None],
+        n_steps=10,
+    )
+    fn = function([x], [ys1, ys2])
+    res = fn(-1)
+    np.testing.assert_almost_equal(res[0], np.arange(10))
+    np.testing.assert_almost_equal(res[1], np.arange(10) * 2)
+
+
+def test_scan_with_sequence_and_carried_state():
+    xs = vector("xs")
+    ys = scan(
+        fn=lambda x, ytm1: (ytm1 + 1) * x,
+        init_states=[zeros(())],
+        sequences=[xs],
+    )
+    fn = function([xs], ys)
+    np.testing.assert_almost_equal(fn([1, 2, 3]), [1, 4, 15])
+
+
+def test_scan_taking_grads_wrt_non_sequence():
+    # Tests sequence + non-carried state
+    xs = vector("xs")
+    ys = xs**2
+
+    J = scan(
+        lambda i, ys, xs: grad(ys[i], wrt=xs),
+        sequences=arange(ys.shape[0]),
+        non_sequences=[ys, xs],
+    )
+
+    f = pytensor.function([xs], J)
+    np.testing.assert_array_equal(f([4, 4]), np.c_[[8, 0], [0, 8]])
+
+
+def test_scan_taking_grads_wrt_sequence():
+    # This is not possible with the old Scan
+    xs = vector("xs")
+    ys = xs**2
+
+    J = scan(
+        lambda y, xs: grad(y, wrt=xs),
+        sequences=[ys],
+        non_sequences=[xs],
+    )
+
+    f = pytensor.function([xs], J)
+    np.testing.assert_array_equal(f([4, 4]), np.c_[[8, 0], [0, 8]])
+
+
+def test_while_scan():
+    xs = scan(
+        fn=lambda x: (x + 1, until((x + 1) >= 9)),
+        init_states=[-1],
+        n_steps=20,
+    )
+
+    f = pytensor.function([], xs)
+    np.testing.assert_array_equal(f(), np.arange(10))
+
+
+def test_scan_rvs():
+    rng = shared(np.random.default_rng(123))
+    test_rng = np.random.default_rng(123)
+
+    def normal_fn(prev_rng):
+        next_rng, x = normal(rng=prev_rng).owner.outputs
+        return next_rng, x
+
+    [rngs, xs] = scan(
+        fn=normal_fn,
+        init_states=[rng, None],
+        n_steps=5,
+    )
+    fn = function([], xs, updates={rng: rngs[-1]})
+
+    for i in range(3):
+        res = fn()
+        np.testing.assert_almost_equal(res, test_rng.normal(size=5))
+
+
+def test_map():
+    xs = vector("xs")
+    ys = map(
+        fn=lambda x: x * 100,
+        sequences=xs,
+    )
+    np.testing.assert_almost_equal(
+        ys.eval({xs: np.arange(10, dtype=config.floatX)}), np.arange(10) * 100
+    )
+
+
+def test_reduce():
+    xs = vector("xs")
+    y = reduce(
+        fn=lambda x, acc: acc + x,
+        init_states=zeros(()),
+        sequences=xs,
+    )
+    np.testing.assert_almost_equal(
+        y.eval({xs: np.arange(10, dtype=config.floatX)}), np.arange(10).cumsum()[-1]
+    )
+
+
+def test_filter():
+    xs = vector("xs")
+    ys = filter(
+        fn=lambda x: eq(x % 2, 0),
+        sequences=xs,
+    )
+    np.testing.assert_array_equal(
+        ys.eval({xs: np.arange(0, 20, dtype=config.floatX)}), np.arange(0, 20, 2)
+    )
+
+
+def test_scan_grad():
+    # Gradient wrt the initial state: xs = [x0*2, x0*4, ..., x0*32]
+    x0 = scalar("x0")
+    xs = scan(fn=lambda xtm1: xtm1 * 2, init_states=[x0], n_steps=5)
+    np.testing.assert_allclose(grad(xs.sum(), x0).eval({x0: 1.0}), 62.0)
+
+    g_last = grad(xs[-1], x0)
+    np.testing.assert_allclose(g_last.eval({x0: 1.0}), 32.0)
+    # The one-hot cotangent of xs[-1] is folded into the initial state cotangent
+    # of the backward scan, instead of being streamed as a sequence
+    assert not any(
+        isinstance(var.owner.op, IncSubtensor)
+        for var in ancestors([g_last])
+        if var.owner is not None
+    )
+
+    # Gradients wrt initial state, sequence and non-sequence
+    # in a linear recurrence: y_t = y_{t-1} * c + x_t
+    ws = vector("ws")
+    c = scalar("c")
+    ys = scan(
+        fn=lambda w, ytm1, c: ytm1 * c + w,
+        init_states=[x0],
+        sequences=[ws],
+        non_sequences=[c],
+    )
+    cost = ys.sum()
+    test_point = {
+        x0: 0.5,
+        ws: np.array([1.0, 2.0, 3.0], dtype=config.floatX),
+        c: 2.0,
+    }
+    gx0, gws, gc = grad(cost, [x0, ws, c])
+    np.testing.assert_allclose(gx0.eval(test_point), 14.0)
+    np.testing.assert_allclose(gws.eval(test_point), [7.0, 3.0, 1.0])
+    np.testing.assert_allclose(gc.eval(test_point), 15.5)
+
+    # Inner outputs that are ancestors of other inner outputs must still
+    # accumulate the gradients flowing through their consumers
+    ys1, ys2 = scan(
+        fn=lambda xtm1: (xtm1 + 1, (xtm1 + 1) * 2),
+        init_states=[x0, None],
+        n_steps=10,
+    )
+    np.testing.assert_allclose(grad(ys1.sum() + ys2.sum(), x0).eval({x0: 0.0}), 30.0)
+
+
+def test_while_scan_grad():
+    # The number of iterations depends on the value of the initial state
+    x0 = scalar("x0")
+    xs = scan(
+        fn=lambda x: (x * 2, until((x * 2) >= 16)),
+        init_states=[x0],
+        n_steps=100,
+    )
+    # Starting at 1.0 the loop runs 4 times, so xs[-1] = x0 * 16
+    fn = function([x0], grad(xs[-1], x0))
+    np.testing.assert_allclose(fn(1.0), 16.0)
+    # Starting at 4.0 it runs only 2 times
+    np.testing.assert_allclose(fn(4.0), 4.0)
+
+
+def test_scan_grad_of_grad():
+    # xs[-1] = x0 ** 4, by repeated squaring
+    x0 = scalar("x0")
+    xs = scan(fn=lambda x: x * x, init_states=[x0], n_steps=2)
+    g1 = grad(xs[-1], x0)  # 4 * x0**3
+    g2 = grad(g1, x0)  # 12 * x0**2
+    g3 = grad(g2, x0)  # 24 * x0
+    fn = function([x0], [g1, g2])
+    np.testing.assert_allclose(fn(2.0), [32.0, 48.0])
+    # The third order graph is too big to compile with the default backend
+    fn3 = function([x0], g3, mode="FAST_COMPILE")
+    np.testing.assert_allclose(fn3(2.0), 48.0)

--- a/tests/loop/test_legacy_compat.py
+++ b/tests/loop/test_legacy_compat.py
@@ -1,0 +1,103 @@
+"""Run the legacy scan test suite against the new scan constructor.
+
+This is a temporary local harness to measure feature parity: an adapter maps
+the legacy `pytensor.scan` signature to `pytensor.loop.basic.scan`, and the
+legacy tests are re-exported with the adapter patched in. Tests that use
+features the new constructor does not support yet are skipped by the adapter.
+
+Run with:
+    LOOP_LEGACY_COMPAT=1 pytest tests/loop/test_legacy_compat.py
+"""
+
+import os
+
+import pytest
+
+from pytensor.loop.basic import scan as loop_scan
+from pytensor.scan.utils import until
+
+
+if not os.environ.get("LOOP_LEGACY_COMPAT"):
+    pytest.skip(
+        "Set LOOP_LEGACY_COMPAT=1 to run the legacy scan suite against the new constructor",
+        allow_module_level=True,
+    )
+
+import tests.scan.test_basic as legacy_test_basic
+
+
+def scan_compat(
+    fn,
+    sequences=None,
+    outputs_info=None,
+    non_sequences=None,
+    n_steps=None,
+    truncate_gradient=-1,
+    go_backwards=False,
+    mode=None,
+    name=None,
+    profile=False,
+    allow_gc=None,
+    strict=False,
+    return_list=False,
+    return_updates=True,
+):
+    if truncate_gradient != -1:
+        pytest.skip("truncate_gradient not supported by new scan constructor")
+
+    if outputs_info is None:
+        init_states = None
+    else:
+        if not isinstance(outputs_info, list | tuple):
+            outputs_info = [outputs_info]
+        init_states = []
+        for info in outputs_info:
+            if isinstance(info, dict):
+                taps = info.get("taps", [-1])
+                if taps != [-1]:
+                    pytest.skip(
+                        f"taps {taps} not supported by new scan constructor yet"
+                    )
+                init_states.append(info["initial"])
+            else:
+                init_states.append(info)
+
+    if go_backwards and sequences is not None:
+        if not isinstance(sequences, list | tuple):
+            sequences = [sequences]
+        sequences = [s[::-1] for s in sequences]
+
+    def fn_compat(*args):
+        res = fn(*args)
+        if isinstance(res, tuple) and len(res) == 2 and isinstance(res[1], dict):
+            outputs, updates = res
+            if updates:
+                pytest.skip("updates dict not supported by new scan constructor")
+            res = outputs
+        if isinstance(res, dict):
+            pytest.skip("updates dict not supported by new scan constructor")
+        return res
+
+    traces = loop_scan(
+        fn=fn_compat,
+        init_states=init_states,
+        sequences=sequences,
+        non_sequences=non_sequences,
+        n_steps=n_steps,
+    )
+
+    if return_list and not isinstance(traces, list):
+        traces = [traces]
+    if return_updates:
+        return traces, {}
+    return traces
+
+
+# Patch the module global so all legacy tests build graphs with the new constructor
+legacy_test_basic.scan = scan_compat
+legacy_test_basic.until = until
+
+# Re-export every test so pytest collects it from this module
+for _name in dir(legacy_test_basic):
+    if _name.startswith(("test_", "Test")):
+        globals()[_name] = getattr(legacy_test_basic, _name)

--- a/tests/loop/test_op.py
+++ b/tests/loop/test_op.py
@@ -1,0 +1,195 @@
+import numpy as np
+import pytest
+
+import pytensor
+from pytensor import config, function, shared
+from pytensor.compile import DeepCopyOp
+from pytensor.graph import FunctionGraph
+from pytensor.graph.fg import FrozenFunctionGraph
+from pytensor.graph.rewriting.basic import in2out
+from pytensor.loop.op import Scan, scan_view_last_state
+from pytensor.scan.op import Scan as LegacyScan
+from pytensor.tensor import constant, empty, lscalar, scalar, vector
+from pytensor.tensor.random import normal
+from pytensor.tensor.random.type import RandomGeneratorType
+from pytensor.typed_list import TypedListType
+
+
+def test_fori_scan():
+    x = scalar("x")
+    update_fg = FunctionGraph([x], [constant(np.array(True)), x + 2])
+
+    n_iters = 10
+    y, ys = Scan(update_fg=update_fg)(n_iters, x)
+
+    fn = function([x], [y, ys])
+
+    [scan_node] = (
+        node for node in fn.maker.fgraph.apply_nodes if isinstance(node.op, LegacyScan)
+    )
+    assert not scan_node.op.info.as_while
+    assert fn.maker.fgraph.outputs[1].type.shape == (10,)
+
+    y_eval, ys_eval = fn(0)
+    np.testing.assert_array_equal(ys_eval, np.arange(2, 22, 2))
+    np.testing.assert_array_equal(ys_eval[-1], y_eval)
+
+
+def test_scan_immutable_and_mergeable():
+    # The inner graph is stored frozen, so the Op is hashable and structurally
+    # identical Scans compare equal (and merge into a single node).
+    def make_scan():
+        x = scalar("x")
+        return Scan(update_fg=FunctionGraph([x], [constant(np.array(True)), x + 2]))
+
+    op1, op2 = make_scan(), make_scan()
+    assert isinstance(op1.update_fg, FrozenFunctionGraph)
+    assert op1.update_fg.clone(check_integrity=False) is op1.update_fg
+    assert op1 == op2 and hash(op1) == hash(op2)
+
+    x = scalar("x")
+    y1, _ = op1(10, x)
+    y2, _ = op2(10, x)
+    fn = function([x], [y1, y2])
+    scan_nodes = [
+        node for node in fn.maker.fgraph.apply_nodes if isinstance(node.op, LegacyScan)
+    ]
+    assert len(scan_nodes) == 1
+
+
+def test_fori_scan_shape():
+    x = scalar("x")
+    update_fg = FunctionGraph([x], [constant(np.array(True)), x + 2])
+
+    n_iters = 10
+    _, ys = Scan(update_fg=update_fg)(n_iters, x)
+
+    fn = function([x], ys.shape, on_unused_input="ignore")
+    nodes = tuple(fn.maker.fgraph.apply_nodes)
+    assert len(nodes) == 1
+    assert isinstance(nodes[0].op, DeepCopyOp)
+    assert fn(0) == 10
+
+
+def test_while_scan():
+    i = lscalar("i")
+    x = scalar("x")
+    update_fg = FunctionGraph([i, x], [(i + 1) < 10, i + 1, x + 2])
+
+    max_iters = 1000
+    _, y, _, ys = Scan(update_fg=update_fg)(max_iters, np.array(0, dtype="int64"), x)
+
+    fn = function([x], [y, ys])
+
+    [scan_node] = (
+        node for node in fn.maker.fgraph.apply_nodes if isinstance(node.op, LegacyScan)
+    )
+    assert scan_node.op.info.as_while
+
+    y_eval, ys_eval = fn(0)
+    np.testing.assert_array_equal(ys_eval, np.arange(2, 22, 2))
+    np.testing.assert_array_equal(ys_eval[-1], y_eval)
+
+
+def test_while_scan_shape():
+    i = lscalar("i")
+    x = scalar("x")
+    update_fg = FunctionGraph([i, x], [(i + 1) < 10, i + 1, x + 2])
+
+    max_iters = 1000
+    _, _, _, ys = Scan(update_fg=update_fg)(max_iters, np.array(0, dtype="int64"), x)
+
+    fn = function([x], ys.shape)
+    [scan_node] = (
+        node for node in fn.maker.fgraph.apply_nodes if isinstance(node.op, LegacyScan)
+    )
+    assert scan_node.op.info.as_while
+    assert fn(0) == 10
+
+
+def test_foreach_scan():
+    idx = scalar("idx", dtype="int64")
+    dummy_x0 = empty(())
+    xs = vector("xs")
+    const = scalar("const")
+    update_fg = FunctionGraph(
+        [idx, dummy_x0, xs, const], [constant(np.array(True)), idx + 1, xs[idx] * const]
+    )
+
+    n_steps = xs.shape[0]
+    _, _, _, ys = Scan(update_fg=update_fg)(n_steps, 0, dummy_x0, xs, const)
+
+    fn = pytensor.function([xs, const], ys)
+
+    np.testing.assert_almost_equal(
+        fn(np.arange(10, dtype=config.floatX), 100), np.arange(10) * 100
+    )
+
+
+def test_fori_random_scan():
+    # Non-tensor states (e.g. RandomGenerators) can be carried but not traced:
+    # their TypedList trace has no legacy-Scan representation.
+    rng_test = np.random.default_rng(123)
+    rng_shared = shared(np.random.default_rng(123))
+    n_iters = 5
+
+    dummy_init = empty(())
+    rng = rng_shared.type()
+    update_fg = FunctionGraph(
+        [dummy_init, rng],
+        [constant(np.array(True)), *normal(rng=rng).owner.outputs[::-1]],
+    )
+
+    _last_y, last_rng, ys, rngs = Scan(update_fg=update_fg)(
+        n_iters, dummy_init, rng_shared
+    )
+    assert isinstance(last_rng.type, RandomGeneratorType)
+    assert isinstance(rngs.type, TypedListType)
+
+    # Using the RNG trace cannot be lowered to the legacy Scan
+    with pytest.raises(NotImplementedError, match="can be carried"):
+        function([], [ys, rngs], updates={rng_shared: last_rng}, mode="CVM")
+
+    # Carrying the RNG without tracing it lowers fine
+    fn = function([], ys, updates={rng_shared: last_rng}, mode="CVM")
+    for _ in range(2):
+        for y_res in fn():
+            np.testing.assert_almost_equal(y_res, rng_test.normal())
+
+
+def test_scan_nit_sot_output():
+    # An inner output beyond the carries becomes a nit-sot: no input, no final,
+    # and it lowers to a legacy nit_sot rather than a (fake) sit-sot.
+    c = scalar("c")
+    x = scalar("x")
+    update_fg = FunctionGraph([c, x], [constant(np.array(True)), c + x, c * x])
+    scan_op = Scan(update_fg=update_fg, n_carries=1)
+    assert scan_op.n_states == 1
+    assert scan_op.n_outputs == 1
+
+    # Output layout: carry final, carry trace, output trace
+    final_c, _c_trace, out_trace = scan_op(5, c, x)
+    fn = function([c, x], [final_c, out_trace])
+    [scan_node] = (
+        node for node in fn.maker.fgraph.apply_nodes if isinstance(node.op, LegacyScan)
+    )
+    assert scan_node.op.info.n_nit_sot == 1
+
+    final_val, out_val = fn(0.0, 2.0)
+    np.testing.assert_array_equal(out_val, np.array([0.0, 4.0, 8.0, 12.0, 16.0]))
+    assert final_val == 10.0
+
+
+def test_scan_view_last_state():
+    x = scalar("x")
+    update_fg = FunctionGraph([x], [x > 5, x + 2])
+
+    n_iters = 10
+    y1, ys = Scan(update_fg=update_fg)(n_iters, x)
+
+    y2 = ys[-1]
+    fgraph = FunctionGraph(outputs=[y2, ys], clone=False)
+    assert fgraph.outputs[0] is not y1
+    in2out(scan_view_last_state).apply(fgraph)
+    assert fgraph.outputs[0] is y1
+    assert fgraph.outputs[1] is ys


### PR DESCRIPTION
Related to #189 

This PR implements a new low level `Loop` `Op` which can be easily transpiled to `Numba` (the Python perform method takes 9 lines, yay to not having to support `C` in the future).

It also implements a new higher level `Scan` `Op` which returns as outputs the last states + intermediate states of a looping operation. This `Op` cannot be directly evaluated, and must be rewritten as a `Loop` `Op` in Python/Numba backends. For the `JAX` backend it's probably fine to transpile directly from this representation into a `lax.scan` as the signatures are pretty much identical. That was not done in this PR.

The reason for the two types of outputs, is that they are useful in different contexts. Final states are sometimes all one needs, whereas intermediate states are generally needed for back propagation (not implemented yet). This allows us to choose which one (or both) of the outputs we want during compilation, without having to do complicated graph analysis. 

The existing `save_mem_new_scan` is used to convert a general scan into a `loop` that only returns the last computed state. It's... pretty complicated (although it also covers cases where more than 1 but less than all steps being requested, but OTOH it can't handle while loops #178):

https://github.com/pymc-devs/pytensor/blob/8ad33179b12a4c0207b2a654badc608e211e8bb9/pytensor/scan/rewriting.py#L1119

Taking that as a reference I would say the new conversion rewrite from Scan to Loop is much much simpler. Most of it is boilerplate code for defining the right trace inputs and new FunctionGraph

***

Both `Ops` expect a `FunctionGraph` as input. This should probably be created by a user-facing helper that accepts a callable like scan does now. ~~That was not done yet, as I first wanted to discuss the general design.~~ Done

## Design issues
~1. The current implementation of Loop assumes there are as many states as outputs of the inner function. This does not make sense for mapping or "filling" operations such as filling a tensor with random values. In one of the tests I had to create a dummy `x` input to accommodate this restriction. Should we use `NoneConst` to represent outputs that don't feed into the next state? I think there is something similar being done with the old `Scan` where the `outputs_info` must explicitly be `None` in these cases.~

2. Scan and Loop can now take random types as inputs (scan can't return it as a sequence). This makes random seeding much more explicit compared to the old Scan, which was based on default updates of shared variables. However it highlights the awkwardness of the random API when we want to access the next random state. Should we perhaps add a `return_rng_update` to `__call__`, so that it doesn't hide the next rng state output?

3. Do we want to be able to represent empty Loop / Sequences? If so, how should we go about that? `IfElse` is one option, but perhaps it would be nice to represent it in the same `Loop` `Op`?

4. What do we want to do in terms of inplacing optimizations?

## TODO
If people are on board with the approach
- [ ] Implement Numba dispatch
- [x] Implement JAX dispatch
- [ ] Implement L_op and R_op
- [x] Implement friendly user facing functions
- [ ] Decide on which meta-parameters to preserve (`mode`, `truncate_gradient`, `reverse` and so on)
- [x] Add rewrite that replaces `trace[-1]` by the first set of outputs (final state). That way we can keep the old API, while retaining the benefit of doing while Scans without tracing when it's not needed.