### PR TITLE
Fix non-contiguous reshapes in numba backend

### DIFF
--- a/pytensor/link/numba/dispatch/elemwise.py
+++ b/pytensor/link/numba/dispatch/elemwise.py
@@ -841,7 +841,7 @@ def numba_funcify_DimShuffle(op, node, **kwargs):
 
         @numba_basic.numba_njit
         def dimshuffle_inner(x, shuffle):
-            return np.reshape(x, ())
+            return np.reshape(np.ascontiguousarray(x), ())
 
     # Without the following wrapper function we would see this error:
     # E   No implementation of function Function(<built-in function getitem>) found for signature:

--- a/tests/link/numba/test_elemwise.py
+++ b/tests/link/numba/test_elemwise.py
@@ -218,6 +218,17 @@ def test_Dimshuffle_returns_array():
     assert out.ndim == 0
 
 
+def test_Dimshuffle_non_contiguous():
+    """The numba impl of reshape doesn't work with
+    non-contiguous arrays, make sure we work around that."""
+    x = at.dvector()
+    idx = at.vector(dtype="int64")
+    op = pytensor.tensor.elemwise.DimShuffle([True], [])
+    out = op(at.specify_shape(x[idx][::2], (1,)))
+    func = pytensor.function([x, idx], out, mode="NUMBA")
+    assert func(np.zeros(3), np.array([1])).ndim == 0
+
+
 @pytest.mark.parametrize(
     "careduce_fn, axis, v",
     [


### PR DESCRIPTION
`np.reshape(x, some_shape)` fails in numba if x is not contiguous. This can lead to compilation failures. We can work around this by converting to a contiguous array if it is not already the case. This is happening in code in dim_shuffle where the output shape is `()`, so a valid input array will always be contiguous, but numba doesn't seem to realize this.

Fixes https://github.com/pymc-devs/nutpie/issues/40.

### Checklist
+ [x] Explain motivation and implementation 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [x] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇