### PR TITLE
Allow string keys in `eval` utility

### DIFF
--- a/pytensor/graph/basic.py
+++ b/pytensor/graph/basic.py
@@ -581,11 +581,18 @@ class Variable(Node, Generic[_TypeType, OptionalApplyType]):
         for i in inputs_to_values:
             if isinstance(i, str):
                 nodes_with_matching_names = get_var_by_name([self], i)
-                if len(nodes_with_matching_names) == 0:
+                length_of_nodes_with_matching_names = len(nodes_with_matching_names)
+                if length_of_nodes_with_matching_names == 0:
                     raise Exception(f"{i} not found in graph")
                 else:
+                    if length_of_nodes_with_matching_names > 1:
+                        warnings.warn(
+                            f"Found {length_of_nodes_with_matching_names} pytensor variables with name {i} taking the first declared named variable for computation"
+                        )
                     process_input_to_values[
-                        nodes_with_matching_names[0]
+                        nodes_with_matching_names[
+                            length_of_nodes_with_matching_names - 1
+                        ]
                     ] = inputs_to_values[i]
             else:
                 process_input_to_values[i] = inputs_to_values[i]

--- a/pytensor/graph/basic.py
+++ b/pytensor/graph/basic.py
@@ -605,13 +605,12 @@ class Variable(Node, Generic[_TypeType, OptionalApplyType]):
                     if not matching_vars:
                         raise Exception(f"{key} not found in graph")
                     elif len(matching_vars) > 1:
-                            raise Exception(
-                                f"Found multiple variables with name {key}"
-                            )
+                        raise Exception(f"Found multiple variables with name {key}")
                     new_input_to_values[matching_vars[0]] = value
                 else:
                     new_input_to_values[key] = value
             return new_input_to_values
+
         inputs_to_values = convert_string_keys_to_variables(inputs_to_values)
 
         if not hasattr(self, "_fn_cache"):

--- a/pytensor/graph/basic.py
+++ b/pytensor/graph/basic.py
@@ -597,27 +597,22 @@ class Variable(Node, Generic[_TypeType, OptionalApplyType]):
         if inputs_to_values is None:
             inputs_to_values = {}
 
-        def convert_string_keys_to_variables():
-            process_input_to_values = {}
-            for i in inputs_to_values:
-                if isinstance(i, str):
-                    nodes_with_matching_names = get_var_by_name([self], i)
-                    length_of_nodes_with_matching_names = len(nodes_with_matching_names)
-                    if length_of_nodes_with_matching_names == 0:
-                        raise Exception(f"{i} not found in graph")
-                    else:
-                        if length_of_nodes_with_matching_names > 1:
+        def convert_string_keys_to_variables(input_to_values):
+            new_input_to_values = {}
+            for key, value in inputs_to_values.items():
+                if isinstance(key, str):
+                    matching_vars = get_var_by_name([self], key)
+                    if not matching_vars:
+                        raise Exception(f"{key} not found in graph")
+                    elif len(matching_vars) > 1:
                             raise Exception(
-                                f"Found {length_of_nodes_with_matching_names} pytensor variables with name {i}"
+                                f"Found multiple variables with name {key}"
                             )
-                        process_input_to_values[
-                            nodes_with_matching_names[0]
-                        ] = inputs_to_values[i]
+                    new_input_to_values[matching_vars[0]] = value
                 else:
-                    process_input_to_values[i] = inputs_to_values[i]
-            return process_input_to_values
-
-        inputs_to_values = convert_string_keys_to_variables()
+                    new_input_to_values[key] = value
+            return new_input_to_values
+        inputs_to_values = convert_string_keys_to_variables(inputs_to_values)
 
         if not hasattr(self, "_fn_cache"):
             self._fn_cache = dict()

--- a/pytensor/graph/basic.py
+++ b/pytensor/graph/basic.py
@@ -611,9 +611,7 @@ class Variable(Node, Generic[_TypeType, OptionalApplyType]):
                                 f"Found {length_of_nodes_with_matching_names} pytensor variables with name {i}"
                             )
                         process_input_to_values[
-                            nodes_with_matching_names[
-                                length_of_nodes_with_matching_names - 1
-                            ]
+                            nodes_with_matching_names[0]
                         ] = inputs_to_values[i]
                 else:
                     process_input_to_values[i] = inputs_to_values[i]

--- a/tests/graph/test_basic.py
+++ b/tests/graph/test_basic.py
@@ -313,6 +313,13 @@ class TestEval:
         with pytest.raises(Exception, match="Found 2 pytensor variables with name e"):
             t.eval({"e": 1})
 
+    def test_eval_errors_with_no_name_exists(self):
+        e = scalars("e")
+        t = e + 1
+        t.name = "p"
+        with pytest.raises(Exception, match="o not found in graph"):
+            t.eval({"o": 1})
+
 
 class TestAutoName:
     def test_auto_name(self):

--- a/tests/graph/test_basic.py
+++ b/tests/graph/test_basic.py
@@ -290,11 +290,9 @@ class TestToposort:
 
 class TestEval:
     def setup_method(self):
-        self.x, self.y, self.e = scalars("x", "y", "e")
+        self.x, self.y = scalars("x", "y")
         self.z = self.x + self.y
         self.w = 2 * self.z
-        self.t = self.e + 1
-        self.t.name = "e"
 
     def test_eval(self):
         assert self.w.eval({self.x: 1.0, self.y: 2.0}) == 6.0
@@ -308,8 +306,12 @@ class TestEval:
         assert self.w.eval({"x": 1.0, self.y: 2.0}) == 6.0
         assert self.w.eval({self.z: 3}) == 6.0
 
-    def test_eval_with_strings_with_mulitple_same_name(self):
-        assert self.t.eval({"e": 1.0}) == 2.0
+    def test_eval_errors_having_mulitple_variables_same_name(self):
+        e = scalars("e")
+        t = e + 1
+        t.name = "e"
+        with pytest.raises(Exception, match="Found 2 pytensor variables with name e"):
+            t.eval({"e": 1})
 
 
 class TestAutoName:

--- a/tests/graph/test_basic.py
+++ b/tests/graph/test_basic.py
@@ -310,7 +310,7 @@ class TestEval:
         e = scalars("e")
         t = e + 1
         t.name = "e"
-        with pytest.raises(Exception, match="Found 2 pytensor variables with name e"):
+        with pytest.raises(Exception, match="Found multiple variables with name e"):
             t.eval({"e": 1})
 
     def test_eval_errors_with_no_name_exists(self):

--- a/tests/graph/test_basic.py
+++ b/tests/graph/test_basic.py
@@ -302,6 +302,14 @@ class TestEval:
             pickle.loads(pickle.dumps(self.w)), "_fn_cache"
         ), "temporary functions must not be serialized"
 
+    def test_eval_with_strings(self):
+        assert self.w.eval({"x": 1.0, "y": 2.0}) == 6.0
+        assert self.w.eval({self.z: 3}) == 6.0
+        assert hasattr(self.w, "_fn_cache"), "variable must have cache after eval"
+        assert not hasattr(
+            pickle.loads(pickle.dumps(self.w)), "_fn_cache"
+        ), "temporary functions must not be serialized"
+
 
 class TestAutoName:
     def test_auto_name(self):

--- a/tests/graph/test_basic.py
+++ b/tests/graph/test_basic.py
@@ -290,9 +290,11 @@ class TestToposort:
 
 class TestEval:
     def setup_method(self):
-        self.x, self.y = scalars("x", "y")
+        self.x, self.y, self.e = scalars("x", "y", "e")
         self.z = self.x + self.y
         self.w = 2 * self.z
+        self.t = self.e + 1
+        self.t.name = "e"
 
     def test_eval(self):
         assert self.w.eval({self.x: 1.0, self.y: 2.0}) == 6.0
@@ -303,12 +305,11 @@ class TestEval:
         ), "temporary functions must not be serialized"
 
     def test_eval_with_strings(self):
-        assert self.w.eval({"x": 1.0, "y": 2.0}) == 6.0
+        assert self.w.eval({"x": 1.0, self.y: 2.0}) == 6.0
         assert self.w.eval({self.z: 3}) == 6.0
-        assert hasattr(self.w, "_fn_cache"), "variable must have cache after eval"
-        assert not hasattr(
-            pickle.loads(pickle.dumps(self.w)), "_fn_cache"
-        ), "temporary functions must not be serialized"
+
+    def test_eval_with_strings_with_mulitple_same_name(self):
+        assert self.t.eval({"e": 1.0}) == 2.0
 
 
 class TestAutoName:

--- a/tests/graph/test_basic.py
+++ b/tests/graph/test_basic.py
@@ -306,14 +306,14 @@ class TestEval:
         assert self.w.eval({"x": 1.0, self.y: 2.0}) == 6.0
         assert self.w.eval({self.z: 3}) == 6.0
 
-    def test_eval_errors_having_mulitple_variables_same_name(self):
+    def test_eval_with_strings_multiple_matches(self):
         e = scalars("e")
         t = e + 1
         t.name = "e"
         with pytest.raises(Exception, match="Found multiple variables with name e"):
             t.eval({"e": 1})
 
-    def test_eval_errors_with_no_name_exists(self):
+    def test_eval_with_strings_no_match(self):
         e = scalars("e")
         t = e + 1
         t.name = "p"


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

### Motivation for these changes
Closes #227 

### Implementation details
 I have implemented a function that converts the dictionary with string keys to pytensor. The pytensor variable for the corresponding name is found using the function "get_var_by_name".

### Checklist
+ [x] Explain motivation and implementation 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇


## Major / Breaking Changes
- ...

## New features
- ... Its and enhancement of current functionality eval present in graph/basic.py under Variable class. Through this enhancement eval will accept string i.e. pytensor node name. 

## Bugfixes
- ...

## Documentation
- ...

## Maintenance
- ...

