### PR TITLE
Add jax implementation of `pt.linalg.pinv`

### DIFF
--- a/pytensor/link/jax/dispatch/nlinalg.py
+++ b/pytensor/link/jax/dispatch/nlinalg.py
@@ -3,7 +3,16 @@ import jax.numpy as jnp
 from pytensor.link.jax.dispatch import jax_funcify
 from pytensor.tensor.blas import BatchedDot
 from pytensor.tensor.math import Dot, MaxAndArgmax
-from pytensor.tensor.nlinalg import SVD, Det, Eig, Eigh, MatrixInverse, QRFull, SLogDet, MatrixPinv
+from pytensor.tensor.nlinalg import (
+    SVD,
+    Det,
+    Eig,
+    Eigh,
+    MatrixInverse,
+    MatrixPinv,
+    QRFull,
+    SLogDet,
+)
 
 
 @jax_funcify.register(SVD)
@@ -119,7 +128,7 @@ def jax_funcify_MaxAndArgmax(op, **kwargs):
             x, jnp.concatenate((keep_axes, jnp.array(axes, dtype="int64")))
         )
         kept_shape = transposed_x.shape[: len(keep_axes)]
-        reduced_shape = transposed_x.shape[len(keep_axes):]
+        reduced_shape = transposed_x.shape[len(keep_axes) :]
 
         # Numpy.prod returns 1.0 when arg is empty, so we cast it to int64
         # Otherwise reshape would complain citing float arg

--- a/pytensor/link/jax/dispatch/nlinalg.py
+++ b/pytensor/link/jax/dispatch/nlinalg.py
@@ -3,7 +3,7 @@ import jax.numpy as jnp
 from pytensor.link.jax.dispatch import jax_funcify
 from pytensor.tensor.blas import BatchedDot
 from pytensor.tensor.math import Dot, MaxAndArgmax
-from pytensor.tensor.nlinalg import SVD, Det, Eig, Eigh, MatrixInverse, QRFull, SLogDet
+from pytensor.tensor.nlinalg import SVD, Det, Eig, Eigh, MatrixInverse, QRFull, SLogDet, MatrixPinv
 
 
 @jax_funcify.register(SVD)
@@ -77,6 +77,14 @@ def jax_funcify_Dot(op, **kwargs):
     return dot
 
 
+@jax_funcify.register(MatrixPinv)
+def jax_funcify_Pinv(op, **kwargs):
+    def pinv(x):
+        return jnp.linalg.pinv(x)
+
+    return pinv
+
+
 @jax_funcify.register(BatchedDot)
 def jax_funcify_BatchedDot(op, **kwargs):
     def batched_dot(a, b):
@@ -111,7 +119,7 @@ def jax_funcify_MaxAndArgmax(op, **kwargs):
             x, jnp.concatenate((keep_axes, jnp.array(axes, dtype="int64")))
         )
         kept_shape = transposed_x.shape[: len(keep_axes)]
-        reduced_shape = transposed_x.shape[len(keep_axes) :]
+        reduced_shape = transposed_x.shape[len(keep_axes):]
 
         # Numpy.prod returns 1.0 when arg is empty, so we cast it to int64
         # Otherwise reshape would complain citing float arg

--- a/tests/link/jax/test_nlinalg.py
+++ b/tests/link/jax/test_nlinalg.py
@@ -134,3 +134,13 @@ def test_tensor_basics():
     out = at_max(y)
     fgraph = FunctionGraph([y], [out])
     compare_jax_and_py(fgraph, [get_test_value(i) for i in fgraph.inputs])
+
+
+def test_pinv():
+    x = matrix('x')
+    x_inv = at_nlinalg.pinv(x)
+
+    fgraph = FunctionGraph([x], [x_inv])
+    x_np = np.array([[1.0, 2.0], [3.0, 4.0]])
+    compare_jax_and_py(fgraph, [x_np])
+

--- a/tests/link/jax/test_nlinalg.py
+++ b/tests/link/jax/test_nlinalg.py
@@ -1,5 +1,3 @@
-# jax = pytest.importorskip("jax")
-import jax
 import numpy as np
 import pytest
 from packaging.version import parse as version_parse
@@ -20,7 +18,7 @@ from pytensor.tensor.type import dvector, matrix, scalar, tensor3, vector
 from tests.link.jax.test_basic import compare_jax_and_py
 
 
-jax.config.update("jax_platform_name", "cpu")
+jax = pytest.importorskip("jax")
 
 
 def test_jax_BatchedDot():

--- a/tests/link/jax/test_nlinalg.py
+++ b/tests/link/jax/test_nlinalg.py
@@ -1,3 +1,5 @@
+# jax = pytest.importorskip("jax")
+import jax
 import numpy as np
 import pytest
 from packaging.version import parse as version_parse
@@ -18,7 +20,7 @@ from pytensor.tensor.type import dvector, matrix, scalar, tensor3, vector
 from tests.link.jax.test_basic import compare_jax_and_py
 
 
-jax = pytest.importorskip("jax")
+jax.config.update("jax_platform_name", "cpu")
 
 
 def test_jax_BatchedDot():
@@ -137,10 +139,9 @@ def test_tensor_basics():
 
 
 def test_pinv():
-    x = matrix('x')
+    x = matrix("x")
     x_inv = at_nlinalg.pinv(x)
 
     fgraph = FunctionGraph([x], [x_inv])
     x_np = np.array([[1.0, 2.0], [3.0, 4.0]])
     compare_jax_and_py(fgraph, [x_np])
-


### PR DESCRIPTION
### Motivation for these changes
Add a jax implementation of `pt.linalg.pinv`

### Implementation details
Not the most elaborate PR:

```
@jax_funcify.register(MatrixPinv)
def jax_funcify_Pinv(op, **kwargs):
    def pinv(x):
        return jnp.linalg.pinv(x)

    return pinv
```

### Checklist
+ [ x] Explain motivation and implementation 👆
+ [ x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x ] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [x ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇


## Major / Breaking Changes
None

## New features
You can compile graphs with `pinv` to JAX

## Bugfixes
None

## Documentation
None

## Maintenance
None

