### PR TITLE
Fix numba impl of empty DimShuffle

### DIFF
--- a/pytensor/link/numba/dispatch/elemwise.py
+++ b/pytensor/link/numba/dispatch/elemwise.py
@@ -843,7 +843,7 @@ def numba_funcify_DimShuffle(op, node, **kwargs):
 
         @numba_basic.numba_njit
         def dimshuffle_inner(x, shuffle):
-            return x.item()
+            return np.reshape(x, ())
 
     # Without the following wrapper function we would see this error:
     # E   No implementation of function Function(<built-in function getitem>) found for signature:

--- a/tests/link/numba/test_elemwise.py
+++ b/tests/link/numba/test_elemwise.py
@@ -211,6 +211,14 @@ def test_Dimshuffle(v, new_order):
     )
 
 
+def test_Dimshuffle_returns_array():
+    x = at.vector("x", shape=(1,))
+    y = 2 * at_elemwise.DimShuffle([True], [])(x)
+    func = pytensor.function([x], y, mode="NUMBA")
+    out = func(np.zeros(1))
+    assert out.ndim == 0
+
+
 @pytest.mark.parametrize(
     "careduce_fn, axis, v",
     [


### PR DESCRIPTION
The previous version returned a scalar instead of an array, which can then lead to errors in later code that expects to receive an array.

Fixes https://github.com/pymc-devs/nutpie/issues/37

### Checklist
+ [x] Explain motivation and implementation 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [x] Are the changes covered by tests and docstrings?
