### PR TITLE
Add explicit support for Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,8 @@ jobs:
             float32: 1
           - python-version: "3.8"
             part: "tests/tensor/test_math.py"
+          - fast-compile: 1
+            float32: 1
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,13 +86,10 @@ jobs:
           - "tests/tensor/test_blas.py tests/tensor/test_elemwise.py tests/tensor/test_math_scipy.py"
         exclude:
           - python-version: "3.8"
-            fast-compile: 0
-            float32: 1
-          - python-version: "3.10"
             fast-compile: 1
-          - python-version: "3.10"
+          - python-version: "3.8"
             float32: 1
-          - python-version: "3.10"
+          - python-version: "3.8"
             part: "tests/tensor/test_math.py"
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,9 +73,9 @@ jobs:
         python-version: ["3.8", "3.11"]
         fast-compile: [0,1]
         float32: [0,1]
-        install-numba: [1]
+        install-numba: [0]
         part:
-          - "tests --ignore=tests/tensor --ignore=tests/scan --ignore=tests/sparse"
+          - "tests --ignore=tests/tensor --ignore=tests/scan --ignore=tests/sparse --ignore=tests/link/numba"
           - "tests/scan"
           - "tests/sparse"
           - "tests/tensor --ignore=tests/tensor/conv --ignore=tests/tensor/rewriting --ignore=tests/tensor/test_math.py --ignore=tests/tensor/test_basic.py --ignore=tests/tensor/test_blas.py --ignore=tests/tensor/test_math_scipy.py --ignore=tests/tensor/test_inplace.py --ignore=tests/tensor/test_elemwise.py"
@@ -93,6 +93,27 @@ jobs:
             part: "tests/tensor/test_math.py"
           - fast-compile: 1
             float32: 1
+        include:
+          - install-numba: 1
+            python-version: "3.8"
+            fast-compile: 0
+            float32: 0
+            part: "tests/link/numba"
+          - install-numba: 1
+            python-version: "3.10"
+            fast-compile: 0
+            float32: 0
+            part: "tests/link/numba"
+          - install-numba: 1
+            python-version: "3.10"
+            fast-compile: 1
+            float32: 0
+            part: "tests/link/numba"
+          - install-numba: 1
+            python-version: "3.10"
+            fast-compile: 0
+            float32: 1
+            part: "tests/link/numba"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
     if: ${{ needs.changes.outputs.changes == 'true' }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.8", "3.11"]
         fast-compile: [0,1]
         float32: [0,1]
         install-numba: [1]
@@ -222,7 +222,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
     if: ${{ needs.changes.outputs.changes == 'true' }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 
 keywords = [


### PR DESCRIPTION
~~Depends on next Numba release for support of Python 3.11: https://github.com/numba/numba/issues/8304~~

Not testing Numba on Python 3.11 for now

The last two commits of this PR should be removed once:
1. Numba supports Python 3.11
2. The mypy issue mentioned below is sorted out

***
## Other unrelated CI changes
1. Don't run both fast-compile and float32 to reduce a big chunk of the tests combinations. Both modes are arguably very specialized on their own, and if we need tests to check their interaction we should add them explicitly. In general, the biggest issue with float32 is some Ops that would upcast stuff to float64. Fast-compile has less optimizations / introduces less specialized Ops, so this should be less of a concern for maintaining float32.
2. Exclude fast-compile/float32 from the oldest supported Python version. Run them on the newest instead.