### PR TITLE
Revert "Run numba tests in python 3.10 instead of 3.11"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,7 +139,7 @@ jobs:
         shell: bash -l {0}
         run: |
           mamba install --yes -q "python~=${PYTHON_VERSION}=*_cpython" mkl numpy scipy pip mkl-service graphviz cython pytest coverage pytest-cov pytest-benchmark sympy
-          if [[ $INSTALL_NUMBA == "1" ]]; then mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" "numba>=0.55" numba-scipy; fi
+          if [[ $INSTALL_NUMBA == "1" ]]; then mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" "numba>=0.57" numba-scipy; fi
           mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" jax jaxlib numpyro
           pip install -e ./
           mamba list && pip freeze
@@ -192,7 +192,7 @@ jobs:
         - name: Install dependencies
           shell: bash -l {0}
           run: |
-            mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" mkl numpy scipy pip mkl-service cython pytest "numba>=0.55" numba-scipy jax jaxlib pytest-benchmark
+            mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" mkl numpy scipy pip mkl-service cython pytest "numba>=0.57" numba-scipy jax jaxlib pytest-benchmark
             pip install -e ./
             mamba list && pip freeze
             python -c 'import pytensor; print(pytensor.config.__str__(print_doc=False))'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,9 +73,9 @@ jobs:
         python-version: ["3.8", "3.11"]
         fast-compile: [0,1]
         float32: [0,1]
-        install-numba: [0]
+        install-numba: [1]
         part:
-          - "tests --ignore=tests/tensor --ignore=tests/scan --ignore=tests/sparse --ignore=tests/link/numba"
+          - "tests --ignore=tests/tensor --ignore=tests/scan --ignore=tests/sparse"
           - "tests/scan"
           - "tests/sparse"
           - "tests/tensor --ignore=tests/tensor/conv --ignore=tests/tensor/rewriting --ignore=tests/tensor/test_math.py --ignore=tests/tensor/test_basic.py --ignore=tests/tensor/test_blas.py --ignore=tests/tensor/test_math_scipy.py --ignore=tests/tensor/test_inplace.py --ignore=tests/tensor/test_elemwise.py"
@@ -93,27 +93,6 @@ jobs:
             part: "tests/tensor/test_math.py"
           - fast-compile: 1
             float32: 1
-        include:
-          - install-numba: 1
-            python-version: "3.8"
-            fast-compile: 0
-            float32: 0
-            part: "tests/link/numba"
-          - install-numba: 1
-            python-version: "3.10"
-            fast-compile: 0
-            float32: 0
-            part: "tests/link/numba"
-          - install-numba: 1
-            python-version: "3.10"
-            fast-compile: 1
-            float32: 0
-            part: "tests/link/numba"
-          - install-numba: 1
-            python-version: "3.10"
-            fast-compile: 0
-            float32: 1
-            part: "tests/link/numba"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - mkl-service
   - libblas=*=*mkl
   # numba backend
-  - numba>=0.55
+  - numba>=0.57
   - numba-scipy
   # For testing
   - coveralls

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-import os
-
 import numpy
 from setuptools import Extension, setup
 from setuptools.dist import Distribution
@@ -13,22 +11,6 @@ dist.parse_config_files()
 
 
 NAME: str = dist.get_name()  # type: ignore
-
-# Handle builds of nightly release
-if "BUILD_PYTENSOR_NIGHTLY" in os.environ:
-    NAME += "-nightly"
-
-    from versioneer import get_versions as original_get_versions
-
-    def get_versions():
-        from datetime import datetime, timezone
-
-        suffix = datetime.now(timezone.utc).strftime(r".dev%Y%m%d")
-        versions = original_get_versions()
-        versions["version"] = versions["version"].split("+")[0] + suffix
-        return versions
-
-    versioneer.get_versions = get_versions
 
 
 if __name__ == "__main__":

--- a/tests/link/numba/test_basic.py
+++ b/tests/link/numba/test_basic.py
@@ -530,9 +530,6 @@ def test_AdvancedIncSubtensor1(x, y, indices):
             at.as_tensor(np.arange(3 * 4 * 5).reshape((3, 4, 5))),
             at.as_tensor(rng.poisson(size=(2, 5))),
             ([1, 1], [2, 2]),
-            marks=pytest.mark.xfail(
-                reason="Duplicate index handling hasn't been implemented, yet."
-            ),
         ),
     ],
 )

--- a/tests/link/numba/test_extra_ops.py
+++ b/tests/link/numba/test_extra_ops.py
@@ -459,9 +459,6 @@ def test_UnravelIndex(arr, shape, order, exc):
             "left",
             None,
             None,
-            marks=pytest.mark.xfail(
-                reason="This won't work until https://github.com/numba/numba/pull/7005 is merged"
-            ),
         ),
         (
             set_test_value(at.vector(), np.array([1.0, 2.0, 3.0], dtype=config.floatX)),


### PR DESCRIPTION
This reverts commit 277559b411886c3dc1161cf197c5f250048ecec5 and  tests numba compatibility with py311

Closes #239 
