### PR TITLE
Only build Extension if not building a universal wheel.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
-import os
-
+import os, sys
+import logging
 import numpy
 from setuptools import Extension, setup
 from setuptools.dist import Distribution
 
 import versioneer
-
 
 dist = Distribution()
 dist.parse_config_files()
@@ -30,17 +29,21 @@ if "BUILD_PYTENSOR_NIGHTLY" in os.environ:
 
     versioneer.get_versions = get_versions
 
+ext_modules = []
+if "--universal" not in sys.argv:
+    # Building non-binary wheels does not support Extensions
+    ext_modules.append(
+        Extension(
+                    name="pytensor.scan.scan_perform",
+                    sources=["pytensor/scan/scan_perform.pyx"],
+                    include_dirs=[numpy.get_include()],
+                )
+    )
 
 if __name__ == "__main__":
     setup(
         name=NAME,
         version=versioneer.get_version(),
         cmdclass=versioneer.get_cmdclass(),
-        ext_modules=[
-            Extension(
-                name="pytensor.scan.scan_perform",
-                sources=["pytensor/scan/scan_perform.pyx"],
-                include_dirs=[numpy.get_include()],
-            ),
-        ],
+        ext_modules=ext_modules
     )


### PR DESCRIPTION
Closes #285.

We probably want to add the universal build and upload to our auto-builder (not sure how that works, maybe someone can point me in the right direction).

The use-case for this is that pyodide requires universal wheels. However, I'm a bit concerned that with this change, non-pyodide users will somehow install these wheels and then only super-slow Python mode. At least we have a warning but still, could be an unwanted side-effect. As we have binary-wheels I *hope* that those should always get installed instead, but I'm not sure.

Still, with this change, we can directly install pymc in the browser without further modifications.

### Checklist
+ [ ] Explain motivation and implementation 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [ ] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇


## Major / Breaking Changes
- ...

## New features
- ...

## Bugfixes
- ...

## Documentation
- ...

## Maintenance
- ...

