### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,11 +50,14 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     if: ${{ needs.changes.outputs.changes == 'true' }}
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: ${{ matrix.python-version }}
     - uses: pre-commit/action@v3.0.0
 
   test_ubuntu:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/humitos/mirrors-autoflake.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ name = "pytensor"
 dynamic = [
   'version'
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     {name = "pymc-devs", email = "pymc.devs@gmail.com"}
 ]
@@ -34,7 +34,6 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/pytensor/link/numba/dispatch/elemwise_codegen.py
+++ b/pytensor/link/numba/dispatch/elemwise_codegen.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, List, Optional, Tuple
 
 import numba


### PR DESCRIPTION
In addition:
* Make annotations compatible with oldest supported Python version (mypy was failing on Python 3.8)
* Test pre-commit in all supported versions
* Updated isort dependency

Closes #76