### PR TITLE
Fetch all commits and tags when building sdist

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -24,6 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           submodules: true
 
       - name: Build SDist


### PR DESCRIPTION
Otherwise the version comes up as "untagged" and the sdist can't be uploaded to PyPI.

<!-- !! Thank your for opening a PR !! -->

### Motivation for these changes
No sdist appeared on the latest PyPI release.

### Implementation details
Enable checking out tags so that versioneer can do its thing.


### Checklist
+ [X] Explain motivation and implementation 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [ ] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇


## Major / Breaking Changes
- ...

## New features
- ...

## Bugfixes
- Fix missing sdist on PyPI

## Documentation
- ...

## Maintenance
- ...

