### PR TITLE
Don't fail on benchmark alert

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -218,8 +218,8 @@ jobs:
             external-data-json-path: ./cache/benchmark-data.json
             alert-threshold: '200%'
             github-token: ${{ secrets.GITHUB_TOKEN }}
-            comment-on-alert: ${{ github.event_name == 'push' }}
-            fail-on-alert: true
+            comment-on-alert: false
+            fail-on-alert: false
             auto-push: false
 
   all-checks:


### PR DESCRIPTION
The benchmark CI seems too flaky to be used as a required condition.

We will leave it to the reviewers to assess the need to investigate individual cases where it fails.