### PR TITLE
Fix DeprecationWarning from scipy.sparse.base

### DIFF
--- a/pytensor/sparse/basic.py
+++ b/pytensor/sparse/basic.py
@@ -129,7 +129,7 @@ def _is_dense(x):
     return isinstance(x, np.ndarray)
 
 
-@_as_symbolic.register(scipy.sparse.base.spmatrix)
+@_as_symbolic.register(scipy.sparse.spmatrix)
 def as_symbolic_sparse(x, **kwargs):
     return as_sparse_variable(x, **kwargs)
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

### Motivation for these changes

Scipy versions after 1.8 deprecated a bunch of namespaces in order to clarify the intended public namespaces: https://docs.scipy.org/doc/scipy/release.1.8.0.html

Turns out that the annotation on `sparse.basic.as_symbolic_sparse` accesses a "private" scipy namespace, so importing pytensor when a newer scipy is installed will yield the following warning.

```python
>>> import scipy, warnings
>>> scipy.__version__
'1.10.0'
>>> warnings.resetwarnings()
>>> import pytensor
/home/cove/pytensor/pytensor/sparse/basic.py:132: DeprecationWarning: Please use `spmatrix` from the `scipy.sparse` namespace, the `scipy.sparse.base` namespace is deprecated.
  @_as_symbolic.register(scipy.sparse.base.spmatrix)
```

Not a big deal (and `numba-scipy` currently requires `scipy<=1.7.3`), but newer scipy happened to be installed on my system and this had been bugging me. :D

### Checklist
+ [x] Explain motivation and implementation 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [x] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇

(Not much more to note, pretty simple!)