### PR TITLE
Implement scalar loop for iterative gradients

### DIFF
--- a/pytensor/graph/basic.py
+++ b/pytensor/graph/basic.py
@@ -1115,12 +1115,12 @@ def truncated_graph_inputs(
 
 
 def clone(
-    inputs: List[Variable],
-    outputs: List[Variable],
+    inputs: Sequence[Variable],
+    outputs: Sequence[Variable],
     copy_inputs: bool = True,
     copy_orphans: Optional[bool] = None,
     clone_inner_graphs: bool = False,
-) -> Tuple[Collection[Variable], Collection[Variable]]:
+) -> Tuple[List[Variable], List[Variable]]:
     r"""Copies the sub-graph contained between inputs and outputs.
 
     Parameters

--- a/pytensor/tensor/elemwise.py
+++ b/pytensor/tensor/elemwise.py
@@ -636,6 +636,9 @@ class Elemwise(OpenMPOp):
                 return DimShuffle((), ["x"] * nd)(res)
 
             new_r = Elemwise(node.op, {})(*[transform(ipt) for ipt in node.inputs])
+            if isinstance(new_r, (list, tuple)):
+                # Scalar Op with multiple outputs
+                new_r = new_r[r.owner.outputs.index(r)]
             return new_r
 
         ret = []

--- a/pytensor/tensor/rewriting/elemwise.py
+++ b/pytensor/tensor/rewriting/elemwise.py
@@ -22,6 +22,7 @@ from pytensor.graph.rewriting.basic import (
 )
 from pytensor.graph.rewriting.db import SequenceDB
 from pytensor.graph.utils import InconsistencyError, MethodNotDefined
+from pytensor.scalar.loop import ScalarLoop
 from pytensor.tensor.basic import (
     MakeVector,
     alloc,
@@ -66,9 +67,12 @@ class InplaceElemwiseOptimizer(GraphRewriter):
                 print(blanc, n, ndim[n], file=stream)
 
     def candidate_input_idxs(self, node):
-        if isinstance(node.op.scalar_op, aes.Composite) and len(node.outputs) > 1:
-            # TODO: Implement specialized InplaceCompositeOptimizer with logic
-            #  needed to correctly assign inplace for multi-output Composites
+        # TODO: Implement specialized InplaceCompositeOptimizer with logic
+        #  needed to correctly assign inplace for multi-output Composites
+        #  and ScalarLoops
+        if isinstance(node.op.scalar_op, ScalarLoop):
+            return []
+        if isinstance(node.op.scalar_op, aes.Composite) and (len(node.outputs) > 1):
             return []
         else:
             return range(len(node.outputs))

--- a/tests/scalar/test_loop.py
+++ b/tests/scalar/test_loop.py
@@ -1,0 +1,279 @@
+import re
+
+import numpy as np
+import pytest
+
+from pytensor import Mode, function
+from pytensor.scalar import (
+    Composite,
+    as_scalar,
+    cos,
+    exp,
+    float16,
+    float32,
+    float64,
+    identity,
+    int64,
+    sin,
+)
+from pytensor.scalar.loop import ScalarLoop
+from pytensor.tensor import exp as tensor_exp
+
+
+mode = pytest.mark.parametrize(
+    "mode",
+    [
+        Mode(optimizer="fast_compile", linker="py"),
+        Mode(optimizer="fast_compile", linker="cvm"),
+    ],
+)
+
+
+@mode
+def test_single_output(mode):
+    n_steps = int64("n_steps")
+    x0 = float64("x0")
+    const = float64("const")
+    x = x0 + const
+
+    op = ScalarLoop(init=[x0], constant=[const], update=[x])
+    x = op(n_steps, x0, const)
+
+    fn = function([n_steps, x0, const], x, mode=mode)
+    np.testing.assert_allclose(fn(5, 0, 1), 5)
+    np.testing.assert_allclose(fn(5, 0, 2), 10)
+    np.testing.assert_allclose(fn(4, 3, -1), -1)
+
+
+@mode
+def test_multiple_output(mode):
+    n_steps = int64("n_steps")
+    x0 = float64("x0")
+    y0 = int64("y0")
+    const = float64("const")
+    x = x0 + const
+    y = y0 + 1
+
+    op = ScalarLoop(init=[x0, y0], constant=[const], update=[x, y])
+    x, y = op(n_steps, x0, y0, const)
+
+    fn = function([n_steps, x0, y0, const], [x, y], mode=mode)
+
+    res_x, res_y = fn(n_steps=5, x0=0, y0=0, const=1)
+    np.testing.assert_allclose(res_x, 5)
+    np.testing.assert_allclose(res_y, 5)
+
+    res_x, res_y = fn(n_steps=5, x0=0, y0=0, const=2)
+    np.testing.assert_allclose(res_x, 10)
+    np.testing.assert_allclose(res_y, 5)
+
+    res_x, res_y = fn(n_steps=4, x0=3, y0=2, const=-1)
+    np.testing.assert_allclose(res_x, -1)
+    np.testing.assert_allclose(res_y, 6)
+
+
+@mode
+def test_input_not_aliased_to_update(mode):
+    n_steps = int64("n_steps")
+    x0 = float64("x0")
+    y0 = float64("y0")
+    const = float64("const")
+
+    def update(x_prev, y_prev):
+        x = x_prev + const
+        # y depends on x_prev, so x_prev should not be overriden by x!
+        y = y_prev + x_prev
+        return [x, y]
+
+    op = ScalarLoop(init=[x0, y0], constant=[const], update=update(x0, y0))
+    x, y = op(n_steps, x0, y0, const)
+
+    fn = function([n_steps, x0, y0, const], y, mode=mode)
+    np.testing.assert_allclose(fn(n_steps=1, x0=0, y0=0, const=1), 0.0)
+    np.testing.assert_allclose(fn(n_steps=2, x0=0, y0=0, const=1), 1.0)
+    np.testing.assert_allclose(fn(n_steps=3, x0=0, y0=0, const=1), 3.0)
+    np.testing.assert_allclose(fn(n_steps=4, x0=0, y0=0, const=1), 6.0)
+    np.testing.assert_allclose(fn(n_steps=5, x0=0, y0=0, const=1), 10.0)
+
+
+@mode
+def test_until(mode):
+    n_steps = int64("n_steps")
+    x0 = float64("x0")
+    x = x0 + 1
+    until = x >= 10
+
+    op = ScalarLoop(init=[x0], update=[x], until=until, until_condition_failed="ignore")
+    fn = function([n_steps, x0], op(n_steps, x0), mode=mode)
+    np.testing.assert_allclose(fn(n_steps=20, x0=0), 10)
+    np.testing.assert_allclose(fn(n_steps=20, x0=1), 10)
+    np.testing.assert_allclose(fn(n_steps=5, x0=1), 6)
+
+    op = ScalarLoop(
+        init=[x0],
+        update=[x],
+        until=until,
+        until_condition_failed="warn",
+        name="TestLoop",
+    )
+    fn = function([n_steps, x0], op(n_steps, x0), mode=mode)
+    np.testing.assert_allclose(fn(n_steps=20, x0=0), 10)
+    np.testing.assert_allclose(fn(n_steps=20, x0=1), 10)
+    with pytest.warns(
+        RuntimeWarning, match="Until condition in ScalarLoop TestLoop not reached!"
+    ):
+        np.testing.assert_allclose(fn(n_steps=5, x0=1), 6)
+
+    op = ScalarLoop(
+        init=[x0],
+        update=[x],
+        until=until,
+        until_condition_failed="raise",
+        name="TestLoop",
+    )
+    fn = function([n_steps, x0], op(n_steps, x0), mode=mode)
+    np.testing.assert_allclose(fn(n_steps=20, x0=0), 10)
+    np.testing.assert_allclose(fn(n_steps=20, x0=1), 10)
+    with pytest.raises(
+        RuntimeError, match="Until condition in ScalarLoop TestLoop not reached!"
+    ):
+        fn(n_steps=5, x0=1)
+
+
+def test_update_missing_error():
+    x0 = float64("x0")
+    const = float64("const")
+    with pytest.raises(
+        ValueError, match="An update must be given for each init variable"
+    ):
+        ScalarLoop(init=[x0], constant=[const], update=[])
+
+
+def test_init_update_type_error():
+    x0 = float32("x0")
+    const = float64("const")
+    x = x0 + const
+    assert x.type.dtype == "float64"
+    with pytest.raises(TypeError, match="Init and update types must be the same"):
+        ScalarLoop(init=[x0], constant=[const], update=[x])
+
+
+def test_rebuild_dtype():
+    n_steps = int64("n_steps")
+    x0 = float64("x0")
+    const = float64("const")
+    x = x0 + const
+    op = ScalarLoop(init=[x0], constant=[const], update=[x])
+
+    # If x0 is float32 but const is still float64, the output type will not be able to match
+    x0_float32 = float32("x0_float32")
+    with pytest.raises(TypeError, match="Init and update types must be the same"):
+        op(n_steps, x0_float32, const)
+
+    # Now it should be fine
+    const_float32 = float32("const_float32")
+    y = op(n_steps, x0_float32, const_float32)
+    assert y.dtype == "float32"
+
+
+def test_non_scalar_error():
+    x0 = float64("x0")
+    x = as_scalar(tensor_exp(x0))
+
+    with pytest.raises(
+        TypeError, match="must be composed exclusively of ScalarOp nodes"
+    ):
+        ScalarLoop(init=[x0], constant=[], update=[x])
+
+
+def test_n_steps_type_error():
+    x0 = float64("x0")
+    const = float64("const")
+    x = x0 + const
+
+    op = ScalarLoop(init=[x0], constant=[const], update=[x])
+    with pytest.raises(
+        TypeError, match=re.escape("(n_steps) must be of integer type. Got float64")
+    ):
+        op(float64("n_steps"), x0, const)
+
+
+def test_same_out_as_inp_error():
+    xtm2 = float64("xtm2")
+    xtm1 = float64("xtm1")
+    x = xtm2 + xtm1
+
+    with pytest.raises(
+        ValueError, match="Some inputs and outputs are the same variable"
+    ):
+        ScalarLoop(init=[xtm2, xtm1], update=[xtm1, x])
+
+
+@mode
+def test_lags(mode):
+    n_steps = int64("n_steps")
+    xtm2 = float64("xtm2")
+    xtm1 = float64("xtm1")
+    x = xtm2 + xtm1
+
+    op = ScalarLoop(init=[xtm2, xtm1], update=[identity(xtm1), x])
+    _, x = op(n_steps, xtm2, xtm1)
+
+    fn = function([n_steps, xtm2, xtm1], x, mode=mode)
+    np.testing.assert_allclose(fn(n_steps=5, xtm2=0, xtm1=1), 8)
+
+
+@mode
+def test_inner_composite(mode):
+    n_steps = int64("n_steps")
+    x = float64("x")
+
+    one = Composite([x], [cos(exp(x)) ** 2 + sin(exp(x)) ** 2])(x)
+
+    op = ScalarLoop(init=[x], update=[one + x])
+    y = op(n_steps, x)
+
+    fn = function([n_steps, x], y, mode=mode)
+    np.testing.assert_allclose(fn(n_steps=5, x=2.53), 2.53 + 5)
+
+    # Now with a dtype that must be rebuilt
+    x16 = float16("x16")
+    y16 = op(n_steps, x16)
+    assert y16.type.dtype == "float16"
+
+    fn32 = function([n_steps, x16], y16, mode=mode)
+    np.testing.assert_allclose(
+        fn32(n_steps=9, x16=np.array(4.73, dtype="float16")),
+        4.73 + 9,
+        rtol=1e-3,
+    )
+
+
+@mode
+def test_inner_loop(mode):
+    n_steps = int64("n_steps")
+    x = float64("x")
+
+    x_in = float64("x_in")
+    inner_loop_op = ScalarLoop(init=[x_in], update=[x_in + 1])
+
+    outer_loop_op = ScalarLoop(
+        init=[x], update=[inner_loop_op(n_steps, x)], constant=[n_steps]
+    )
+    y = outer_loop_op(n_steps, x, n_steps)
+
+    fn = function([n_steps, x], y, mode=mode)
+    np.testing.assert_allclose(fn(n_steps=5, x=0), 5**2)
+    np.testing.assert_allclose(fn(n_steps=7, x=0), 7**2)
+    np.testing.assert_allclose(fn(n_steps=7, x=1), 7**2 + 1)
+
+    # Now with a dtype that must be rebuilt
+    x16 = float16("x16")
+    y16 = outer_loop_op(n_steps, x16, n_steps)
+    assert y16.type.dtype == "float16"
+
+    fn32 = function([n_steps, x16], y16, mode=mode)
+    np.testing.assert_allclose(
+        fn32(n_steps=3, x16=np.array(2.5, dtype="float16")),
+        3**2 + 2.5,
+    )

--- a/tests/scalar/test_math.py
+++ b/tests/scalar/test_math.py
@@ -8,7 +8,7 @@ from pytensor.graph.fg import FunctionGraph
 from pytensor.link.c.basic import CLinker
 from pytensor.scalar.math import (
     betainc,
-    betainc_der,
+    betainc_grad,
     gammainc,
     gammaincc,
     gammal,
@@ -82,7 +82,7 @@ def test_betainc():
 
 def test_betainc_derivative_nan():
     a, b, x = at.scalars("a", "b", "x")
-    res = betainc_der(a, b, x, True)
+    res = betainc_grad(a, b, x, True)
     test_func = function([a, b, x], res, mode=Mode("py"))
     assert not np.isnan(test_func(1, 1, 1))
     assert np.isnan(test_func(1, 1, -1))


### PR DESCRIPTION
Used in the derivatives of `betainc`, `gammainc`, `gammaincc` and `hyp2f1`. 

It should be considerably faster than the old numpy loops, and easier to dispatch to numba and jax as well.

Alternative to #174 

Closes #83 

This is the kind of C code that is generated for the gammaincc gradient inner loop:
<details>
<summary>Toggle C code</summary>

```c

{
    bool until = 1;

    // Set carried inputs to initial state variables
    // Expressions in the loop will depend on these ones
    npy_float64 V41_i_copy0 = V41_i;
    npy_float64 V41_i_copy1 = V41_i;
    npy_float64 V41_i_copy2 = V41_i;
    npy_float64 V43_i_copy3 = V43_i;
    npy_float64 V43_i_copy4 = V43_i;
    npy_float64 V43_i_copy5 = V43_i;
    npy_int8 V39_i_copy6 = V39_i;
    npy_int8 V39_i_copy7 = V39_i;
    npy_int8 V39_i_copy8 = V39_i;
    npy_float64 V41_i_copy9 = V41_i;
    npy_int8 V39_i_copy10 = V39_i;
    npy_int8 V27_i_copy11 = V27_i;
    npy_int32 V37_i_copy12 = V37_i;

    // Loop away
    for (npy_int32 i = 0; i < V45_i; i++)
    {
        npy_float64 V47_tmp1;
        V47_tmp1 = V35_i + V37_i_copy12;

        npy_float64 V47_tmp2;
        V47_tmp2 = 1.0 / V47_tmp1;

        npy_float64 V47_tmp3;
        V47_tmp3 = V43_i_copy3 - V41_i_copy9;

        npy_float64 V47_tmp4;
        V47_tmp4 = exp((npy_float64)V47_tmp3);

        npy_int8 V47_tmp5;
        V47_tmp5 = V39_i_copy6 * V39_i_copy10;

        npy_float64 V47_tmp6;
        V47_tmp6 = V47_tmp5 * V47_tmp4;

        npy_float64 V47_tmp7;
        V47_tmp7 = V47_tmp6 + V47_tmp2;

        npy_float64 V47_tmp8;
        V47_tmp8 = fabs(V47_tmp7);

        npy_float64 V47_tmp9;
        V47_tmp9 = log((npy_float64)V47_tmp8);

        V25_i = V37_i_copy12 + 1;

        npy_float64 V47_tmp10;
        V47_tmp10 = V31_i + V37_i_copy12;

        npy_float64 V47_tmp11;
        V47_tmp11 = V47_tmp10 * V25_i;

        npy_float64 V47_tmp12;
        V47_tmp12 = V33_i + V37_i_copy12;

        npy_float64 V47_tmp13;
        V47_tmp13 = V47_tmp1 * V47_tmp12;

        npy_float64 V47_tmp14;
        V47_tmp14 = V47_tmp13 / V47_tmp11;

        npy_float64 V47_tmp15;
        V47_tmp15 = fabs(V47_tmp14);

        npy_float64 V47_tmp16;
        V47_tmp16 = log((npy_float64)V47_tmp15);

        npy_float64 V47_tmp17;
        V47_tmp17 = V41_i_copy9 + V47_tmp16;

        V19_i = V47_tmp17 + V29_i;

        V7_i = V19_i + V47_tmp9;

        npy_float64 V47_tmp18;
        V47_tmp18 = exp((npy_float64)V7_i);

        npy_bool V47_tmp19;
        V47_tmp19 = (V47_tmp14 > 0);

        npy_int8 V47_tmp20;
        V47_tmp20 = V47_tmp19 ? 1 : -1;

        V21_i = V47_tmp20 * V39_i_copy10;

        npy_bool V47_tmp21;
        V47_tmp21 = (V47_tmp7 > 0);

        npy_int8 V47_tmp22;
        V47_tmp22 = V47_tmp21 ? 1 : -1;

        V13_i = V47_tmp22 * V21_i;

        npy_float64 V47_tmp23;
        V47_tmp23 = V13_i * V47_tmp18;

        npy_float64 V47_tmp24;
        V47_tmp24 = V47_tmp23 * V27_i_copy11;

        npy_float64 V47_tmp25;
        V47_tmp25 = V41_i_copy0 + V47_tmp24;

        npy_bool V47_tmp26;
        V47_tmp26 = (V47_tmp14 == 0);

        V1_i = V47_tmp26 ? V41_i_copy0 : V47_tmp25;

        npy_float64 V47_tmp27;
        V47_tmp27 = 1.0 / V47_tmp12;

        npy_float64 V47_tmp28;
        V47_tmp28 = V43_i_copy4 - V41_i_copy9;

        npy_float64 V47_tmp29;
        V47_tmp29 = exp((npy_float64)V47_tmp28);

        npy_int8 V47_tmp30;
        V47_tmp30 = V39_i_copy7 * V39_i_copy10;

        npy_float64 V47_tmp31;
        V47_tmp31 = V47_tmp30 * V47_tmp29;

        npy_float64 V47_tmp32;
        V47_tmp32 = V47_tmp31 + V47_tmp27;

        npy_float64 V47_tmp33;
        V47_tmp33 = fabs(V47_tmp32);

        npy_float64 V47_tmp34;
        V47_tmp34 = log((npy_float64)V47_tmp33);

        V9_i = V19_i + V47_tmp34;

        npy_float64 V47_tmp35;
        V47_tmp35 = exp((npy_float64)V9_i);

        npy_bool V47_tmp36;
        V47_tmp36 = (V47_tmp32 > 0);

        npy_int8 V47_tmp37;
        V47_tmp37 = V47_tmp36 ? 1 : -1;

        V15_i = V47_tmp37 * V21_i;

        npy_float64 V47_tmp38;
        V47_tmp38 = V15_i * V47_tmp35;

        npy_float64 V47_tmp39;
        V47_tmp39 = V47_tmp38 * V27_i_copy11;

        npy_float64 V47_tmp40;
        V47_tmp40 = V41_i_copy1 + V47_tmp39;

        V3_i = V47_tmp26 ? V41_i_copy1 : V47_tmp40;

        npy_float64 V47_tmp41;
        V47_tmp41 = 1.0 / V47_tmp10;

        npy_float64 V47_tmp42;
        V47_tmp42 = V43_i_copy5 - V41_i_copy9;

        npy_float64 V47_tmp43;
        V47_tmp43 = exp((npy_float64)V47_tmp42);

        npy_int8 V47_tmp44;
        V47_tmp44 = V39_i_copy8 * V39_i_copy10;

        npy_float64 V47_tmp45;
        V47_tmp45 = V47_tmp44 * V47_tmp43;

        npy_float64 V47_tmp46;
        V47_tmp46 = V47_tmp45 - V47_tmp41;

        npy_float64 V47_tmp47;
        V47_tmp47 = fabs(V47_tmp46);

        npy_float64 V47_tmp48;
        V47_tmp48 = log((npy_float64)V47_tmp47);

        V11_i = V19_i + V47_tmp48;

        npy_float64 V47_tmp49;
        V47_tmp49 = exp((npy_float64)V11_i);

        npy_bool V47_tmp50;
        V47_tmp50 = (V47_tmp46 > 0);

        npy_int8 V47_tmp51;
        V47_tmp51 = V47_tmp50 ? 1 : -1;

        V17_i = V47_tmp51 * V21_i;

        npy_float64 V47_tmp52;
        V47_tmp52 = V17_i * V47_tmp49;

        npy_float64 V47_tmp53;
        V47_tmp53 = V47_tmp52 * V27_i_copy11;

        npy_float64 V47_tmp54;
        V47_tmp54 = V41_i_copy2 + V47_tmp53;

        V5_i = V47_tmp26 ? V41_i_copy2 : V47_tmp54;

        V23_i = V27_i_copy11 * V27_i;

        npy_float64 V47_tmp55;
        V47_tmp55 = fabs(V47_tmp53);

        npy_float64 V47_tmp56;
        V47_tmp56 = fabs(V47_tmp39);

        npy_float64 V47_tmp57;
        V47_tmp57 = fabs(V47_tmp24);

        npy_float64 V47_tmp58;
        V47_tmp58 = ((V47_tmp56) > (V47_tmp57) ? (V47_tmp56) : ((V47_tmp57) >= (V47_tmp56) ? (V47_tmp57) : nan("")));

        npy_float64 V47_tmp59;
        V47_tmp59 = ((V47_tmp55) > (V47_tmp58) ? (V47_tmp55) : ((V47_tmp58) >= (V47_tmp55) ? (V47_tmp58) : nan("")));

        npy_bool V47_tmp60;
        V47_tmp60 = (V47_tmp59 <= 1e-14);

        npy_bool V47_tmp61;
        V47_tmp61 = (V25_i > 10);

        npy_bool V47_tmp62;
        V47_tmp62 = (V47_tmp61 & V47_tmp60);

        until = (V47_tmp26 | V47_tmp62);

        // Set carried inputs to output variables
        V41_i_copy0 = V1_i;
        V41_i_copy1 = V3_i;
        V41_i_copy2 = V5_i;
        V43_i_copy3 = V7_i;
        V43_i_copy4 = V9_i;
        V43_i_copy5 = V11_i;
        V39_i_copy6 = V13_i;
        V39_i_copy7 = V15_i;
        V39_i_copy8 = V17_i;
        V41_i_copy9 = V19_i;
        V39_i_copy10 = V21_i;
        V27_i_copy11 = V23_i;
        V37_i_copy12 = V25_i;

        if (until)
        {
            break;
        }
    }

    if (!until)
    {
        PyErr_WarnEx(PyExc_RuntimeWarning, "Until condition in ScalarLoop hyp2f1_grad not reached!", 1);
    }
}
```
</details>