### PR TITLE
Fix JAX Scan for output ndim > 1

### DIFF
--- a/pytensor/link/jax/dispatch/scan.py
+++ b/pytensor/link/jax/dispatch/scan.py
@@ -3,7 +3,7 @@ import jax.numpy as jnp
 
 from pytensor.link.jax.dispatch.basic import jax_funcify
 from pytensor.scan.op import Scan
-from pytensor.compile.sharedvalue import SharedVariable
+
 
 @jax_funcify.register(Scan)
 def jax_funcify_Scan(op: Scan, **kwargs):
@@ -42,11 +42,12 @@ def jax_funcify_Scan(op: Scan, **kwargs):
             op.outer_non_seqs(outer_inputs),
         )  # JAX `init`
 
-        ndim_out_core = [getattr(x, 'ndim', 0) for x in op.fgraph.outputs]
-        ndim_in_core  = [getattr(x, 'ndim', 0) for x in mit_sot_init + sit_sot_init]
+        ndim_out_core = [getattr(x, "ndim", 0) for x in op.fgraph.outputs]
+        ndim_in_core = [getattr(x, "ndim", 0) for x in mit_sot_init + sit_sot_init]
 
-        n_batchdims = [int(dims_out > 0) for dims_out, dims_in in zip(ndim_out_core, ndim_in_core)] +\
-            [0] * op.info.n_nit_sot
+        n_batchdims = [
+            int(dims_out > 0) for dims_out, dims_in in zip(ndim_out_core, ndim_in_core)
+        ] + [0] * op.info.n_nit_sot
 
         def jax_args_to_inner_func_args(carry, x):
             """Convert JAX scan arguments into format expected by scan_inner_func.
@@ -157,13 +158,17 @@ def jax_funcify_Scan(op: Scan, **kwargs):
                 + op.outer_nitsot(outer_inputs)
             )
             partial_traces = []
-            for init_state, trace, n_batchdim, buffer in zip(init_states, traces, n_batchdims, buffers):
+            for init_state, trace, n_batchdim, buffer in zip(
+                init_states, traces, n_batchdims, buffers
+            ):
                 if init_state is not None:
                     # MIT-SOT and SIT-SOT: The final output should be as long as the input buffer
                     batch_idx = range(n_batchdim)
                     full_trace = jnp.concatenate(
-                        [jnp.atleast_1d(jnp.expand_dims(init_state, batch_idx)), 
-                        jnp.atleast_1d(trace)],
+                        [
+                            jnp.atleast_1d(jnp.expand_dims(init_state, batch_idx)),
+                            jnp.atleast_1d(trace),
+                        ],
                         axis=0,
                     )
                     buffer_size = buffer.shape[0]

--- a/tests/link/jax/test_scan.py
+++ b/tests/link/jax/test_scan.py
@@ -13,14 +13,11 @@ from pytensor.scan.basic import scan
 from pytensor.scan.op import Scan
 from pytensor.tensor import random
 from pytensor.tensor.math import gammaln, log
-from pytensor.tensor.type import lscalar, scalar, vector, dmatrix, dvector
+from pytensor.tensor.type import dmatrix, dvector, lscalar, scalar, vector
 from tests.link.jax.test_basic import compare_jax_and_py
 
 
-# jax = pytest.importorskip("jax")
-
-import jax
-jax.config.update('jax_platform_name', 'cpu')
+jax = pytest.importorskip("jax")
 
 
 @pytest.mark.parametrize("view", [None, (-1,), slice(-2, None, None)])
@@ -322,22 +319,24 @@ def test_scan_mitsot_with_nonseq():
     compare_jax_and_py(out_fg, test_input_vals)
 
 
-@pytest.mark.parametrize('x0_func', [dvector, dmatrix])
-@pytest.mark.parametrize('A_func',  [dmatrix, dmatrix])
+@pytest.mark.parametrize("x0_func", [dvector, dmatrix])
+@pytest.mark.parametrize("A_func", [dmatrix, dmatrix])
 def test_nd_scan_sit_sot(x0_func, A_func):
-    x0 = x0_func('x0')
-    A  = A_func('A')
+    x0 = x0_func("x0")
+    A = A_func("A")
 
     n_steps = 3
     k = 3
 
     # Must specify mode = JAX for the inner func to avoid a GEMM Op in the JAX graph
-    xs, _ = scan(lambda X, A: A @ X, 
-                            non_sequences=[A],
-                            outputs_info=[x0],
-                            n_steps=n_steps,
-                            mode=get_mode('JAX'))
-                
+    xs, _ = scan(
+        lambda X, A: A @ X,
+        non_sequences=[A],
+        outputs_info=[x0],
+        n_steps=n_steps,
+        mode=get_mode("JAX"),
+    )
+
     x0_val = np.arange(k) if x0.ndim == 1 else np.diag(np.arange(k))
     A_val = np.eye(k)
 
@@ -347,19 +346,21 @@ def test_nd_scan_sit_sot(x0_func, A_func):
 
 
 def test_nd_scan_sit_sot_with_seq():
-    x = dmatrix('x0')
-    A  = dmatrix('A')
+    x = dmatrix("x0")
+    A = dmatrix("A")
 
     n_steps = 3
     k = 3
 
     # Must specify mode = JAX for the inner func to avoid a GEMM Op in the JAX graph
-    xs, _ = scan(lambda X, A: A @ X, 
-                            non_sequences=[A],
-                            sequences=[x],
-                            n_steps=n_steps,
-                            mode=get_mode('JAX'))
-                
+    xs, _ = scan(
+        lambda X, A: A @ X,
+        non_sequences=[A],
+        sequences=[x],
+        n_steps=n_steps,
+        mode=get_mode("JAX"),
+    )
+
     x_val = np.tile(np.arange(k), n_steps).reshape(n_steps, k)
     A_val = np.eye(k)
 
@@ -369,9 +370,9 @@ def test_nd_scan_sit_sot_with_seq():
 
 
 def test_nd_scan_mit_sot():
-    x0 = dmatrix('x0')
-    A  = dmatrix('A')
-    B  = dmatrix('B')
+    x0 = dmatrix("x0")
+    A = dmatrix("A")
+    B = dmatrix("B")
 
     # Must specify mode = JAX for the inner func to avoid a GEMM Op in the JAX graph
     xs, _ = scan(
@@ -379,7 +380,7 @@ def test_nd_scan_mit_sot():
         outputs_info=[{"initial": x0, "taps": [-3, -1]}],
         non_sequences=[A, B],
         n_steps=10,
-        mode = get_mode('JAX')
+        mode=get_mode("JAX"),
     )
 
     fg = FunctionGraph([x0, A, B], [xs])
@@ -392,8 +393,8 @@ def test_nd_scan_mit_sot():
 
 
 def test_nd_scan_sit_sot_with_carry():
-    x0 = dvector('x0')
-    A  = dmatrix('A')
+    x0 = dvector("x0")
+    A = dmatrix("A")
 
     def step(x, A):
         return A @ x, x.sum()
@@ -404,7 +405,7 @@ def test_nd_scan_sit_sot_with_carry():
         outputs_info=[x0, None],
         non_sequences=[A],
         n_steps=10,
-        mode = get_mode('JAX')
+        mode=get_mode("JAX"),
     )
 
     fg = FunctionGraph([x0, A], xs)

--- a/tests/link/jax/test_scan.py
+++ b/tests/link/jax/test_scan.py
@@ -346,11 +346,11 @@ def test_nd_scan_sit_sot(x0_func, A_func):
 
 
 def test_nd_scan_sit_sot_with_seq():
-    x = dmatrix("x0")
-    A = dmatrix("A")
-
     n_steps = 3
     k = 3
+
+    x = at.matrix("x0", shape=(n_steps, k))
+    A = at.matrix("A", shape=(k, k))
 
     # Must specify mode = JAX for the inner func to avoid a GEMM Op in the JAX graph
     xs, _ = scan(
@@ -370,9 +370,9 @@ def test_nd_scan_sit_sot_with_seq():
 
 
 def test_nd_scan_mit_sot():
-    x0 = dmatrix("x0")
-    A = dmatrix("A")
-    B = dmatrix("B")
+    x0 = at.matrix("x0", shape=(3, 3))
+    A = at.matrix("A", shape=(3, 3))
+    B = at.matrix("B", shape=(3, 3))
 
     # Must specify mode = JAX for the inner func to avoid a GEMM Op in the JAX graph
     xs, _ = scan(
@@ -385,6 +385,7 @@ def test_nd_scan_mit_sot():
 
     fg = FunctionGraph([x0, A, B], [xs])
     x0_val = np.r_[[np.arange(3).tolist()] * 3]
+    print(x0_val)
     A_val = np.eye(3)
     B_val = np.eye(3)
 
@@ -393,8 +394,8 @@ def test_nd_scan_mit_sot():
 
 
 def test_nd_scan_sit_sot_with_carry():
-    x0 = dvector("x0")
-    A = dmatrix("A")
+    x0 = at.vector("x0", shape=(3,))
+    A = at.matrix("A", shape=(3, 3))
 
     def step(x, A):
         return A @ x, x.sum()

--- a/tests/link/jax/test_scan.py
+++ b/tests/link/jax/test_scan.py
@@ -337,8 +337,10 @@ def test_nd_scan_sit_sot(x0_func, A_func):
         mode=get_mode("JAX"),
     )
 
-    x0_val = np.arange(k) if x0.ndim == 1 else np.diag(np.arange(k))
-    A_val = np.eye(k)
+    x0_val = (
+        np.arange(k, dtype=config.floatX) if x0.ndim == 1 else np.diag(np.arange(k))
+    )
+    A_val = np.eye(k, dtype=config.floatX)
 
     fg = FunctionGraph([x0, A], [xs])
     test_input_vals = [x0_val, A_val]
@@ -361,8 +363,8 @@ def test_nd_scan_sit_sot_with_seq():
         mode=get_mode("JAX"),
     )
 
-    x_val = np.tile(np.arange(k), n_steps).reshape(n_steps, k)
-    A_val = np.eye(k)
+    x_val = np.tile(np.arange(k, dtype=config.floatX), n_steps).reshape(n_steps, k)
+    A_val = np.eye(k, dtype=config.floatX)
 
     fg = FunctionGraph([x, A], [xs])
     test_input_vals = [x_val, A_val]
@@ -384,10 +386,9 @@ def test_nd_scan_mit_sot():
     )
 
     fg = FunctionGraph([x0, A, B], [xs])
-    x0_val = np.r_[[np.arange(3).tolist()] * 3]
-    print(x0_val)
-    A_val = np.eye(3)
-    B_val = np.eye(3)
+    x0_val = np.r_[[np.arange(3, dtype=config.floatX).tolist()] * 3]
+    A_val = np.eye(3, dtype=config.floatX)
+    B_val = np.eye(3, dtype=config.floatX)
 
     test_input_vals = [x0_val, A_val, B_val]
     compare_jax_and_py(fg, test_input_vals)
@@ -410,8 +411,8 @@ def test_nd_scan_sit_sot_with_carry():
     )
 
     fg = FunctionGraph([x0, A], xs)
-    x0_val = np.arange(3)
-    A_val = np.eye(3)
+    x0_val = np.arange(3, dtype=config.floatX)
+    A_val = np.eye(3, dtype=config.floatX)
 
     test_input_vals = [x0_val, A_val]
     compare_jax_and_py(fg, test_input_vals)

--- a/tests/link/jax/test_scan.py
+++ b/tests/link/jax/test_scan.py
@@ -13,11 +13,14 @@ from pytensor.scan.basic import scan
 from pytensor.scan.op import Scan
 from pytensor.tensor import random
 from pytensor.tensor.math import gammaln, log
-from pytensor.tensor.type import lscalar, scalar, vector
+from pytensor.tensor.type import lscalar, scalar, vector, dmatrix, dvector
 from tests.link.jax.test_basic import compare_jax_and_py
 
 
-jax = pytest.importorskip("jax")
+# jax = pytest.importorskip("jax")
+
+import jax
+jax.config.update('jax_platform_name', 'cpu')
 
 
 @pytest.mark.parametrize("view", [None, (-1,), slice(-2, None, None)])
@@ -317,3 +320,96 @@ def test_scan_mitsot_with_nonseq():
 
     test_input_vals = [np.array(10.0).astype(config.floatX)]
     compare_jax_and_py(out_fg, test_input_vals)
+
+
+@pytest.mark.parametrize('x0_func', [dvector, dmatrix])
+@pytest.mark.parametrize('A_func',  [dmatrix, dmatrix])
+def test_nd_scan_sit_sot(x0_func, A_func):
+    x0 = x0_func('x0')
+    A  = A_func('A')
+
+    n_steps = 3
+    k = 3
+
+    # Must specify mode = JAX for the inner func to avoid a GEMM Op in the JAX graph
+    xs, _ = scan(lambda X, A: A @ X, 
+                            non_sequences=[A],
+                            outputs_info=[x0],
+                            n_steps=n_steps,
+                            mode=get_mode('JAX'))
+                
+    x0_val = np.arange(k) if x0.ndim == 1 else np.diag(np.arange(k))
+    A_val = np.eye(k)
+
+    fg = FunctionGraph([x0, A], [xs])
+    test_input_vals = [x0_val, A_val]
+    compare_jax_and_py(fg, test_input_vals)
+
+
+def test_nd_scan_sit_sot_with_seq():
+    x = dmatrix('x0')
+    A  = dmatrix('A')
+
+    n_steps = 3
+    k = 3
+
+    # Must specify mode = JAX for the inner func to avoid a GEMM Op in the JAX graph
+    xs, _ = scan(lambda X, A: A @ X, 
+                            non_sequences=[A],
+                            sequences=[x],
+                            n_steps=n_steps,
+                            mode=get_mode('JAX'))
+                
+    x_val = np.tile(np.arange(k), n_steps).reshape(n_steps, k)
+    A_val = np.eye(k)
+
+    fg = FunctionGraph([x, A], [xs])
+    test_input_vals = [x_val, A_val]
+    compare_jax_and_py(fg, test_input_vals)
+
+
+def test_nd_scan_mit_sot():
+    x0 = dmatrix('x0')
+    A  = dmatrix('A')
+    B  = dmatrix('B')
+
+    # Must specify mode = JAX for the inner func to avoid a GEMM Op in the JAX graph
+    xs, _ = scan(
+        lambda xtm3, xtm1, A, B: A @ xtm3 + B @ xtm1,
+        outputs_info=[{"initial": x0, "taps": [-3, -1]}],
+        non_sequences=[A, B],
+        n_steps=10,
+        mode = get_mode('JAX')
+    )
+
+    fg = FunctionGraph([x0, A, B], [xs])
+    x0_val = np.r_[[np.arange(3).tolist()] * 3]
+    A_val = np.eye(3)
+    B_val = np.eye(3)
+
+    test_input_vals = [x0_val, A_val, B_val]
+    compare_jax_and_py(fg, test_input_vals)
+
+
+def test_nd_scan_sit_sot_with_carry():
+    x0 = dvector('x0')
+    A  = dmatrix('A')
+
+    def step(x, A):
+        return A @ x, x.sum()
+
+    # Must specify mode = JAX for the inner func to avoid a GEMM Op in the JAX graph
+    xs, _ = scan(
+        step,
+        outputs_info=[x0, None],
+        non_sequences=[A],
+        n_steps=10,
+        mode = get_mode('JAX')
+    )
+
+    fg = FunctionGraph([x0, A], xs)
+    x0_val = np.arange(3)
+    A_val = np.eye(3)
+
+    test_input_vals = [x0_val, A_val]
+    compare_jax_and_py(fg, test_input_vals)

--- a/tests/link/jax/test_scan.py
+++ b/tests/link/jax/test_scan.py
@@ -1,7 +1,5 @@
 import re
 
-# jax = pytest.importorskip("jax")
-import jax
 import numpy as np
 import pytest
 
@@ -19,8 +17,7 @@ from pytensor.tensor.type import dmatrix, dvector, lscalar, scalar, vector
 from tests.link.jax.test_basic import compare_jax_and_py
 
 
-jax.config.update("jax_platform_name", "cpu")
-config.floatX = "float32"
+jax = pytest.importorskip("jax")
 
 
 @pytest.mark.parametrize("view", [None, (-1,), slice(-2, None, None)])

--- a/tests/link/jax/test_scan.py
+++ b/tests/link/jax/test_scan.py
@@ -1,5 +1,7 @@
 import re
 
+# jax = pytest.importorskip("jax")
+import jax
 import numpy as np
 import pytest
 
@@ -17,7 +19,8 @@ from pytensor.tensor.type import dmatrix, dvector, lscalar, scalar, vector
 from tests.link.jax.test_basic import compare_jax_and_py
 
 
-jax = pytest.importorskip("jax")
+jax.config.update("jax_platform_name", "cpu")
+config.floatX = "float32"
 
 
 @pytest.mark.parametrize("view", [None, (-1,), slice(-2, None, None)])
@@ -338,7 +341,9 @@ def test_nd_scan_sit_sot(x0_func, A_func):
     )
 
     x0_val = (
-        np.arange(k, dtype=config.floatX) if x0.ndim == 1 else np.diag(np.arange(k))
+        np.arange(k, dtype=config.floatX)
+        if x0.ndim == 1
+        else np.diag(np.arange(k, dtype=config.floatX))
     )
     A_val = np.eye(k, dtype=config.floatX)
 
@@ -363,7 +368,7 @@ def test_nd_scan_sit_sot_with_seq():
         mode=get_mode("JAX"),
     )
 
-    x_val = np.tile(np.arange(k, dtype=config.floatX), n_steps).reshape(n_steps, k)
+    x_val = np.arange(n_steps * k, dtype=config.floatX).reshape(n_steps, k)
     A_val = np.eye(k, dtype=config.floatX)
 
     fg = FunctionGraph([x, A], [xs])
@@ -386,7 +391,7 @@ def test_nd_scan_mit_sot():
     )
 
     fg = FunctionGraph([x0, A, B], [xs])
-    x0_val = np.r_[[np.arange(3, dtype=config.floatX).tolist()] * 3]
+    x0_val = np.arange(9, dtype=config.floatX).reshape(3, 3)
     A_val = np.eye(3, dtype=config.floatX)
     B_val = np.eye(3, dtype=config.floatX)
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

### Motivation for these changes

Closes #287 Currently, JAX compilation of scans with n-dimensional outputs fails.

### Implementation details
Checks input and output dimensions, and adds a batch dimension to initial inputs where necessary.

Marked as draft because there are still some problems:

1. Currently, just check if output.ndim > 1 and insert a single dimension to the initial input if so. I think this is the only case possible given the shape checking that is done by `scan` itself. Since all outputs must be 1 dimension smaller than the inputs, I don't think it's possible to reach a case where more than 1 batch dimension needs to be inserted. Nevertheless, the machinery to do this exists in this code if necessary.

2. Big problem: nd sequences and mit_sots do not work. This is captured by two tests in this PR:  `test_nd_scan_mit_sot` and `test_nd_scan_sit_sot_with_seq`. The error raised in both cases is `NotImplementedError: JAX does not support slicing arrays with a dynamic slice length.`. I'm not sure why the slices are dynamic though, we should be able to pre-compute all the required slices? It just doesn't seem much different from the normal 1d array case.

### Checklist
+ [ x] Explain motivation and implementation 👆
+ [x ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ x] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [ x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [x ] Are the changes covered by tests and docstrings?
+ [x ] Fill out the short summary sections 👇


## Major / Breaking Changes
I hope none, all tests in test/linker/jax/test_scan pass

## New features
JAX support for more flavors of scan

## Bugfixes
Scan no longer errors when outputs are ndim > 1 and mode = JAX 

## Documentation
None

## Maintenance
- ...

