### PR TITLE
Extend support of RandomVariables in JAX backend

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
         run: |
           mamba install --yes -q "python~=${PYTHON_VERSION}=*_cpython" mkl numpy scipy pip mkl-service graphviz cython pytest coverage pytest-cov pytest-benchmark sympy
           if [[ $INSTALL_NUMBA == "1" ]]; then mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" "numba>=0.55" numba-scipy; fi
-          mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" jax jaxlib
+          mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" jax jaxlib numpyro
           pip install -e ./
           mamba list && pip freeze
           python -c 'import pytensor; print(pytensor.config.__str__(print_doc=False))'

--- a/pytensor/link/jax/dispatch/extra_ops.py
+++ b/pytensor/link/jax/dispatch/extra_ops.py
@@ -3,6 +3,7 @@ import warnings
 import jax.numpy as jnp
 
 from pytensor.link.jax.dispatch.basic import jax_funcify
+from pytensor.tensor.basic import infer_static_shape
 from pytensor.tensor.extra_ops import (
     Bartlett,
     BroadcastTo,
@@ -102,8 +103,12 @@ def jax_funcify_RavelMultiIndex(op, **kwargs):
 
 
 @jax_funcify.register(BroadcastTo)
-def jax_funcify_BroadcastTo(op, **kwargs):
+def jax_funcify_BroadcastTo(op, node, **kwargs):
+    shape = node.inputs[1:]
+    static_shape = infer_static_shape(shape)[1]
+
     def broadcast_to(x, *shape):
+        shape = tuple(st if st is not None else s for s, st in zip(shape, static_shape))
         return jnp.broadcast_to(x, shape)
 
     return broadcast_to

--- a/pytensor/link/jax/dispatch/random.py
+++ b/pytensor/link/jax/dispatch/random.py
@@ -260,23 +260,6 @@ def jax_sample_fn_t(op):
     return sample_fn
 
 
-@jax_sample_fn.register(aer.HalfNormalRV)
-def jax_sample_fn_halfnormal(op):
-    """JAX implementation of `HalfNormalRV`."""
-
-    def sample_fn(rng, size, dtype, *parameters):
-        rng_key = rng["jax_state"]
-        rng_key, sampling_key = jax.random.split(rng_key, 2)
-        loc, scale = parameters
-        sample = (
-            loc + jax.numpy.abs(jax.random.normal(sampling_key, size, dtype)) * scale
-        )
-        rng["jax_state"] = rng_key
-        return (rng, sample)
-
-    return sample_fn
-
-
 @jax_sample_fn.register(aer.ChoiceRV)
 def jax_funcify_choice(op):
     """JAX implementation of `ChoiceRV`."""
@@ -303,21 +286,5 @@ def jax_sample_fn_permutation(op):
         sample = jax.random.permutation(sampling_key, x)
         rng["jax_state"] = rng_key
         return (rng, sample)
-
-    return sample_fn
-
-
-@jax_sample_fn.register(aer.LogNormalRV)
-def jax_sample_fn_lognormal(op):
-    """JAX implementation of `LogNormalRV`."""
-
-    def sample_fn(rng, size, dtype, *parameters):
-        rng_key = rng["jax_state"]
-        rng_key, sampling_key = jax.random.split(rng_key, 2)
-        loc, scale = parameters
-        sample = loc + jax.random.normal(sampling_key, size, dtype) * scale
-        sample_exp = jax.numpy.exp(sample)
-        rng["jax_state"] = rng_key
-        return (rng, sample_exp)
 
     return sample_fn

--- a/pytensor/link/jax/dispatch/random.py
+++ b/pytensor/link/jax/dispatch/random.py
@@ -179,6 +179,7 @@ def jax_sample_fn_no_dtype(op):
 
 
 @jax_sample_fn.register(aer.RandIntRV)
+@jax_sample_fn.register(aer.IntegersRV)
 @jax_sample_fn.register(aer.UniformRV)
 def jax_sample_fn_uniform(op):
     """JAX implementation of random variables with uniform density.
@@ -188,6 +189,9 @@ def jax_sample_fn_uniform(op):
 
     """
     name = op.name
+    # IntegersRV is equivalent to RandintRV
+    if isinstance(op, aer.IntegersRV):
+        name = "randint"
     jax_op = getattr(jax.random, name)
 
     def sample_fn(rng, size, dtype, *parameters):

--- a/pytensor/tensor/random/rewriting/jax.py
+++ b/pytensor/tensor/random/rewriting/jax.py
@@ -2,10 +2,11 @@ from pytensor.compile import optdb
 from pytensor.graph.rewriting.basic import in2out, node_rewriter
 from pytensor.graph.rewriting.db import SequenceDB
 from pytensor.tensor import abs as abs_t
-from pytensor.tensor import exp, floor, log, log1p, reciprocal, sqrt
+from pytensor.tensor import broadcast_arrays, exp, floor, log, log1p, reciprocal, sqrt
 from pytensor.tensor.basic import MakeVector, cast, ones_like, switch, zeros_like
 from pytensor.tensor.elemwise import DimShuffle
 from pytensor.tensor.random.basic import (
+    BetaBinomialRV,
     ChiSquareRV,
     GenGammaRV,
     GeometricRV,
@@ -14,6 +15,8 @@ from pytensor.tensor.random.basic import (
     LogNormalRV,
     NegBinomialRV,
     WaldRV,
+    beta,
+    binomial,
     gamma,
     normal,
     poisson,
@@ -133,6 +136,15 @@ def wald_from_normal_uniform(fgraph, node):
     return [next_rng, cast(w, dtype=node.default_output().dtype)]
 
 
+@node_rewriter([BetaBinomialRV])
+def beta_binomial_from_beta_binomial(fgraph, node):
+    rng, *other_inputs, n, a, b = node.inputs
+    n, a, b = broadcast_arrays(n, a, b)
+    next_rng, b = beta.make_node(rng, *other_inputs, a, b).outputs
+    next_rng, b = binomial.make_node(next_rng, *other_inputs, n, b).outputs
+    return [next_rng, b]
+
+
 random_vars_opt = SequenceDB()
 random_vars_opt.register(
     "lognormal_from_normal",
@@ -172,6 +184,11 @@ random_vars_opt.register(
 random_vars_opt.register(
     "wald_from_normal_uniform",
     in2out(wald_from_normal_uniform),
+    "jax",
+)
+random_vars_opt.register(
+    "beta_binomial_from_beta_binomial",
+    in2out(beta_binomial_from_beta_binomial),
     "jax",
 )
 optdb.register("jax_random_vars_rewrites", random_vars_opt, "jax", position=110)

--- a/pytensor/tensor/random/rewriting/jax.py
+++ b/pytensor/tensor/random/rewriting/jax.py
@@ -1,7 +1,24 @@
 from pytensor.compile import optdb
 from pytensor.graph.rewriting.basic import in2out, node_rewriter
-from pytensor.tensor.basic import MakeVector
+from pytensor.graph.rewriting.db import SequenceDB
+from pytensor.tensor import abs as abs_t
+from pytensor.tensor import exp, floor, log, log1p, reciprocal, sqrt
+from pytensor.tensor.basic import MakeVector, cast, ones_like, switch, zeros_like
 from pytensor.tensor.elemwise import DimShuffle
+from pytensor.tensor.random.basic import (
+    ChiSquareRV,
+    GenGammaRV,
+    GeometricRV,
+    HalfNormalRV,
+    InvGammaRV,
+    LogNormalRV,
+    NegBinomialRV,
+    WaldRV,
+    gamma,
+    normal,
+    poisson,
+    uniform,
+)
 from pytensor.tensor.random.op import RandomVariable
 
 
@@ -46,6 +63,118 @@ def size_parameter_as_tuple(fgraph, node):
         new_node = node.clone_with_new_inputs(new_inputs)
         return new_node.outputs
 
+
+@node_rewriter([LogNormalRV])
+def lognormal_from_normal(fgraph, node):
+    next_rng, n = normal.make_node(*node.inputs).outputs
+    return [next_rng, exp(n)]
+
+
+@node_rewriter([HalfNormalRV])
+def halfnormal_from_normal(fgraph, node):
+    *other_inputs, loc, scale = node.inputs
+    next_rng, n = normal.make_node(*other_inputs, zeros_like(loc), scale).outputs
+    h = abs_t(n) + loc
+    return [next_rng, cast(h, dtype=node.default_output().dtype)]
+
+
+@node_rewriter([GeometricRV])
+def geometric_from_uniform(fgraph, node):
+    *other_inputs, p = node.inputs
+    next_rng, u = uniform.make_node(*other_inputs, zeros_like(p), 1).outputs
+    g = floor(log(u) / log1p(-p)) + 1
+    return [next_rng, cast(g, dtype=node.default_output().dtype)]
+
+
+@node_rewriter([NegBinomialRV])
+def negative_binomial_from_gamma_poisson(fgraph, node):
+    rng, *other_inputs, n, p = node.inputs
+    next_rng, g = gamma.make_node(rng, *other_inputs, n, p / (1 - p)).outputs
+    next_rng, p = poisson.make_node(next_rng, *other_inputs, g).outputs
+    return [next_rng, p]
+
+
+@node_rewriter([InvGammaRV])
+def inverse_gamma_from_gamma(fgraph, node):
+    *other_inputs, shape, scale = node.inputs
+    next_rng, g = gamma.make_node(*other_inputs, shape, scale).outputs
+    return [next_rng, reciprocal(g)]
+
+
+@node_rewriter([ChiSquareRV])
+def chi_square_from_gamma(fgraph, node):
+    *other_inputs, df = node.inputs
+    next_rng, g = gamma.make_node(*other_inputs, df / 2, 1 / 2).outputs
+    return [next_rng, g]
+
+
+@node_rewriter([GenGammaRV])
+def generalized_gamma_from_gamma(fgraph, node):
+    *other_inputs, alpha, p, lambd = node.inputs
+    next_rng, g = gamma.make_node(*other_inputs, alpha / p, ones_like(lambd)).outputs
+    g = (g ** reciprocal(p)) * lambd
+    return [next_rng, cast(g, dtype=node.default_output().dtype)]
+
+
+@node_rewriter([WaldRV])
+def wald_from_normal_uniform(fgraph, node):
+    rng, *other_inputs, mean, scale = node.inputs
+    next_rng, n = normal.make_node(
+        rng, *other_inputs, zeros_like(mean), ones_like(scale)
+    ).outputs
+    next_rng, u = uniform.make_node(
+        next_rng, *other_inputs, zeros_like(mean), ones_like(scale)
+    ).outputs
+
+    mu_2l = mean / (2 * scale)
+    y = mean * n * n
+    x = mean + mu_2l * (y - sqrt(4 * scale * y + y * y))
+    w = switch(u <= mean / (mean + x), x, mean * mean / x)
+    return [next_rng, cast(w, dtype=node.default_output().dtype)]
+
+
+random_vars_opt = SequenceDB()
+random_vars_opt.register(
+    "lognormal_from_normal",
+    in2out(lognormal_from_normal),
+    "jax",
+)
+random_vars_opt.register(
+    "halfnormal_from_normal",
+    in2out(halfnormal_from_normal),
+    "jax",
+)
+random_vars_opt.register(
+    "geometric_from_uniform",
+    in2out(geometric_from_uniform),
+    "jax",
+)
+random_vars_opt.register(
+    "negative_binomial_from_gamma_poisson",
+    in2out(negative_binomial_from_gamma_poisson),
+    "jax",
+)
+random_vars_opt.register(
+    "inverse_gamma_from_gamma",
+    in2out(inverse_gamma_from_gamma),
+    "jax",
+)
+random_vars_opt.register(
+    "chi_square_from_gamma",
+    in2out(chi_square_from_gamma),
+    "jax",
+)
+random_vars_opt.register(
+    "generalized_gamma_from_gamma",
+    in2out(generalized_gamma_from_gamma),
+    "jax",
+)
+random_vars_opt.register(
+    "wald_from_normal_uniform",
+    in2out(wald_from_normal_uniform),
+    "jax",
+)
+optdb.register("jax_random_vars_rewrites", random_vars_opt, "jax", position=110)
 
 optdb.register(
     "jax_size_parameter_as_tuple", in2out(size_parameter_as_tuple), "jax", position=100

--- a/tests/link/jax/test_random.py
+++ b/tests/link/jax/test_random.py
@@ -238,6 +238,22 @@ def test_random_updates(rng_ctor):
             lambda *args: args,
         ),
         (
+            aer.integers,
+            [
+                set_test_value(
+                    at.lscalar(),
+                    np.array(0, dtype=np.int64),
+                ),
+                set_test_value(  # high-value necessary since test on cdf
+                    at.lscalar(),
+                    np.array(1000, dtype=np.int64),
+                ),
+            ],
+            (),
+            "randint",
+            lambda *args: args,
+        ),
+        (
             aer.standard_normal,
             [],
             (2,),
@@ -376,7 +392,11 @@ def test_random_RandomVariable(rv_op, dist_params, base_size, cdf_name, params_c
         The parameters passed to the op.
 
     """
-    rng = shared(np.random.RandomState(29402))
+    if rv_op is aer.integers:
+        # Integers only accepts Generator, not RandomState
+        rng = shared(np.random.default_rng(29402))
+    else:
+        rng = shared(np.random.RandomState(29402))
     g = rv_op(*dist_params, size=(10_000,) + base_size, rng=rng)
     g_fn = function(dist_params, g, mode=jax_mode)
     samples = g_fn(


### PR DESCRIPTION
This PR extends the number of RandomVariables supported in the JAX backend, with two strategies:

1. Rewrites that convert RVS to equivalent expressions that use RVs supported natively by JAX
2. Optional dependency on NumPyro routines for more complex expressions

The rewrites from 1. may be reused with other backends later (e.g, Numba). This seems like a cleaner solution than implementing the same logic in the different dispatched functions of each backend.