### PR TITLE
Fix `pt.stack` type hints

### DIFF
--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -1280,15 +1280,15 @@ class TestJoinAndSplit:
 
     def test_stack_scalar_make_vector_constant(self):
         # Test that calling stack() on scalars instantiates MakeVector,
-        # event when the scalar are simple int type.
+        # even when the scalars are non-symbolic ints.
         a = iscalar("a")
         b = lscalar("b")
         # test when the constant is the first element.
         # The first element is used in a special way
-        s = stack([10, a, b, np.int8(3)])
+        s = stack([10, a, b, np.int8(3), np.array(4, dtype=np.int8)])
         f = function([a, b], s, mode=self.mode)
         val = f(1, 2)
-        assert np.all(val == [10, 1, 2, 3])
+        assert np.all(val == [10, 1, 2, 3, 4])
         topo = f.maker.fgraph.toposort()
         assert len([n for n in topo if isinstance(n.op, MakeVector)]) > 0
         assert len([n for n in topo if isinstance(n, type(self.join_op))]) == 0
@@ -1333,10 +1333,13 @@ class TestJoinAndSplit:
             stack([a, b], -4)
 
         # Testing depreciation warning is now an informative error
-        with pytest.raises(
-            TypeError, match=r"First argument should be Sequence\[TensorVariable\]"
-        ):
+        with pytest.raises(TypeError, match="First argument should be a Sequence"):
             s = stack(a, b)
+
+    def test_stack_empty(self):
+        # Do not support stacking an empty sequence
+        with pytest.raises(ValueError, match="No tensor arguments provided"):
+            stack([])
 
     def test_stack_hessian(self):
         # Test the gradient of stack when used in hessian, see gh-1589


### PR DESCRIPTION
Seeking to address #193, making type hints for `pt.stack` more accurate.

### Implementation details
I chose to type hint as TensorLike, defined [here](https://github.com/pymc-devs/pytensor/blob/main/pytensor/tensor/__init__.py#L14) as Variable | Sequence[Variable] | npt.ArrayLike. I hope this will address all cases that mypy was complaining about. I also updated the docs and errors accordingly.

Lastly, because there was a case that coerces a list of zero-dim Variables into MakeVector, I also allowed a parallel case of zero-dim numpy arrays to use MakeVector rather than Join and updated a test to cover this case.

### Checklist
+ [x] Explain motivation and implementation 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
     + ^Yes although I had to update my local pre-commit config to `isort 5.11.5` due to a bug with pre-commit initialization ([error with poetry](https://github.com/PyCQA/isort/releases/tag/5.11.5))
+ [x] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- na

## New features
- pt.stack([np.array(1), np.array(2)]) will use MakeVector rather than Join

## Bugfixes
- More accurate type hints

## Documentation
- ...

## Maintenance
- ...

Please let me know if you have any feedback!