### PR TITLE
Allow default_output to be any valid Python index

### DIFF
--- a/pytensor/graph/basic.py
+++ b/pytensor/graph/basic.py
@@ -193,11 +193,9 @@ class Apply(Node, Generic[OpType]):
             if len(self.outputs) == 1:
                 return self.outputs[0]
             else:
-                raise ValueError(f"{self.op}.default_output should be an output index.")
-        elif not isinstance(do, int):
-            raise ValueError(f"{self.op}.default_output should be an int or long")
-        elif do < 0 or do >= len(self.outputs):
-            raise ValueError(f"{self.op}.default_output is out of range.")
+                raise ValueError(
+                    f"Multi-output Op {self.op} default_output not specified"
+                )
         return self.outputs[do]
 
     def __str__(self):

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -80,7 +80,7 @@ def _as_tensor_Apply(x, name, ndim, **kwargs):
     # use Apply's default output mechanism
     if (x.op.default_output is None) and (len(x.outputs) != 1):
         raise TypeError(
-            "Multi-output Op encountered. "
+            "Multi-output Op without default_output encountered. "
             "Retry using only one of the outputs directly."
         )
 


### PR DESCRIPTION
This showed up in https://discourse.pymc.io/t/m-h-algorithm-with-custom-distribution-with-scipy/11866/4?u=ricardov94

I don't see any reason to break away from Python indexing expectations...