### PR TITLE
Import CompileError from setuptools not distutils

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         - numpy>=1.20
         - pandas
         - types-filelock
-        - types-setuptools
+        - types-setuptools>=67.6.0.8
         always_run: true
         require_serial: true
         pass_filenames: false

--- a/pytensor/link/c/exceptions.py
+++ b/pytensor/link/c/exceptions.py
@@ -1,4 +1,4 @@
-from setuptools._distutils.errors import CompileError as BaseCompileError
+from setuptools.errors import CompileError as BaseCompileError
 
 
 class MissingGXX(Exception):


### PR DESCRIPTION
In combination wtih https://github.com/python/typeshed/pull/10057, closes #240.

### Motivation for these changes
Fix failing CI

### Implementation details
Update deprecated import


### Checklist
+ [X] Explain motivation and implementation 👆
+ [X] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [X] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [X] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇


## Major / Breaking Changes
- ...

## New features
- ...

## Bugfixes
- ...

## Documentation
- ...

## Maintenance
- Partial preparation for [PEP 632](https://peps.python.org/pep-0632/#migration-advice), deprecation of distutils

