### PR TITLE
Implement Blockwise Op to vectorize existing Ops

### DIFF
--- a/pytensor/compile/mode.py
+++ b/pytensor/compile/mode.py
@@ -251,13 +251,14 @@ optdb.register("uncanonicalize", EquilibriumDB(), "fast_run", position=3)
 # especially constant merge
 optdb.register("merge2", MergeOptimizer(), "fast_run", "merge", position=49)
 
+optdb.register("py_only", EquilibriumDB(), "fast_compile", position=49.1)
+
 optdb.register(
     "add_destroy_handler", AddDestroyHandler(), "fast_run", "inplace", position=49.5
 )
 
 # final pass just to make sure
 optdb.register("merge3", MergeOptimizer(), "fast_run", "merge", position=100)
-optdb.register("py_only", EquilibriumDB(), "fast_compile", position=100)
 
 _tags: Union[Tuple[str, str], Tuple]
 

--- a/pytensor/graph/__init__.py
+++ b/pytensor/graph/__init__.py
@@ -9,7 +9,7 @@ from pytensor.graph.basic import (
     clone,
     ancestors,
 )
-from pytensor.graph.replace import clone_replace, graph_replace
+from pytensor.graph.replace import clone_replace, graph_replace, vectorize
 from pytensor.graph.op import Op
 from pytensor.graph.type import Type
 from pytensor.graph.fg import FunctionGraph

--- a/pytensor/link/numba/dispatch/nlinalg.py
+++ b/pytensor/link/numba/dispatch/nlinalg.py
@@ -14,7 +14,6 @@ from pytensor.tensor.nlinalg import (
     Det,
     Eig,
     Eigh,
-    Inv,
     MatrixInverse,
     MatrixPinv,
     QRFull,
@@ -123,18 +122,6 @@ def numba_funcify_Eigh(op, node, **kwargs):
             return np.linalg.eigh(x)
 
     return eigh
-
-
-@numba_funcify.register(Inv)
-def numba_funcify_Inv(op, node, **kwargs):
-    out_dtype = node.outputs[0].type.numpy_dtype
-    inputs_cast = int_to_float_fn(node.inputs, out_dtype)
-
-    @numba_basic.numba_njit(inline="always")
-    def inv(x):
-        return np.linalg.inv(inputs_cast(x)).astype(out_dtype)
-
-    return inv
 
 
 @numba_funcify.register(MatrixInverse)

--- a/pytensor/scalar/loop.py
+++ b/pytensor/scalar/loop.py
@@ -2,7 +2,8 @@ from itertools import chain
 from typing import Optional, Sequence, Tuple
 
 from pytensor.compile import rebuild_collect_shared
-from pytensor.graph import Constant, FunctionGraph, Variable, clone
+from pytensor.graph.basic import Constant, Variable, clone
+from pytensor.graph.fg import FunctionGraph
 from pytensor.scalar.basic import ScalarInnerGraphOp, as_scalar
 
 

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -3764,7 +3764,7 @@ def stacklists(arg):
         return arg
 
 
-def swapaxes(y, axis1, axis2):
+def swapaxes(y, axis1: int, axis2: int) -> TensorVariable:
     "Swap the axes of a tensor."
     y = as_tensor_variable(y)
     ndim = y.ndim

--- a/pytensor/tensor/blockwise.py
+++ b/pytensor/tensor/blockwise.py
@@ -1,0 +1,413 @@
+import re
+from functools import singledispatch
+from typing import Any, Dict, List, Optional, Sequence, Tuple, cast
+
+import numpy as np
+
+from pytensor import config
+from pytensor.gradient import DisconnectedType
+from pytensor.graph.basic import Apply, Constant, Variable
+from pytensor.graph.null_type import NullType
+from pytensor.graph.op import Op
+from pytensor.tensor import as_tensor_variable
+from pytensor.tensor.shape import shape_padleft
+from pytensor.tensor.type import continuous_dtypes, discrete_dtypes, tensor
+from pytensor.tensor.utils import broadcast_static_dim_lengths, import_func_from_string
+from pytensor.tensor.variable import TensorVariable
+
+
+# TODO: Implement vectorize helper to batch whole graphs (similar to what Blockwise does for the grad)
+
+# Copied verbatim from numpy.lib.function_base
+# https://github.com/numpy/numpy/blob/f2db090eb95b87d48a3318c9a3f9d38b67b0543c/numpy/lib/function_base.py#L1999-L2029
+_DIMENSION_NAME = r"\w+"
+_CORE_DIMENSION_LIST = "(?:{0:}(?:,{0:})*)?".format(_DIMENSION_NAME)
+_ARGUMENT = rf"\({_CORE_DIMENSION_LIST}\)"
+_ARGUMENT_LIST = "{0:}(?:,{0:})*".format(_ARGUMENT)
+_SIGNATURE = "^{0:}->{0:}$".format(_ARGUMENT_LIST)
+
+
+def _parse_gufunc_signature(signature):
+    """
+    Parse string signatures for a generalized universal function.
+
+    Arguments
+    ---------
+    signature : string
+        Generalized universal function signature, e.g., ``(m,n),(n,p)->(m,p)``
+        for ``np.matmul``.
+
+    Returns
+    -------
+    Tuple of input and output core dimensions parsed from the signature, each
+    of the form List[Tuple[str, ...]].
+    """
+    signature = re.sub(r"\s+", "", signature)
+
+    if not re.match(_SIGNATURE, signature):
+        raise ValueError(f"not a valid gufunc signature: {signature}")
+    return tuple(
+        [
+            tuple(re.findall(_DIMENSION_NAME, arg))
+            for arg in re.findall(_ARGUMENT, arg_list)
+        ]
+        for arg_list in signature.split("->")
+    )
+
+
+def safe_signature(
+    core_inputs: Sequence[Variable],
+    core_outputs: Sequence[Variable],
+) -> str:
+    def operand_sig(operand: Variable, prefix: str) -> str:
+        operands = ",".join(f"{prefix}{i}" for i in range(operand.type.ndim))
+        return f"({operands})"
+
+    inputs_sig = ",".join(
+        operand_sig(i, prefix=f"i{n}") for n, i in enumerate(core_inputs)
+    )
+    outputs_sig = ",".join(
+        operand_sig(o, prefix=f"o{n}") for n, o in enumerate(core_outputs)
+    )
+    return f"{inputs_sig}->{outputs_sig}"
+
+
+@singledispatch
+def _vectorize_node(op: Op, node: Apply, *bached_inputs) -> Apply:
+    if hasattr(op, "gufunc_signature"):
+        signature = op.gufunc_signature
+    else:
+        # TODO: This is pretty bad for shape inference and merge optimization!
+        #  Should get better as we add signatures to our Ops
+        signature = safe_signature(node.inputs, node.outputs)
+    return cast(Apply, Blockwise(op, signature=signature).make_node(*bached_inputs))
+
+
+def vectorize_node(node: Apply, *batched_inputs) -> Apply:
+    """Returns vectorized version of node with new batched inputs."""
+    op = node.op
+    return _vectorize_node(op, node, *batched_inputs)
+
+
+class Blockwise(Op):
+    """Generalizes a core `Op` to work with batched dimensions.
+
+    TODO: Dispatch JAX (should be easy with the vectorize macro)
+    TODO: Dispatch Numba
+    TODO: C implementation?
+    TODO: Fuse Blockwise?
+    """
+
+    __props__ = ("core_op", "signature")
+
+    def __init__(
+        self,
+        core_op: Op,
+        signature: Optional[str] = None,
+        name: Optional[str] = None,
+        **kwargs,
+    ):
+        """
+
+        Parameters
+        ----------
+        core_op
+            An instance of a subclass of `Op` which works on the core case.
+        signature
+            Generalized universal function signature,
+            e.g., (m,n),(n)->(m) for vectorized matrix-vector multiplication
+
+        """
+        if isinstance(core_op, Blockwise):
+            raise TypeError("Core Op is already a Blockwise")
+
+        if signature is None:
+            signature = getattr(core_op, "gufunc_signature", None)
+            if signature is None:
+                raise ValueError(
+                    f"Signature not provided nor found in core_op {core_op}"
+                )
+
+        self.core_op = core_op
+        self.signature = signature
+        self.name = name
+        self.inputs_sig, self.outputs_sig = _parse_gufunc_signature(signature)
+        self._gufunc = None
+        super().__init__(**kwargs)
+
+    def _create_dummy_core_node(self, inputs: Sequence[TensorVariable]) -> Apply:
+        core_input_types = []
+        for i, (inp, sig) in enumerate(zip(inputs, self.inputs_sig)):
+            if inp.type.ndim < len(sig):
+                raise ValueError(
+                    f"Input {i} {inp} has insufficient core dimensions for signature {self.signature}"
+                )
+            # ndim_supp = 0 case
+            if not sig:
+                core_shape = ()
+            else:
+                core_shape = inp.type.shape[-len(sig) :]
+            core_input_types.append(tensor(dtype=inp.type.dtype, shape=core_shape))
+
+        core_node = self.core_op.make_node(*core_input_types)
+
+        if len(core_node.outputs) != len(self.outputs_sig):
+            raise ValueError(
+                f"Insufficient number of outputs for signature {self.signature}: {len(core_node.outputs)}"
+            )
+        for i, (core_out, sig) in enumerate(zip(core_node.outputs, self.outputs_sig)):
+            if core_out.type.ndim != len(sig):
+                raise ValueError(
+                    f"Output {i} of {self.core_op} has wrong number of core dimensions for signature {self.signature}: {core_out.type.ndim}"
+                )
+
+        return core_node
+
+    def make_node(self, *inputs):
+        inputs = [as_tensor_variable(i) for i in inputs]
+
+        core_node = self._create_dummy_core_node(inputs)
+
+        batch_ndims = max(
+            inp.type.ndim - len(sig) for inp, sig in zip(inputs, self.inputs_sig)
+        )
+
+        batched_inputs = []
+        batch_shapes = []
+        for i, (inp, sig) in enumerate(zip(inputs, self.inputs_sig)):
+            # Append missing dims to the left
+            missing_batch_ndims = batch_ndims - (inp.type.ndim - len(sig))
+            if missing_batch_ndims:
+                inp = shape_padleft(inp, missing_batch_ndims)
+            batched_inputs.append(inp)
+
+            if not sig:
+                batch_shapes.append(inp.type.shape)
+            else:
+                batch_shapes.append(inp.type.shape[: -len(sig)])
+
+        try:
+            batch_shape = tuple(
+                [
+                    broadcast_static_dim_lengths(batch_dims)
+                    for batch_dims in zip(*batch_shapes)
+                ]
+            )
+        except ValueError:
+            raise ValueError(
+                f"Incompatible Blockwise batch input shapes {[inp.type.shape for inp in inputs]}"
+            )
+
+        batched_outputs = [
+            tensor(dtype=core_out.type.dtype, shape=batch_shape + core_out.type.shape)
+            for core_out in core_node.outputs
+        ]
+
+        return Apply(self, batched_inputs, batched_outputs)
+
+    def _batch_ndim_from_outputs(self, outputs: Sequence[TensorVariable]) -> int:
+        return cast(int, outputs[0].type.ndim - len(self.outputs_sig[0]))
+
+    def infer_shape(
+        self, fgraph, node, input_shapes
+    ) -> List[Tuple[TensorVariable, ...]]:
+        from pytensor.tensor import broadcast_shape
+        from pytensor.tensor.shape import Shape_i
+
+        batch_ndims = self._batch_ndim_from_outputs(node.outputs)
+        core_dims: Dict[str, Any] = {}
+        batch_shapes = []
+        for input_shape, sig in zip(input_shapes, self.inputs_sig):
+            batch_shapes.append(input_shape[:batch_ndims])
+            core_shape = input_shape[batch_ndims:]
+
+            for core_dim, dim_name in zip(core_shape, sig):
+                prev_core_dim = core_dims.get(core_dim)
+                if prev_core_dim is None:
+                    core_dims[dim_name] = core_dim
+                # Prefer constants
+                elif not isinstance(prev_core_dim, Constant):
+                    core_dims[dim_name] = core_dim
+
+        batch_shape = broadcast_shape(*batch_shapes, arrays_are_shapes=True)
+
+        out_shapes = []
+        for output, sig in zip(node.outputs, self.outputs_sig):
+            core_out_shape = []
+            for i, dim_name in enumerate(sig):
+                # The output dim is the same as another input dim
+                if dim_name in core_dims:
+                    core_out_shape.append(core_dims[dim_name])
+                else:
+                    # TODO: We could try to make use of infer_shape of core_op
+                    core_out_shape.append(Shape_i(batch_ndims + i)(output))
+            out_shapes.append((*batch_shape, *core_out_shape))
+
+        return out_shapes
+
+    def connection_pattern(self, node):
+        if hasattr(self.core_op, "connection_pattern"):
+            return self.core_op.connection_pattern(node)
+
+        return [[True for _ in node.outputs] for _ in node.inputs]
+
+    def _bgrad(self, inputs, outputs, ograds):
+        # Grad, with respect to broadcasted versions of inputs
+
+        def as_core(t, core_t):
+            # Inputs could be NullType or DisconnectedType
+            if isinstance(t.type, (NullType, DisconnectedType)):
+                return t
+            return core_t.type()
+
+        with config.change_flags(compute_test_value="off"):
+            safe_inputs = [
+                tensor(dtype=inp.type.dtype, shape=(None,) * len(sig))
+                for inp, sig in zip(inputs, self.inputs_sig)
+            ]
+            core_node = self._create_dummy_core_node(safe_inputs)
+
+            core_inputs = [
+                as_core(inp, core_inp)
+                for inp, core_inp in zip(inputs, core_node.inputs)
+            ]
+            core_ograds = [
+                as_core(ograd, core_ograd)
+                for ograd, core_ograd in zip(ograds, core_node.outputs)
+            ]
+            core_outputs = core_node.outputs
+
+            core_igrads = self.core_op.L_op(core_inputs, core_outputs, core_ograds)
+
+        batch_ndims = self._batch_ndim_from_outputs(outputs)
+
+        def transform(var):
+            # From a graph of ScalarOps, make a graph of Broadcast ops.
+            if isinstance(var.type, (NullType, DisconnectedType)):
+                return var
+            if var in core_inputs:
+                return inputs[core_inputs.index(var)]
+            if var in core_outputs:
+                return outputs[core_outputs.index(var)]
+            if var in core_ograds:
+                return ograds[core_ograds.index(var)]
+
+            node = var.owner
+
+            # The gradient contains a constant, which may be responsible for broadcasting
+            if node is None:
+                if batch_ndims:
+                    var = shape_padleft(var, batch_ndims)
+                return var
+
+            batched_inputs = [transform(inp) for inp in node.inputs]
+            batched_node = vectorize_node(node, *batched_inputs)
+            batched_var = batched_node.outputs[var.owner.outputs.index(var)]
+
+            return batched_var
+
+        ret = []
+        for core_igrad, ipt in zip(core_igrads, inputs):
+            # Undefined gradient
+            if core_igrad is None:
+                ret.append(None)
+            else:
+                ret.append(transform(core_igrad))
+
+        return ret
+
+    def L_op(self, inputs, outs, ograds):
+        from pytensor.tensor.math import sum as pt_sum
+
+        # Compute grad with respect to broadcasted input
+        rval = self._bgrad(inputs, outs, ograds)
+
+        # TODO: (Borrowed from Elemwise) make sure that zeros are clearly identifiable
+        # to the gradient.grad method when the outputs have
+        # some integer and some floating point outputs
+        if any(out.type.dtype not in continuous_dtypes for out in outs):
+            # For integer output, return value may only be zero or undefined
+            # We don't bother with trying to check that the scalar ops
+            # correctly returned something that evaluates to 0, we just make
+            # the return value obviously zero so that gradient.grad can tell
+            # this op did the right thing.
+            new_rval = []
+            for elem, inp in zip(rval, inputs):
+                if isinstance(elem.type, (NullType, DisconnectedType)):
+                    new_rval.append(elem)
+                else:
+                    elem = inp.zeros_like()
+                    if str(elem.type.dtype) not in continuous_dtypes:
+                        elem = elem.astype(config.floatX)
+                    assert str(elem.type.dtype) not in discrete_dtypes
+                    new_rval.append(elem)
+            return new_rval
+
+        # Sum out the broadcasted dimensions
+        batch_ndims = self._batch_ndim_from_outputs(outs)
+        batch_shape = outs[0].type.shape[:batch_ndims]
+        for i, (inp, sig) in enumerate(zip(inputs, self.inputs_sig)):
+            if isinstance(rval[i].type, (NullType, DisconnectedType)):
+                continue
+
+            assert inp.type.ndim == batch_ndims + len(sig)
+
+            to_sum = [
+                j
+                for j, (inp_s, out_s) in enumerate(zip(inp.type.shape, batch_shape))
+                if inp_s == 1 and out_s != 1
+            ]
+            if to_sum:
+                rval[i] = pt_sum(rval[i], axis=to_sum, keepdims=True)
+
+        return rval
+
+    def _create_gufunc(self, node):
+        if hasattr(self.core_op, "gufunc_spec"):
+            self._gufunc = import_func_from_string(self.core_op.gufunc_spec[0])
+            if self._gufunc:
+                return self._gufunc
+
+        n_outs = len(self.outputs_sig)
+        core_node = self._create_dummy_core_node(node.inputs)
+
+        def core_func(*inner_inputs):
+            inner_outputs = [[None] for _ in range(n_outs)]
+
+            inner_inputs = [np.asarray(inp) for inp in inner_inputs]
+            self.core_op.perform(core_node, inner_inputs, inner_outputs)
+
+            if len(inner_outputs) == 1:
+                return inner_outputs[0][0]
+            else:
+                return tuple(r[0] for r in inner_outputs)
+
+        self._gufunc = np.vectorize(core_func, signature=self.signature)
+        return self._gufunc
+
+    def perform(self, node, inputs, output_storage):
+        gufunc = self._gufunc
+
+        if gufunc is None:
+            gufunc = self._create_gufunc(node)
+
+        res = gufunc(*inputs)
+        if not isinstance(res, tuple):
+            res = (res,)
+
+        for node_out, out_storage, r in zip(node.outputs, output_storage, res):
+            out_dtype = getattr(node_out, "dtype", None)
+            if out_dtype and out_dtype != r.dtype:
+                r = np.asarray(r, dtype=out_dtype)
+            out_storage[0] = r
+
+    def __str__(self):
+        if self.name is None:
+            return f"{type(self).__name__}{{{self.core_op}, {self.signature}}}"
+        else:
+            return self.name
+
+
+@_vectorize_node.register(Blockwise)
+def vectorize_not_needed(op, node, *batch_inputs):
+    return op.make_node(*batch_inputs)

--- a/pytensor/tensor/elemwise.py
+++ b/pytensor/tensor/elemwise.py
@@ -8,6 +8,7 @@ from pytensor.configdefaults import config
 from pytensor.gradient import DisconnectedType
 from pytensor.graph.basic import Apply
 from pytensor.graph.null_type import NullType
+from pytensor.graph.replace import _vectorize_node
 from pytensor.graph.utils import MethodNotDefined
 from pytensor.link.c.basic import failure_code
 from pytensor.link.c.op import COp, ExternalCOp, OpenMPOp
@@ -22,7 +23,7 @@ from pytensor.scalar.basic import transfer_type, upcast
 from pytensor.tensor import elemwise_cgen as cgen
 from pytensor.tensor import get_vector_length
 from pytensor.tensor.basic import _get_vector_length, as_tensor_variable
-from pytensor.tensor.blockwise import _vectorize_node, vectorize_not_needed
+from pytensor.tensor.blockwise import vectorize_not_needed
 from pytensor.tensor.type import (
     TensorType,
     continuous_dtypes,

--- a/pytensor/tensor/nlinalg.py
+++ b/pytensor/tensor/nlinalg.py
@@ -1,6 +1,5 @@
-import typing
 from functools import partial
-from typing import Callable, Tuple
+from typing import Tuple
 
 import numpy as np
 
@@ -271,7 +270,6 @@ class Eig(Op):
 
     """
 
-    _numop = staticmethod(np.linalg.eig)
     __props__: Tuple[str, ...] = ()
 
     def make_node(self, x):
@@ -284,7 +282,7 @@ class Eig(Op):
     def perform(self, node, inputs, outputs):
         (x,) = inputs
         (w, v) = outputs
-        w[0], v[0] = (z.astype(x.dtype) for z in self._numop(x))
+        w[0], v[0] = (z.astype(x.dtype) for z in np.linalg.eig(x))
 
     def infer_shape(self, fgraph, node, shapes):
         n = shapes[0][0]
@@ -300,7 +298,6 @@ class Eigh(Eig):
 
     """
 
-    _numop = typing.cast(Callable, staticmethod(np.linalg.eigh))
     __props__ = ("UPLO",)
 
     def __init__(self, UPLO="L"):
@@ -315,7 +312,7 @@ class Eigh(Eig):
         # LAPACK.  Rather than trying to reproduce the (rather
         # involved) logic, we just probe linalg.eigh with a trivial
         # input.
-        w_dtype = self._numop([[np.dtype(x.dtype).type()]])[0].dtype.name
+        w_dtype = np.linalg.eigh([[np.dtype(x.dtype).type()]])[0].dtype.name
         w = vector(dtype=w_dtype)
         v = matrix(dtype=w_dtype)
         return Apply(self, [x], [w, v])
@@ -323,7 +320,7 @@ class Eigh(Eig):
     def perform(self, node, inputs, outputs):
         (x,) = inputs
         (w, v) = outputs
-        w[0], v[0] = self._numop(x, self.UPLO)
+        w[0], v[0] = np.linalg.eigh(x, self.UPLO)
 
     def grad(self, inputs, g_outputs):
         r"""The gradient function should return
@@ -446,7 +443,6 @@ class QRFull(Op):
 
     """
 
-    _numop = staticmethod(np.linalg.qr)
     __props__ = ("mode",)
 
     def __init__(self, mode):
@@ -478,7 +474,7 @@ class QRFull(Op):
     def perform(self, node, inputs, outputs):
         (x,) = inputs
         assert x.ndim == 2, "The input of qr function should be a matrix."
-        res = self._numop(x, self.mode)
+        res = np.linalg.qr(x, self.mode)
         if self.mode != "r":
             outputs[0][0], outputs[1][0] = res
         else:
@@ -547,7 +543,6 @@ class SVD(Op):
     """
 
     # See doc in the docstring of the function just after this class.
-    _numop = staticmethod(np.linalg.svd)
     __props__ = ("full_matrices", "compute_uv")
 
     def __init__(self, full_matrices=True, compute_uv=True):
@@ -575,10 +570,10 @@ class SVD(Op):
         assert x.ndim == 2, "The input of svd function should be a matrix."
         if self.compute_uv:
             u, s, vt = outputs
-            u[0], s[0], vt[0] = self._numop(x, self.full_matrices, self.compute_uv)
+            u[0], s[0], vt[0] = np.linalg.svd(x, self.full_matrices, self.compute_uv)
         else:
             (s,) = outputs
-            s[0] = self._numop(x, self.full_matrices, self.compute_uv)
+            s[0] = np.linalg.svd(x, self.full_matrices, self.compute_uv)
 
     def infer_shape(self, fgraph, node, shapes):
         (x_shape,) = shapes
@@ -730,7 +725,6 @@ class TensorInv(Op):
     PyTensor utilization of numpy.linalg.tensorinv;
     """
 
-    _numop = staticmethod(np.linalg.tensorinv)
     __props__ = ("ind",)
 
     def __init__(self, ind=2):
@@ -744,7 +738,7 @@ class TensorInv(Op):
     def perform(self, node, inputs, outputs):
         (a,) = inputs
         (x,) = outputs
-        x[0] = self._numop(a, self.ind)
+        x[0] = np.linalg.tensorinv(a, self.ind)
 
     def infer_shape(self, fgraph, node, shapes):
         sp = shapes[0][self.ind :] + shapes[0][: self.ind]
@@ -790,7 +784,6 @@ class TensorSolve(Op):
 
     """
 
-    _numop = staticmethod(np.linalg.tensorsolve)
     __props__ = ("axes",)
 
     def __init__(self, axes=None):
@@ -809,7 +802,7 @@ class TensorSolve(Op):
             b,
         ) = inputs
         (x,) = outputs
-        x[0] = self._numop(a, b, self.axes)
+        x[0] = np.linalg.tensorsolve(a, b, self.axes)
 
 
 def tensorsolve(a, b, axes=None):

--- a/pytensor/tensor/nlinalg.py
+++ b/pytensor/tensor/nlinalg.py
@@ -78,25 +78,6 @@ def pinv(x, hermitian=False):
     return MatrixPinv(hermitian=hermitian)(x)
 
 
-class Inv(Op):
-    """Computes the inverse of one or more matrices."""
-
-    def make_node(self, x):
-        x = as_tensor_variable(x)
-        return Apply(self, [x], [x.type()])
-
-    def perform(self, node, inputs, outputs):
-        (x,) = inputs
-        (z,) = outputs
-        z[0] = np.linalg.inv(x).astype(x.dtype)
-
-    def infer_shape(self, fgraph, node, shapes):
-        return shapes
-
-
-inv = Inv()
-
-
 class MatrixInverse(Op):
     r"""Computes the inverse of a matrix :math:`A`.
 
@@ -169,7 +150,7 @@ class MatrixInverse(Op):
         return shapes
 
 
-matrix_inverse = MatrixInverse()
+inv = matrix_inverse = MatrixInverse()
 
 
 def matrix_dot(*args):

--- a/pytensor/tensor/random/op.py
+++ b/pytensor/tensor/random/op.py
@@ -7,6 +7,7 @@ import pytensor
 from pytensor.configdefaults import config
 from pytensor.graph.basic import Apply, Variable, equal_computations
 from pytensor.graph.op import Op
+from pytensor.graph.replace import _vectorize_node
 from pytensor.misc.safe_asarray import _asarray
 from pytensor.scalar import ScalarVariable
 from pytensor.tensor.basic import (
@@ -17,7 +18,6 @@ from pytensor.tensor.basic import (
     get_vector_length,
     infer_static_shape,
 )
-from pytensor.tensor.blockwise import _vectorize_node
 from pytensor.tensor.random.type import RandomGeneratorType, RandomStateType, RandomType
 from pytensor.tensor.random.utils import (
     broadcast_params,

--- a/pytensor/tensor/rewriting/__init__.py
+++ b/pytensor/tensor/rewriting/__init__.py
@@ -2,6 +2,7 @@ import pytensor.tensor.rewriting.basic
 import pytensor.tensor.rewriting.blas
 import pytensor.tensor.rewriting.blas_c
 import pytensor.tensor.rewriting.blas_scipy
+import pytensor.tensor.rewriting.blockwise
 import pytensor.tensor.rewriting.elemwise
 import pytensor.tensor.rewriting.extra_ops
 

--- a/pytensor/tensor/rewriting/blockwise.py
+++ b/pytensor/tensor/rewriting/blockwise.py
@@ -1,7 +1,8 @@
 from pytensor.compile.mode import optdb
 from pytensor.graph import node_rewriter
+from pytensor.graph.replace import vectorize_node
 from pytensor.graph.rewriting.basic import copy_stack_trace, out2in
-from pytensor.tensor.blockwise import Blockwise, vectorize_node
+from pytensor.tensor.blockwise import Blockwise
 
 
 @node_rewriter([Blockwise])

--- a/pytensor/tensor/rewriting/blockwise.py
+++ b/pytensor/tensor/rewriting/blockwise.py
@@ -1,0 +1,41 @@
+from pytensor.compile.mode import optdb
+from pytensor.graph import node_rewriter
+from pytensor.graph.rewriting.basic import copy_stack_trace, out2in
+from pytensor.tensor.blockwise import Blockwise, vectorize_node
+
+
+@node_rewriter([Blockwise])
+def local_useless_blockwise(fgraph, node):
+    """
+    If there is a dispatch implementation that does not require Blockwise, use that instead.
+    This means a user created a Blockwise manually when there was no need.
+
+    Note: This rewrite is not registered by default anywhere
+    """
+    op = node.op
+    inputs = node.inputs
+    dummy_core_node = op._create_dummy_core_node(node.inputs)
+    vect_node = vectorize_node(dummy_core_node, *inputs)
+    if not isinstance(vect_node.op, Blockwise):
+        return copy_stack_trace(node.outputs, vect_node.outputs)
+
+
+@node_rewriter([Blockwise])
+def local_useless_unbatched_blockwise(fgraph, node):
+    """Remove Blockwise that don't have any batched dims."""
+    op = node.op
+    inputs = node.inputs
+
+    if max(inp.type.ndim - len(sig) for inp, sig in zip(inputs, op.inputs_sig)) == 0:
+        return copy_stack_trace(node.outputs, op.core_op.make_node(*inputs).outputs)
+
+
+# We register this rewrite late, so that other rewrites need only target Blockwise Ops
+optdb.register(
+    "local_useless_unbatched_blockwise",
+    out2in(local_useless_unbatched_blockwise, ignore_newtrees=True),
+    "fast_run",
+    "fast_compile",
+    "blockwise",
+    position=49,
+)

--- a/pytensor/tensor/rewriting/linalg.py
+++ b/pytensor/tensor/rewriting/linalg.py
@@ -1,32 +1,58 @@
 import logging
+from typing import cast
 
 from pytensor.graph.rewriting.basic import node_rewriter
-from pytensor.tensor import basic as at
+from pytensor.tensor.basic import TensorVariable, diagonal, swapaxes
 from pytensor.tensor.blas import Dot22
+from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.elemwise import DimShuffle
 from pytensor.tensor.math import Dot, Prod, log, prod
-from pytensor.tensor.nlinalg import Det, MatrixInverse
+from pytensor.tensor.nlinalg import MatrixInverse, det
 from pytensor.tensor.rewriting.basic import (
     register_canonicalize,
     register_specialize,
     register_stabilize,
 )
-from pytensor.tensor.slinalg import Cholesky, Solve, SolveTriangular, cholesky, solve
+from pytensor.tensor.slinalg import Cholesky, Solve, cholesky, solve, solve_triangular
 
 
 logger = logging.getLogger(__name__)
 
 
+def is_matrix_transpose(x: TensorVariable) -> bool:
+    """Check if a variable corresponds to a transpose of the last two axes"""
+    node = x.owner
+    if (
+        node
+        and isinstance(node.op, DimShuffle)
+        and not (node.op.drop or node.op.augment)
+    ):
+        [inp] = node.inputs
+        ndims = inp.type.ndim
+        if ndims < 2:
+            return False
+        transpose_order = tuple(range(ndims - 2)) + (ndims - 1, ndims - 2)
+        return cast(bool, node.op.new_order == transpose_order)
+    return False
+
+
+def _T(x: TensorVariable) -> TensorVariable:
+    """Matrix transpose for potentially higher dimensionality tensors"""
+    return swapaxes(x, -1, -2)
+
+
 @register_canonicalize
 @node_rewriter([DimShuffle])
 def transinv_to_invtrans(fgraph, node):
-    if isinstance(node.op, DimShuffle):
-        if node.op.new_order == (1, 0):
-            (A,) = node.inputs
-            if A.owner:
-                if isinstance(A.owner.op, MatrixInverse):
-                    (X,) = A.owner.inputs
-                    return [A.owner.op(node.op(X))]
+    if is_matrix_transpose(node.outputs[0]):
+        (A,) = node.inputs
+        if (
+            A.owner
+            and isinstance(A.owner.op, Blockwise)
+            and isinstance(A.owner.op.core_op, MatrixInverse)
+        ):
+            (X,) = A.owner.inputs
+            return [A.owner.op(node.op(X))]
 
 
 @register_stabilize
@@ -37,43 +63,72 @@ def inv_as_solve(fgraph, node):
     """
     if isinstance(node.op, (Dot, Dot22)):
         l, r = node.inputs
-        if l.owner and isinstance(l.owner.op, MatrixInverse):
+        if (
+            l.owner
+            and isinstance(l.owner.op, Blockwise)
+            and isinstance(l.owner.op.core_op, MatrixInverse)
+        ):
             return [solve(l.owner.inputs[0], r)]
-        if r.owner and isinstance(r.owner.op, MatrixInverse):
+        if (
+            r.owner
+            and isinstance(r.owner.op, Blockwise)
+            and isinstance(r.owner.op.core_op, MatrixInverse)
+        ):
             x = r.owner.inputs[0]
             if getattr(x.tag, "symmetric", None) is True:
-                return [solve(x, l.T).T]
+                return [_T(solve(x, _T(l)))]
             else:
-                return [solve(x.T, l.T).T]
+                return [_T(solve(_T(x), _T(l)))]
 
 
 @register_stabilize
 @register_canonicalize
-@node_rewriter([Solve])
+@node_rewriter([Blockwise])
 def generic_solve_to_solve_triangular(fgraph, node):
     """
     If any solve() is applied to the output of a cholesky op, then
     replace it with a triangular solve.
 
     """
-    if isinstance(node.op, Solve):
-        A, b = node.inputs  # result is solution Ax=b
-        if A.owner and isinstance(A.owner.op, Cholesky):
-            if A.owner.op.lower:
-                return [SolveTriangular(lower=True)(A, b)]
-            else:
-                return [SolveTriangular(lower=False)(A, b)]
-        if (
-            A.owner
-            and isinstance(A.owner.op, DimShuffle)
-            and A.owner.op.new_order == (1, 0)
-        ):
-            (A_T,) = A.owner.inputs
-            if A_T.owner and isinstance(A_T.owner.op, Cholesky):
-                if A_T.owner.op.lower:
-                    return [SolveTriangular(lower=False)(A, b)]
+    if isinstance(node.op.core_op, Solve):
+        if node.op.core_op.assume_a == "gen":
+            A, b = node.inputs  # result is solution Ax=b
+            if (
+                A.owner
+                and isinstance(A.owner.op, Blockwise)
+                and isinstance(A.owner.op.core_op, Cholesky)
+            ):
+                if A.owner.op.core_op.lower:
+                    return [
+                        solve_triangular(
+                            A, b, lower=True, b_ndim=node.op.core_op.b_ndim
+                        )
+                    ]
                 else:
-                    return [SolveTriangular(lower=True)(A, b)]
+                    return [
+                        solve_triangular(
+                            A, b, lower=False, b_ndim=node.op.core_op.b_ndim
+                        )
+                    ]
+            if is_matrix_transpose(A):
+                (A_T,) = A.owner.inputs
+                if (
+                    A_T.owner
+                    and isinstance(A_T.owner.op, Blockwise)
+                    and isinstance(A_T.owner.op, Cholesky)
+                ):
+                    if A_T.owner.op.lower:
+                        return [
+                            solve_triangular(
+                                A, b, lower=False, b_ndim=node.op.core_op.b_ndim
+                            )
+                        ]
+                    else:
+                        return [
+                            solve_triangular(
+                                A, b, lower=True, b_ndim=node.op.core_op.b_ndim
+                            )
+                        ]
 
 
 @register_canonicalize
@@ -81,34 +136,33 @@ def generic_solve_to_solve_triangular(fgraph, node):
 @register_specialize
 @node_rewriter([DimShuffle])
 def no_transpose_symmetric(fgraph, node):
-    if isinstance(node.op, DimShuffle):
+    if is_matrix_transpose(node.outputs[0]):
         x = node.inputs[0]
-        if x.type.ndim == 2 and getattr(x.tag, "symmetric", None) is True:
-            if node.op.new_order == [1, 0]:
-                return [x]
+        if getattr(x.tag, "symmetric", None):
+            return [x]
 
 
 @register_stabilize
-@node_rewriter([Solve])
+@node_rewriter([Blockwise])
 def psd_solve_with_chol(fgraph, node):
     """
     This utilizes a boolean `psd` tag on matrices.
     """
-    if isinstance(node.op, Solve):
+    if isinstance(node.op.core_op, Solve) and node.op.core_op.b_ndim == 2:
         A, b = node.inputs  # result is solution Ax=b
         if getattr(A.tag, "psd", None) is True:
             L = cholesky(A)
             # N.B. this can be further reduced to a yet-unwritten cho_solve Op
-            #     __if__ no other Op makes use of the the L matrix during the
+            #     __if__ no other Op makes use of the L matrix during the
             #     stabilization
-            Li_b = Solve(assume_a="sym", lower=True)(L, b)
-            x = Solve(assume_a="sym", lower=False)(L.T, Li_b)
+            Li_b = solve(L, b, assume_a="sym", lower=True, b_ndim=2)
+            x = solve(_T(L), Li_b, assume_a="sym", lower=False, b_ndim=2)
             return [x]
 
 
 @register_canonicalize
 @register_stabilize
-@node_rewriter([Cholesky])
+@node_rewriter([Blockwise])
 def cholesky_ldotlt(fgraph, node):
     """
     rewrite cholesky(dot(L, L.T), lower=True) = L, where L is lower triangular,
@@ -116,7 +170,7 @@ def cholesky_ldotlt(fgraph, node):
 
     This utilizes a boolean `lower_triangular` or `upper_triangular` tag on matrices.
     """
-    if not isinstance(node.op, Cholesky):
+    if not isinstance(node.op.core_op, Cholesky):
         return
 
     A = node.inputs[0]
@@ -128,45 +182,40 @@ def cholesky_ldotlt(fgraph, node):
     # cholesky(dot(L,L.T)) case
     if (
         getattr(l.tag, "lower_triangular", False)
-        and r.owner
-        and isinstance(r.owner.op, DimShuffle)
-        and r.owner.op.new_order == (1, 0)
+        and is_matrix_transpose(r)
         and r.owner.inputs[0] == l
     ):
-        if node.op.lower:
+        if node.op.core_op.lower:
             return [l]
         return [r]
 
     # cholesky(dot(U.T,U)) case
     if (
         getattr(r.tag, "upper_triangular", False)
-        and l.owner
-        and isinstance(l.owner.op, DimShuffle)
-        and l.owner.op.new_order == (1, 0)
+        and is_matrix_transpose(l)
         and l.owner.inputs[0] == r
     ):
-        if node.op.lower:
+        if node.op.core_op.lower:
             return [l]
         return [r]
 
 
 @register_stabilize
 @register_specialize
-@node_rewriter([Det])
+@node_rewriter([det])
 def local_det_chol(fgraph, node):
     """
     If we have det(X) and there is already an L=cholesky(X)
     floating around, then we can use prod(diag(L)) to get the determinant.
 
     """
-    if isinstance(node.op, Det):
-        (x,) = node.inputs
-        for cl, xpos in fgraph.clients[x]:
-            if cl == "output":
-                continue
-            if isinstance(cl.op, Cholesky):
-                L = cl.outputs[0]
-                return [prod(at.extract_diag(L) ** 2)]
+    (x,) = node.inputs
+    for cl, xpos in fgraph.clients[x]:
+        if cl == "output":
+            continue
+        if isinstance(cl.op, Blockwise) and isinstance(cl.op.core_op, Cholesky):
+            L = cl.outputs[0]
+            return [prod(diagonal(L, axis1=-2, axis2=-1) ** 2, axis=-1)]
 
 
 @register_canonicalize
@@ -177,16 +226,15 @@ def local_log_prod_sqr(fgraph, node):
     """
     This utilizes a boolean `positive` tag on matrices.
     """
-    if node.op == log:
-        (x,) = node.inputs
-        if x.owner and isinstance(x.owner.op, Prod):
-            # we cannot always make this substitution because
-            # the prod might include negative terms
-            p = x.owner.inputs[0]
+    (x,) = node.inputs
+    if x.owner and isinstance(x.owner.op, Prod):
+        # we cannot always make this substitution because
+        # the prod might include negative terms
+        p = x.owner.inputs[0]
 
-            # p is the matrix we're reducing with prod
-            if getattr(p.tag, "positive", None) is True:
-                return [log(p).sum(axis=x.owner.op.axis)]
+        # p is the matrix we're reducing with prod
+        if getattr(p.tag, "positive", None) is True:
+            return [log(p).sum(axis=x.owner.op.axis)]
 
-            # TODO: have a reduction like prod and sum that simply
-            # returns the sign of the prod multiplication.
+        # TODO: have a reduction like prod and sum that simply
+        # returns the sign of the prod multiplication.

--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -1,7 +1,7 @@
 import logging
 import typing
 import warnings
-from typing import TYPE_CHECKING, Literal, Union
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
 import numpy as np
 import scipy.linalg
@@ -13,6 +13,7 @@ from pytensor.graph.op import Op
 from pytensor.tensor import as_tensor_variable
 from pytensor.tensor import basic as at
 from pytensor.tensor import math as atm
+from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.nlinalg import matrix_dot
 from pytensor.tensor.shape import reshape
 from pytensor.tensor.type import matrix, tensor, vector
@@ -48,6 +49,7 @@ class Cholesky(Op):
     # TODO: LAPACK wrapper with in-place behavior, for solve also
 
     __props__ = ("lower", "destructive", "on_error")
+    gufunc_signature = "(m,m)->(m,m)"
 
     def __init__(self, *, lower=True, on_error="raise"):
         self.lower = lower
@@ -109,7 +111,7 @@ class Cholesky(Op):
 
         def conjugate_solve_triangular(outer, inner):
             """Computes L^{-T} P L^{-1} for lower-triangular L."""
-            solve_upper = SolveTriangular(lower=False)
+            solve_upper = SolveTriangular(lower=False, b_ndim=2)
             return solve_upper(outer.T, solve_upper(outer.T, inner.T).T)
 
         s = conjugate_solve_triangular(
@@ -128,7 +130,7 @@ class Cholesky(Op):
 
 
 def cholesky(x, lower=True, on_error="raise"):
-    return Cholesky(lower=lower, on_error=on_error)(x)
+    return Blockwise(Cholesky(lower=lower, on_error=on_error))(x)
 
 
 class SolveBase(Op):
@@ -137,6 +139,7 @@ class SolveBase(Op):
     __props__ = (
         "lower",
         "check_finite",
+        "b_ndim",
     )
 
     def __init__(
@@ -144,9 +147,16 @@ class SolveBase(Op):
         *,
         lower=False,
         check_finite=True,
+        b_ndim,
     ):
         self.lower = lower
         self.check_finite = check_finite
+        assert b_ndim in (1, 2)
+        self.b_ndim = b_ndim
+        if b_ndim == 1:
+            self.gufunc_signature = "(m,m),(m)->(m)"
+        else:
+            self.gufunc_signature = "(m,m),(m,n)->(m,n)"
 
     def perform(self, node, inputs, outputs):
         pass
@@ -157,8 +167,8 @@ class SolveBase(Op):
 
         if A.ndim != 2:
             raise ValueError(f"`A` must be a matrix; got {A.type} instead.")
-        if b.ndim not in (1, 2):
-            raise ValueError(f"`b` must be a matrix or a vector; got {b.type} instead.")
+        if b.ndim != self.b_ndim:
+            raise ValueError(f"`b` must have {self.b_ndim} dims; got {b.type} instead.")
 
         # Infer dtype by solving the most simple case with 1x1 matrices
         o_dtype = scipy.linalg.solve(
@@ -209,6 +219,16 @@ class SolveBase(Op):
         return [A_bar, b_bar]
 
 
+def _default_b_ndim(b, b_ndim):
+    if b_ndim is not None:
+        assert b_ndim in (1, 2)
+        return b_ndim
+
+    b = as_tensor_variable(b)
+    if b_ndim is None:
+        return min(b.ndim, 2)  # By default assume the core case is a matrix
+
+
 class CholeskySolve(SolveBase):
     def __init__(self, **kwargs):
         kwargs.setdefault("lower", True)
@@ -228,7 +248,7 @@ class CholeskySolve(SolveBase):
         raise NotImplementedError()
 
 
-def cho_solve(c_and_lower, b, *, check_finite=True):
+def cho_solve(c_and_lower, b, *, check_finite=True, b_ndim: Optional[int] = None):
     """Solve the linear equations A x = b, given the Cholesky factorization of A.
 
     Parameters
@@ -241,9 +261,15 @@ def cho_solve(c_and_lower, b, *, check_finite=True):
         Whether to check that the input matrices contain only finite numbers.
         Disabling may give a performance gain, but may result in problems
         (crashes, non-termination) if the inputs do contain infinities or NaNs.
+        b_ndim : int
+        Whether the core case of b is a vector (1) or matrix (2).
+        This will influence how batched dimensions are interpreted.
     """
     A, lower = c_and_lower
-    return CholeskySolve(lower=lower, check_finite=check_finite)(A, b)
+    b_ndim = _default_b_ndim(b, b_ndim)
+    return Blockwise(
+        CholeskySolve(lower=lower, check_finite=check_finite, b_ndim=b_ndim)
+    )(A, b)
 
 
 class SolveTriangular(SolveBase):
@@ -254,6 +280,7 @@ class SolveTriangular(SolveBase):
         "unit_diagonal",
         "lower",
         "check_finite",
+        "b_ndim",
     )
 
     def __init__(self, *, trans=0, unit_diagonal=False, **kwargs):
@@ -291,6 +318,7 @@ def solve_triangular(
     lower: bool = False,
     unit_diagonal: bool = False,
     check_finite: bool = True,
+    b_ndim: Optional[int] = None,
 ) -> TensorVariable:
     """Solve the equation `a x = b` for `x`, assuming `a` is a triangular matrix.
 
@@ -314,12 +342,19 @@ def solve_triangular(
         Whether to check that the input matrices contain only finite numbers.
         Disabling may give a performance gain, but may result in problems
         (crashes, non-termination) if the inputs do contain infinities or NaNs.
+    b_ndim : int
+        Whether the core case of b is a vector (1) or matrix (2).
+        This will influence how batched dimensions are interpreted.
     """
-    return SolveTriangular(
-        lower=lower,
-        trans=trans,
-        unit_diagonal=unit_diagonal,
-        check_finite=check_finite,
+    b_ndim = _default_b_ndim(b, b_ndim)
+    return Blockwise(
+        SolveTriangular(
+            lower=lower,
+            trans=trans,
+            unit_diagonal=unit_diagonal,
+            check_finite=check_finite,
+            b_ndim=b_ndim,
+        )
     )(a, b)
 
 
@@ -332,6 +367,7 @@ class Solve(SolveBase):
         "assume_a",
         "lower",
         "check_finite",
+        "b_ndim",
     )
 
     def __init__(self, *, assume_a="gen", **kwargs):
@@ -352,7 +388,15 @@ class Solve(SolveBase):
         )
 
 
-def solve(a, b, *, assume_a="gen", lower=False, check_finite=True):
+def solve(
+    a,
+    b,
+    *,
+    assume_a="gen",
+    lower=False,
+    check_finite=True,
+    b_ndim: Optional[int] = None,
+):
     """Solves the linear equation set ``a * x = b`` for the unknown ``x`` for square ``a`` matrix.
 
     If the data matrix is known to be a particular type then supplying the
@@ -375,9 +419,9 @@ def solve(a, b, *, assume_a="gen", lower=False, check_finite=True):
 
     Parameters
     ----------
-    a : (N, N) array_like
+    a : (..., N, N) array_like
         Square input data
-    b : (N, NRHS) array_like
+    b : (..., N, NRHS) array_like
         Input data for the right hand side.
     lower : bool, optional
         If True, only the data contained in the lower triangle of `a`. Default
@@ -388,11 +432,18 @@ def solve(a, b, *, assume_a="gen", lower=False, check_finite=True):
         (crashes, non-termination) if the inputs do contain infinities or NaNs.
     assume_a : str, optional
         Valid entries are explained above.
+    b_ndim : int
+        Whether the core case of b is a vector (1) or matrix (2).
+        This will influence how batched dimensions are interpreted.
     """
-    return Solve(
-        lower=lower,
-        check_finite=check_finite,
-        assume_a=assume_a,
+    b_ndim = _default_b_ndim(b, b_ndim)
+    return Blockwise(
+        Solve(
+            lower=lower,
+            check_finite=check_finite,
+            assume_a=assume_a,
+            b_ndim=b_ndim,
+        )
     )(a, b)
 
 

--- a/scripts/mypy-failing.txt
+++ b/scripts/mypy-failing.txt
@@ -33,4 +33,3 @@ pytensor/tensor/subtensor.py
 pytensor/tensor/type.py
 pytensor/tensor/type_other.py
 pytensor/tensor/variable.py
-pytensor/tensor/nlinalg.py

--- a/tests/link/numba/test_nlinalg.py
+++ b/tests/link/numba/test_nlinalg.py
@@ -46,7 +46,7 @@ rng = np.random.default_rng(42849)
     ],
 )
 def test_Cholesky(x, lower, exc):
-    g = slinalg.Cholesky(lower)(x)
+    g = slinalg.Cholesky(lower=lower)(x)
 
     if isinstance(g, list):
         g_fg = FunctionGraph(outputs=g)
@@ -91,7 +91,7 @@ def test_Cholesky(x, lower, exc):
     ],
 )
 def test_Solve(A, x, lower, exc):
-    g = slinalg.Solve(lower)(A, x)
+    g = slinalg.Solve(lower=lower)(A, x)
 
     if isinstance(g, list):
         g_fg = FunctionGraph(outputs=g)
@@ -125,7 +125,7 @@ def test_Solve(A, x, lower, exc):
     ],
 )
 def test_SolveTriangular(A, x, lower, exc):
-    g = slinalg.SolveTriangular(lower)(A, x)
+    g = slinalg.SolveTriangular(lower=lower)(A, x)
 
     if isinstance(g, list):
         g_fg = FunctionGraph(outputs=g)

--- a/tests/link/numba/test_nlinalg.py
+++ b/tests/link/numba/test_nlinalg.py
@@ -353,26 +353,6 @@ def test_Eigh(x, uplo, exc):
             (),
         ),
         (
-            nlinalg.Inv,
-            set_test_value(
-                at.dmatrix(),
-                (lambda x: x.T.dot(x))(rng.random(size=(3, 3)).astype("float64")),
-            ),
-            None,
-            (),
-        ),
-        (
-            nlinalg.Inv,
-            set_test_value(
-                at.lmatrix(),
-                (lambda x: x.T.dot(x))(
-                    rng.integers(1, 10, size=(3, 3)).astype("int64")
-                ),
-            ),
-            None,
-            (),
-        ),
-        (
             nlinalg.MatrixPinv,
             set_test_value(
                 at.dmatrix(),

--- a/tests/link/numba/test_nlinalg.py
+++ b/tests/link/numba/test_nlinalg.py
@@ -91,7 +91,7 @@ def test_Cholesky(x, lower, exc):
     ],
 )
 def test_Solve(A, x, lower, exc):
-    g = slinalg.Solve(lower=lower)(A, x)
+    g = slinalg.Solve(lower=lower, b_ndim=1)(A, x)
 
     if isinstance(g, list):
         g_fg = FunctionGraph(outputs=g)
@@ -125,7 +125,7 @@ def test_Solve(A, x, lower, exc):
     ],
 )
 def test_SolveTriangular(A, x, lower, exc):
-    g = slinalg.SolveTriangular(lower=lower)(A, x)
+    g = slinalg.SolveTriangular(lower=lower, b_ndim=1)(A, x)
 
     if isinstance(g, list):
         g_fg = FunctionGraph(outputs=g)

--- a/tests/tensor/random/test_op.py
+++ b/tests/tensor/random/test_op.py
@@ -5,7 +5,9 @@ import pytensor.tensor as at
 from pytensor import config, function
 from pytensor.gradient import NullTypeGradError, grad
 from pytensor.raise_op import Assert
+from pytensor.tensor.blockwise import vectorize_node
 from pytensor.tensor.math import eq
+from pytensor.tensor.random import normal
 from pytensor.tensor.random.op import RandomState, RandomVariable, default_rng
 from pytensor.tensor.shape import specify_shape
 from pytensor.tensor.type import all_dtypes, iscalar, tensor
@@ -202,3 +204,37 @@ def test_RandomVariable_incompatible_size():
         ValueError, match="Size length is incompatible with batched dimensions"
     ):
         rv_op(np.zeros((2, 4, 3)), 1, size=(4,))
+
+
+def test_vectorize_node():
+    vec = tensor(shape=(None,))
+    vec.tag.test_value = [0, 0, 0]
+    mat = tensor(shape=(None, None))
+    mat.tag.test_value = [[0, 0, 0], [1, 1, 1]]
+
+    # Test without size
+    node = normal(vec).owner
+    new_inputs = node.inputs.copy()
+    new_inputs[3] = mat
+    vect_node = vectorize_node(node, *new_inputs)
+    assert vect_node.op is normal
+    assert vect_node.inputs[3] is mat
+
+    # Test with size, new size provided
+    node = normal(vec, size=(3,)).owner
+    new_inputs = node.inputs.copy()
+    new_inputs[1] = (2, 3)
+    new_inputs[3] = mat
+    vect_node = vectorize_node(node, *new_inputs)
+    assert vect_node.op is normal
+    assert tuple(vect_node.inputs[1].eval()) == (2, 3)
+    assert vect_node.inputs[3] is mat
+
+    # Test with size, new size not provided
+    node = normal(vec, size=(3,)).owner
+    new_inputs = node.inputs.copy()
+    new_inputs[3] = mat
+    vect_node = vectorize_node(node, *new_inputs)
+    assert vect_node.op is normal
+    assert vect_node.inputs[3] is mat
+    assert tuple(vect_node.inputs[1].eval({mat: mat.tag.test_value})) == (2, 3)

--- a/tests/tensor/random/test_op.py
+++ b/tests/tensor/random/test_op.py
@@ -4,8 +4,8 @@ import pytest
 import pytensor.tensor as at
 from pytensor import config, function
 from pytensor.gradient import NullTypeGradError, grad
+from pytensor.graph.replace import vectorize_node
 from pytensor.raise_op import Assert
-from pytensor.tensor.blockwise import vectorize_node
 from pytensor.tensor.math import eq
 from pytensor.tensor.random import normal
 from pytensor.tensor.random.op import RandomState, RandomVariable, default_rng

--- a/tests/tensor/rewriting/test_blockwise.py
+++ b/tests/tensor/rewriting/test_blockwise.py
@@ -1,0 +1,38 @@
+from pytensor import function
+from pytensor.graph import FunctionGraph
+from pytensor.scalar import log as scalar_log
+from pytensor.tensor import matrix, tensor3
+from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.elemwise import Elemwise
+from pytensor.tensor.nlinalg import MatrixPinv
+from pytensor.tensor.rewriting.blockwise import local_useless_blockwise
+
+
+def test_useless_blockwise_of_elemwise():
+    x = matrix("x")
+    out = Blockwise(Elemwise(scalar_log), signature="()->()")(x)
+    assert isinstance(out.owner.op, Blockwise)
+    assert isinstance(out.owner.op.core_op, Elemwise)
+
+    fg = FunctionGraph([x], [out], clone=False)
+    [new_out] = local_useless_blockwise.transform(fg, out.owner)
+    assert isinstance(new_out.owner.op, Elemwise)
+
+
+def test_useless_unbatched_blockwise():
+    x = matrix("x")
+    blockwise_op = Blockwise(MatrixPinv(hermitian=False), signature="(m,n)->(n,m)")
+    out = blockwise_op(x)
+
+    assert isinstance(out.owner.op, Blockwise)
+    assert isinstance(out.owner.op.core_op, MatrixPinv)
+
+    fn = function([x], out, mode="FAST_COMPILE")
+    assert isinstance(fn.maker.fgraph.outputs[0].owner.op, MatrixPinv)
+
+    # Test that it's not removed when there are batched dims
+    x = tensor3("x")
+    out = blockwise_op(x)
+    fn = function([x], out, mode="FAST_COMPILE")
+    assert isinstance(fn.maker.fgraph.outputs[0].owner.op, Blockwise)
+    assert isinstance(fn.maker.fgraph.outputs[0].owner.op.core_op, MatrixPinv)

--- a/tests/tensor/test_blockwise.py
+++ b/tests/tensor/test_blockwise.py
@@ -24,6 +24,7 @@ def test_vectorize_blockwise():
     assert isinstance(vect_node.op, Blockwise) and isinstance(
         vect_node.op.core_op, MatrixInverse
     )
+    assert vect_node.op.signature == ("(m,m)->(m,m)")
     assert vect_node.inputs[0] is tns
 
     # Useless blockwise
@@ -253,6 +254,11 @@ class TestMatrixInverse(MatrixOpBlockwiseTester):
     signature = "(m, m) -> (m, m)"
 
 
-class TestSolve(BlockwiseOpTester):
-    core_op = Solve(lower=True)
+class TestSolveVector(BlockwiseOpTester):
+    core_op = Solve(lower=True, b_ndim=1)
     signature = "(m, m),(m) -> (m)"
+
+
+class TestSolveMatrix(BlockwiseOpTester):
+    core_op = Solve(lower=True, b_ndim=2)
+    signature = "(m, m),(m, n) -> (m, n)"

--- a/tests/tensor/test_blockwise.py
+++ b/tests/tensor/test_blockwise.py
@@ -8,8 +8,9 @@ import pytensor
 from pytensor import config
 from pytensor.gradient import grad
 from pytensor.graph import Apply, Op
+from pytensor.graph.replace import vectorize_node
 from pytensor.tensor import tensor
-from pytensor.tensor.blockwise import Blockwise, _parse_gufunc_signature, vectorize_node
+from pytensor.tensor.blockwise import Blockwise, _parse_gufunc_signature
 from pytensor.tensor.nlinalg import MatrixInverse
 from pytensor.tensor.slinalg import Cholesky, Solve
 

--- a/tests/tensor/test_blockwise.py
+++ b/tests/tensor/test_blockwise.py
@@ -1,0 +1,258 @@
+from itertools import product
+from typing import Optional, Tuple, Union
+
+import numpy as np
+import pytest
+
+import pytensor
+from pytensor import config
+from pytensor.gradient import grad
+from pytensor.graph import Apply, Op
+from pytensor.tensor import tensor
+from pytensor.tensor.blockwise import Blockwise, _parse_gufunc_signature, vectorize_node
+from pytensor.tensor.nlinalg import MatrixInverse
+from pytensor.tensor.slinalg import Cholesky, Solve
+
+
+def test_vectorize_blockwise():
+    mat = tensor(shape=(None, None))
+    tns = tensor(shape=(None, None, None))
+
+    # Something that falls back to Blockwise
+    node = MatrixInverse()(mat).owner
+    vect_node = vectorize_node(node, tns)
+    assert isinstance(vect_node.op, Blockwise) and isinstance(
+        vect_node.op.core_op, MatrixInverse
+    )
+    assert vect_node.inputs[0] is tns
+
+    # Useless blockwise
+    tns4 = tensor(shape=(5, None, None, None))
+    new_vect_node = vectorize_node(vect_node, tns4)
+    assert new_vect_node.op is vect_node.op
+    assert isinstance(new_vect_node.op, Blockwise) and isinstance(
+        new_vect_node.op.core_op, MatrixInverse
+    )
+    assert new_vect_node.inputs[0] is tns4
+
+
+class TestOp(Op):
+    def make_node(self, *inputs):
+        return Apply(self, inputs, [i.type() for i in inputs])
+
+    def perform(self, *args, **kwargs):
+        raise NotImplementedError("Test Op should not be present in final graph")
+
+
+test_op = TestOp()
+
+
+def test_vectorize_node_default_signature():
+    vec = tensor(shape=(None,))
+    mat = tensor(shape=(5, None))
+    node = test_op.make_node(vec, mat)
+
+    vect_node = vectorize_node(node, mat, mat)
+    assert isinstance(vect_node.op, Blockwise) and isinstance(
+        vect_node.op.core_op, TestOp
+    )
+    assert vect_node.op.signature == ("(i00),(i10,i11)->(o00),(o10,o11)")
+
+    with pytest.raises(
+        ValueError, match="Signature not provided nor found in core_op TestOp"
+    ):
+        Blockwise(test_op)
+
+    vect_node = Blockwise(test_op, signature="(m),(n)->(m),(n)").make_node(vec, mat)
+    assert vect_node.outputs[0].type.shape == (
+        5,
+        None,
+    )
+    assert vect_node.outputs[0].type.shape == (
+        5,
+        None,
+    )
+
+
+def test_blockwise_shape():
+    # Single output
+    inp = tensor(shape=(5, None, None))
+    inp_test = np.zeros((5, 4, 3), dtype=config.floatX)
+
+    # Shape can be inferred from inputs
+    op = Blockwise(test_op, signature="(m, n) -> (n, m)")
+    out = op(inp)
+    assert out.type.shape == (5, None, None)
+
+    shape_fn = pytensor.function([inp], out.shape)
+    assert not any(
+        isinstance(getattr(n.op, "core_op", n.op), TestOp)
+        for n in shape_fn.maker.fgraph.apply_nodes
+    )
+    assert tuple(shape_fn(inp_test)) == (5, 3, 4)
+
+    # Shape can only be partially inferred from inputs
+    op = Blockwise(test_op, signature="(m, n) -> (m, k)")
+    out = op(inp)
+    assert out.type.shape == (5, None, None)
+
+    shape_fn = pytensor.function([inp], out.shape)
+    assert any(
+        isinstance(getattr(n.op, "core_op", n.op), TestOp)
+        for n in shape_fn.maker.fgraph.apply_nodes
+    )
+
+    shape_fn = pytensor.function([inp], out.shape[:-1])
+    assert not any(
+        isinstance(getattr(n.op, "core_op", n.op), TestOp)
+        for n in shape_fn.maker.fgraph.apply_nodes
+    )
+    assert tuple(shape_fn(inp_test)) == (5, 4)
+
+    # Mutiple outputs
+    inp1 = tensor(shape=(7, 1, None, None))
+    inp2 = tensor(shape=(1, 5, None, None))
+    inp1_test = np.zeros((7, 1, 4, 3), dtype=config.floatX)
+    inp2_test = np.zeros((1, 5, 4, 3), dtype=config.floatX)
+
+    op = Blockwise(test_op, signature="(m, n), (m, n) -> (n, m), (m, k)")
+    outs = op(inp1, inp2)
+    assert outs[0].type.shape == (7, 5, None, None)
+    assert outs[1].type.shape == (7, 5, None, None)
+
+    shape_fn = pytensor.function([inp1, inp2], [out.shape for out in outs])
+    assert any(
+        isinstance(getattr(n.op, "core_op", n.op), TestOp)
+        for n in shape_fn.maker.fgraph.apply_nodes
+    )
+
+    shape_fn = pytensor.function([inp1, inp2], outs[0].shape)
+    assert not any(
+        isinstance(getattr(n.op, "core_op", n.op), TestOp)
+        for n in shape_fn.maker.fgraph.apply_nodes
+    )
+    assert tuple(shape_fn(inp1_test, inp2_test)) == (7, 5, 3, 4)
+
+    shape_fn = pytensor.function([inp1, inp2], [outs[0].shape, outs[1].shape[:-1]])
+    assert not any(
+        isinstance(getattr(n.op, "core_op", n.op), TestOp)
+        for n in shape_fn.maker.fgraph.apply_nodes
+    )
+    assert tuple(shape_fn(inp1_test, inp2_test)[0]) == (7, 5, 3, 4)
+    assert tuple(shape_fn(inp1_test, inp2_test)[1]) == (7, 5, 4)
+
+
+class BlockwiseOpTester:
+    """Base class to test Blockwise works for specific Ops"""
+
+    core_op = None
+    signature = None
+    batcheable_axes = None
+
+    @classmethod
+    def setup_class(cls):
+        seed = sum(map(ord, str(cls.core_op)))
+        cls.rng = np.random.default_rng(seed)
+        cls.params_sig, cls.outputs_sig = _parse_gufunc_signature(cls.signature)
+        if cls.batcheable_axes is None:
+            cls.batcheable_axes = list(range(len(cls.params_sig)))
+        batch_shapes = [(), (1,), (5,), (1, 1), (1, 5), (3, 1), (3, 5)]
+        cls.test_batch_shapes = list(
+            product(batch_shapes, repeat=len(cls.batcheable_axes))
+        )
+        cls.block_op = Blockwise(core_op=cls.core_op, signature=cls.signature)
+
+    @staticmethod
+    def parse_shape(shape: Tuple[Union[str, int], ...]) -> Tuple[int, ...]:
+        """
+        Convert (5, "m", "n") -> (5, 7, 11)
+        """
+        mapping = {"m": 7, "n": 11, "k": 19}
+        return tuple(mapping.get(p, p) for p in shape)
+
+    def create_testvals(self, shape):
+        return self.rng.normal(size=self.parse_shape(shape)).astype(config.floatX)
+
+    def create_batched_inputs(self, batch_idx: Optional[int] = None):
+        for batch_shapes in self.test_batch_shapes:
+            vec_inputs = []
+            vec_inputs_testvals = []
+            for idx, (batch_shape, param_sig) in enumerate(
+                zip(batch_shapes, self.params_sig)
+            ):
+                if batch_idx is not None and idx != batch_idx:
+                    # Skip out combinations in which other inputs are batched
+                    if batch_shape != ():
+                        break
+                vec_inputs.append(tensor(shape=batch_shape + (None,) * len(param_sig)))
+                vec_inputs_testvals.append(
+                    self.create_testvals(shape=batch_shape + param_sig)
+                )
+            else:  # no-break
+                yield vec_inputs, vec_inputs_testvals
+
+    def test_perform(self):
+        base_inputs = [
+            tensor(shape=(None,) * len(param_sig)) for param_sig in self.params_sig
+        ]
+        core_func = pytensor.function(base_inputs, self.core_op(*base_inputs))
+        np_func = np.vectorize(core_func, signature=self.signature)
+
+        for vec_inputs, vec_inputs_testvals in self.create_batched_inputs():
+            pt_func = pytensor.function(vec_inputs, self.block_op(*vec_inputs))
+            if len(self.outputs_sig) != 1:
+                raise NotImplementedError("Did not implement test for multi-output Ops")
+            np.testing.assert_allclose(
+                pt_func(*vec_inputs_testvals),
+                np_func(*vec_inputs_testvals),
+            )
+
+    def test_grad(self):
+        base_inputs = [
+            tensor(shape=(None,) * len(param_sig)) for param_sig in self.params_sig
+        ]
+        out = self.core_op(*base_inputs).sum()
+        # Create separate numpy vectorized functions for each input
+        np_funcs = []
+        for i, inp in enumerate(base_inputs):
+            core_grad_func = pytensor.function(base_inputs, grad(out, wrt=inp))
+            params_sig = self.signature.split("->")[0]
+            param_sig = f"({','.join(self.params_sig[i])})"
+            grad_sig = f"{params_sig}->{param_sig}"
+            np_func = np.vectorize(core_grad_func, signature=grad_sig)
+            np_funcs.append(np_func)
+
+        # We test gradient wrt to one batched input at a time
+        for test_input_idx in range(len(base_inputs)):
+            for vec_inputs, vec_inputs_testvals in self.create_batched_inputs(
+                batch_idx=test_input_idx
+            ):
+                out = self.block_op(*vec_inputs).sum()
+                pt_func = pytensor.function(
+                    vec_inputs, grad(out, wrt=vec_inputs[test_input_idx])
+                )
+                pt_out = pt_func(*vec_inputs_testvals)
+                np_out = np_funcs[test_input_idx](*vec_inputs_testvals)
+                np.testing.assert_allclose(pt_out, np_out, atol=1e-6)
+
+
+class MatrixOpBlockwiseTester(BlockwiseOpTester):
+    def create_testvals(self, shape):
+        # Return a posdef matrix
+        X = super().create_testvals(shape)
+        return np.einsum("...ij,...kj->...ik", X, X)
+
+
+class TestCholesky(MatrixOpBlockwiseTester):
+    core_op = Cholesky(lower=True)
+    signature = "(m, m) -> (m, m)"
+
+
+class TestMatrixInverse(MatrixOpBlockwiseTester):
+    core_op = MatrixInverse()
+    signature = "(m, m) -> (m, m)"
+
+
+class TestSolve(BlockwiseOpTester):
+    core_op = Solve(lower=True)
+    signature = "(m, m),(m) -> (m)"

--- a/tests/tensor/test_elemwise.py
+++ b/tests/tensor/test_elemwise.py
@@ -17,10 +17,13 @@ from pytensor.link.basic import PerformLinker
 from pytensor.link.c.basic import CLinker, OpWiseCLinker
 from pytensor.tensor import as_tensor_variable
 from pytensor.tensor.basic import second
+from pytensor.tensor.blockwise import vectorize_node
 from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
-from pytensor.tensor.math import all as at_all
-from pytensor.tensor.math import any as at_any
+from pytensor.tensor.math import Any, Sum
+from pytensor.tensor.math import all as pt_all
+from pytensor.tensor.math import any as pt_any
 from pytensor.tensor.math import exp
+from pytensor.tensor.math import sum as pt_sum
 from pytensor.tensor.type import (
     TensorType,
     bmatrix,
@@ -470,12 +473,12 @@ class TestCAReduce(unittest_tools.InferShapeTester):
                         axis2.append(a)
                 assert len(axis2) == len(tosum)
                 tosum = tuple(axis2)
-            if tensor_op == at_all:
+            if tensor_op == pt_all:
                 for axis in sorted(tosum, reverse=True):
                     zv = np.all(zv, axis)
                 if len(tosum) == 0:
                     zv = zv != 0
-            elif tensor_op == at_any:
+            elif tensor_op == pt_any:
                 for axis in sorted(tosum, reverse=True):
                     zv = np.any(zv, axis)
                 if len(tosum) == 0:
@@ -553,8 +556,8 @@ class TestCAReduce(unittest_tools.InferShapeTester):
             self.with_mode(Mode(linker="py"), aes.mul, dtype=dtype)
             self.with_mode(Mode(linker="py"), aes.scalar_maximum, dtype=dtype)
             self.with_mode(Mode(linker="py"), aes.scalar_minimum, dtype=dtype)
-            self.with_mode(Mode(linker="py"), aes.and_, dtype=dtype, tensor_op=at_all)
-            self.with_mode(Mode(linker="py"), aes.or_, dtype=dtype, tensor_op=at_any)
+            self.with_mode(Mode(linker="py"), aes.and_, dtype=dtype, tensor_op=pt_all)
+            self.with_mode(Mode(linker="py"), aes.or_, dtype=dtype, tensor_op=pt_any)
         for dtype in ["int8", "uint8"]:
             self.with_mode(Mode(linker="py"), aes.or_, dtype=dtype)
             self.with_mode(Mode(linker="py"), aes.and_, dtype=dtype)
@@ -575,14 +578,14 @@ class TestCAReduce(unittest_tools.InferShapeTester):
                 aes.or_,
                 dtype=dtype,
                 test_nan=True,
-                tensor_op=at_any,
+                tensor_op=pt_any,
             )
             self.with_mode(
                 Mode(linker="py"),
                 aes.and_,
                 dtype=dtype,
                 test_nan=True,
-                tensor_op=at_all,
+                tensor_op=pt_all,
             )
 
     @pytest.mark.skipif(
@@ -606,8 +609,8 @@ class TestCAReduce(unittest_tools.InferShapeTester):
         for dtype in ["bool", "floatX", "int8", "uint8"]:
             self.with_mode(Mode(linker="c"), aes.scalar_minimum, dtype=dtype)
             self.with_mode(Mode(linker="c"), aes.scalar_maximum, dtype=dtype)
-            self.with_mode(Mode(linker="c"), aes.and_, dtype=dtype, tensor_op=at_all)
-            self.with_mode(Mode(linker="c"), aes.or_, dtype=dtype, tensor_op=at_any)
+            self.with_mode(Mode(linker="c"), aes.and_, dtype=dtype, tensor_op=pt_all)
+            self.with_mode(Mode(linker="c"), aes.or_, dtype=dtype, tensor_op=pt_any)
         for dtype in ["bool", "int8", "uint8"]:
             self.with_mode(Mode(linker="c"), aes.or_, dtype=dtype)
             self.with_mode(Mode(linker="c"), aes.and_, dtype=dtype)
@@ -915,3 +918,50 @@ def test_not_implemented_elemwise_grad():
     # Verify that trying to use the not implemented gradient fails.
     with pytest.raises(pytensor.gradient.NullTypeGradError):
         pytensor.gradient.grad(test_op(x, 2), x)
+
+
+class TestVectorize:
+    def test_elemwise(self):
+        vec = tensor(shape=(None,))
+        mat = tensor(shape=(None, None))
+
+        node = exp(vec).owner
+        vect_node = vectorize_node(node, mat)
+        assert vect_node.op == exp
+        assert vect_node.inputs[0] is mat
+
+    def test_dimshuffle(self):
+        vec = tensor(shape=(None,))
+        mat = tensor(shape=(None, None))
+
+        node = exp(vec).owner
+        vect_node = vectorize_node(node, mat)
+        assert vect_node.op == exp
+        assert vect_node.inputs[0] is mat
+
+        col_mat = tensor(shape=(None, 1))
+        tcol_mat = tensor(shape=(None, None, 1))
+        node = col_mat.dimshuffle(0).owner  # drop column
+        vect_node = vectorize_node(node, tcol_mat)
+        assert isinstance(vect_node.op, DimShuffle)
+        assert vect_node.op.new_order == (0, 1)
+        assert vect_node.inputs[0] is tcol_mat
+        assert vect_node.outputs[0].type.shape == (None, None)
+
+    def test_CAReduce(self):
+        mat = tensor(shape=(None, None))
+        tns = tensor(shape=(None, None, None))
+
+        node = pt_sum(mat).owner
+        vect_node = vectorize_node(node, tns)
+        assert isinstance(vect_node.op, Sum)
+        assert vect_node.op.axis == (1, 2)
+        assert vect_node.inputs[0] is tns
+
+        bool_mat = tensor(dtype="bool", shape=(None, None))
+        bool_tns = tensor(dtype="bool", shape=(None, None, None))
+        node = pt_any(bool_mat, axis=-2).owner
+        vect_node = vectorize_node(node, bool_tns)
+        assert isinstance(vect_node.op, Any)
+        assert vect_node.op.axis == (1,)
+        assert vect_node.inputs[0] is bool_tns

--- a/tests/tensor/test_elemwise.py
+++ b/tests/tensor/test_elemwise.py
@@ -13,11 +13,11 @@ from pytensor.compile.mode import Mode
 from pytensor.configdefaults import config
 from pytensor.graph.basic import Apply, Variable
 from pytensor.graph.fg import FunctionGraph
+from pytensor.graph.replace import vectorize_node
 from pytensor.link.basic import PerformLinker
 from pytensor.link.c.basic import CLinker, OpWiseCLinker
 from pytensor.tensor import as_tensor_variable
 from pytensor.tensor.basic import second
-from pytensor.tensor.blockwise import vectorize_node
 from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
 from pytensor.tensor.math import Any, Sum
 from pytensor.tensor.math import all as pt_all

--- a/tests/tensor/test_slinalg.py
+++ b/tests/tensor/test_slinalg.py
@@ -361,7 +361,7 @@ class TestCholeskySolve(utt.InferShapeTester):
         super().setup_method()
 
     def test_repr(self):
-        assert repr(CholeskySolve()) == "CholeskySolve{(True, True)}"
+        assert repr(CholeskySolve()) == "CholeskySolve(lower=True,check_finite=True)"
 
     def test_infer_shape(self):
         rng = np.random.default_rng(utt.fetch_seed())


### PR DESCRIPTION
Critical for https://github.com/pymc-devs/pymc/issues/5383

This PR was done almost completely from scratch, although the general principles and some of the code were obviously inspired by https://github.com/aesara-devs/aesara/pull/1215

For fairness, all authors of the commits in that PR were added as co-authors here.

CC @purna135

Some design questions:
1. Do we want to make Blockwise the "default" form of an Op (in terms of rewrites), and only later specialize if they were not needed?  **Decided yes**
2. Do we want to fuse consecutive Blockwises with the same batched dims, similarly to how we fuse consecutive Elemwises? **Not for now**
3. Can Rop be implemented just as the batched core Rop, like L_op?

Important follow-up:
1. Dispatch to JAX and Numba
2. ~~Create a PyTensor "vectorize" function that vectorizes the whole graph, similar to what the `L_op` method has to do~~ Included as the last commit

```python
from pytensor.graph import vectorize

# Original graph
x = pt.vector("x")
y = pt.exp(x) / pt.sum(pt.exp(x))

new_x = pt.matrix("new_x")
[new_y] = vectorize([y], {x: new_x})

fn = pytensor.function([new_x], new_y)
fn([[0, 1, 2], [2, 1, 0]])
# array([[0.09003057, 0.24472847, 0.66524096],
#        [0.66524096, 0.24472847, 0.09003057]])
```

Important to test:
1. Whether this works with Ops with inner graphs (Scan, Composite)