### PR TITLE
Fix a typo in Graph Rewriting Doc

### DIFF
--- a/doc/extending/graph_rewriting.rst
+++ b/doc/extending/graph_rewriting.rst
@@ -603,7 +603,7 @@ An :class:`EquilibriumDB` contains :class:`NodeRewriter` or :class:`RewriteDatab
 has a name and an arbitrary number of tags. When a :class:`RewriteDatabaseQuery` is applied to
 an :class:`EquilibriumDB`, all :class:`NodeRewriter`\s that match the query are
 inserted into an :class:`EquilibriumGraphRewriter`, which is returned. If the
-:class:`SequenceDB` contains :class:`RewriteDatabase` instances, the
+:class:`EquilibriumDB` contains :class:`RewriteDatabase` instances, the
 :class:`RewriteDatabaseQuery` will be passed to them as well and the
 :class:`NodeRewriter`\s they return will be put in their places
 (note that as of yet no :class:`RewriteDatabase` can produce :class:`NodeRewriter` objects, so this


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

### Motivation for these changes
There's a very minor incorrect mention of `SequenceDB` instead of `EquilibriumDB` in the Graph Rewriting Doc.

### Implementation details

### Checklist
+ [x] Explain motivation and implementation 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [ ] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇


## Major / Breaking Changes
- ...

## New features
- ...

