### PR TITLE
Speedup Numba Scans with vector inputs

### DIFF
--- a/pytensor/link/numba/dispatch/scan.py
+++ b/pytensor/link/numba/dispatch/scan.py
@@ -190,8 +190,8 @@ def numba_funcify_Scan(op, node, **kwargs):
         output_storage_post_proc_stmts.append(
             dedent(
                 f"""
-                {outer_in_name}_shift = (i + {tap_size}) % ({storage_size})
-                if {outer_in_name}_shift > 0:
+                if (i + {tap_size}) > {storage_size}:
+                    {outer_in_name}_shift = (i + {tap_size}) % ({storage_size})
                     {outer_in_name}_left = {outer_in_name}[:{outer_in_name}_shift]
                     {outer_in_name}_right = {outer_in_name}[{outer_in_name}_shift:]
                     {outer_in_name} = np.concatenate(({outer_in_name}_right, {outer_in_name}_left))

--- a/pytensor/link/numba/dispatch/scan.py
+++ b/pytensor/link/numba/dispatch/scan.py
@@ -367,8 +367,6 @@ def scan({", ".join(outer_in_names)}):
     }
     global_env["np"] = np
 
-    scalar_op_fn = compile_function_src(
-        scan_op_src, "scan", {**globals(), **global_env}
-    )
+    scan_op_fn = compile_function_src(scan_op_src, "scan", {**globals(), **global_env})
 
-    return numba_basic.numba_njit(scalar_op_fn)
+    return numba_basic.numba_njit(scan_op_fn)


### PR DESCRIPTION
Related to #233 

In talks with @jessegrabowski and @aseyboldt we found out that there is a large overhead of `asarray` when indexing vector inputs to create taps, as these become non-array numerical variables that must be wrapped again into a scalar tensor (at least until we allow proper scalar inputs in Scan).

The new benchmark test runs 2.5x faster on my machine compared to main. 

The scan function used to look like this
```python
def scan(n_steps, outer_in_1, outer_in_2, outer_in_3, outer_in_4):

    outer_in_3_len = outer_in_3.shape[0]
    outer_in_3_mitsot_storage = outer_in_3
    outer_in_4_len = outer_in_4.shape[0]
    outer_in_4_sitsot_storage = outer_in_4

    i = 0
    cond = np.array(False)
    while i < n_steps and not cond.item():
        (inner_out_0, inner_out_1) = scan_inner_func(np.asarray(outer_in_1[i]), np.asarray(outer_in_2[i]), np.asarray(outer_in_3_mitsot_storage[(i) % outer_in_3_len]), np.asarray(outer_in_3_mitsot_storage[(i + 1) % outer_in_3_len]), np.asarray(outer_in_4_sitsot_storage[(i) % outer_in_4_len]))

        outer_in_3_mitsot_storage[(i + 2) % outer_in_3_len] = inner_out_0
        outer_in_4_sitsot_storage[(i + 1) % outer_in_4_len] = inner_out_1
        i += 1

    if (i + 2) > outer_in_3_len:
        outer_in_3_mitsot_storage_shift = (i + 2) % (outer_in_3_len)
        outer_in_3_mitsot_storage_left = outer_in_3_mitsot_storage[:outer_in_3_mitsot_storage_shift]
        outer_in_3_mitsot_storage_right = outer_in_3_mitsot_storage[outer_in_3_mitsot_storage_shift:]
        outer_in_3_mitsot_storage = np.concatenate((outer_in_3_mitsot_storage_right, outer_in_3_mitsot_storage_left))
    if (i + 1) > outer_in_4_len:
        outer_in_4_sitsot_storage_shift = (i + 1) % (outer_in_4_len)
        outer_in_4_sitsot_storage_left = outer_in_4_sitsot_storage[:outer_in_4_sitsot_storage_shift]
        outer_in_4_sitsot_storage_right = outer_in_4_sitsot_storage[outer_in_4_sitsot_storage_shift:]
        outer_in_4_sitsot_storage = np.concatenate((outer_in_4_sitsot_storage_right, outer_in_4_sitsot_storage_left))

    return outer_in_3_mitsot_storage, outer_in_4_sitsot_storage
```

And now looks like this
```python
def scan(n_steps, outer_in_1, outer_in_2, outer_in_3, outer_in_4):

    outer_in_3_len = outer_in_3.shape[0]
    outer_in_3_mitsot_storage = outer_in_3
    outer_in_4_len = outer_in_4.shape[0]
    outer_in_4_sitsot_storage = outer_in_4

    outer_in_1_temp_scalar_0 = np.empty((), dtype=np.float64)
    outer_in_2_temp_scalar_0 = np.empty((), dtype=np.float64)
    outer_in_3_mitsot_storage_temp_scalar_0 = np.empty((), dtype=np.float64)
    outer_in_3_mitsot_storage_temp_scalar_1 = np.empty((), dtype=np.float64)
    outer_in_4_sitsot_storage_temp_scalar_0 = np.empty((), dtype=np.float64)

    i = 0
    cond = np.array(False)
    while i < n_steps and not cond.item():
        outer_in_1_temp_scalar_0[()] = outer_in_1[i]
        outer_in_2_temp_scalar_0[()] = outer_in_2[i]
        outer_in_3_mitsot_storage_temp_scalar_0[()] = outer_in_3_mitsot_storage[(i) % outer_in_3_len]
        outer_in_3_mitsot_storage_temp_scalar_1[()] = outer_in_3_mitsot_storage[(i + 1) % outer_in_3_len]
        outer_in_4_sitsot_storage_temp_scalar_0[()] = outer_in_4_sitsot_storage[(i) % outer_in_4_len]

        (inner_out_0, inner_out_1) = scan_inner_func(outer_in_1_temp_scalar_0, outer_in_2_temp_scalar_0, outer_in_3_mitsot_storage_temp_scalar_0, outer_in_3_mitsot_storage_temp_scalar_1, outer_in_4_sitsot_storage_temp_scalar_0)

        outer_in_3_mitsot_storage[(i + 2) % outer_in_3_len] = inner_out_0
        outer_in_4_sitsot_storage[(i + 1) % outer_in_4_len] = inner_out_1
        i += 1

    if (i + 2) > outer_in_3_len:
        outer_in_3_mitsot_storage_shift = (i + 2) % (outer_in_3_len)
        outer_in_3_mitsot_storage_left = outer_in_3_mitsot_storage[:outer_in_3_mitsot_storage_shift]
        outer_in_3_mitsot_storage_right = outer_in_3_mitsot_storage[outer_in_3_mitsot_storage_shift:]
        outer_in_3_mitsot_storage = np.concatenate((outer_in_3_mitsot_storage_right, outer_in_3_mitsot_storage_left))
    if (i + 1) > outer_in_4_len:
        outer_in_4_sitsot_storage_shift = (i + 1) % (outer_in_4_len)
        outer_in_4_sitsot_storage_left = outer_in_4_sitsot_storage[:outer_in_4_sitsot_storage_shift]
        outer_in_4_sitsot_storage_right = outer_in_4_sitsot_storage[outer_in_4_sitsot_storage_shift:]
        outer_in_4_sitsot_storage = np.concatenate((outer_in_4_sitsot_storage_right, outer_in_4_sitsot_storage_left))

    return outer_in_3_mitsot_storage, outer_in_4_sitsot_storage
 ```
