### PR TITLE
Improve Op string representation and debug_print formatting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,69 +22,69 @@ Getting started
 
 .. code-block:: python
 
-  import pytensor
-  from pytensor import tensor as pt
+    import pytensor
+    from pytensor import tensor as pt
 
-  # Declare two symbolic floating-point scalars
-  a = pt.dscalar("a")
-  b = pt.dscalar("b")
+    # Declare two symbolic floating-point scalars
+    a = pt.dscalar("a")
+    b = pt.dscalar("b")
 
-  # Create a simple example expression
-  c = a + b
+    # Create a simple example expression
+    c = a + b
 
-  # Convert the expression into a callable object that takes `(a, b)`
-  # values as input and computes the value of `c`.
-  f_c = pytensor.function([a, b], c)
+    # Convert the expression into a callable object that takes `(a, b)`
+    # values as input and computes the value of `c`.
+    f_c = pytensor.function([a, b], c)
 
-  assert f_c(1.5, 2.5) == 4.0
+    assert f_c(1.5, 2.5) == 4.0
 
-  # Compute the gradient of the example expression with respect to `a`
-  dc = pytensor.grad(c, a)
+    # Compute the gradient of the example expression with respect to `a`
+    dc = pytensor.grad(c, a)
 
-  f_dc = pytensor.function([a, b], dc)
+    f_dc = pytensor.function([a, b], dc)
 
-  assert f_dc(1.5, 2.5) == 1.0
+    assert f_dc(1.5, 2.5) == 1.0
 
-  # Compiling functions with `pytensor.function` also optimizes
-  # expression graphs by removing unnecessary operations and
-  # replacing computations with more efficient ones.
+    # Compiling functions with `pytensor.function` also optimizes
+    # expression graphs by removing unnecessary operations and
+    # replacing computations with more efficient ones.
 
-  v = pt.vector("v")
-  M = pt.matrix("M")
+    v = pt.vector("v")
+    M = pt.matrix("M")
 
-  d = a/a + (M + a).dot(v)
+    d = a/a + (M + a).dot(v)
 
-  pytensor.dprint(d)
-  # Elemwise{add,no_inplace} [id A] ''
-  #  |InplaceDimShuffle{x} [id B] ''
-  #  | |Elemwise{true_div,no_inplace} [id C] ''
-  #  |   |a [id D]
-  #  |   |a [id D]
-  #  |dot [id E] ''
-  #    |Elemwise{add,no_inplace} [id F] ''
-  #    | |M [id G]
-  #    | |InplaceDimShuffle{x,x} [id H] ''
-  #    |   |a [id D]
-  #    |v [id I]
+    pytensor.dprint(d)
+    #  Add [id A]
+    #  ├─ ExpandDims{axis=0} [id B]
+    #  │  └─ True_div [id C]
+    #  │     ├─ a [id D]
+    #  │     └─ a [id D]
+    #  └─ dot [id E]
+    #     ├─ Add [id F]
+    #     │  ├─ M [id G]
+    #     │  └─ ExpandDims{axes=[0, 1]} [id H]
+    #     │     └─ a [id D]
+    #     └─ v [id I]
 
-  f_d = pytensor.function([a, v, M], d)
+    f_d = pytensor.function([a, v, M], d)
 
-  # `a/a` -> `1` and the dot product is replaced with a BLAS function
-  # (i.e. CGemv)
-  pytensor.dprint(f_d)
-  # Elemwise{Add}[(0, 1)] [id A] ''   5
-  #  |TensorConstant{(1,) of 1.0} [id B]
-  #  |CGemv{inplace} [id C] ''   4
-  #    |AllocEmpty{dtype='float64'} [id D] ''   3
-  #    | |Shape_i{0} [id E] ''   2
-  #    |   |M [id F]
-  #    |TensorConstant{1.0} [id G]
-  #    |Elemwise{add,no_inplace} [id H] ''   1
-  #    | |M [id F]
-  #    | |InplaceDimShuffle{x,x} [id I] ''   0
-  #    |   |a [id J]
-  #    |v [id K]
-  #    |TensorConstant{0.0} [id L]
+    # `a/a` -> `1` and the dot product is replaced with a BLAS function
+    # (i.e. CGemv)
+    pytensor.dprint(f_d)
+    # Add [id A] 5
+    #  ├─ [1.] [id B]
+    #  └─ CGemv{inplace} [id C] 4
+    #     ├─ AllocEmpty{dtype='float64'} [id D] 3
+    #     │  └─ Shape_i{0} [id E] 2
+    #     │     └─ M [id F]
+    #     ├─ 1.0 [id G]
+    #     ├─ Add [id H] 1
+    #     │  ├─ M [id F]
+    #     │  └─ ExpandDims{axes=[0, 1]} [id I] 0
+    #     │     └─ a [id J]
+    #     ├─ v [id K]
+    #     └─ 0.0 [id L]
 
 See `the PyTensor documentation <https://pytensor.readthedocs.io/en/latest/>`__ for in-depth tutorials.
 

--- a/pytensor/graph/basic.py
+++ b/pytensor/graph/basic.py
@@ -763,13 +763,20 @@ class Constant(AtomicVariable[_TypeType]):
         return (self.type, self.data)
 
     def __str__(self):
-        if self.name is not None:
-            return self.name
-        else:
-            name = str(self.data)
-            if len(name) > 20:
-                name = name[:10] + "..." + name[-10:]
-            return f"{type(self).__name__}{{{name}}}"
+        data_str = str(self.data)
+        if len(data_str) > 20:
+            data_str = data_str[:10].strip() + " ... " + data_str[-10:].strip()
+
+        if self.name is None:
+            return data_str
+
+        return f"{self.name}{{{data_str}}}"
+
+    def __repr__(self):
+        data_str = repr(self.data)
+        if len(data_str) > 20:
+            data_str = data_str[:10].strip() + " ... " + data_str[-10:].strip()
+        return f"{type(self).__name__}({repr(self.type)}, data={data_str})"
 
     def clone(self, **kwargs):
         return self

--- a/pytensor/graph/op.py
+++ b/pytensor/graph/op.py
@@ -621,6 +621,11 @@ class Op(MetaObject):
     def __str__(self):
         return getattr(type(self), "__name__", super().__str__())
 
+    def __repr__(self):
+        props = getattr(self, "__props__", ())
+        props = ",".join(f"{prop}={getattr(self, prop, '?')}" for prop in props)
+        return f"{self.__class__.__name__}({props})"
+
 
 class _NoPythonOp(Op):
     """A class used to indicate that an `Op` does not provide a Python implementation.

--- a/pytensor/graph/utils.py
+++ b/pytensor/graph/utils.py
@@ -234,6 +234,7 @@ class MetaType(ABCMeta):
 
                 dct["__eq__"] = __eq__
 
+            # FIXME: This overrides __str__ inheritance when props are provided
             if "__str__" not in dct:
                 if len(props) == 0:
 

--- a/pytensor/scan/op.py
+++ b/pytensor/scan/op.py
@@ -1282,27 +1282,18 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         )
 
     def __str__(self):
-        device_str = "cpu"
-        if self.info.as_while:
-            name = "do_while"
-        else:
-            name = "for"
-        aux_txt = "%s"
+        inplace = "none"
         if len(self.destroy_map.keys()) > 0:
             # Check if all outputs are inplace
             if sorted(self.destroy_map.keys()) == sorted(
                 range(self.info.n_mit_mot + self.info.n_mit_sot + self.info.n_sit_sot)
             ):
-                aux_txt += "all_inplace,%s,%s}"
+                inplace = "all"
             else:
-                aux_txt += "{inplace{"
-                for k in self.destroy_map.keys():
-                    aux_txt += str(k) + ","
-                aux_txt += "},%s,%s}"
-        else:
-            aux_txt += "{%s,%s}"
-        aux_txt = aux_txt % (name, device_str, str(self.name))
-        return aux_txt
+                inplace = str(list(self.destroy_map.keys()))
+        return (
+            f"Scan{{{self.name}, while_loop={self.info.as_while}, inplace={inplace}}}"
+        )
 
     def __hash__(self):
         return hash(

--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -42,7 +42,8 @@ from pytensor.tensor.math import (
     All,
     Any,
     Dot,
-    NonZeroCAReduce,
+    FixedOpCAReduce,
+    NonZeroDimsCAReduce,
     Prod,
     ProdWithoutZeros,
     Sum,
@@ -1671,7 +1672,8 @@ ALL_REDUCE = (
         ProdWithoutZeros,
     ]
     + CAReduce.__subclasses__()
-    + NonZeroCAReduce.__subclasses__()
+    + FixedOpCAReduce.__subclasses__()
+    + NonZeroDimsCAReduce.__subclasses__()
 )
 
 

--- a/pytensor/tensor/type.py
+++ b/pytensor/tensor/type.py
@@ -386,6 +386,8 @@ class TensorType(CType[np.ndarray], HasDataType, HasShape):
         if self.name:
             return self.name
         else:
+            shape = self.shape
+            len_shape = len(shape)
 
             def shape_str(s):
                 if s is None:
@@ -393,14 +395,18 @@ class TensorType(CType[np.ndarray], HasDataType, HasShape):
                 else:
                     return str(s)
 
-            formatted_shape = ", ".join([shape_str(s) for s in self.shape])
-            if len(self.shape) == 1:
+            formatted_shape = ", ".join([shape_str(s) for s in shape])
+            if len_shape == 1:
                 formatted_shape += ","
 
-            return f"TensorType({self.dtype}, ({formatted_shape}))"
+            if len_shape > 2:
+                name = f"Tensor{len_shape}"
+            else:
+                name = ("Scalar", "Vector", "Matrix")[len_shape]
+            return f"{name}({self.dtype}, shape=({formatted_shape}))"
 
     def __repr__(self):
-        return str(self)
+        return f"TensorType({self.dtype}, shape={self.shape})"
 
     @staticmethod
     def may_share_memory(a, b):

--- a/pytensor/tensor/var.py
+++ b/pytensor/tensor/var.py
@@ -1023,21 +1023,6 @@ class TensorConstant(TensorVariable, Constant[_TensorTypeType]):
 
         Constant.__init__(self, new_type, data, name)
 
-    def __str__(self):
-        unique_val = get_unique_value(self)
-        if unique_val is not None:
-            val = f"{self.data.shape} of {unique_val}"
-        else:
-            val = f"{self.data}"
-        if len(val) > 20:
-            val = val[:10].strip() + " ... " + val[-10:].strip()
-
-        if self.name is not None:
-            name = self.name
-        else:
-            name = "TensorConstant"
-        return f"{name}{{{val}}}"
-
     def signature(self):
         return TensorConstantSignature((self.type, self.data))
 

--- a/pytensor/tensor/var.py
+++ b/pytensor/tensor/var.py
@@ -1030,7 +1030,7 @@ class TensorConstant(TensorVariable, Constant[_TensorTypeType]):
         else:
             val = f"{self.data}"
         if len(val) > 20:
-            val = val[:10] + ".." + val[-10:]
+            val = val[:10].strip() + " ... " + val[-10:].strip()
 
         if self.name is not None:
             name = self.name

--- a/pytensor/tensor/var.py
+++ b/pytensor/tensor/var.py
@@ -616,9 +616,9 @@ class _tensor_py_operators:
         except TypeError:
             # This prevents accidental iteration via sum(self)
             raise TypeError(
-                "TensorType does not support iteration. "
-                "Maybe you are using builtins.sum instead of "
-                "pytensor.tensor.math.sum? (Maybe .max?)"
+                "TensorType does not support iteration.\n"
+                "\tDid you pass a PyTensor variable to a function that expects a list?\n"
+                "\tMaybe you are using builtins.sum instead of pytensor.tensor.sum?"
             )
 
     @property

--- a/tests/compile/test_builders.py
+++ b/tests/compile/test_builders.py
@@ -579,9 +579,9 @@ def test_debugprint():
 Inner graphs:
 
 OpFromGraph{inline=False} [id A]
- ← Elemwise{add,no_inplace} [id E]
+ ← Add [id E]
     ├─ *0-<TensorType(float64, (?, ?))> [id F]
-    └─ Elemwise{mul,no_inplace} [id G]
+    └─ Mul [id G]
        ├─ *1-<TensorType(float64, (?, ?))> [id H]
        └─ *2-<TensorType(float64, (?, ?))> [id I]
 """

--- a/tests/compile/test_builders.py
+++ b/tests/compile/test_builders.py
@@ -580,10 +580,10 @@ Inner graphs:
 
 OpFromGraph{inline=False} [id A]
  ← Add [id E]
-    ├─ *0-<TensorType(float64, (?, ?))> [id F]
+    ├─ *0-<Matrix(float64, shape=(?, ?))> [id F]
     └─ Mul [id G]
-       ├─ *1-<TensorType(float64, (?, ?))> [id H]
-       └─ *2-<TensorType(float64, (?, ?))> [id I]
+       ├─ *1-<Matrix(float64, shape=(?, ?))> [id H]
+       └─ *2-<Matrix(float64, shape=(?, ?))> [id I]
 """
 
     for truth, out in zip(exp_res.split("\n"), lines):

--- a/tests/compile/test_builders.py
+++ b/tests/compile/test_builders.py
@@ -572,18 +572,18 @@ def test_debugprint():
     lines = output_str.split("\n")
 
     exp_res = """OpFromGraph{inline=False} [id A]
- |x [id B]
- |y [id C]
- |z [id D]
+ ├─ x [id B]
+ ├─ y [id C]
+ └─ z [id D]
 
 Inner graphs:
 
 OpFromGraph{inline=False} [id A]
- >Elemwise{add,no_inplace} [id E]
- > |*0-<TensorType(float64, (?, ?))> [id F]
- > |Elemwise{mul,no_inplace} [id G]
- >   |*1-<TensorType(float64, (?, ?))> [id H]
- >   |*2-<TensorType(float64, (?, ?))> [id I]
+ ← Elemwise{add,no_inplace} [id E]
+    ├─ *0-<TensorType(float64, (?, ?))> [id F]
+    └─ Elemwise{mul,no_inplace} [id G]
+       ├─ *1-<TensorType(float64, (?, ?))> [id H]
+       └─ *2-<TensorType(float64, (?, ?))> [id I]
 """
 
     for truth, out in zip(exp_res.split("\n"), lines):

--- a/tests/graph/rewriting/test_basic.py
+++ b/tests/graph/rewriting/test_basic.py
@@ -166,7 +166,7 @@ class TestPatternNodeRewriter:
         e = op1(op1(x, y), y)
         g = FunctionGraph([y], [e])
         OpKeyPatternNodeRewriter((op1, z, "1"), (op2, "1", z)).rewrite(g)
-        assert str(g) == "FunctionGraph(Op1(Op2(y, z), y))"
+        assert str(g) == "FunctionGraph(Op1(Op2(y, z{2}), y))"
 
     def test_constraints(self):
         x, y, z = MyVariable("x"), MyVariable("y"), MyVariable("z")

--- a/tests/link/test_utils.py
+++ b/tests/link/test_utils.py
@@ -156,7 +156,7 @@ def test_fgraph_to_python_multiline_str():
 
     assert (
         """
-    # Elemwise{add,no_inplace}(Test
+    # Add(Test
     # Op().0, Test
     # Op().1)
     """

--- a/tests/scalar/test_basic.py
+++ b/tests/scalar/test_basic.py
@@ -183,7 +183,7 @@ class TestComposite:
         make_function(DualLinker().accept(g))
 
         assert str(g) == (
-            "FunctionGraph(*1 -> Composite(x, y, z), *1::1, *1::2, *1::3, *1::4, *1::5, *1::6, *1::7)"
+            "FunctionGraph(*1 -> Composite{...}(x, y, z), *1::1, *1::2, *1::3, *1::4, *1::5, *1::6, *1::7)"
         )
 
     def test_non_scalar_error(self):

--- a/tests/scan/test_printing.py
+++ b/tests/scan/test_printing.py
@@ -32,13 +32,13 @@ def test_debugprint_sitsot():
      │  │  ├─ k [id D] (n_steps)
      │  │  ├─ IncSubtensor{Set;:int64:} [id E] (outer_in_sit_sot-0)
      │  │  │  ├─ AllocEmpty{dtype='float64'} [id F]
-     │  │  │  │  ├─ Elemwise{add,no_inplace} [id G]
+     │  │  │  │  ├─ Add [id G]
      │  │  │  │  │  ├─ k [id D]
      │  │  │  │  │  └─ Subtensor{int64} [id H]
      │  │  │  │  │     ├─ Shape [id I]
      │  │  │  │  │     │  └─ Unbroadcast{0} [id J]
      │  │  │  │  │     │     └─ ExpandDims{axis=0} [id K]
-     │  │  │  │  │     │        └─ Elemwise{second,no_inplace} [id L]
+     │  │  │  │  │     │        └─ Second [id L]
      │  │  │  │  │     │           ├─ A [id M]
      │  │  │  │  │     │           └─ ExpandDims{axis=0} [id N]
      │  │  │  │  │     │              └─ TensorConstant{1.0} [id O]
@@ -60,7 +60,7 @@ def test_debugprint_sitsot():
     Inner graphs:
 
     for{cpu,scan_fn} [id C]
-     ← Elemwise{mul,no_inplace} [id W] (inner_out_sit_sot-0)
+     ← Mul [id W] (inner_out_sit_sot-0)
         ├─ *0-<TensorType(float64, (?,))> [id X] -> [id E] (inner_in_sit_sot-0)
         └─ *1-<TensorType(float64, (?,))> [id Y] -> [id M] (inner_in_non_seqs-0)"""
 
@@ -90,13 +90,13 @@ def test_debugprint_sitsot_no_extra_info():
      │  │  ├─ k [id D]
      │  │  ├─ IncSubtensor{Set;:int64:} [id E]
      │  │  │  ├─ AllocEmpty{dtype='float64'} [id F]
-     │  │  │  │  ├─ Elemwise{add,no_inplace} [id G]
+     │  │  │  │  ├─ Add [id G]
      │  │  │  │  │  ├─ k [id D]
      │  │  │  │  │  └─ Subtensor{int64} [id H]
      │  │  │  │  │     ├─ Shape [id I]
      │  │  │  │  │     │  └─ Unbroadcast{0} [id J]
      │  │  │  │  │     │     └─ ExpandDims{axis=0} [id K]
-     │  │  │  │  │     │        └─ Elemwise{second,no_inplace} [id L]
+     │  │  │  │  │     │        └─ Second [id L]
      │  │  │  │  │     │           ├─ A [id M]
      │  │  │  │  │     │           └─ ExpandDims{axis=0} [id N]
      │  │  │  │  │     │              └─ TensorConstant{1.0} [id O]
@@ -118,7 +118,7 @@ def test_debugprint_sitsot_no_extra_info():
     Inner graphs:
 
     for{cpu,scan_fn} [id C]
-     ← Elemwise{mul,no_inplace} [id W]
+     ← Mul [id W]
         ├─ *0-<TensorType(float64, (?,))> [id X] -> [id E]
         └─ *1-<TensorType(float64, (?,))> [id Y] -> [id M]"""
 
@@ -147,9 +147,9 @@ def test_debugprint_nitsot():
     output_str = debugprint(polynomial, file="str", print_op_info=True)
     lines = output_str.split("\n")
 
-    expected_output = """Sum{acc_dtype=float64} [id A]
+    expected_output = """Sum{axes=None} [id A]
      └─ for{cpu,scan_fn} [id B] (outer_out_nit_sot-0)
-        ├─ Elemwise{scalar_minimum,no_inplace} [id C] (outer_in_nit_sot-0)
+        ├─ Minimum [id C] (outer_in_nit_sot-0)
         │  ├─ Subtensor{int64} [id D]
         │  │  ├─ Shape [id E]
         │  │  │  └─ Subtensor{int64::} [id F] 'coefficients[0:]'
@@ -169,24 +169,24 @@ def test_debugprint_nitsot():
         │  ├─ Subtensor{int64::} [id F] 'coefficients[0:]'
         │  │  └─ ···
         │  └─ ScalarFromTensor [id T]
-        │     └─ Elemwise{scalar_minimum,no_inplace} [id C]
+        │     └─ Minimum [id C]
         │        └─ ···
         ├─ Subtensor{:int64:} [id U] (outer_in_seqs-1)
         │  ├─ Subtensor{int64::} [id L]
         │  │  └─ ···
         │  └─ ScalarFromTensor [id V]
-        │     └─ Elemwise{scalar_minimum,no_inplace} [id C]
+        │     └─ Minimum [id C]
         │        └─ ···
-        ├─ Elemwise{scalar_minimum,no_inplace} [id C] (outer_in_nit_sot-0)
+        ├─ Minimum [id C] (outer_in_nit_sot-0)
         │  └─ ···
         └─ x [id W] (outer_in_non_seqs-0)
 
     Inner graphs:
 
     for{cpu,scan_fn} [id B]
-     ← Elemwise{mul,no_inplace} [id X] (inner_out_nit_sot-0)
+     ← Mul [id X] (inner_out_nit_sot-0)
         ├─ *0-<TensorType(float64, ())> [id Y] -> [id S] (inner_in_seqs-0)
-        └─ Elemwise{pow,no_inplace} [id Z]
+        └─ Pow [id Z]
            ├─ *2-<TensorType(float64, ())> [id BA] -> [id W] (inner_in_non_seqs-0)
            └─ *1-<TensorType(int64, ())> [id BB] -> [id U] (inner_in_seqs-1)"""
 
@@ -225,9 +225,9 @@ def test_debugprint_nested_scans():
     output_str = debugprint(final_result, file="str", print_op_info=True)
     lines = output_str.split("\n")
 
-    expected_output = """Sum{acc_dtype=float64} [id A]
+    expected_output = """Sum{axes=None} [id A]
      └─ for{cpu,scan_fn} [id B] (outer_out_nit_sot-0)
-        ├─ Elemwise{scalar_minimum,no_inplace} [id C] (outer_in_nit_sot-0)
+        ├─ Minimum [id C] (outer_in_nit_sot-0)
         │  ├─ Subtensor{int64} [id D]
         │  │  ├─ Shape [id E]
         │  │  │  └─ Subtensor{int64::} [id F] 'c[0:]'
@@ -247,15 +247,15 @@ def test_debugprint_nested_scans():
         │  ├─ Subtensor{int64::} [id F] 'c[0:]'
         │  │  └─ ···
         │  └─ ScalarFromTensor [id T]
-        │     └─ Elemwise{scalar_minimum,no_inplace} [id C]
+        │     └─ Minimum [id C]
         │        └─ ···
         ├─ Subtensor{:int64:} [id U] (outer_in_seqs-1)
         │  ├─ Subtensor{int64::} [id L]
         │  │  └─ ···
         │  └─ ScalarFromTensor [id V]
-        │     └─ Elemwise{scalar_minimum,no_inplace} [id C]
+        │     └─ Minimum [id C]
         │        └─ ···
-        ├─ Elemwise{scalar_minimum,no_inplace} [id C] (outer_in_nit_sot-0)
+        ├─ Minimum [id C] (outer_in_nit_sot-0)
         │  └─ ···
         ├─ A [id W] (outer_in_non_seqs-0)
         └─ k [id X] (outer_in_non_seqs-1)
@@ -263,23 +263,23 @@ def test_debugprint_nested_scans():
     Inner graphs:
 
     for{cpu,scan_fn} [id B]
-     ← Elemwise{mul,no_inplace} [id Y] (inner_out_nit_sot-0)
+     ← Mul [id Y] (inner_out_nit_sot-0)
         ├─ ExpandDims{axis=0} [id Z]
         │  └─ *0-<TensorType(float64, ())> [id BA] -> [id S] (inner_in_seqs-0)
-        └─ Elemwise{pow,no_inplace} [id BB]
+        └─ Pow [id BB]
            ├─ Subtensor{int64} [id BC]
            │  ├─ Subtensor{int64::} [id BD]
            │  │  ├─ for{cpu,scan_fn} [id BE] (outer_out_sit_sot-0)
            │  │  │  ├─ *3-<TensorType(int32, ())> [id BF] -> [id X] (inner_in_non_seqs-1) (n_steps)
            │  │  │  ├─ IncSubtensor{Set;:int64:} [id BG] (outer_in_sit_sot-0)
            │  │  │  │  ├─ AllocEmpty{dtype='float64'} [id BH]
-           │  │  │  │  │  ├─ Elemwise{add,no_inplace} [id BI]
+           │  │  │  │  │  ├─ Add [id BI]
            │  │  │  │  │  │  ├─ *3-<TensorType(int32, ())> [id BF] -> [id X] (inner_in_non_seqs-1)
            │  │  │  │  │  │  └─ Subtensor{int64} [id BJ]
            │  │  │  │  │  │     ├─ Shape [id BK]
            │  │  │  │  │  │     │  └─ Unbroadcast{0} [id BL]
            │  │  │  │  │  │     │     └─ ExpandDims{axis=0} [id BM]
-           │  │  │  │  │  │     │        └─ Elemwise{second,no_inplace} [id BN]
+           │  │  │  │  │  │     │        └─ Second [id BN]
            │  │  │  │  │  │     │           ├─ *2-<TensorType(float64, (?,))> [id BO] -> [id W] (inner_in_non_seqs-0)
            │  │  │  │  │  │     │           └─ ExpandDims{axis=0} [id BP]
            │  │  │  │  │  │     │              └─ TensorConstant{1.0} [id BQ]
@@ -301,7 +301,7 @@ def test_debugprint_nested_scans():
               └─ *1-<TensorType(int64, ())> [id BZ] -> [id U] (inner_in_seqs-1)
 
     for{cpu,scan_fn} [id BE]
-     ← Elemwise{mul,no_inplace} [id CA] (inner_out_sit_sot-0)
+     ← Mul [id CA] (inner_out_sit_sot-0)
         ├─ *0-<TensorType(float64, (?,))> [id CB] -> [id BG] (inner_in_sit_sot-0)
         └─ *1-<TensorType(float64, (?,))> [id CC] -> [id BO] (inner_in_non_seqs-0)"""
 
@@ -318,9 +318,9 @@ def test_debugprint_nested_scans():
     expected_output = """→ c [id A]
     → k [id B]
     → A [id C]
-    Sum{acc_dtype=float64} [id D] 13
+    Sum{axes=None} [id D] 13
      └─ for{cpu,scan_fn} [id E] 12 (outer_out_nit_sot-0)
-        ├─ Elemwise{scalar_minimum,no_inplace} [id F] 7 (outer_in_nit_sot-0)
+        ├─ Minimum [id F] 7 (outer_in_nit_sot-0)
         │  ├─ Subtensor{int64} [id G] 6
         │  │  ├─ Shape [id H] 5
         │  │  │  └─ Subtensor{int64::} [id I] 'c[0:]' 4
@@ -340,15 +340,15 @@ def test_debugprint_nested_scans():
         │  ├─ Subtensor{int64::} [id I] 'c[0:]' 4
         │  │  └─ ···
         │  └─ ScalarFromTensor [id V] 10
-        │     └─ Elemwise{scalar_minimum,no_inplace} [id F] 7
+        │     └─ Minimum [id F] 7
         │        └─ ···
         ├─ Subtensor{:int64:} [id W] 9 (outer_in_seqs-1)
         │  ├─ Subtensor{int64::} [id N] 1
         │  │  └─ ···
         │  └─ ScalarFromTensor [id X] 8
-        │     └─ Elemwise{scalar_minimum,no_inplace} [id F] 7
+        │     └─ Minimum [id F] 7
         │        └─ ···
-        ├─ Elemwise{scalar_minimum,no_inplace} [id F] 7 (outer_in_nit_sot-0)
+        ├─ Minimum [id F] 7 (outer_in_nit_sot-0)
         │  └─ ···
         ├─ A [id C] (outer_in_non_seqs-0)
         └─ k [id B] (outer_in_non_seqs-1)
@@ -360,23 +360,23 @@ def test_debugprint_nested_scans():
      → *1-<TensorType(int64, ())> [id Z] -> [id W] (inner_in_seqs-1)
      → *2-<TensorType(float64, (?,))> [id BA] -> [id C] (inner_in_non_seqs-0)
      → *3-<TensorType(int32, ())> [id BB] -> [id B] (inner_in_non_seqs-1)
-     ← Elemwise{mul,no_inplace} [id BC] (inner_out_nit_sot-0)
+     ← Mul [id BC] (inner_out_nit_sot-0)
         ├─ ExpandDims{axis=0} [id BD]
         │  └─ *0-<TensorType(float64, ())> [id Y] (inner_in_seqs-0)
-        └─ Elemwise{pow,no_inplace} [id BE]
+        └─ Pow [id BE]
            ├─ Subtensor{int64} [id BF]
            │  ├─ Subtensor{int64::} [id BG]
            │  │  ├─ for{cpu,scan_fn} [id BH] (outer_out_sit_sot-0)
            │  │  │  ├─ *3-<TensorType(int32, ())> [id BB] (inner_in_non_seqs-1) (n_steps)
            │  │  │  ├─ IncSubtensor{Set;:int64:} [id BI] (outer_in_sit_sot-0)
            │  │  │  │  ├─ AllocEmpty{dtype='float64'} [id BJ]
-           │  │  │  │  │  ├─ Elemwise{add,no_inplace} [id BK]
+           │  │  │  │  │  ├─ Add [id BK]
            │  │  │  │  │  │  ├─ *3-<TensorType(int32, ())> [id BB] (inner_in_non_seqs-1)
            │  │  │  │  │  │  └─ Subtensor{int64} [id BL]
            │  │  │  │  │  │     ├─ Shape [id BM]
            │  │  │  │  │  │     │  └─ Unbroadcast{0} [id BN]
            │  │  │  │  │  │     │     └─ ExpandDims{axis=0} [id BO]
-           │  │  │  │  │  │     │        └─ Elemwise{second,no_inplace} [id BP]
+           │  │  │  │  │  │     │        └─ Second [id BP]
            │  │  │  │  │  │     │           ├─ *2-<TensorType(float64, (?,))> [id BA] (inner_in_non_seqs-0)
            │  │  │  │  │  │     │           └─ ExpandDims{axis=0} [id BQ]
            │  │  │  │  │  │     │              └─ TensorConstant{1.0} [id BR]
@@ -400,7 +400,7 @@ def test_debugprint_nested_scans():
     for{cpu,scan_fn} [id BH]
      → *0-<TensorType(float64, (?,))> [id CA] -> [id BI] (inner_in_sit_sot-0)
      → *1-<TensorType(float64, (?,))> [id CB] -> [id BA] (inner_in_non_seqs-0)
-     ← Elemwise{mul,no_inplace} [id CC] (inner_out_sit_sot-0)
+     ← Mul [id CC] (inner_out_sit_sot-0)
         ├─ *0-<TensorType(float64, (?,))> [id CA] (inner_in_sit_sot-0)
         └─ *1-<TensorType(float64, (?,))> [id CB] (inner_in_non_seqs-0)"""
 
@@ -429,13 +429,13 @@ def test_debugprint_mitsot():
     output_str = debugprint(final_result, file="str", print_op_info=True)
     lines = output_str.split("\n")
 
-    expected_output = """Elemwise{add,no_inplace} [id A]
+    expected_output = """Add [id A]
      ├─ Subtensor{int64::} [id B]
      │  ├─ for{cpu,scan_fn}.0 [id C] (outer_out_mit_sot-0)
      │  │  ├─ TensorConstant{5} [id D] (n_steps)
      │  │  ├─ IncSubtensor{Set;:int64:} [id E] (outer_in_mit_sot-0)
      │  │  │  ├─ AllocEmpty{dtype='int64'} [id F]
-     │  │  │  │  └─ Elemwise{add,no_inplace} [id G]
+     │  │  │  │  └─ Add [id G]
      │  │  │  │     ├─ TensorConstant{5} [id D]
      │  │  │  │     └─ Subtensor{int64} [id H]
      │  │  │  │        ├─ Shape [id I]
@@ -450,7 +450,7 @@ def test_debugprint_mitsot():
      │  │  │        └─ ···
      │  │  └─ IncSubtensor{Set;:int64:} [id O] (outer_in_mit_sot-1)
      │  │     ├─ AllocEmpty{dtype='int64'} [id P]
-     │  │     │  └─ Elemwise{add,no_inplace} [id Q]
+     │  │     │  └─ Add [id Q]
      │  │     │     ├─ TensorConstant{5} [id D]
      │  │     │     └─ Subtensor{int64} [id R]
      │  │     │        ├─ Shape [id S]
@@ -472,10 +472,10 @@ def test_debugprint_mitsot():
     Inner graphs:
 
     for{cpu,scan_fn} [id C]
-     ← Elemwise{add,no_inplace} [id BB] (inner_out_mit_sot-0)
+     ← Add [id BB] (inner_out_mit_sot-0)
         ├─ *1-<TensorType(int64, ())> [id BC] -> [id E] (inner_in_mit_sot-0-1)
         └─ *0-<TensorType(int64, ())> [id BD] -> [id E] (inner_in_mit_sot-0-0)
-     ← Elemwise{add,no_inplace} [id BE] (inner_out_mit_sot-1)
+     ← Add [id BE] (inner_out_mit_sot-1)
         ├─ *3-<TensorType(int64, ())> [id BF] -> [id O] (inner_in_mit_sot-1-1)
         └─ *2-<TensorType(int64, ())> [id BG] -> [id O] (inner_in_mit_sot-1-0)"""
 
@@ -503,20 +503,20 @@ def test_debugprint_mitmot():
 
     expected_output = """Subtensor{int64} [id A]
      ├─ for{cpu,grad_of_scan_fn}.1 [id B] (outer_out_sit_sot-0)
-     │  ├─ Elemwise{sub,no_inplace} [id C] (n_steps)
+     │  ├─ Sub [id C] (n_steps)
      │  │  ├─ Subtensor{int64} [id D]
      │  │  │  ├─ Shape [id E]
      │  │  │  │  └─ for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
      │  │  │  │     ├─ k [id G] (n_steps)
      │  │  │  │     ├─ IncSubtensor{Set;:int64:} [id H] (outer_in_sit_sot-0)
      │  │  │  │     │  ├─ AllocEmpty{dtype='float64'} [id I]
-     │  │  │  │     │  │  ├─ Elemwise{add,no_inplace} [id J]
+     │  │  │  │     │  │  ├─ Add [id J]
      │  │  │  │     │  │  │  ├─ k [id G]
      │  │  │  │     │  │  │  └─ Subtensor{int64} [id K]
      │  │  │  │     │  │  │     ├─ Shape [id L]
      │  │  │  │     │  │  │     │  └─ Unbroadcast{0} [id M]
      │  │  │  │     │  │  │     │     └─ ExpandDims{axis=0} [id N]
-     │  │  │  │     │  │  │     │        └─ Elemwise{second,no_inplace} [id O]
+     │  │  │  │     │  │  │     │        └─ Second [id O]
      │  │  │  │     │  │  │     │           ├─ A [id P]
      │  │  │  │     │  │  │     │           └─ ExpandDims{axis=0} [id Q]
      │  │  │  │     │  │  │     │              └─ TensorConstant{1.0} [id R]
@@ -542,7 +542,7 @@ def test_debugprint_mitmot():
      │  │  │  │  └─ ScalarConstant{-1} [id BC]
      │  │  │  └─ ScalarConstant{-1} [id BD]
      │  │  └─ ScalarFromTensor [id BE]
-     │  │     └─ Elemwise{sub,no_inplace} [id C]
+     │  │     └─ Sub [id C]
      │  │        └─ ···
      │  ├─ Subtensor{:int64:} [id BF] (outer_in_seqs-1)
      │  │  ├─ Subtensor{:int64:} [id BG]
@@ -552,31 +552,31 @@ def test_debugprint_mitmot():
      │  │  │  │  └─ ScalarConstant{-1} [id BI]
      │  │  │  └─ ScalarConstant{-1} [id BJ]
      │  │  └─ ScalarFromTensor [id BK]
-     │  │     └─ Elemwise{sub,no_inplace} [id C]
+     │  │     └─ Sub [id C]
      │  │        └─ ···
      │  ├─ Subtensor{::int64} [id BL] (outer_in_mit_mot-0)
      │  │  ├─ IncSubtensor{Inc;int64::} [id BM]
-     │  │  │  ├─ Elemwise{second,no_inplace} [id BN]
+     │  │  │  ├─ Second [id BN]
      │  │  │  │  ├─ for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  └─ ···
      │  │  │  │  └─ ExpandDims{axes=[0, 1]} [id BO]
      │  │  │  │     └─ TensorConstant{0.0} [id BP]
      │  │  │  ├─ IncSubtensor{Inc;int64} [id BQ]
-     │  │  │  │  ├─ Elemwise{second,no_inplace} [id BR]
+     │  │  │  │  ├─ Second [id BR]
      │  │  │  │  │  ├─ Subtensor{int64::} [id BS]
      │  │  │  │  │  │  ├─ for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  │  │  └─ ···
      │  │  │  │  │  │  └─ ScalarConstant{1} [id BT]
      │  │  │  │  │  └─ ExpandDims{axes=[0, 1]} [id BU]
      │  │  │  │  │     └─ TensorConstant{0.0} [id BV]
-     │  │  │  │  ├─ Elemwise{second} [id BW]
+     │  │  │  │  ├─ Second [id BW]
      │  │  │  │  │  ├─ Subtensor{int64} [id BX]
      │  │  │  │  │  │  ├─ Subtensor{int64::} [id BS]
      │  │  │  │  │  │  │  └─ ···
      │  │  │  │  │  │  └─ ScalarConstant{-1} [id BY]
      │  │  │  │  │  └─ ExpandDims{axis=0} [id BZ]
-     │  │  │  │  │     └─ Elemwise{second,no_inplace} [id CA]
-     │  │  │  │  │        ├─ Sum{acc_dtype=float64} [id CB]
+     │  │  │  │  │     └─ Second [id CA]
+     │  │  │  │  │        ├─ Sum{axes=None} [id CB]
      │  │  │  │  │        │  └─ Subtensor{int64} [id BX]
      │  │  │  │  │        │     └─ ···
      │  │  │  │  │        └─ TensorConstant{1.0} [id CC]
@@ -585,8 +585,8 @@ def test_debugprint_mitmot():
      │  │  └─ ScalarConstant{-1} [id CD]
      │  ├─ Alloc [id CE] (outer_in_sit_sot-0)
      │  │  ├─ TensorConstant{0.0} [id CF]
-     │  │  ├─ Elemwise{add,no_inplace} [id CG]
-     │  │  │  ├─ Elemwise{sub,no_inplace} [id C]
+     │  │  ├─ Add [id CG]
+     │  │  │  ├─ Sub [id C]
      │  │  │  │  └─ ···
      │  │  │  └─ TensorConstant{1} [id CH]
      │  │  └─ Subtensor{int64} [id CI]
@@ -599,19 +599,19 @@ def test_debugprint_mitmot():
     Inner graphs:
 
     for{cpu,grad_of_scan_fn} [id B]
-     ← Elemwise{add,no_inplace} [id CM] (inner_out_mit_mot-0-0)
-        ├─ Elemwise{mul} [id CN]
+     ← Add [id CM] (inner_out_mit_mot-0-0)
+        ├─ Mul [id CN]
         │  ├─ *2-<TensorType(float64, (?,))> [id CO] -> [id BL] (inner_in_mit_mot-0-0)
         │  └─ *5-<TensorType(float64, (?,))> [id CP] -> [id P] (inner_in_non_seqs-0)
         └─ *3-<TensorType(float64, (?,))> [id CQ] -> [id BL] (inner_in_mit_mot-0-1)
-     ← Elemwise{add,no_inplace} [id CR] (inner_out_sit_sot-0)
-        ├─ Elemwise{mul} [id CS]
+     ← Add [id CR] (inner_out_sit_sot-0)
+        ├─ Mul [id CS]
         │  ├─ *2-<TensorType(float64, (?,))> [id CO] -> [id BL] (inner_in_mit_mot-0-0)
         │  └─ *0-<TensorType(float64, (?,))> [id CT] -> [id Z] (inner_in_seqs-0)
         └─ *4-<TensorType(float64, (?,))> [id CU] -> [id CE] (inner_in_sit_sot-0)
 
     for{cpu,scan_fn} [id F]
-     ← Elemwise{mul,no_inplace} [id CV] (inner_out_sit_sot-0)
+     ← Mul [id CV] (inner_out_sit_sot-0)
         ├─ *0-<TensorType(float64, (?,))> [id CT] -> [id H] (inner_in_sit_sot-0)
         └─ *1-<TensorType(float64, (?,))> [id CW] -> [id P] (inner_in_non_seqs-0)"""
 
@@ -654,7 +654,7 @@ def test_debugprint_compiled_fn():
     Inner graphs:
 
     forall_inplace,cpu,scan_fn} [id A]
-     ← Elemwise{Composite{Switch(LT(i0, i1), i2, i0)}} [id I] (inner_out_sit_sot-0)
+     ← Composite{switch(lt(i0, i1), i2, i0)} [id I] (inner_out_sit_sot-0)
         ├─ TensorConstant{0} [id J]
         ├─ Subtensor{int64, int64, uint8} [id K]
         │  ├─ *2-<TensorType(float64, (20000, 2, 2))> [id L] -> [id H] (inner_in_non_seqs-0)
@@ -665,7 +665,7 @@ def test_debugprint_compiled_fn():
         │  └─ ScalarConstant{0} [id Q]
         └─ TensorConstant{1} [id R]
 
-    Elemwise{Composite{Switch(LT(i0, i1), i2, i0)}} [id I]
+    Composite{switch(lt(i0, i1), i2, i0)} [id I]
      ← Switch [id S] 'o0'
         ├─ LT [id T]
         │  ├─ i0 [id U]

--- a/tests/scan/test_printing.py
+++ b/tests/scan/test_printing.py
@@ -27,39 +27,42 @@ def test_debugprint_sitsot():
     lines = output_str.split("\n")
 
     expected_output = """Subtensor{int64} [id A]
-     |Subtensor{int64::} [id B]
-     | |for{cpu,scan_fn} [id C] (outer_out_sit_sot-0)
-     | | |k [id D] (n_steps)
-     | | |IncSubtensor{Set;:int64:} [id E] (outer_in_sit_sot-0)
-     | | | |AllocEmpty{dtype='float64'} [id F]
-     | | | | |Elemwise{add,no_inplace} [id G]
-     | | | | | |k [id D]
-     | | | | | |Subtensor{int64} [id H]
-     | | | | |   |Shape [id I]
-     | | | | |   | |Unbroadcast{0} [id J]
-     | | | | |   |   |InplaceDimShuffle{x,0} [id K]
-     | | | | |   |     |Elemwise{second,no_inplace} [id L]
-     | | | | |   |       |A [id M]
-     | | | | |   |       |InplaceDimShuffle{x} [id N]
-     | | | | |   |         |TensorConstant{1.0} [id O]
-     | | | | |   |ScalarConstant{0} [id P]
-     | | | | |Subtensor{int64} [id Q]
-     | | | |   |Shape [id R]
-     | | | |   | |Unbroadcast{0} [id J]
-     | | | |   |ScalarConstant{1} [id S]
-     | | | |Unbroadcast{0} [id J]
-     | | | |ScalarFromTensor [id T]
-     | | |   |Subtensor{int64} [id H]
-     | | |A [id M] (outer_in_non_seqs-0)
-     | |ScalarConstant{1} [id U]
-     |ScalarConstant{-1} [id V]
+     ├─ Subtensor{int64::} [id B]
+     │  ├─ for{cpu,scan_fn} [id C] (outer_out_sit_sot-0)
+     │  │  ├─ k [id D] (n_steps)
+     │  │  ├─ IncSubtensor{Set;:int64:} [id E] (outer_in_sit_sot-0)
+     │  │  │  ├─ AllocEmpty{dtype='float64'} [id F]
+     │  │  │  │  ├─ Elemwise{add,no_inplace} [id G]
+     │  │  │  │  │  ├─ k [id D]
+     │  │  │  │  │  └─ Subtensor{int64} [id H]
+     │  │  │  │  │     ├─ Shape [id I]
+     │  │  │  │  │     │  └─ Unbroadcast{0} [id J]
+     │  │  │  │  │     │     └─ InplaceDimShuffle{x,0} [id K]
+     │  │  │  │  │     │        └─ Elemwise{second,no_inplace} [id L]
+     │  │  │  │  │     │           ├─ A [id M]
+     │  │  │  │  │     │           └─ InplaceDimShuffle{x} [id N]
+     │  │  │  │  │     │              └─ TensorConstant{1.0} [id O]
+     │  │  │  │  │     └─ ScalarConstant{0} [id P]
+     │  │  │  │  └─ Subtensor{int64} [id Q]
+     │  │  │  │     ├─ Shape [id R]
+     │  │  │  │     │  └─ Unbroadcast{0} [id J]
+     │  │  │  │     │     └─ ···
+     │  │  │  │     └─ ScalarConstant{1} [id S]
+     │  │  │  ├─ Unbroadcast{0} [id J]
+     │  │  │  │  └─ ···
+     │  │  │  └─ ScalarFromTensor [id T]
+     │  │  │     └─ Subtensor{int64} [id H]
+     │  │  │        └─ ···
+     │  │  └─ A [id M] (outer_in_non_seqs-0)
+     │  └─ ScalarConstant{1} [id U]
+     └─ ScalarConstant{-1} [id V]
 
     Inner graphs:
 
-    for{cpu,scan_fn} [id C] (outer_out_sit_sot-0)
-     >Elemwise{mul,no_inplace} [id W] (inner_out_sit_sot-0)
-     > |*0-<TensorType(float64, (?,))> [id X] -> [id E] (inner_in_sit_sot-0)
-     > |*1-<TensorType(float64, (?,))> [id Y] -> [id M] (inner_in_non_seqs-0)"""
+    for{cpu,scan_fn} [id C]
+     ← Elemwise{mul,no_inplace} [id W] (inner_out_sit_sot-0)
+        ├─ *0-<TensorType(float64, (?,))> [id X] -> [id E] (inner_in_sit_sot-0)
+        └─ *1-<TensorType(float64, (?,))> [id Y] -> [id M] (inner_in_non_seqs-0)"""
 
     for truth, out in zip(expected_output.split("\n"), lines):
         assert truth.strip() == out.strip()
@@ -82,39 +85,42 @@ def test_debugprint_sitsot_no_extra_info():
     lines = output_str.split("\n")
 
     expected_output = """Subtensor{int64} [id A]
-     |Subtensor{int64::} [id B]
-     | |for{cpu,scan_fn} [id C]
-     | | |k [id D]
-     | | |IncSubtensor{Set;:int64:} [id E]
-     | | | |AllocEmpty{dtype='float64'} [id F]
-     | | | | |Elemwise{add,no_inplace} [id G]
-     | | | | | |k [id D]
-     | | | | | |Subtensor{int64} [id H]
-     | | | | |   |Shape [id I]
-     | | | | |   | |Unbroadcast{0} [id J]
-     | | | | |   |   |InplaceDimShuffle{x,0} [id K]
-     | | | | |   |     |Elemwise{second,no_inplace} [id L]
-     | | | | |   |       |A [id M]
-     | | | | |   |       |InplaceDimShuffle{x} [id N]
-     | | | | |   |         |TensorConstant{1.0} [id O]
-     | | | | |   |ScalarConstant{0} [id P]
-     | | | | |Subtensor{int64} [id Q]
-     | | | |   |Shape [id R]
-     | | | |   | |Unbroadcast{0} [id J]
-     | | | |   |ScalarConstant{1} [id S]
-     | | | |Unbroadcast{0} [id J]
-     | | | |ScalarFromTensor [id T]
-     | | |   |Subtensor{int64} [id H]
-     | | |A [id M]
-     | |ScalarConstant{1} [id U]
-     |ScalarConstant{-1} [id V]
+     ├─ Subtensor{int64::} [id B]
+     │  ├─ for{cpu,scan_fn} [id C]
+     │  │  ├─ k [id D]
+     │  │  ├─ IncSubtensor{Set;:int64:} [id E]
+     │  │  │  ├─ AllocEmpty{dtype='float64'} [id F]
+     │  │  │  │  ├─ Elemwise{add,no_inplace} [id G]
+     │  │  │  │  │  ├─ k [id D]
+     │  │  │  │  │  └─ Subtensor{int64} [id H]
+     │  │  │  │  │     ├─ Shape [id I]
+     │  │  │  │  │     │  └─ Unbroadcast{0} [id J]
+     │  │  │  │  │     │     └─ InplaceDimShuffle{x,0} [id K]
+     │  │  │  │  │     │        └─ Elemwise{second,no_inplace} [id L]
+     │  │  │  │  │     │           ├─ A [id M]
+     │  │  │  │  │     │           └─ InplaceDimShuffle{x} [id N]
+     │  │  │  │  │     │              └─ TensorConstant{1.0} [id O]
+     │  │  │  │  │     └─ ScalarConstant{0} [id P]
+     │  │  │  │  └─ Subtensor{int64} [id Q]
+     │  │  │  │     ├─ Shape [id R]
+     │  │  │  │     │  └─ Unbroadcast{0} [id J]
+     │  │  │  │     │     └─ ···
+     │  │  │  │     └─ ScalarConstant{1} [id S]
+     │  │  │  ├─ Unbroadcast{0} [id J]
+     │  │  │  │  └─ ···
+     │  │  │  └─ ScalarFromTensor [id T]
+     │  │  │     └─ Subtensor{int64} [id H]
+     │  │  │        └─ ···
+     │  │  └─ A [id M]
+     │  └─ ScalarConstant{1} [id U]
+     └─ ScalarConstant{-1} [id V]
 
     Inner graphs:
 
     for{cpu,scan_fn} [id C]
-     >Elemwise{mul,no_inplace} [id W]
-     > |*0-<TensorType(float64, (?,))> [id X] -> [id E]
-     > |*1-<TensorType(float64, (?,))> [id Y] -> [id M]"""
+     ← Elemwise{mul,no_inplace} [id W]
+        ├─ *0-<TensorType(float64, (?,))> [id X] -> [id E]
+        └─ *1-<TensorType(float64, (?,))> [id Y] -> [id M]"""
 
     for truth, out in zip(expected_output.split("\n"), lines):
         assert truth.strip() == out.strip()
@@ -142,42 +148,47 @@ def test_debugprint_nitsot():
     lines = output_str.split("\n")
 
     expected_output = """Sum{acc_dtype=float64} [id A]
-     |for{cpu,scan_fn} [id B] (outer_out_nit_sot-0)
-       |Elemwise{scalar_minimum,no_inplace} [id C] (outer_in_nit_sot-0)
-       | |Subtensor{int64} [id D]
-       | | |Shape [id E]
-       | | | |Subtensor{int64::} [id F] 'coefficients[0:]'
-       | | |   |coefficients [id G]
-       | | |   |ScalarConstant{0} [id H]
-       | | |ScalarConstant{0} [id I]
-       | |Subtensor{int64} [id J]
-       |   |Shape [id K]
-       |   | |Subtensor{int64::} [id L]
-       |   |   |ARange{dtype='int64'} [id M]
-       |   |   | |TensorConstant{0} [id N]
-       |   |   | |TensorConstant{10000} [id O]
-       |   |   | |TensorConstant{1} [id P]
-       |   |   |ScalarConstant{0} [id Q]
-       |   |ScalarConstant{0} [id R]
-       |Subtensor{:int64:} [id S] (outer_in_seqs-0)
-       | |Subtensor{int64::} [id F] 'coefficients[0:]'
-       | |ScalarFromTensor [id T]
-       |   |Elemwise{scalar_minimum,no_inplace} [id C]
-       |Subtensor{:int64:} [id U] (outer_in_seqs-1)
-       | |Subtensor{int64::} [id L]
-       | |ScalarFromTensor [id V]
-       |   |Elemwise{scalar_minimum,no_inplace} [id C]
-       |Elemwise{scalar_minimum,no_inplace} [id C] (outer_in_nit_sot-0)
-       |x [id W] (outer_in_non_seqs-0)
+     └─ for{cpu,scan_fn} [id B] (outer_out_nit_sot-0)
+        ├─ Elemwise{scalar_minimum,no_inplace} [id C] (outer_in_nit_sot-0)
+        │  ├─ Subtensor{int64} [id D]
+        │  │  ├─ Shape [id E]
+        │  │  │  └─ Subtensor{int64::} [id F] 'coefficients[0:]'
+        │  │  │     ├─ coefficients [id G]
+        │  │  │     └─ ScalarConstant{0} [id H]
+        │  │  └─ ScalarConstant{0} [id I]
+        │  └─ Subtensor{int64} [id J]
+        │     ├─ Shape [id K]
+        │     │  └─ Subtensor{int64::} [id L]
+        │     │     ├─ ARange{dtype='int64'} [id M]
+        │     │     │  ├─ TensorConstant{0} [id N]
+        │     │     │  ├─ TensorConstant{10000} [id O]
+        │     │     │  └─ TensorConstant{1} [id P]
+        │     │     └─ ScalarConstant{0} [id Q]
+        │     └─ ScalarConstant{0} [id R]
+        ├─ Subtensor{:int64:} [id S] (outer_in_seqs-0)
+        │  ├─ Subtensor{int64::} [id F] 'coefficients[0:]'
+        │  │  └─ ···
+        │  └─ ScalarFromTensor [id T]
+        │     └─ Elemwise{scalar_minimum,no_inplace} [id C]
+        │        └─ ···
+        ├─ Subtensor{:int64:} [id U] (outer_in_seqs-1)
+        │  ├─ Subtensor{int64::} [id L]
+        │  │  └─ ···
+        │  └─ ScalarFromTensor [id V]
+        │     └─ Elemwise{scalar_minimum,no_inplace} [id C]
+        │        └─ ···
+        ├─ Elemwise{scalar_minimum,no_inplace} [id C] (outer_in_nit_sot-0)
+        │  └─ ···
+        └─ x [id W] (outer_in_non_seqs-0)
 
     Inner graphs:
 
-    for{cpu,scan_fn} [id B] (outer_out_nit_sot-0)
-     >Elemwise{mul,no_inplace} [id X] (inner_out_nit_sot-0)
-     > |*0-<TensorType(float64, ())> [id Y] -> [id S] (inner_in_seqs-0)
-     > |Elemwise{pow,no_inplace} [id Z]
-     >   |*2-<TensorType(float64, ())> [id BA] -> [id W] (inner_in_non_seqs-0)
-     >   |*1-<TensorType(int64, ())> [id BB] -> [id U] (inner_in_seqs-1)"""
+    for{cpu,scan_fn} [id B]
+     ← Elemwise{mul,no_inplace} [id X] (inner_out_nit_sot-0)
+        ├─ *0-<TensorType(float64, ())> [id Y] -> [id S] (inner_in_seqs-0)
+        └─ Elemwise{pow,no_inplace} [id Z]
+           ├─ *2-<TensorType(float64, ())> [id BA] -> [id W] (inner_in_non_seqs-0)
+           └─ *1-<TensorType(int64, ())> [id BB] -> [id U] (inner_in_seqs-1)"""
 
     for truth, out in zip(expected_output.split("\n"), lines):
         assert truth.strip() == out.strip()
@@ -215,76 +226,84 @@ def test_debugprint_nested_scans():
     lines = output_str.split("\n")
 
     expected_output = """Sum{acc_dtype=float64} [id A]
-    |for{cpu,scan_fn} [id B] (outer_out_nit_sot-0)
-    |Elemwise{scalar_minimum,no_inplace} [id C] (outer_in_nit_sot-0)
-    | |Subtensor{int64} [id D]
-    | | |Shape [id E]
-    | | | |Subtensor{int64::} [id F] 'c[0:]'
-    | | |   |c [id G]
-    | | |   |ScalarConstant{0} [id H]
-    | | |ScalarConstant{0} [id I]
-    | |Subtensor{int64} [id J]
-    |   |Shape [id K]
-    |   | |Subtensor{int64::} [id L]
-    |   |   |ARange{dtype='int64'} [id M]
-    |   |   | |TensorConstant{0} [id N]
-    |   |   | |TensorConstant{10} [id O]
-    |   |   | |TensorConstant{1} [id P]
-    |   |   |ScalarConstant{0} [id Q]
-    |   |ScalarConstant{0} [id R]
-    |Subtensor{:int64:} [id S] (outer_in_seqs-0)
-    | |Subtensor{int64::} [id F] 'c[0:]'
-    | |ScalarFromTensor [id T]
-    |   |Elemwise{scalar_minimum,no_inplace} [id C]
-    |Subtensor{:int64:} [id U] (outer_in_seqs-1)
-    | |Subtensor{int64::} [id L]
-    | |ScalarFromTensor [id V]
-    |   |Elemwise{scalar_minimum,no_inplace} [id C]
-    |Elemwise{scalar_minimum,no_inplace} [id C] (outer_in_nit_sot-0)
-    |A [id W] (outer_in_non_seqs-0)
-    |k [id X] (outer_in_non_seqs-1)
+     └─ for{cpu,scan_fn} [id B] (outer_out_nit_sot-0)
+        ├─ Elemwise{scalar_minimum,no_inplace} [id C] (outer_in_nit_sot-0)
+        │  ├─ Subtensor{int64} [id D]
+        │  │  ├─ Shape [id E]
+        │  │  │  └─ Subtensor{int64::} [id F] 'c[0:]'
+        │  │  │     ├─ c [id G]
+        │  │  │     └─ ScalarConstant{0} [id H]
+        │  │  └─ ScalarConstant{0} [id I]
+        │  └─ Subtensor{int64} [id J]
+        │     ├─ Shape [id K]
+        │     │  └─ Subtensor{int64::} [id L]
+        │     │     ├─ ARange{dtype='int64'} [id M]
+        │     │     │  ├─ TensorConstant{0} [id N]
+        │     │     │  ├─ TensorConstant{10} [id O]
+        │     │     │  └─ TensorConstant{1} [id P]
+        │     │     └─ ScalarConstant{0} [id Q]
+        │     └─ ScalarConstant{0} [id R]
+        ├─ Subtensor{:int64:} [id S] (outer_in_seqs-0)
+        │  ├─ Subtensor{int64::} [id F] 'c[0:]'
+        │  │  └─ ···
+        │  └─ ScalarFromTensor [id T]
+        │     └─ Elemwise{scalar_minimum,no_inplace} [id C]
+        │        └─ ···
+        ├─ Subtensor{:int64:} [id U] (outer_in_seqs-1)
+        │  ├─ Subtensor{int64::} [id L]
+        │  │  └─ ···
+        │  └─ ScalarFromTensor [id V]
+        │     └─ Elemwise{scalar_minimum,no_inplace} [id C]
+        │        └─ ···
+        ├─ Elemwise{scalar_minimum,no_inplace} [id C] (outer_in_nit_sot-0)
+        │  └─ ···
+        ├─ A [id W] (outer_in_non_seqs-0)
+        └─ k [id X] (outer_in_non_seqs-1)
 
     Inner graphs:
 
-    for{cpu,scan_fn} [id B] (outer_out_nit_sot-0)
-    >Elemwise{mul,no_inplace} [id Y] (inner_out_nit_sot-0)
-    > |InplaceDimShuffle{x} [id Z]
-    > | |*0-<TensorType(float64, ())> [id BA] -> [id S] (inner_in_seqs-0)
-    > |Elemwise{pow,no_inplace} [id BB]
-    >   |Subtensor{int64} [id BC]
-    >   | |Subtensor{int64::} [id BD]
-    >   | | |for{cpu,scan_fn} [id BE] (outer_out_sit_sot-0)
-    >   | | | |*3-<TensorType(int32, ())> [id BF] -> [id X] (inner_in_non_seqs-1) (n_steps)
-    >   | | | |IncSubtensor{Set;:int64:} [id BG] (outer_in_sit_sot-0)
-    >   | | | | |AllocEmpty{dtype='float64'} [id BH]
-    >   | | | | | |Elemwise{add,no_inplace} [id BI]
-    >   | | | | | | |*3-<TensorType(int32, ())> [id BF] -> [id X] (inner_in_non_seqs-1)
-    >   | | | | | | |Subtensor{int64} [id BJ]
-    >   | | | | | |   |Shape [id BK]
-    >   | | | | | |   | |Unbroadcast{0} [id BL]
-    >   | | | | | |   |   |InplaceDimShuffle{x,0} [id BM]
-    >   | | | | | |   |     |Elemwise{second,no_inplace} [id BN]
-    >   | | | | | |   |       |*2-<TensorType(float64, (?,))> [id BO] -> [id W] (inner_in_non_seqs-0)
-    >   | | | | | |   |       |InplaceDimShuffle{x} [id BP]
-    >   | | | | | |   |         |TensorConstant{1.0} [id BQ]
-    >   | | | | | |   |ScalarConstant{0} [id BR]
-    >   | | | | | |Subtensor{int64} [id BS]
-    >   | | | | |   |Shape [id BT]
-    >   | | | | |   | |Unbroadcast{0} [id BL]
-    >   | | | | |   |ScalarConstant{1} [id BU]
-    >   | | | | |Unbroadcast{0} [id BL]
-    >   | | | | |ScalarFromTensor [id BV]
-    >   | | | |   |Subtensor{int64} [id BJ]
-    >   | | | |*2-<TensorType(float64, (?,))> [id BO] -> [id W] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
-    >   | | |ScalarConstant{1} [id BW]
-    >   | |ScalarConstant{-1} [id BX]
-    >   |InplaceDimShuffle{x} [id BY]
-    >     |*1-<TensorType(int64, ())> [id BZ] -> [id U] (inner_in_seqs-1)
+    for{cpu,scan_fn} [id B]
+     ← Elemwise{mul,no_inplace} [id Y] (inner_out_nit_sot-0)
+        ├─ InplaceDimShuffle{x} [id Z]
+        │  └─ *0-<TensorType(float64, ())> [id BA] -> [id S] (inner_in_seqs-0)
+        └─ Elemwise{pow,no_inplace} [id BB]
+           ├─ Subtensor{int64} [id BC]
+           │  ├─ Subtensor{int64::} [id BD]
+           │  │  ├─ for{cpu,scan_fn} [id BE] (outer_out_sit_sot-0)
+           │  │  │  ├─ *3-<TensorType(int32, ())> [id BF] -> [id X] (inner_in_non_seqs-1) (n_steps)
+           │  │  │  ├─ IncSubtensor{Set;:int64:} [id BG] (outer_in_sit_sot-0)
+           │  │  │  │  ├─ AllocEmpty{dtype='float64'} [id BH]
+           │  │  │  │  │  ├─ Elemwise{add,no_inplace} [id BI]
+           │  │  │  │  │  │  ├─ *3-<TensorType(int32, ())> [id BF] -> [id X] (inner_in_non_seqs-1)
+           │  │  │  │  │  │  └─ Subtensor{int64} [id BJ]
+           │  │  │  │  │  │     ├─ Shape [id BK]
+           │  │  │  │  │  │     │  └─ Unbroadcast{0} [id BL]
+           │  │  │  │  │  │     │     └─ InplaceDimShuffle{x,0} [id BM]
+           │  │  │  │  │  │     │        └─ Elemwise{second,no_inplace} [id BN]
+           │  │  │  │  │  │     │           ├─ *2-<TensorType(float64, (?,))> [id BO] -> [id W] (inner_in_non_seqs-0)
+           │  │  │  │  │  │     │           └─ InplaceDimShuffle{x} [id BP]
+           │  │  │  │  │  │     │              └─ TensorConstant{1.0} [id BQ]
+           │  │  │  │  │  │     └─ ScalarConstant{0} [id BR]
+           │  │  │  │  │  └─ Subtensor{int64} [id BS]
+           │  │  │  │  │     ├─ Shape [id BT]
+           │  │  │  │  │     │  └─ Unbroadcast{0} [id BL]
+           │  │  │  │  │     │     └─ ···
+           │  │  │  │  │     └─ ScalarConstant{1} [id BU]
+           │  │  │  │  ├─ Unbroadcast{0} [id BL]
+           │  │  │  │  │  └─ ···
+           │  │  │  │  └─ ScalarFromTensor [id BV]
+           │  │  │  │     └─ Subtensor{int64} [id BJ]
+           │  │  │  │        └─ ···
+           │  │  │  └─ *2-<TensorType(float64, (?,))> [id BO] -> [id W] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
+           │  │  └─ ScalarConstant{1} [id BW]
+           │  └─ ScalarConstant{-1} [id BX]
+           └─ InplaceDimShuffle{x} [id BY]
+              └─ *1-<TensorType(int64, ())> [id BZ] -> [id U] (inner_in_seqs-1)
 
-    for{cpu,scan_fn} [id BE] (outer_out_sit_sot-0)
-    >Elemwise{mul,no_inplace} [id CA] (inner_out_sit_sot-0)
-    > |*0-<TensorType(float64, (?,))> [id CB] -> [id BG] (inner_in_sit_sot-0)
-    > |*1-<TensorType(float64, (?,))> [id CC] -> [id BO] (inner_in_non_seqs-0)"""
+    for{cpu,scan_fn} [id BE]
+     ← Elemwise{mul,no_inplace} [id CA] (inner_out_sit_sot-0)
+        ├─ *0-<TensorType(float64, (?,))> [id CB] -> [id BG] (inner_in_sit_sot-0)
+        └─ *1-<TensorType(float64, (?,))> [id CC] -> [id BO] (inner_in_non_seqs-0)"""
 
     for truth, out in zip(expected_output.split("\n"), lines):
         assert truth.strip() == out.strip()
@@ -296,86 +315,94 @@ def test_debugprint_nested_scans():
     )
     lines = output_str.split("\n")
 
-    expected_output = """-c [id A]
-    -k [id B]
-    -A [id C]
+    expected_output = """→ c [id A]
+    → k [id B]
+    → A [id C]
     Sum{acc_dtype=float64} [id D] 13
-    |for{cpu,scan_fn} [id E] 12 (outer_out_nit_sot-0)
-    |Elemwise{scalar_minimum,no_inplace} [id F] 7 (outer_in_nit_sot-0)
-    | |Subtensor{int64} [id G] 6
-    | | |Shape [id H] 5
-    | | | |Subtensor{int64::} [id I] 'c[0:]' 4
-    | | |   |c [id A]
-    | | |   |ScalarConstant{0} [id J]
-    | | |ScalarConstant{0} [id K]
-    | |Subtensor{int64} [id L] 3
-    |   |Shape [id M] 2
-    |   | |Subtensor{int64::} [id N] 1
-    |   |   |ARange{dtype='int64'} [id O] 0
-    |   |   | |TensorConstant{0} [id P]
-    |   |   | |TensorConstant{10} [id Q]
-    |   |   | |TensorConstant{1} [id R]
-    |   |   |ScalarConstant{0} [id S]
-    |   |ScalarConstant{0} [id T]
-    |Subtensor{:int64:} [id U] 11 (outer_in_seqs-0)
-    | |Subtensor{int64::} [id I] 'c[0:]' 4
-    | |ScalarFromTensor [id V] 10
-    |   |Elemwise{scalar_minimum,no_inplace} [id F] 7
-    |Subtensor{:int64:} [id W] 9 (outer_in_seqs-1)
-    | |Subtensor{int64::} [id N] 1
-    | |ScalarFromTensor [id X] 8
-    |   |Elemwise{scalar_minimum,no_inplace} [id F] 7
-    |Elemwise{scalar_minimum,no_inplace} [id F] 7 (outer_in_nit_sot-0)
-    |A [id C] (outer_in_non_seqs-0)
-    |k [id B] (outer_in_non_seqs-1)
+     └─ for{cpu,scan_fn} [id E] 12 (outer_out_nit_sot-0)
+        ├─ Elemwise{scalar_minimum,no_inplace} [id F] 7 (outer_in_nit_sot-0)
+        │  ├─ Subtensor{int64} [id G] 6
+        │  │  ├─ Shape [id H] 5
+        │  │  │  └─ Subtensor{int64::} [id I] 'c[0:]' 4
+        │  │  │     ├─ c [id A]
+        │  │  │     └─ ScalarConstant{0} [id J]
+        │  │  └─ ScalarConstant{0} [id K]
+        │  └─ Subtensor{int64} [id L] 3
+        │     ├─ Shape [id M] 2
+        │     │  └─ Subtensor{int64::} [id N] 1
+        │     │     ├─ ARange{dtype='int64'} [id O] 0
+        │     │     │  ├─ TensorConstant{0} [id P]
+        │     │     │  ├─ TensorConstant{10} [id Q]
+        │     │     │  └─ TensorConstant{1} [id R]
+        │     │     └─ ScalarConstant{0} [id S]
+        │     └─ ScalarConstant{0} [id T]
+        ├─ Subtensor{:int64:} [id U] 11 (outer_in_seqs-0)
+        │  ├─ Subtensor{int64::} [id I] 'c[0:]' 4
+        │  │  └─ ···
+        │  └─ ScalarFromTensor [id V] 10
+        │     └─ Elemwise{scalar_minimum,no_inplace} [id F] 7
+        │        └─ ···
+        ├─ Subtensor{:int64:} [id W] 9 (outer_in_seqs-1)
+        │  ├─ Subtensor{int64::} [id N] 1
+        │  │  └─ ···
+        │  └─ ScalarFromTensor [id X] 8
+        │     └─ Elemwise{scalar_minimum,no_inplace} [id F] 7
+        │        └─ ···
+        ├─ Elemwise{scalar_minimum,no_inplace} [id F] 7 (outer_in_nit_sot-0)
+        │  └─ ···
+        ├─ A [id C] (outer_in_non_seqs-0)
+        └─ k [id B] (outer_in_non_seqs-1)
 
     Inner graphs:
 
-    for{cpu,scan_fn} [id E] (outer_out_nit_sot-0)
-    -*0-<TensorType(float64, ())> [id Y] -> [id U] (inner_in_seqs-0)
-    -*1-<TensorType(int64, ())> [id Z] -> [id W] (inner_in_seqs-1)
-    -*2-<TensorType(float64, (?,))> [id BA] -> [id C] (inner_in_non_seqs-0)
-    -*3-<TensorType(int32, ())> [id BB] -> [id B] (inner_in_non_seqs-1)
-    >Elemwise{mul,no_inplace} [id BC] (inner_out_nit_sot-0)
-    > |InplaceDimShuffle{x} [id BD]
-    > | |*0-<TensorType(float64, ())> [id Y] (inner_in_seqs-0)
-    > |Elemwise{pow,no_inplace} [id BE]
-    >   |Subtensor{int64} [id BF]
-    >   | |Subtensor{int64::} [id BG]
-    >   | | |for{cpu,scan_fn} [id BH] (outer_out_sit_sot-0)
-    >   | | | |*3-<TensorType(int32, ())> [id BB] (inner_in_non_seqs-1) (n_steps)
-    >   | | | |IncSubtensor{Set;:int64:} [id BI] (outer_in_sit_sot-0)
-    >   | | | | |AllocEmpty{dtype='float64'} [id BJ]
-    >   | | | | | |Elemwise{add,no_inplace} [id BK]
-    >   | | | | | | |*3-<TensorType(int32, ())> [id BB] (inner_in_non_seqs-1)
-    >   | | | | | | |Subtensor{int64} [id BL]
-    >   | | | | | |   |Shape [id BM]
-    >   | | | | | |   | |Unbroadcast{0} [id BN]
-    >   | | | | | |   |   |InplaceDimShuffle{x,0} [id BO]
-    >   | | | | | |   |     |Elemwise{second,no_inplace} [id BP]
-    >   | | | | | |   |       |*2-<TensorType(float64, (?,))> [id BA] (inner_in_non_seqs-0)
-    >   | | | | | |   |       |InplaceDimShuffle{x} [id BQ]
-    >   | | | | | |   |         |TensorConstant{1.0} [id BR]
-    >   | | | | | |   |ScalarConstant{0} [id BS]
-    >   | | | | | |Subtensor{int64} [id BT]
-    >   | | | | |   |Shape [id BU]
-    >   | | | | |   | |Unbroadcast{0} [id BN]
-    >   | | | | |   |ScalarConstant{1} [id BV]
-    >   | | | | |Unbroadcast{0} [id BN]
-    >   | | | | |ScalarFromTensor [id BW]
-    >   | | | |   |Subtensor{int64} [id BL]
-    >   | | | |*2-<TensorType(float64, (?,))> [id BA] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
-    >   | | |ScalarConstant{1} [id BX]
-    >   | |ScalarConstant{-1} [id BY]
-    >   |InplaceDimShuffle{x} [id BZ]
-    >     |*1-<TensorType(int64, ())> [id Z] (inner_in_seqs-1)
+    for{cpu,scan_fn} [id E]
+     → *0-<TensorType(float64, ())> [id Y] -> [id U] (inner_in_seqs-0)
+     → *1-<TensorType(int64, ())> [id Z] -> [id W] (inner_in_seqs-1)
+     → *2-<TensorType(float64, (?,))> [id BA] -> [id C] (inner_in_non_seqs-0)
+     → *3-<TensorType(int32, ())> [id BB] -> [id B] (inner_in_non_seqs-1)
+     ← Elemwise{mul,no_inplace} [id BC] (inner_out_nit_sot-0)
+        ├─ InplaceDimShuffle{x} [id BD]
+        │  └─ *0-<TensorType(float64, ())> [id Y] (inner_in_seqs-0)
+        └─ Elemwise{pow,no_inplace} [id BE]
+           ├─ Subtensor{int64} [id BF]
+           │  ├─ Subtensor{int64::} [id BG]
+           │  │  ├─ for{cpu,scan_fn} [id BH] (outer_out_sit_sot-0)
+           │  │  │  ├─ *3-<TensorType(int32, ())> [id BB] (inner_in_non_seqs-1) (n_steps)
+           │  │  │  ├─ IncSubtensor{Set;:int64:} [id BI] (outer_in_sit_sot-0)
+           │  │  │  │  ├─ AllocEmpty{dtype='float64'} [id BJ]
+           │  │  │  │  │  ├─ Elemwise{add,no_inplace} [id BK]
+           │  │  │  │  │  │  ├─ *3-<TensorType(int32, ())> [id BB] (inner_in_non_seqs-1)
+           │  │  │  │  │  │  └─ Subtensor{int64} [id BL]
+           │  │  │  │  │  │     ├─ Shape [id BM]
+           │  │  │  │  │  │     │  └─ Unbroadcast{0} [id BN]
+           │  │  │  │  │  │     │     └─ InplaceDimShuffle{x,0} [id BO]
+           │  │  │  │  │  │     │        └─ Elemwise{second,no_inplace} [id BP]
+           │  │  │  │  │  │     │           ├─ *2-<TensorType(float64, (?,))> [id BA] (inner_in_non_seqs-0)
+           │  │  │  │  │  │     │           └─ InplaceDimShuffle{x} [id BQ]
+           │  │  │  │  │  │     │              └─ TensorConstant{1.0} [id BR]
+           │  │  │  │  │  │     └─ ScalarConstant{0} [id BS]
+           │  │  │  │  │  └─ Subtensor{int64} [id BT]
+           │  │  │  │  │     ├─ Shape [id BU]
+           │  │  │  │  │     │  └─ Unbroadcast{0} [id BN]
+           │  │  │  │  │     │     └─ ···
+           │  │  │  │  │     └─ ScalarConstant{1} [id BV]
+           │  │  │  │  ├─ Unbroadcast{0} [id BN]
+           │  │  │  │  │  └─ ···
+           │  │  │  │  └─ ScalarFromTensor [id BW]
+           │  │  │  │     └─ Subtensor{int64} [id BL]
+           │  │  │  │        └─ ···
+           │  │  │  └─ *2-<TensorType(float64, (?,))> [id BA] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
+           │  │  └─ ScalarConstant{1} [id BX]
+           │  └─ ScalarConstant{-1} [id BY]
+           └─ InplaceDimShuffle{x} [id BZ]
+              └─ *1-<TensorType(int64, ())> [id Z] (inner_in_seqs-1)
 
-    for{cpu,scan_fn} [id BH] (outer_out_sit_sot-0)
-    -*0-<TensorType(float64, (?,))> [id CA] -> [id BI] (inner_in_sit_sot-0)
-    -*1-<TensorType(float64, (?,))> [id CB] -> [id BA] (inner_in_non_seqs-0)
-    >Elemwise{mul,no_inplace} [id CC] (inner_out_sit_sot-0)
-    > |*0-<TensorType(float64, (?,))> [id CA] (inner_in_sit_sot-0)
-    > |*1-<TensorType(float64, (?,))> [id CB] (inner_in_non_seqs-0)"""
+    for{cpu,scan_fn} [id BH]
+     → *0-<TensorType(float64, (?,))> [id CA] -> [id BI] (inner_in_sit_sot-0)
+     → *1-<TensorType(float64, (?,))> [id CB] -> [id BA] (inner_in_non_seqs-0)
+     ← Elemwise{mul,no_inplace} [id CC] (inner_out_sit_sot-0)
+        ├─ *0-<TensorType(float64, (?,))> [id CA] (inner_in_sit_sot-0)
+        └─ *1-<TensorType(float64, (?,))> [id CB] (inner_in_non_seqs-0)"""
 
     for truth, out in zip(expected_output.split("\n"), lines):
         assert truth.strip() == out.strip()
@@ -403,53 +430,54 @@ def test_debugprint_mitsot():
     lines = output_str.split("\n")
 
     expected_output = """Elemwise{add,no_inplace} [id A]
-    |Subtensor{int64::} [id B]
-    | |for{cpu,scan_fn}.0 [id C] (outer_out_mit_sot-0)
-    | | |TensorConstant{5} [id D] (n_steps)
-    | | |IncSubtensor{Set;:int64:} [id E] (outer_in_mit_sot-0)
-    | | | |AllocEmpty{dtype='int64'} [id F]
-    | | | | |Elemwise{add,no_inplace} [id G]
-    | | | |   |TensorConstant{5} [id D]
-    | | | |   |Subtensor{int64} [id H]
-    | | | |     |Shape [id I]
-    | | | |     | |Subtensor{:int64:} [id J]
-    | | | |     |   |<TensorType(int64, (?,))> [id K]
-    | | | |     |   |ScalarConstant{2} [id L]
-    | | | |     |ScalarConstant{0} [id M]
-    | | | |Subtensor{:int64:} [id J]
-    | | | |ScalarFromTensor [id N]
-    | | |   |Subtensor{int64} [id H]
-    | | |IncSubtensor{Set;:int64:} [id O] (outer_in_mit_sot-1)
-    | |   |AllocEmpty{dtype='int64'} [id P]
-    | |   | |Elemwise{add,no_inplace} [id Q]
-    | |   |   |TensorConstant{5} [id D]
-    | |   |   |Subtensor{int64} [id R]
-    | |   |     |Shape [id S]
-    | |   |     | |Subtensor{:int64:} [id T]
-    | |   |     |   |<TensorType(int64, (?,))> [id U]
-    | |   |     |   |ScalarConstant{2} [id V]
-    | |   |     |ScalarConstant{0} [id W]
-    | |   |Subtensor{:int64:} [id T]
-    | |   |ScalarFromTensor [id X]
-    | |     |Subtensor{int64} [id R]
-    | |ScalarConstant{2} [id Y]
-    |Subtensor{int64::} [id Z]
-    |for{cpu,scan_fn}.1 [id C] (outer_out_mit_sot-1)
-    |ScalarConstant{2} [id BA]
+     ├─ Subtensor{int64::} [id B]
+     │  ├─ for{cpu,scan_fn}.0 [id C] (outer_out_mit_sot-0)
+     │  │  ├─ TensorConstant{5} [id D] (n_steps)
+     │  │  ├─ IncSubtensor{Set;:int64:} [id E] (outer_in_mit_sot-0)
+     │  │  │  ├─ AllocEmpty{dtype='int64'} [id F]
+     │  │  │  │  └─ Elemwise{add,no_inplace} [id G]
+     │  │  │  │     ├─ TensorConstant{5} [id D]
+     │  │  │  │     └─ Subtensor{int64} [id H]
+     │  │  │  │        ├─ Shape [id I]
+     │  │  │  │        │  └─ Subtensor{:int64:} [id J]
+     │  │  │  │        │     ├─ <TensorType(int64, (?,))> [id K]
+     │  │  │  │        │     └─ ScalarConstant{2} [id L]
+     │  │  │  │        └─ ScalarConstant{0} [id M]
+     │  │  │  ├─ Subtensor{:int64:} [id J]
+     │  │  │  │  └─ ···
+     │  │  │  └─ ScalarFromTensor [id N]
+     │  │  │     └─ Subtensor{int64} [id H]
+     │  │  │        └─ ···
+     │  │  └─ IncSubtensor{Set;:int64:} [id O] (outer_in_mit_sot-1)
+     │  │     ├─ AllocEmpty{dtype='int64'} [id P]
+     │  │     │  └─ Elemwise{add,no_inplace} [id Q]
+     │  │     │     ├─ TensorConstant{5} [id D]
+     │  │     │     └─ Subtensor{int64} [id R]
+     │  │     │        ├─ Shape [id S]
+     │  │     │        │  └─ Subtensor{:int64:} [id T]
+     │  │     │        │     ├─ <TensorType(int64, (?,))> [id U]
+     │  │     │        │     └─ ScalarConstant{2} [id V]
+     │  │     │        └─ ScalarConstant{0} [id W]
+     │  │     ├─ Subtensor{:int64:} [id T]
+     │  │     │  └─ ···
+     │  │     └─ ScalarFromTensor [id X]
+     │  │        └─ Subtensor{int64} [id R]
+     │  │           └─ ···
+     │  └─ ScalarConstant{2} [id Y]
+     └─ Subtensor{int64::} [id Z]
+        ├─ for{cpu,scan_fn}.1 [id C] (outer_out_mit_sot-1)
+        │  └─ ···
+        └─ ScalarConstant{2} [id BA]
 
     Inner graphs:
 
-    for{cpu,scan_fn}.0 [id C] (outer_out_mit_sot-0)
-    >Elemwise{add,no_inplace} [id BB] (inner_out_mit_sot-0)
-    > |*1-<TensorType(int64, ())> [id BC] -> [id E] (inner_in_mit_sot-0-1)
-    > |*0-<TensorType(int64, ())> [id BD] -> [id E] (inner_in_mit_sot-0-0)
-    >Elemwise{add,no_inplace} [id BE] (inner_out_mit_sot-1)
-    > |*3-<TensorType(int64, ())> [id BF] -> [id O] (inner_in_mit_sot-1-1)
-    > |*2-<TensorType(int64, ())> [id BG] -> [id O] (inner_in_mit_sot-1-0)
-
-    for{cpu,scan_fn}.1 [id C] (outer_out_mit_sot-1)
-    >Elemwise{add,no_inplace} [id BB] (inner_out_mit_sot-0)
-    >Elemwise{add,no_inplace} [id BE] (inner_out_mit_sot-1)"""
+    for{cpu,scan_fn} [id C]
+     ← Elemwise{add,no_inplace} [id BB] (inner_out_mit_sot-0)
+        ├─ *1-<TensorType(int64, ())> [id BC] -> [id E] (inner_in_mit_sot-0-1)
+        └─ *0-<TensorType(int64, ())> [id BD] -> [id E] (inner_in_mit_sot-0-0)
+     ← Elemwise{add,no_inplace} [id BE] (inner_out_mit_sot-1)
+        ├─ *3-<TensorType(int64, ())> [id BF] -> [id O] (inner_in_mit_sot-1-1)
+        └─ *2-<TensorType(int64, ())> [id BG] -> [id O] (inner_in_mit_sot-1-0)"""
 
     for truth, out in zip(expected_output.split("\n"), lines):
         assert truth.strip() == out.strip()
@@ -474,106 +502,118 @@ def test_debugprint_mitmot():
     lines = output_str.split("\n")
 
     expected_output = """Subtensor{int64} [id A]
-    |for{cpu,grad_of_scan_fn}.1 [id B] (outer_out_sit_sot-0)
-    | |Elemwise{sub,no_inplace} [id C] (n_steps)
-    | | |Subtensor{int64} [id D]
-    | | | |Shape [id E]
-    | | | | |for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
-    | | | |   |k [id G] (n_steps)
-    | | | |   |IncSubtensor{Set;:int64:} [id H] (outer_in_sit_sot-0)
-    | | | |   | |AllocEmpty{dtype='float64'} [id I]
-    | | | |   | | |Elemwise{add,no_inplace} [id J]
-    | | | |   | | | |k [id G]
-    | | | |   | | | |Subtensor{int64} [id K]
-    | | | |   | | |   |Shape [id L]
-    | | | |   | | |   | |Unbroadcast{0} [id M]
-    | | | |   | | |   |   |InplaceDimShuffle{x,0} [id N]
-    | | | |   | | |   |     |Elemwise{second,no_inplace} [id O]
-    | | | |   | | |   |       |A [id P]
-    | | | |   | | |   |       |InplaceDimShuffle{x} [id Q]
-    | | | |   | | |   |         |TensorConstant{1.0} [id R]
-    | | | |   | | |   |ScalarConstant{0} [id S]
-    | | | |   | | |Subtensor{int64} [id T]
-    | | | |   | |   |Shape [id U]
-    | | | |   | |   | |Unbroadcast{0} [id M]
-    | | | |   | |   |ScalarConstant{1} [id V]
-    | | | |   | |Unbroadcast{0} [id M]
-    | | | |   | |ScalarFromTensor [id W]
-    | | | |   |   |Subtensor{int64} [id K]
-    | | | |   |A [id P] (outer_in_non_seqs-0)
-    | | | |ScalarConstant{0} [id X]
-    | | |TensorConstant{1} [id Y]
-    | |Subtensor{:int64:} [id Z] (outer_in_seqs-0)
-    | | |Subtensor{::int64} [id BA]
-    | | | |Subtensor{:int64:} [id BB]
-    | | | | |for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
-    | | | | |ScalarConstant{-1} [id BC]
-    | | | |ScalarConstant{-1} [id BD]
-    | | |ScalarFromTensor [id BE]
-    | |   |Elemwise{sub,no_inplace} [id C]
-    | |Subtensor{:int64:} [id BF] (outer_in_seqs-1)
-    | | |Subtensor{:int64:} [id BG]
-    | | | |Subtensor{::int64} [id BH]
-    | | | | |for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
-    | | | | |ScalarConstant{-1} [id BI]
-    | | | |ScalarConstant{-1} [id BJ]
-    | | |ScalarFromTensor [id BK]
-    | |   |Elemwise{sub,no_inplace} [id C]
-    | |Subtensor{::int64} [id BL] (outer_in_mit_mot-0)
-    | | |IncSubtensor{Inc;int64::} [id BM]
-    | | | |Elemwise{second,no_inplace} [id BN]
-    | | | | |for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
-    | | | | |InplaceDimShuffle{x,x} [id BO]
-    | | | |   |TensorConstant{0.0} [id BP]
-    | | | |IncSubtensor{Inc;int64} [id BQ]
-    | | | | |Elemwise{second,no_inplace} [id BR]
-    | | | | | |Subtensor{int64::} [id BS]
-    | | | | | | |for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
-    | | | | | | |ScalarConstant{1} [id BT]
-    | | | | | |InplaceDimShuffle{x,x} [id BU]
-    | | | | |   |TensorConstant{0.0} [id BV]
-    | | | | |Elemwise{second} [id BW]
-    | | | | | |Subtensor{int64} [id BX]
-    | | | | | | |Subtensor{int64::} [id BS]
-    | | | | | | |ScalarConstant{-1} [id BY]
-    | | | | | |InplaceDimShuffle{x} [id BZ]
-    | | | | |   |Elemwise{second,no_inplace} [id CA]
-    | | | | |     |Sum{acc_dtype=float64} [id CB]
-    | | | | |     | |Subtensor{int64} [id BX]
-    | | | | |     |TensorConstant{1.0} [id CC]
-    | | | | |ScalarConstant{-1} [id BY]
-    | | | |ScalarConstant{1} [id BT]
-    | | |ScalarConstant{-1} [id CD]
-    | |Alloc [id CE] (outer_in_sit_sot-0)
-    | | |TensorConstant{0.0} [id CF]
-    | | |Elemwise{add,no_inplace} [id CG]
-    | | | |Elemwise{sub,no_inplace} [id C]
-    | | | |TensorConstant{1} [id CH]
-    | | |Subtensor{int64} [id CI]
-    | |   |Shape [id CJ]
-    | |   | |A [id P]
-    | |   |ScalarConstant{0} [id CK]
-    | |A [id P] (outer_in_non_seqs-0)
-    |ScalarConstant{-1} [id CL]
+     ├─ for{cpu,grad_of_scan_fn}.1 [id B] (outer_out_sit_sot-0)
+     │  ├─ Elemwise{sub,no_inplace} [id C] (n_steps)
+     │  │  ├─ Subtensor{int64} [id D]
+     │  │  │  ├─ Shape [id E]
+     │  │  │  │  └─ for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
+     │  │  │  │     ├─ k [id G] (n_steps)
+     │  │  │  │     ├─ IncSubtensor{Set;:int64:} [id H] (outer_in_sit_sot-0)
+     │  │  │  │     │  ├─ AllocEmpty{dtype='float64'} [id I]
+     │  │  │  │     │  │  ├─ Elemwise{add,no_inplace} [id J]
+     │  │  │  │     │  │  │  ├─ k [id G]
+     │  │  │  │     │  │  │  └─ Subtensor{int64} [id K]
+     │  │  │  │     │  │  │     ├─ Shape [id L]
+     │  │  │  │     │  │  │     │  └─ Unbroadcast{0} [id M]
+     │  │  │  │     │  │  │     │     └─ InplaceDimShuffle{x,0} [id N]
+     │  │  │  │     │  │  │     │        └─ Elemwise{second,no_inplace} [id O]
+     │  │  │  │     │  │  │     │           ├─ A [id P]
+     │  │  │  │     │  │  │     │           └─ InplaceDimShuffle{x} [id Q]
+     │  │  │  │     │  │  │     │              └─ TensorConstant{1.0} [id R]
+     │  │  │  │     │  │  │     └─ ScalarConstant{0} [id S]
+     │  │  │  │     │  │  └─ Subtensor{int64} [id T]
+     │  │  │  │     │  │     ├─ Shape [id U]
+     │  │  │  │     │  │     │  └─ Unbroadcast{0} [id M]
+     │  │  │  │     │  │     │     └─ ···
+     │  │  │  │     │  │     └─ ScalarConstant{1} [id V]
+     │  │  │  │     │  ├─ Unbroadcast{0} [id M]
+     │  │  │  │     │  │  └─ ···
+     │  │  │  │     │  └─ ScalarFromTensor [id W]
+     │  │  │  │     │     └─ Subtensor{int64} [id K]
+     │  │  │  │     │        └─ ···
+     │  │  │  │     └─ A [id P] (outer_in_non_seqs-0)
+     │  │  │  └─ ScalarConstant{0} [id X]
+     │  │  └─ TensorConstant{1} [id Y]
+     │  ├─ Subtensor{:int64:} [id Z] (outer_in_seqs-0)
+     │  │  ├─ Subtensor{::int64} [id BA]
+     │  │  │  ├─ Subtensor{:int64:} [id BB]
+     │  │  │  │  ├─ for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
+     │  │  │  │  │  └─ ···
+     │  │  │  │  └─ ScalarConstant{-1} [id BC]
+     │  │  │  └─ ScalarConstant{-1} [id BD]
+     │  │  └─ ScalarFromTensor [id BE]
+     │  │     └─ Elemwise{sub,no_inplace} [id C]
+     │  │        └─ ···
+     │  ├─ Subtensor{:int64:} [id BF] (outer_in_seqs-1)
+     │  │  ├─ Subtensor{:int64:} [id BG]
+     │  │  │  ├─ Subtensor{::int64} [id BH]
+     │  │  │  │  ├─ for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
+     │  │  │  │  │  └─ ···
+     │  │  │  │  └─ ScalarConstant{-1} [id BI]
+     │  │  │  └─ ScalarConstant{-1} [id BJ]
+     │  │  └─ ScalarFromTensor [id BK]
+     │  │     └─ Elemwise{sub,no_inplace} [id C]
+     │  │        └─ ···
+     │  ├─ Subtensor{::int64} [id BL] (outer_in_mit_mot-0)
+     │  │  ├─ IncSubtensor{Inc;int64::} [id BM]
+     │  │  │  ├─ Elemwise{second,no_inplace} [id BN]
+     │  │  │  │  ├─ for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
+     │  │  │  │  │  └─ ···
+     │  │  │  │  └─ InplaceDimShuffle{x,x} [id BO]
+     │  │  │  │     └─ TensorConstant{0.0} [id BP]
+     │  │  │  ├─ IncSubtensor{Inc;int64} [id BQ]
+     │  │  │  │  ├─ Elemwise{second,no_inplace} [id BR]
+     │  │  │  │  │  ├─ Subtensor{int64::} [id BS]
+     │  │  │  │  │  │  ├─ for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
+     │  │  │  │  │  │  │  └─ ···
+     │  │  │  │  │  │  └─ ScalarConstant{1} [id BT]
+     │  │  │  │  │  └─ InplaceDimShuffle{x,x} [id BU]
+     │  │  │  │  │     └─ TensorConstant{0.0} [id BV]
+     │  │  │  │  ├─ Elemwise{second} [id BW]
+     │  │  │  │  │  ├─ Subtensor{int64} [id BX]
+     │  │  │  │  │  │  ├─ Subtensor{int64::} [id BS]
+     │  │  │  │  │  │  │  └─ ···
+     │  │  │  │  │  │  └─ ScalarConstant{-1} [id BY]
+     │  │  │  │  │  └─ InplaceDimShuffle{x} [id BZ]
+     │  │  │  │  │     └─ Elemwise{second,no_inplace} [id CA]
+     │  │  │  │  │        ├─ Sum{acc_dtype=float64} [id CB]
+     │  │  │  │  │        │  └─ Subtensor{int64} [id BX]
+     │  │  │  │  │        │     └─ ···
+     │  │  │  │  │        └─ TensorConstant{1.0} [id CC]
+     │  │  │  │  └─ ScalarConstant{-1} [id BY]
+     │  │  │  └─ ScalarConstant{1} [id BT]
+     │  │  └─ ScalarConstant{-1} [id CD]
+     │  ├─ Alloc [id CE] (outer_in_sit_sot-0)
+     │  │  ├─ TensorConstant{0.0} [id CF]
+     │  │  ├─ Elemwise{add,no_inplace} [id CG]
+     │  │  │  ├─ Elemwise{sub,no_inplace} [id C]
+     │  │  │  │  └─ ···
+     │  │  │  └─ TensorConstant{1} [id CH]
+     │  │  └─ Subtensor{int64} [id CI]
+     │  │     ├─ Shape [id CJ]
+     │  │     │  └─ A [id P]
+     │  │     └─ ScalarConstant{0} [id CK]
+     │  └─ A [id P] (outer_in_non_seqs-0)
+     └─ ScalarConstant{-1} [id CL]
 
     Inner graphs:
 
-    for{cpu,grad_of_scan_fn}.1 [id B] (outer_out_sit_sot-0)
-    >Elemwise{add,no_inplace} [id CM] (inner_out_mit_mot-0-0)
-    > |Elemwise{mul} [id CN]
-    > | |*2-<TensorType(float64, (?,))> [id CO] -> [id BL] (inner_in_mit_mot-0-0)
-    > | |*5-<TensorType(float64, (?,))> [id CP] -> [id P] (inner_in_non_seqs-0)
-    > |*3-<TensorType(float64, (?,))> [id CQ] -> [id BL] (inner_in_mit_mot-0-1)
-    >Elemwise{add,no_inplace} [id CR] (inner_out_sit_sot-0)
-    > |Elemwise{mul} [id CS]
-    > | |*2-<TensorType(float64, (?,))> [id CO] -> [id BL] (inner_in_mit_mot-0-0)
-    > | |*0-<TensorType(float64, (?,))> [id CT] -> [id Z] (inner_in_seqs-0)
-    > |*4-<TensorType(float64, (?,))> [id CU] -> [id CE] (inner_in_sit_sot-0)
+    for{cpu,grad_of_scan_fn} [id B]
+     ← Elemwise{add,no_inplace} [id CM] (inner_out_mit_mot-0-0)
+        ├─ Elemwise{mul} [id CN]
+        │  ├─ *2-<TensorType(float64, (?,))> [id CO] -> [id BL] (inner_in_mit_mot-0-0)
+        │  └─ *5-<TensorType(float64, (?,))> [id CP] -> [id P] (inner_in_non_seqs-0)
+        └─ *3-<TensorType(float64, (?,))> [id CQ] -> [id BL] (inner_in_mit_mot-0-1)
+     ← Elemwise{add,no_inplace} [id CR] (inner_out_sit_sot-0)
+        ├─ Elemwise{mul} [id CS]
+        │  ├─ *2-<TensorType(float64, (?,))> [id CO] -> [id BL] (inner_in_mit_mot-0-0)
+        │  └─ *0-<TensorType(float64, (?,))> [id CT] -> [id Z] (inner_in_seqs-0)
+        └─ *4-<TensorType(float64, (?,))> [id CU] -> [id CE] (inner_in_sit_sot-0)
 
-    for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
-    >Elemwise{mul,no_inplace} [id CV] (inner_out_sit_sot-0)
-    > |*0-<TensorType(float64, (?,))> [id CT] -> [id H] (inner_in_sit_sot-0)
-    > |*1-<TensorType(float64, (?,))> [id CW] -> [id P] (inner_in_non_seqs-0)"""
+    for{cpu,scan_fn} [id F]
+     ← Elemwise{mul,no_inplace} [id CV] (inner_out_sit_sot-0)
+        ├─ *0-<TensorType(float64, (?,))> [id CT] -> [id H] (inner_in_sit_sot-0)
+        └─ *1-<TensorType(float64, (?,))> [id CW] -> [id P] (inner_in_non_seqs-0)"""
 
     for truth, out in zip(expected_output.split("\n"), lines):
         assert truth.strip() == out.strip()
@@ -602,40 +642,39 @@ def test_debugprint_compiled_fn():
     out = pytensor.function([M], out, updates=updates, mode="FAST_RUN")
 
     expected_output = """forall_inplace,cpu,scan_fn} [id A] 2 (outer_out_sit_sot-0)
-     |TensorConstant{20000} [id B] (n_steps)
-     |TensorConstant{[    0    ..998 19999]} [id C] (outer_in_seqs-0)
-     |IncSubtensor{InplaceSet;:int64:} [id D] 1 (outer_in_sit_sot-0)
-     | |AllocEmpty{dtype='int64'} [id E] 0
-     | | |TensorConstant{20000} [id B]
-     | |TensorConstant{(1,) of 0} [id F]
-     | |ScalarConstant{1} [id G]
-     |<TensorType(float64, (20000, 2, 2))> [id H] (outer_in_non_seqs-0)
+     ├─ TensorConstant{20000} [id B] (n_steps)
+     ├─ TensorConstant{[    0    ..998 19999]} [id C] (outer_in_seqs-0)
+     ├─ IncSubtensor{InplaceSet;:int64:} [id D] 1 (outer_in_sit_sot-0)
+     │  ├─ AllocEmpty{dtype='int64'} [id E] 0
+     │  │  └─ TensorConstant{20000} [id B]
+     │  ├─ TensorConstant{(1,) of 0} [id F]
+     │  └─ ScalarConstant{1} [id G]
+     └─ <TensorType(float64, (20000, 2, 2))> [id H] (outer_in_non_seqs-0)
 
     Inner graphs:
 
-    forall_inplace,cpu,scan_fn} [id A] (outer_out_sit_sot-0)
-     >Elemwise{Composite} [id I] (inner_out_sit_sot-0)
-     > |TensorConstant{0} [id J]
-     > |Subtensor{int64, int64, uint8} [id K]
-     > | |*2-<TensorType(float64, (20000, 2, 2))> [id L] -> [id H] (inner_in_non_seqs-0)
-     > | |ScalarFromTensor [id M]
-     > | | |*0-<TensorType(int64, ())> [id N] -> [id C] (inner_in_seqs-0)
-     > | |ScalarFromTensor [id O]
-     > | | |*1-<TensorType(int64, ())> [id P] -> [id D] (inner_in_sit_sot-0)
-     > | |ScalarConstant{0} [id Q]
-     > |TensorConstant{1} [id R]
+    forall_inplace,cpu,scan_fn} [id A]
+     ← Elemwise{Composite} [id I] (inner_out_sit_sot-0)
+        ├─ TensorConstant{0} [id J]
+        ├─ Subtensor{int64, int64, uint8} [id K]
+        │  ├─ *2-<TensorType(float64, (20000, 2, 2))> [id L] -> [id H] (inner_in_non_seqs-0)
+        │  ├─ ScalarFromTensor [id M]
+        │  │  └─ *0-<TensorType(int64, ())> [id N] -> [id C] (inner_in_seqs-0)
+        │  ├─ ScalarFromTensor [id O]
+        │  │  └─ *1-<TensorType(int64, ())> [id P] -> [id D] (inner_in_sit_sot-0)
+        │  └─ ScalarConstant{0} [id Q]
+        └─ TensorConstant{1} [id R]
 
     Elemwise{Composite} [id I]
-     >Switch [id S]
-     > |LT [id T]
-     > | |<int64> [id U]
-     > | |<float64> [id V]
-     > |<int64> [id W]
-     > |<int64> [id U]
+     ← Switch [id S]
+        ├─ LT [id T]
+        │  ├─ <int64> [id U]
+        │  └─ <float64> [id V]
+        ├─ <int64> [id W]
+        └─ <int64> [id U]
     """
 
     output_str = debugprint(out, file="str", print_op_info=True)
-    print(output_str)
     lines = output_str.split("\n")
 
     for truth, out in zip(expected_output.split("\n"), lines):

--- a/tests/scan/test_printing.py
+++ b/tests/scan/test_printing.py
@@ -28,7 +28,7 @@ def test_debugprint_sitsot():
 
     expected_output = """Subtensor{i} [id A]
      ├─ Subtensor{start:} [id B]
-     │  ├─ for{cpu,scan_fn} [id C] (outer_out_sit_sot-0)
+     │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id C] (outer_out_sit_sot-0)
      │  │  ├─ k [id D] (n_steps)
      │  │  ├─ SetSubtensor{:stop} [id E] (outer_in_sit_sot-0)
      │  │  │  ├─ AllocEmpty{dtype='float64'} [id F]
@@ -59,7 +59,7 @@ def test_debugprint_sitsot():
 
     Inner graphs:
 
-    for{cpu,scan_fn} [id C]
+    Scan{scan_fn, while_loop=False, inplace=none} [id C]
      ← Mul [id W] (inner_out_sit_sot-0)
         ├─ *0-<TensorType(float64, (?,))> [id X] -> [id E] (inner_in_sit_sot-0)
         └─ *1-<TensorType(float64, (?,))> [id Y] -> [id M] (inner_in_non_seqs-0)"""
@@ -86,7 +86,7 @@ def test_debugprint_sitsot_no_extra_info():
 
     expected_output = """Subtensor{i} [id A]
      ├─ Subtensor{start:} [id B]
-     │  ├─ for{cpu,scan_fn} [id C]
+     │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id C]
      │  │  ├─ k [id D]
      │  │  ├─ SetSubtensor{:stop} [id E]
      │  │  │  ├─ AllocEmpty{dtype='float64'} [id F]
@@ -117,7 +117,7 @@ def test_debugprint_sitsot_no_extra_info():
 
     Inner graphs:
 
-    for{cpu,scan_fn} [id C]
+    Scan{scan_fn, while_loop=False, inplace=none} [id C]
      ← Mul [id W]
         ├─ *0-<TensorType(float64, (?,))> [id X] -> [id E]
         └─ *1-<TensorType(float64, (?,))> [id Y] -> [id M]"""
@@ -148,7 +148,7 @@ def test_debugprint_nitsot():
     lines = output_str.split("\n")
 
     expected_output = """Sum{axes=None} [id A]
-     └─ for{cpu,scan_fn} [id B] (outer_out_nit_sot-0)
+     └─ Scan{scan_fn, while_loop=False, inplace=none} [id B] (outer_out_nit_sot-0)
         ├─ Minimum [id C] (outer_in_nit_sot-0)
         │  ├─ Subtensor{i} [id D]
         │  │  ├─ Shape [id E]
@@ -183,7 +183,7 @@ def test_debugprint_nitsot():
 
     Inner graphs:
 
-    for{cpu,scan_fn} [id B]
+    Scan{scan_fn, while_loop=False, inplace=none} [id B]
      ← Mul [id X] (inner_out_nit_sot-0)
         ├─ *0-<TensorType(float64, ())> [id Y] -> [id S] (inner_in_seqs-0)
         └─ Pow [id Z]
@@ -226,7 +226,7 @@ def test_debugprint_nested_scans():
     lines = output_str.split("\n")
 
     expected_output = """Sum{axes=None} [id A]
-     └─ for{cpu,scan_fn} [id B] (outer_out_nit_sot-0)
+     └─ Scan{scan_fn, while_loop=False, inplace=none} [id B] (outer_out_nit_sot-0)
         ├─ Minimum [id C] (outer_in_nit_sot-0)
         │  ├─ Subtensor{i} [id D]
         │  │  ├─ Shape [id E]
@@ -262,14 +262,14 @@ def test_debugprint_nested_scans():
 
     Inner graphs:
 
-    for{cpu,scan_fn} [id B]
+    Scan{scan_fn, while_loop=False, inplace=none} [id B]
      ← Mul [id Y] (inner_out_nit_sot-0)
         ├─ ExpandDims{axis=0} [id Z]
         │  └─ *0-<TensorType(float64, ())> [id BA] -> [id S] (inner_in_seqs-0)
         └─ Pow [id BB]
            ├─ Subtensor{i} [id BC]
            │  ├─ Subtensor{start:} [id BD]
-           │  │  ├─ for{cpu,scan_fn} [id BE] (outer_out_sit_sot-0)
+           │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id BE] (outer_out_sit_sot-0)
            │  │  │  ├─ *3-<TensorType(int32, ())> [id BF] -> [id X] (inner_in_non_seqs-1) (n_steps)
            │  │  │  ├─ SetSubtensor{:stop} [id BG] (outer_in_sit_sot-0)
            │  │  │  │  ├─ AllocEmpty{dtype='float64'} [id BH]
@@ -300,7 +300,7 @@ def test_debugprint_nested_scans():
            └─ ExpandDims{axis=0} [id BY]
               └─ *1-<TensorType(int64, ())> [id BZ] -> [id U] (inner_in_seqs-1)
 
-    for{cpu,scan_fn} [id BE]
+    Scan{scan_fn, while_loop=False, inplace=none} [id BE]
      ← Mul [id CA] (inner_out_sit_sot-0)
         ├─ *0-<TensorType(float64, (?,))> [id CB] -> [id BG] (inner_in_sit_sot-0)
         └─ *1-<TensorType(float64, (?,))> [id CC] -> [id BO] (inner_in_non_seqs-0)"""
@@ -319,7 +319,7 @@ def test_debugprint_nested_scans():
     → k [id B]
     → A [id C]
     Sum{axes=None} [id D] 13
-     └─ for{cpu,scan_fn} [id E] 12 (outer_out_nit_sot-0)
+     └─ Scan{scan_fn, while_loop=False, inplace=none} [id E] 12 (outer_out_nit_sot-0)
         ├─ Minimum [id F] 7 (outer_in_nit_sot-0)
         │  ├─ Subtensor{i} [id G] 6
         │  │  ├─ Shape [id H] 5
@@ -355,7 +355,7 @@ def test_debugprint_nested_scans():
 
     Inner graphs:
 
-    for{cpu,scan_fn} [id E]
+    Scan{scan_fn, while_loop=False, inplace=none} [id E]
      → *0-<TensorType(float64, ())> [id Y] -> [id U] (inner_in_seqs-0)
      → *1-<TensorType(int64, ())> [id Z] -> [id W] (inner_in_seqs-1)
      → *2-<TensorType(float64, (?,))> [id BA] -> [id C] (inner_in_non_seqs-0)
@@ -366,7 +366,7 @@ def test_debugprint_nested_scans():
         └─ Pow [id BE]
            ├─ Subtensor{i} [id BF]
            │  ├─ Subtensor{start:} [id BG]
-           │  │  ├─ for{cpu,scan_fn} [id BH] (outer_out_sit_sot-0)
+           │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id BH] (outer_out_sit_sot-0)
            │  │  │  ├─ *3-<TensorType(int32, ())> [id BB] (inner_in_non_seqs-1) (n_steps)
            │  │  │  ├─ SetSubtensor{:stop} [id BI] (outer_in_sit_sot-0)
            │  │  │  │  ├─ AllocEmpty{dtype='float64'} [id BJ]
@@ -397,7 +397,7 @@ def test_debugprint_nested_scans():
            └─ ExpandDims{axis=0} [id BZ]
               └─ *1-<TensorType(int64, ())> [id Z] (inner_in_seqs-1)
 
-    for{cpu,scan_fn} [id BH]
+    Scan{scan_fn, while_loop=False, inplace=none} [id BH]
      → *0-<TensorType(float64, (?,))> [id CA] -> [id BI] (inner_in_sit_sot-0)
      → *1-<TensorType(float64, (?,))> [id CB] -> [id BA] (inner_in_non_seqs-0)
      ← Mul [id CC] (inner_out_sit_sot-0)
@@ -431,7 +431,7 @@ def test_debugprint_mitsot():
 
     expected_output = """Add [id A]
      ├─ Subtensor{start:} [id B]
-     │  ├─ for{cpu,scan_fn}.0 [id C] (outer_out_mit_sot-0)
+     │  ├─ Scan{scan_fn, while_loop=False, inplace=none}.0 [id C] (outer_out_mit_sot-0)
      │  │  ├─ TensorConstant{5} [id D] (n_steps)
      │  │  ├─ SetSubtensor{:stop} [id E] (outer_in_mit_sot-0)
      │  │  │  ├─ AllocEmpty{dtype='int64'} [id F]
@@ -465,13 +465,13 @@ def test_debugprint_mitsot():
      │  │           └─ ···
      │  └─ ScalarConstant{2} [id Y]
      └─ Subtensor{start:} [id Z]
-        ├─ for{cpu,scan_fn}.1 [id C] (outer_out_mit_sot-1)
+        ├─ Scan{scan_fn, while_loop=False, inplace=none}.1 [id C] (outer_out_mit_sot-1)
         │  └─ ···
         └─ ScalarConstant{2} [id BA]
 
     Inner graphs:
 
-    for{cpu,scan_fn} [id C]
+    Scan{scan_fn, while_loop=False, inplace=none} [id C]
      ← Add [id BB] (inner_out_mit_sot-0)
         ├─ *1-<TensorType(int64, ())> [id BC] -> [id E] (inner_in_mit_sot-0-1)
         └─ *0-<TensorType(int64, ())> [id BD] -> [id E] (inner_in_mit_sot-0-0)
@@ -502,11 +502,11 @@ def test_debugprint_mitmot():
     lines = output_str.split("\n")
 
     expected_output = """Subtensor{i} [id A]
-     ├─ for{cpu,grad_of_scan_fn}.1 [id B] (outer_out_sit_sot-0)
+     ├─ Scan{grad_of_scan_fn, while_loop=False, inplace=none}.1 [id B] (outer_out_sit_sot-0)
      │  ├─ Sub [id C] (n_steps)
      │  │  ├─ Subtensor{i} [id D]
      │  │  │  ├─ Shape [id E]
-     │  │  │  │  └─ for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
+     │  │  │  │  └─ Scan{scan_fn, while_loop=False, inplace=none} [id F] (outer_out_sit_sot-0)
      │  │  │  │     ├─ k [id G] (n_steps)
      │  │  │  │     ├─ SetSubtensor{:stop} [id H] (outer_in_sit_sot-0)
      │  │  │  │     │  ├─ AllocEmpty{dtype='float64'} [id I]
@@ -537,7 +537,7 @@ def test_debugprint_mitmot():
      │  ├─ Subtensor{:stop} [id Z] (outer_in_seqs-0)
      │  │  ├─ Subtensor{::step} [id BA]
      │  │  │  ├─ Subtensor{:stop} [id BB]
-     │  │  │  │  ├─ for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
+     │  │  │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  └─ ···
      │  │  │  │  └─ ScalarConstant{-1} [id BC]
      │  │  │  └─ ScalarConstant{-1} [id BD]
@@ -547,7 +547,7 @@ def test_debugprint_mitmot():
      │  ├─ Subtensor{:stop} [id BF] (outer_in_seqs-1)
      │  │  ├─ Subtensor{:stop} [id BG]
      │  │  │  ├─ Subtensor{::step} [id BH]
-     │  │  │  │  ├─ for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
+     │  │  │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  └─ ···
      │  │  │  │  └─ ScalarConstant{-1} [id BI]
      │  │  │  └─ ScalarConstant{-1} [id BJ]
@@ -557,14 +557,14 @@ def test_debugprint_mitmot():
      │  ├─ Subtensor{::step} [id BL] (outer_in_mit_mot-0)
      │  │  ├─ IncSubtensor{start:} [id BM]
      │  │  │  ├─ Second [id BN]
-     │  │  │  │  ├─ for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
+     │  │  │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  └─ ···
      │  │  │  │  └─ ExpandDims{axes=[0, 1]} [id BO]
      │  │  │  │     └─ TensorConstant{0.0} [id BP]
      │  │  │  ├─ IncSubtensor{i} [id BQ]
      │  │  │  │  ├─ Second [id BR]
      │  │  │  │  │  ├─ Subtensor{start:} [id BS]
-     │  │  │  │  │  │  ├─ for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
+     │  │  │  │  │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  │  │  └─ ···
      │  │  │  │  │  │  └─ ScalarConstant{1} [id BT]
      │  │  │  │  │  └─ ExpandDims{axes=[0, 1]} [id BU]
@@ -598,7 +598,7 @@ def test_debugprint_mitmot():
 
     Inner graphs:
 
-    for{cpu,grad_of_scan_fn} [id B]
+    Scan{grad_of_scan_fn, while_loop=False, inplace=none} [id B]
      ← Add [id CM] (inner_out_mit_mot-0-0)
         ├─ Mul [id CN]
         │  ├─ *2-<TensorType(float64, (?,))> [id CO] -> [id BL] (inner_in_mit_mot-0-0)
@@ -610,7 +610,7 @@ def test_debugprint_mitmot():
         │  └─ *0-<TensorType(float64, (?,))> [id CT] -> [id Z] (inner_in_seqs-0)
         └─ *4-<TensorType(float64, (?,))> [id CU] -> [id CE] (inner_in_sit_sot-0)
 
-    for{cpu,scan_fn} [id F]
+    Scan{scan_fn, while_loop=False, inplace=none} [id F]
      ← Mul [id CV] (inner_out_sit_sot-0)
         ├─ *0-<TensorType(float64, (?,))> [id CT] -> [id H] (inner_in_sit_sot-0)
         └─ *1-<TensorType(float64, (?,))> [id CW] -> [id P] (inner_in_non_seqs-0)"""
@@ -641,7 +641,7 @@ def test_debugprint_compiled_fn():
     # (i.e. from `Scan._fn`)
     out = pytensor.function([M], out, updates=updates, mode="FAST_RUN")
 
-    expected_output = """forall_inplace,cpu,scan_fn} [id A] 2 (outer_out_sit_sot-0)
+    expected_output = """Scan{scan_fn, while_loop=False, inplace=all} [id A] 2 (outer_out_sit_sot-0)
      ├─ TensorConstant{20000} [id B] (n_steps)
      ├─ TensorConstant{[    0    ..998 19999]} [id C] (outer_in_seqs-0)
      ├─ SetSubtensor{:stop} [id D] 1 (outer_in_sit_sot-0)
@@ -653,7 +653,7 @@ def test_debugprint_compiled_fn():
 
     Inner graphs:
 
-    forall_inplace,cpu,scan_fn} [id A]
+    Scan{scan_fn, while_loop=False, inplace=all} [id A]
      ← Composite{switch(lt(i0, i1), i2, i0)} [id I] (inner_out_sit_sot-0)
         ├─ TensorConstant{0} [id J]
         ├─ Subtensor{i, j, k} [id K]

--- a/tests/scan/test_printing.py
+++ b/tests/scan/test_printing.py
@@ -26,15 +26,15 @@ def test_debugprint_sitsot():
     output_str = debugprint(final_result, file="str", print_op_info=True)
     lines = output_str.split("\n")
 
-    expected_output = """Subtensor{int64} [id A]
-     ├─ Subtensor{int64::} [id B]
+    expected_output = """Subtensor{i} [id A]
+     ├─ Subtensor{start:} [id B]
      │  ├─ for{cpu,scan_fn} [id C] (outer_out_sit_sot-0)
      │  │  ├─ k [id D] (n_steps)
-     │  │  ├─ IncSubtensor{Set;:int64:} [id E] (outer_in_sit_sot-0)
+     │  │  ├─ SetSubtensor{:stop} [id E] (outer_in_sit_sot-0)
      │  │  │  ├─ AllocEmpty{dtype='float64'} [id F]
      │  │  │  │  ├─ Add [id G]
      │  │  │  │  │  ├─ k [id D]
-     │  │  │  │  │  └─ Subtensor{int64} [id H]
+     │  │  │  │  │  └─ Subtensor{i} [id H]
      │  │  │  │  │     ├─ Shape [id I]
      │  │  │  │  │     │  └─ Unbroadcast{0} [id J]
      │  │  │  │  │     │     └─ ExpandDims{axis=0} [id K]
@@ -43,7 +43,7 @@ def test_debugprint_sitsot():
      │  │  │  │  │     │           └─ ExpandDims{axis=0} [id N]
      │  │  │  │  │     │              └─ TensorConstant{1.0} [id O]
      │  │  │  │  │     └─ ScalarConstant{0} [id P]
-     │  │  │  │  └─ Subtensor{int64} [id Q]
+     │  │  │  │  └─ Subtensor{i} [id Q]
      │  │  │  │     ├─ Shape [id R]
      │  │  │  │     │  └─ Unbroadcast{0} [id J]
      │  │  │  │     │     └─ ···
@@ -51,7 +51,7 @@ def test_debugprint_sitsot():
      │  │  │  ├─ Unbroadcast{0} [id J]
      │  │  │  │  └─ ···
      │  │  │  └─ ScalarFromTensor [id T]
-     │  │  │     └─ Subtensor{int64} [id H]
+     │  │  │     └─ Subtensor{i} [id H]
      │  │  │        └─ ···
      │  │  └─ A [id M] (outer_in_non_seqs-0)
      │  └─ ScalarConstant{1} [id U]
@@ -84,15 +84,15 @@ def test_debugprint_sitsot_no_extra_info():
     output_str = debugprint(final_result, file="str", print_op_info=False)
     lines = output_str.split("\n")
 
-    expected_output = """Subtensor{int64} [id A]
-     ├─ Subtensor{int64::} [id B]
+    expected_output = """Subtensor{i} [id A]
+     ├─ Subtensor{start:} [id B]
      │  ├─ for{cpu,scan_fn} [id C]
      │  │  ├─ k [id D]
-     │  │  ├─ IncSubtensor{Set;:int64:} [id E]
+     │  │  ├─ SetSubtensor{:stop} [id E]
      │  │  │  ├─ AllocEmpty{dtype='float64'} [id F]
      │  │  │  │  ├─ Add [id G]
      │  │  │  │  │  ├─ k [id D]
-     │  │  │  │  │  └─ Subtensor{int64} [id H]
+     │  │  │  │  │  └─ Subtensor{i} [id H]
      │  │  │  │  │     ├─ Shape [id I]
      │  │  │  │  │     │  └─ Unbroadcast{0} [id J]
      │  │  │  │  │     │     └─ ExpandDims{axis=0} [id K]
@@ -101,7 +101,7 @@ def test_debugprint_sitsot_no_extra_info():
      │  │  │  │  │     │           └─ ExpandDims{axis=0} [id N]
      │  │  │  │  │     │              └─ TensorConstant{1.0} [id O]
      │  │  │  │  │     └─ ScalarConstant{0} [id P]
-     │  │  │  │  └─ Subtensor{int64} [id Q]
+     │  │  │  │  └─ Subtensor{i} [id Q]
      │  │  │  │     ├─ Shape [id R]
      │  │  │  │     │  └─ Unbroadcast{0} [id J]
      │  │  │  │     │     └─ ···
@@ -109,7 +109,7 @@ def test_debugprint_sitsot_no_extra_info():
      │  │  │  ├─ Unbroadcast{0} [id J]
      │  │  │  │  └─ ···
      │  │  │  └─ ScalarFromTensor [id T]
-     │  │  │     └─ Subtensor{int64} [id H]
+     │  │  │     └─ Subtensor{i} [id H]
      │  │  │        └─ ···
      │  │  └─ A [id M]
      │  └─ ScalarConstant{1} [id U]
@@ -150,29 +150,29 @@ def test_debugprint_nitsot():
     expected_output = """Sum{axes=None} [id A]
      └─ for{cpu,scan_fn} [id B] (outer_out_nit_sot-0)
         ├─ Minimum [id C] (outer_in_nit_sot-0)
-        │  ├─ Subtensor{int64} [id D]
+        │  ├─ Subtensor{i} [id D]
         │  │  ├─ Shape [id E]
-        │  │  │  └─ Subtensor{int64::} [id F] 'coefficients[0:]'
+        │  │  │  └─ Subtensor{start:} [id F] 'coefficients[0:]'
         │  │  │     ├─ coefficients [id G]
         │  │  │     └─ ScalarConstant{0} [id H]
         │  │  └─ ScalarConstant{0} [id I]
-        │  └─ Subtensor{int64} [id J]
+        │  └─ Subtensor{i} [id J]
         │     ├─ Shape [id K]
-        │     │  └─ Subtensor{int64::} [id L]
+        │     │  └─ Subtensor{start:} [id L]
         │     │     ├─ ARange{dtype='int64'} [id M]
         │     │     │  ├─ TensorConstant{0} [id N]
         │     │     │  ├─ TensorConstant{10000} [id O]
         │     │     │  └─ TensorConstant{1} [id P]
         │     │     └─ ScalarConstant{0} [id Q]
         │     └─ ScalarConstant{0} [id R]
-        ├─ Subtensor{:int64:} [id S] (outer_in_seqs-0)
-        │  ├─ Subtensor{int64::} [id F] 'coefficients[0:]'
+        ├─ Subtensor{:stop} [id S] (outer_in_seqs-0)
+        │  ├─ Subtensor{start:} [id F] 'coefficients[0:]'
         │  │  └─ ···
         │  └─ ScalarFromTensor [id T]
         │     └─ Minimum [id C]
         │        └─ ···
-        ├─ Subtensor{:int64:} [id U] (outer_in_seqs-1)
-        │  ├─ Subtensor{int64::} [id L]
+        ├─ Subtensor{:stop} [id U] (outer_in_seqs-1)
+        │  ├─ Subtensor{start:} [id L]
         │  │  └─ ···
         │  └─ ScalarFromTensor [id V]
         │     └─ Minimum [id C]
@@ -228,29 +228,29 @@ def test_debugprint_nested_scans():
     expected_output = """Sum{axes=None} [id A]
      └─ for{cpu,scan_fn} [id B] (outer_out_nit_sot-0)
         ├─ Minimum [id C] (outer_in_nit_sot-0)
-        │  ├─ Subtensor{int64} [id D]
+        │  ├─ Subtensor{i} [id D]
         │  │  ├─ Shape [id E]
-        │  │  │  └─ Subtensor{int64::} [id F] 'c[0:]'
+        │  │  │  └─ Subtensor{start:} [id F] 'c[0:]'
         │  │  │     ├─ c [id G]
         │  │  │     └─ ScalarConstant{0} [id H]
         │  │  └─ ScalarConstant{0} [id I]
-        │  └─ Subtensor{int64} [id J]
+        │  └─ Subtensor{i} [id J]
         │     ├─ Shape [id K]
-        │     │  └─ Subtensor{int64::} [id L]
+        │     │  └─ Subtensor{start:} [id L]
         │     │     ├─ ARange{dtype='int64'} [id M]
         │     │     │  ├─ TensorConstant{0} [id N]
         │     │     │  ├─ TensorConstant{10} [id O]
         │     │     │  └─ TensorConstant{1} [id P]
         │     │     └─ ScalarConstant{0} [id Q]
         │     └─ ScalarConstant{0} [id R]
-        ├─ Subtensor{:int64:} [id S] (outer_in_seqs-0)
-        │  ├─ Subtensor{int64::} [id F] 'c[0:]'
+        ├─ Subtensor{:stop} [id S] (outer_in_seqs-0)
+        │  ├─ Subtensor{start:} [id F] 'c[0:]'
         │  │  └─ ···
         │  └─ ScalarFromTensor [id T]
         │     └─ Minimum [id C]
         │        └─ ···
-        ├─ Subtensor{:int64:} [id U] (outer_in_seqs-1)
-        │  ├─ Subtensor{int64::} [id L]
+        ├─ Subtensor{:stop} [id U] (outer_in_seqs-1)
+        │  ├─ Subtensor{start:} [id L]
         │  │  └─ ···
         │  └─ ScalarFromTensor [id V]
         │     └─ Minimum [id C]
@@ -267,15 +267,15 @@ def test_debugprint_nested_scans():
         ├─ ExpandDims{axis=0} [id Z]
         │  └─ *0-<TensorType(float64, ())> [id BA] -> [id S] (inner_in_seqs-0)
         └─ Pow [id BB]
-           ├─ Subtensor{int64} [id BC]
-           │  ├─ Subtensor{int64::} [id BD]
+           ├─ Subtensor{i} [id BC]
+           │  ├─ Subtensor{start:} [id BD]
            │  │  ├─ for{cpu,scan_fn} [id BE] (outer_out_sit_sot-0)
            │  │  │  ├─ *3-<TensorType(int32, ())> [id BF] -> [id X] (inner_in_non_seqs-1) (n_steps)
-           │  │  │  ├─ IncSubtensor{Set;:int64:} [id BG] (outer_in_sit_sot-0)
+           │  │  │  ├─ SetSubtensor{:stop} [id BG] (outer_in_sit_sot-0)
            │  │  │  │  ├─ AllocEmpty{dtype='float64'} [id BH]
            │  │  │  │  │  ├─ Add [id BI]
            │  │  │  │  │  │  ├─ *3-<TensorType(int32, ())> [id BF] -> [id X] (inner_in_non_seqs-1)
-           │  │  │  │  │  │  └─ Subtensor{int64} [id BJ]
+           │  │  │  │  │  │  └─ Subtensor{i} [id BJ]
            │  │  │  │  │  │     ├─ Shape [id BK]
            │  │  │  │  │  │     │  └─ Unbroadcast{0} [id BL]
            │  │  │  │  │  │     │     └─ ExpandDims{axis=0} [id BM]
@@ -284,7 +284,7 @@ def test_debugprint_nested_scans():
            │  │  │  │  │  │     │           └─ ExpandDims{axis=0} [id BP]
            │  │  │  │  │  │     │              └─ TensorConstant{1.0} [id BQ]
            │  │  │  │  │  │     └─ ScalarConstant{0} [id BR]
-           │  │  │  │  │  └─ Subtensor{int64} [id BS]
+           │  │  │  │  │  └─ Subtensor{i} [id BS]
            │  │  │  │  │     ├─ Shape [id BT]
            │  │  │  │  │     │  └─ Unbroadcast{0} [id BL]
            │  │  │  │  │     │     └─ ···
@@ -292,7 +292,7 @@ def test_debugprint_nested_scans():
            │  │  │  │  ├─ Unbroadcast{0} [id BL]
            │  │  │  │  │  └─ ···
            │  │  │  │  └─ ScalarFromTensor [id BV]
-           │  │  │  │     └─ Subtensor{int64} [id BJ]
+           │  │  │  │     └─ Subtensor{i} [id BJ]
            │  │  │  │        └─ ···
            │  │  │  └─ *2-<TensorType(float64, (?,))> [id BO] -> [id W] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
            │  │  └─ ScalarConstant{1} [id BW]
@@ -321,29 +321,29 @@ def test_debugprint_nested_scans():
     Sum{axes=None} [id D] 13
      └─ for{cpu,scan_fn} [id E] 12 (outer_out_nit_sot-0)
         ├─ Minimum [id F] 7 (outer_in_nit_sot-0)
-        │  ├─ Subtensor{int64} [id G] 6
+        │  ├─ Subtensor{i} [id G] 6
         │  │  ├─ Shape [id H] 5
-        │  │  │  └─ Subtensor{int64::} [id I] 'c[0:]' 4
+        │  │  │  └─ Subtensor{start:} [id I] 'c[0:]' 4
         │  │  │     ├─ c [id A]
         │  │  │     └─ ScalarConstant{0} [id J]
         │  │  └─ ScalarConstant{0} [id K]
-        │  └─ Subtensor{int64} [id L] 3
+        │  └─ Subtensor{i} [id L] 3
         │     ├─ Shape [id M] 2
-        │     │  └─ Subtensor{int64::} [id N] 1
+        │     │  └─ Subtensor{start:} [id N] 1
         │     │     ├─ ARange{dtype='int64'} [id O] 0
         │     │     │  ├─ TensorConstant{0} [id P]
         │     │     │  ├─ TensorConstant{10} [id Q]
         │     │     │  └─ TensorConstant{1} [id R]
         │     │     └─ ScalarConstant{0} [id S]
         │     └─ ScalarConstant{0} [id T]
-        ├─ Subtensor{:int64:} [id U] 11 (outer_in_seqs-0)
-        │  ├─ Subtensor{int64::} [id I] 'c[0:]' 4
+        ├─ Subtensor{:stop} [id U] 11 (outer_in_seqs-0)
+        │  ├─ Subtensor{start:} [id I] 'c[0:]' 4
         │  │  └─ ···
         │  └─ ScalarFromTensor [id V] 10
         │     └─ Minimum [id F] 7
         │        └─ ···
-        ├─ Subtensor{:int64:} [id W] 9 (outer_in_seqs-1)
-        │  ├─ Subtensor{int64::} [id N] 1
+        ├─ Subtensor{:stop} [id W] 9 (outer_in_seqs-1)
+        │  ├─ Subtensor{start:} [id N] 1
         │  │  └─ ···
         │  └─ ScalarFromTensor [id X] 8
         │     └─ Minimum [id F] 7
@@ -364,15 +364,15 @@ def test_debugprint_nested_scans():
         ├─ ExpandDims{axis=0} [id BD]
         │  └─ *0-<TensorType(float64, ())> [id Y] (inner_in_seqs-0)
         └─ Pow [id BE]
-           ├─ Subtensor{int64} [id BF]
-           │  ├─ Subtensor{int64::} [id BG]
+           ├─ Subtensor{i} [id BF]
+           │  ├─ Subtensor{start:} [id BG]
            │  │  ├─ for{cpu,scan_fn} [id BH] (outer_out_sit_sot-0)
            │  │  │  ├─ *3-<TensorType(int32, ())> [id BB] (inner_in_non_seqs-1) (n_steps)
-           │  │  │  ├─ IncSubtensor{Set;:int64:} [id BI] (outer_in_sit_sot-0)
+           │  │  │  ├─ SetSubtensor{:stop} [id BI] (outer_in_sit_sot-0)
            │  │  │  │  ├─ AllocEmpty{dtype='float64'} [id BJ]
            │  │  │  │  │  ├─ Add [id BK]
            │  │  │  │  │  │  ├─ *3-<TensorType(int32, ())> [id BB] (inner_in_non_seqs-1)
-           │  │  │  │  │  │  └─ Subtensor{int64} [id BL]
+           │  │  │  │  │  │  └─ Subtensor{i} [id BL]
            │  │  │  │  │  │     ├─ Shape [id BM]
            │  │  │  │  │  │     │  └─ Unbroadcast{0} [id BN]
            │  │  │  │  │  │     │     └─ ExpandDims{axis=0} [id BO]
@@ -381,7 +381,7 @@ def test_debugprint_nested_scans():
            │  │  │  │  │  │     │           └─ ExpandDims{axis=0} [id BQ]
            │  │  │  │  │  │     │              └─ TensorConstant{1.0} [id BR]
            │  │  │  │  │  │     └─ ScalarConstant{0} [id BS]
-           │  │  │  │  │  └─ Subtensor{int64} [id BT]
+           │  │  │  │  │  └─ Subtensor{i} [id BT]
            │  │  │  │  │     ├─ Shape [id BU]
            │  │  │  │  │     │  └─ Unbroadcast{0} [id BN]
            │  │  │  │  │     │     └─ ···
@@ -389,7 +389,7 @@ def test_debugprint_nested_scans():
            │  │  │  │  ├─ Unbroadcast{0} [id BN]
            │  │  │  │  │  └─ ···
            │  │  │  │  └─ ScalarFromTensor [id BW]
-           │  │  │  │     └─ Subtensor{int64} [id BL]
+           │  │  │  │     └─ Subtensor{i} [id BL]
            │  │  │  │        └─ ···
            │  │  │  └─ *2-<TensorType(float64, (?,))> [id BA] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
            │  │  └─ ScalarConstant{1} [id BX]
@@ -430,41 +430,41 @@ def test_debugprint_mitsot():
     lines = output_str.split("\n")
 
     expected_output = """Add [id A]
-     ├─ Subtensor{int64::} [id B]
+     ├─ Subtensor{start:} [id B]
      │  ├─ for{cpu,scan_fn}.0 [id C] (outer_out_mit_sot-0)
      │  │  ├─ TensorConstant{5} [id D] (n_steps)
-     │  │  ├─ IncSubtensor{Set;:int64:} [id E] (outer_in_mit_sot-0)
+     │  │  ├─ SetSubtensor{:stop} [id E] (outer_in_mit_sot-0)
      │  │  │  ├─ AllocEmpty{dtype='int64'} [id F]
      │  │  │  │  └─ Add [id G]
      │  │  │  │     ├─ TensorConstant{5} [id D]
-     │  │  │  │     └─ Subtensor{int64} [id H]
+     │  │  │  │     └─ Subtensor{i} [id H]
      │  │  │  │        ├─ Shape [id I]
-     │  │  │  │        │  └─ Subtensor{:int64:} [id J]
+     │  │  │  │        │  └─ Subtensor{:stop} [id J]
      │  │  │  │        │     ├─ <TensorType(int64, (?,))> [id K]
      │  │  │  │        │     └─ ScalarConstant{2} [id L]
      │  │  │  │        └─ ScalarConstant{0} [id M]
-     │  │  │  ├─ Subtensor{:int64:} [id J]
+     │  │  │  ├─ Subtensor{:stop} [id J]
      │  │  │  │  └─ ···
      │  │  │  └─ ScalarFromTensor [id N]
-     │  │  │     └─ Subtensor{int64} [id H]
+     │  │  │     └─ Subtensor{i} [id H]
      │  │  │        └─ ···
-     │  │  └─ IncSubtensor{Set;:int64:} [id O] (outer_in_mit_sot-1)
+     │  │  └─ SetSubtensor{:stop} [id O] (outer_in_mit_sot-1)
      │  │     ├─ AllocEmpty{dtype='int64'} [id P]
      │  │     │  └─ Add [id Q]
      │  │     │     ├─ TensorConstant{5} [id D]
-     │  │     │     └─ Subtensor{int64} [id R]
+     │  │     │     └─ Subtensor{i} [id R]
      │  │     │        ├─ Shape [id S]
-     │  │     │        │  └─ Subtensor{:int64:} [id T]
+     │  │     │        │  └─ Subtensor{:stop} [id T]
      │  │     │        │     ├─ <TensorType(int64, (?,))> [id U]
      │  │     │        │     └─ ScalarConstant{2} [id V]
      │  │     │        └─ ScalarConstant{0} [id W]
-     │  │     ├─ Subtensor{:int64:} [id T]
+     │  │     ├─ Subtensor{:stop} [id T]
      │  │     │  └─ ···
      │  │     └─ ScalarFromTensor [id X]
-     │  │        └─ Subtensor{int64} [id R]
+     │  │        └─ Subtensor{i} [id R]
      │  │           └─ ···
      │  └─ ScalarConstant{2} [id Y]
-     └─ Subtensor{int64::} [id Z]
+     └─ Subtensor{start:} [id Z]
         ├─ for{cpu,scan_fn}.1 [id C] (outer_out_mit_sot-1)
         │  └─ ···
         └─ ScalarConstant{2} [id BA]
@@ -501,18 +501,18 @@ def test_debugprint_mitmot():
     output_str = debugprint(final_result, file="str", print_op_info=True)
     lines = output_str.split("\n")
 
-    expected_output = """Subtensor{int64} [id A]
+    expected_output = """Subtensor{i} [id A]
      ├─ for{cpu,grad_of_scan_fn}.1 [id B] (outer_out_sit_sot-0)
      │  ├─ Sub [id C] (n_steps)
-     │  │  ├─ Subtensor{int64} [id D]
+     │  │  ├─ Subtensor{i} [id D]
      │  │  │  ├─ Shape [id E]
      │  │  │  │  └─ for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
      │  │  │  │     ├─ k [id G] (n_steps)
-     │  │  │  │     ├─ IncSubtensor{Set;:int64:} [id H] (outer_in_sit_sot-0)
+     │  │  │  │     ├─ SetSubtensor{:stop} [id H] (outer_in_sit_sot-0)
      │  │  │  │     │  ├─ AllocEmpty{dtype='float64'} [id I]
      │  │  │  │     │  │  ├─ Add [id J]
      │  │  │  │     │  │  │  ├─ k [id G]
-     │  │  │  │     │  │  │  └─ Subtensor{int64} [id K]
+     │  │  │  │     │  │  │  └─ Subtensor{i} [id K]
      │  │  │  │     │  │  │     ├─ Shape [id L]
      │  │  │  │     │  │  │     │  └─ Unbroadcast{0} [id M]
      │  │  │  │     │  │  │     │     └─ ExpandDims{axis=0} [id N]
@@ -521,7 +521,7 @@ def test_debugprint_mitmot():
      │  │  │  │     │  │  │     │           └─ ExpandDims{axis=0} [id Q]
      │  │  │  │     │  │  │     │              └─ TensorConstant{1.0} [id R]
      │  │  │  │     │  │  │     └─ ScalarConstant{0} [id S]
-     │  │  │  │     │  │  └─ Subtensor{int64} [id T]
+     │  │  │  │     │  │  └─ Subtensor{i} [id T]
      │  │  │  │     │  │     ├─ Shape [id U]
      │  │  │  │     │  │     │  └─ Unbroadcast{0} [id M]
      │  │  │  │     │  │     │     └─ ···
@@ -529,14 +529,14 @@ def test_debugprint_mitmot():
      │  │  │  │     │  ├─ Unbroadcast{0} [id M]
      │  │  │  │     │  │  └─ ···
      │  │  │  │     │  └─ ScalarFromTensor [id W]
-     │  │  │  │     │     └─ Subtensor{int64} [id K]
+     │  │  │  │     │     └─ Subtensor{i} [id K]
      │  │  │  │     │        └─ ···
      │  │  │  │     └─ A [id P] (outer_in_non_seqs-0)
      │  │  │  └─ ScalarConstant{0} [id X]
      │  │  └─ TensorConstant{1} [id Y]
-     │  ├─ Subtensor{:int64:} [id Z] (outer_in_seqs-0)
-     │  │  ├─ Subtensor{::int64} [id BA]
-     │  │  │  ├─ Subtensor{:int64:} [id BB]
+     │  ├─ Subtensor{:stop} [id Z] (outer_in_seqs-0)
+     │  │  ├─ Subtensor{::step} [id BA]
+     │  │  │  ├─ Subtensor{:stop} [id BB]
      │  │  │  │  ├─ for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  └─ ···
      │  │  │  │  └─ ScalarConstant{-1} [id BC]
@@ -544,9 +544,9 @@ def test_debugprint_mitmot():
      │  │  └─ ScalarFromTensor [id BE]
      │  │     └─ Sub [id C]
      │  │        └─ ···
-     │  ├─ Subtensor{:int64:} [id BF] (outer_in_seqs-1)
-     │  │  ├─ Subtensor{:int64:} [id BG]
-     │  │  │  ├─ Subtensor{::int64} [id BH]
+     │  ├─ Subtensor{:stop} [id BF] (outer_in_seqs-1)
+     │  │  ├─ Subtensor{:stop} [id BG]
+     │  │  │  ├─ Subtensor{::step} [id BH]
      │  │  │  │  ├─ for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  └─ ···
      │  │  │  │  └─ ScalarConstant{-1} [id BI]
@@ -554,30 +554,30 @@ def test_debugprint_mitmot():
      │  │  └─ ScalarFromTensor [id BK]
      │  │     └─ Sub [id C]
      │  │        └─ ···
-     │  ├─ Subtensor{::int64} [id BL] (outer_in_mit_mot-0)
-     │  │  ├─ IncSubtensor{Inc;int64::} [id BM]
+     │  ├─ Subtensor{::step} [id BL] (outer_in_mit_mot-0)
+     │  │  ├─ IncSubtensor{start:} [id BM]
      │  │  │  ├─ Second [id BN]
      │  │  │  │  ├─ for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  └─ ···
      │  │  │  │  └─ ExpandDims{axes=[0, 1]} [id BO]
      │  │  │  │     └─ TensorConstant{0.0} [id BP]
-     │  │  │  ├─ IncSubtensor{Inc;int64} [id BQ]
+     │  │  │  ├─ IncSubtensor{i} [id BQ]
      │  │  │  │  ├─ Second [id BR]
-     │  │  │  │  │  ├─ Subtensor{int64::} [id BS]
+     │  │  │  │  │  ├─ Subtensor{start:} [id BS]
      │  │  │  │  │  │  ├─ for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  │  │  └─ ···
      │  │  │  │  │  │  └─ ScalarConstant{1} [id BT]
      │  │  │  │  │  └─ ExpandDims{axes=[0, 1]} [id BU]
      │  │  │  │  │     └─ TensorConstant{0.0} [id BV]
      │  │  │  │  ├─ Second [id BW]
-     │  │  │  │  │  ├─ Subtensor{int64} [id BX]
-     │  │  │  │  │  │  ├─ Subtensor{int64::} [id BS]
+     │  │  │  │  │  ├─ Subtensor{i} [id BX]
+     │  │  │  │  │  │  ├─ Subtensor{start:} [id BS]
      │  │  │  │  │  │  │  └─ ···
      │  │  │  │  │  │  └─ ScalarConstant{-1} [id BY]
      │  │  │  │  │  └─ ExpandDims{axis=0} [id BZ]
      │  │  │  │  │     └─ Second [id CA]
      │  │  │  │  │        ├─ Sum{axes=None} [id CB]
-     │  │  │  │  │        │  └─ Subtensor{int64} [id BX]
+     │  │  │  │  │        │  └─ Subtensor{i} [id BX]
      │  │  │  │  │        │     └─ ···
      │  │  │  │  │        └─ TensorConstant{1.0} [id CC]
      │  │  │  │  └─ ScalarConstant{-1} [id BY]
@@ -589,7 +589,7 @@ def test_debugprint_mitmot():
      │  │  │  ├─ Sub [id C]
      │  │  │  │  └─ ···
      │  │  │  └─ TensorConstant{1} [id CH]
-     │  │  └─ Subtensor{int64} [id CI]
+     │  │  └─ Subtensor{i} [id CI]
      │  │     ├─ Shape [id CJ]
      │  │     │  └─ A [id P]
      │  │     └─ ScalarConstant{0} [id CK]
@@ -644,7 +644,7 @@ def test_debugprint_compiled_fn():
     expected_output = """forall_inplace,cpu,scan_fn} [id A] 2 (outer_out_sit_sot-0)
      ├─ TensorConstant{20000} [id B] (n_steps)
      ├─ TensorConstant{[    0    ..998 19999]} [id C] (outer_in_seqs-0)
-     ├─ IncSubtensor{InplaceSet;:int64:} [id D] 1 (outer_in_sit_sot-0)
+     ├─ SetSubtensor{:stop} [id D] 1 (outer_in_sit_sot-0)
      │  ├─ AllocEmpty{dtype='int64'} [id E] 0
      │  │  └─ TensorConstant{20000} [id B]
      │  ├─ TensorConstant{(1,) of 0} [id F]
@@ -656,7 +656,7 @@ def test_debugprint_compiled_fn():
     forall_inplace,cpu,scan_fn} [id A]
      ← Composite{switch(lt(i0, i1), i2, i0)} [id I] (inner_out_sit_sot-0)
         ├─ TensorConstant{0} [id J]
-        ├─ Subtensor{int64, int64, uint8} [id K]
+        ├─ Subtensor{i, j, k} [id K]
         │  ├─ *2-<TensorType(float64, (20000, 2, 2))> [id L] -> [id H] (inner_in_non_seqs-0)
         │  ├─ ScalarFromTensor [id M]
         │  │  └─ *0-<TensorType(int64, ())> [id N] -> [id C] (inner_in_seqs-0)

--- a/tests/scan/test_printing.py
+++ b/tests/scan/test_printing.py
@@ -37,10 +37,10 @@ def test_debugprint_sitsot():
      │  │  │  │  │  └─ Subtensor{int64} [id H]
      │  │  │  │  │     ├─ Shape [id I]
      │  │  │  │  │     │  └─ Unbroadcast{0} [id J]
-     │  │  │  │  │     │     └─ InplaceDimShuffle{x,0} [id K]
+     │  │  │  │  │     │     └─ ExpandDims{axis=0} [id K]
      │  │  │  │  │     │        └─ Elemwise{second,no_inplace} [id L]
      │  │  │  │  │     │           ├─ A [id M]
-     │  │  │  │  │     │           └─ InplaceDimShuffle{x} [id N]
+     │  │  │  │  │     │           └─ ExpandDims{axis=0} [id N]
      │  │  │  │  │     │              └─ TensorConstant{1.0} [id O]
      │  │  │  │  │     └─ ScalarConstant{0} [id P]
      │  │  │  │  └─ Subtensor{int64} [id Q]
@@ -95,10 +95,10 @@ def test_debugprint_sitsot_no_extra_info():
      │  │  │  │  │  └─ Subtensor{int64} [id H]
      │  │  │  │  │     ├─ Shape [id I]
      │  │  │  │  │     │  └─ Unbroadcast{0} [id J]
-     │  │  │  │  │     │     └─ InplaceDimShuffle{x,0} [id K]
+     │  │  │  │  │     │     └─ ExpandDims{axis=0} [id K]
      │  │  │  │  │     │        └─ Elemwise{second,no_inplace} [id L]
      │  │  │  │  │     │           ├─ A [id M]
-     │  │  │  │  │     │           └─ InplaceDimShuffle{x} [id N]
+     │  │  │  │  │     │           └─ ExpandDims{axis=0} [id N]
      │  │  │  │  │     │              └─ TensorConstant{1.0} [id O]
      │  │  │  │  │     └─ ScalarConstant{0} [id P]
      │  │  │  │  └─ Subtensor{int64} [id Q]
@@ -264,7 +264,7 @@ def test_debugprint_nested_scans():
 
     for{cpu,scan_fn} [id B]
      ← Elemwise{mul,no_inplace} [id Y] (inner_out_nit_sot-0)
-        ├─ InplaceDimShuffle{x} [id Z]
+        ├─ ExpandDims{axis=0} [id Z]
         │  └─ *0-<TensorType(float64, ())> [id BA] -> [id S] (inner_in_seqs-0)
         └─ Elemwise{pow,no_inplace} [id BB]
            ├─ Subtensor{int64} [id BC]
@@ -278,10 +278,10 @@ def test_debugprint_nested_scans():
            │  │  │  │  │  │  └─ Subtensor{int64} [id BJ]
            │  │  │  │  │  │     ├─ Shape [id BK]
            │  │  │  │  │  │     │  └─ Unbroadcast{0} [id BL]
-           │  │  │  │  │  │     │     └─ InplaceDimShuffle{x,0} [id BM]
+           │  │  │  │  │  │     │     └─ ExpandDims{axis=0} [id BM]
            │  │  │  │  │  │     │        └─ Elemwise{second,no_inplace} [id BN]
            │  │  │  │  │  │     │           ├─ *2-<TensorType(float64, (?,))> [id BO] -> [id W] (inner_in_non_seqs-0)
-           │  │  │  │  │  │     │           └─ InplaceDimShuffle{x} [id BP]
+           │  │  │  │  │  │     │           └─ ExpandDims{axis=0} [id BP]
            │  │  │  │  │  │     │              └─ TensorConstant{1.0} [id BQ]
            │  │  │  │  │  │     └─ ScalarConstant{0} [id BR]
            │  │  │  │  │  └─ Subtensor{int64} [id BS]
@@ -297,7 +297,7 @@ def test_debugprint_nested_scans():
            │  │  │  └─ *2-<TensorType(float64, (?,))> [id BO] -> [id W] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
            │  │  └─ ScalarConstant{1} [id BW]
            │  └─ ScalarConstant{-1} [id BX]
-           └─ InplaceDimShuffle{x} [id BY]
+           └─ ExpandDims{axis=0} [id BY]
               └─ *1-<TensorType(int64, ())> [id BZ] -> [id U] (inner_in_seqs-1)
 
     for{cpu,scan_fn} [id BE]
@@ -361,7 +361,7 @@ def test_debugprint_nested_scans():
      → *2-<TensorType(float64, (?,))> [id BA] -> [id C] (inner_in_non_seqs-0)
      → *3-<TensorType(int32, ())> [id BB] -> [id B] (inner_in_non_seqs-1)
      ← Elemwise{mul,no_inplace} [id BC] (inner_out_nit_sot-0)
-        ├─ InplaceDimShuffle{x} [id BD]
+        ├─ ExpandDims{axis=0} [id BD]
         │  └─ *0-<TensorType(float64, ())> [id Y] (inner_in_seqs-0)
         └─ Elemwise{pow,no_inplace} [id BE]
            ├─ Subtensor{int64} [id BF]
@@ -375,10 +375,10 @@ def test_debugprint_nested_scans():
            │  │  │  │  │  │  └─ Subtensor{int64} [id BL]
            │  │  │  │  │  │     ├─ Shape [id BM]
            │  │  │  │  │  │     │  └─ Unbroadcast{0} [id BN]
-           │  │  │  │  │  │     │     └─ InplaceDimShuffle{x,0} [id BO]
+           │  │  │  │  │  │     │     └─ ExpandDims{axis=0} [id BO]
            │  │  │  │  │  │     │        └─ Elemwise{second,no_inplace} [id BP]
            │  │  │  │  │  │     │           ├─ *2-<TensorType(float64, (?,))> [id BA] (inner_in_non_seqs-0)
-           │  │  │  │  │  │     │           └─ InplaceDimShuffle{x} [id BQ]
+           │  │  │  │  │  │     │           └─ ExpandDims{axis=0} [id BQ]
            │  │  │  │  │  │     │              └─ TensorConstant{1.0} [id BR]
            │  │  │  │  │  │     └─ ScalarConstant{0} [id BS]
            │  │  │  │  │  └─ Subtensor{int64} [id BT]
@@ -394,7 +394,7 @@ def test_debugprint_nested_scans():
            │  │  │  └─ *2-<TensorType(float64, (?,))> [id BA] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
            │  │  └─ ScalarConstant{1} [id BX]
            │  └─ ScalarConstant{-1} [id BY]
-           └─ InplaceDimShuffle{x} [id BZ]
+           └─ ExpandDims{axis=0} [id BZ]
               └─ *1-<TensorType(int64, ())> [id Z] (inner_in_seqs-1)
 
     for{cpu,scan_fn} [id BH]
@@ -515,10 +515,10 @@ def test_debugprint_mitmot():
      │  │  │  │     │  │  │  └─ Subtensor{int64} [id K]
      │  │  │  │     │  │  │     ├─ Shape [id L]
      │  │  │  │     │  │  │     │  └─ Unbroadcast{0} [id M]
-     │  │  │  │     │  │  │     │     └─ InplaceDimShuffle{x,0} [id N]
+     │  │  │  │     │  │  │     │     └─ ExpandDims{axis=0} [id N]
      │  │  │  │     │  │  │     │        └─ Elemwise{second,no_inplace} [id O]
      │  │  │  │     │  │  │     │           ├─ A [id P]
-     │  │  │  │     │  │  │     │           └─ InplaceDimShuffle{x} [id Q]
+     │  │  │  │     │  │  │     │           └─ ExpandDims{axis=0} [id Q]
      │  │  │  │     │  │  │     │              └─ TensorConstant{1.0} [id R]
      │  │  │  │     │  │  │     └─ ScalarConstant{0} [id S]
      │  │  │  │     │  │  └─ Subtensor{int64} [id T]
@@ -559,7 +559,7 @@ def test_debugprint_mitmot():
      │  │  │  ├─ Elemwise{second,no_inplace} [id BN]
      │  │  │  │  ├─ for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  └─ ···
-     │  │  │  │  └─ InplaceDimShuffle{x,x} [id BO]
+     │  │  │  │  └─ ExpandDims{axes=[0, 1]} [id BO]
      │  │  │  │     └─ TensorConstant{0.0} [id BP]
      │  │  │  ├─ IncSubtensor{Inc;int64} [id BQ]
      │  │  │  │  ├─ Elemwise{second,no_inplace} [id BR]
@@ -567,14 +567,14 @@ def test_debugprint_mitmot():
      │  │  │  │  │  │  ├─ for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  │  │  └─ ···
      │  │  │  │  │  │  └─ ScalarConstant{1} [id BT]
-     │  │  │  │  │  └─ InplaceDimShuffle{x,x} [id BU]
+     │  │  │  │  │  └─ ExpandDims{axes=[0, 1]} [id BU]
      │  │  │  │  │     └─ TensorConstant{0.0} [id BV]
      │  │  │  │  ├─ Elemwise{second} [id BW]
      │  │  │  │  │  ├─ Subtensor{int64} [id BX]
      │  │  │  │  │  │  ├─ Subtensor{int64::} [id BS]
      │  │  │  │  │  │  │  └─ ···
      │  │  │  │  │  │  └─ ScalarConstant{-1} [id BY]
-     │  │  │  │  │  └─ InplaceDimShuffle{x} [id BZ]
+     │  │  │  │  │  └─ ExpandDims{axis=0} [id BZ]
      │  │  │  │  │     └─ Elemwise{second,no_inplace} [id CA]
      │  │  │  │  │        ├─ Sum{acc_dtype=float64} [id CB]
      │  │  │  │  │        │  └─ Subtensor{int64} [id BX]

--- a/tests/scan/test_printing.py
+++ b/tests/scan/test_printing.py
@@ -61,8 +61,8 @@ def test_debugprint_sitsot():
 
     Scan{scan_fn, while_loop=False, inplace=none} [id C]
      ← Mul [id W] (inner_out_sit_sot-0)
-        ├─ *0-<TensorType(float64, (?,))> [id X] -> [id E] (inner_in_sit_sot-0)
-        └─ *1-<TensorType(float64, (?,))> [id Y] -> [id M] (inner_in_non_seqs-0)"""
+        ├─ *0-<Vector(float64, shape=(?,))> [id X] -> [id E] (inner_in_sit_sot-0)
+        └─ *1-<Vector(float64, shape=(?,))> [id Y] -> [id M] (inner_in_non_seqs-0)"""
 
     for truth, out in zip(expected_output.split("\n"), lines):
         assert truth.strip() == out.strip()
@@ -119,8 +119,8 @@ def test_debugprint_sitsot_no_extra_info():
 
     Scan{scan_fn, while_loop=False, inplace=none} [id C]
      ← Mul [id W]
-        ├─ *0-<TensorType(float64, (?,))> [id X] -> [id E]
-        └─ *1-<TensorType(float64, (?,))> [id Y] -> [id M]"""
+        ├─ *0-<Vector(float64, shape=(?,))> [id X] -> [id E]
+        └─ *1-<Vector(float64, shape=(?,))> [id Y] -> [id M]"""
 
     for truth, out in zip(expected_output.split("\n"), lines):
         assert truth.strip() == out.strip()
@@ -185,10 +185,10 @@ def test_debugprint_nitsot():
 
     Scan{scan_fn, while_loop=False, inplace=none} [id B]
      ← Mul [id X] (inner_out_nit_sot-0)
-        ├─ *0-<TensorType(float64, ())> [id Y] -> [id S] (inner_in_seqs-0)
+        ├─ *0-<Scalar(float64, shape=())> [id Y] -> [id S] (inner_in_seqs-0)
         └─ Pow [id Z]
-           ├─ *2-<TensorType(float64, ())> [id BA] -> [id W] (inner_in_non_seqs-0)
-           └─ *1-<TensorType(int64, ())> [id BB] -> [id U] (inner_in_seqs-1)"""
+           ├─ *2-<Scalar(float64, shape=())> [id BA] -> [id W] (inner_in_non_seqs-0)
+           └─ *1-<Scalar(int64, shape=())> [id BB] -> [id U] (inner_in_seqs-1)"""
 
     for truth, out in zip(expected_output.split("\n"), lines):
         assert truth.strip() == out.strip()
@@ -265,22 +265,22 @@ def test_debugprint_nested_scans():
     Scan{scan_fn, while_loop=False, inplace=none} [id B]
      ← Mul [id Y] (inner_out_nit_sot-0)
         ├─ ExpandDims{axis=0} [id Z]
-        │  └─ *0-<TensorType(float64, ())> [id BA] -> [id S] (inner_in_seqs-0)
+        │  └─ *0-<Scalar(float64, shape=())> [id BA] -> [id S] (inner_in_seqs-0)
         └─ Pow [id BB]
            ├─ Subtensor{i} [id BC]
            │  ├─ Subtensor{start:} [id BD]
            │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id BE] (outer_out_sit_sot-0)
-           │  │  │  ├─ *3-<TensorType(int32, ())> [id BF] -> [id X] (inner_in_non_seqs-1) (n_steps)
+           │  │  │  ├─ *3-<Scalar(int32, shape=())> [id BF] -> [id X] (inner_in_non_seqs-1) (n_steps)
            │  │  │  ├─ SetSubtensor{:stop} [id BG] (outer_in_sit_sot-0)
            │  │  │  │  ├─ AllocEmpty{dtype='float64'} [id BH]
            │  │  │  │  │  ├─ Add [id BI]
-           │  │  │  │  │  │  ├─ *3-<TensorType(int32, ())> [id BF] -> [id X] (inner_in_non_seqs-1)
+           │  │  │  │  │  │  ├─ *3-<Scalar(int32, shape=())> [id BF] -> [id X] (inner_in_non_seqs-1)
            │  │  │  │  │  │  └─ Subtensor{i} [id BJ]
            │  │  │  │  │  │     ├─ Shape [id BK]
            │  │  │  │  │  │     │  └─ Unbroadcast{0} [id BL]
            │  │  │  │  │  │     │     └─ ExpandDims{axis=0} [id BM]
            │  │  │  │  │  │     │        └─ Second [id BN]
-           │  │  │  │  │  │     │           ├─ *2-<TensorType(float64, (?,))> [id BO] -> [id W] (inner_in_non_seqs-0)
+           │  │  │  │  │  │     │           ├─ *2-<Vector(float64, shape=(?,))> [id BO] -> [id W] (inner_in_non_seqs-0)
            │  │  │  │  │  │     │           └─ ExpandDims{axis=0} [id BP]
            │  │  │  │  │  │     │              └─ TensorConstant{1.0} [id BQ]
            │  │  │  │  │  │     └─ ScalarConstant{0} [id BR]
@@ -294,16 +294,16 @@ def test_debugprint_nested_scans():
            │  │  │  │  └─ ScalarFromTensor [id BV]
            │  │  │  │     └─ Subtensor{i} [id BJ]
            │  │  │  │        └─ ···
-           │  │  │  └─ *2-<TensorType(float64, (?,))> [id BO] -> [id W] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
+           │  │  │  └─ *2-<Vector(float64, shape=(?,))> [id BO] -> [id W] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
            │  │  └─ ScalarConstant{1} [id BW]
            │  └─ ScalarConstant{-1} [id BX]
            └─ ExpandDims{axis=0} [id BY]
-              └─ *1-<TensorType(int64, ())> [id BZ] -> [id U] (inner_in_seqs-1)
+              └─ *1-<Scalar(int64, shape=())> [id BZ] -> [id U] (inner_in_seqs-1)
 
     Scan{scan_fn, while_loop=False, inplace=none} [id BE]
      ← Mul [id CA] (inner_out_sit_sot-0)
-        ├─ *0-<TensorType(float64, (?,))> [id CB] -> [id BG] (inner_in_sit_sot-0)
-        └─ *1-<TensorType(float64, (?,))> [id CC] -> [id BO] (inner_in_non_seqs-0)"""
+        ├─ *0-<Vector(float64, shape=(?,))> [id CB] -> [id BG] (inner_in_sit_sot-0)
+        └─ *1-<Vector(float64, shape=(?,))> [id CC] -> [id BO] (inner_in_non_seqs-0)"""
 
     for truth, out in zip(expected_output.split("\n"), lines):
         assert truth.strip() == out.strip()
@@ -356,28 +356,28 @@ def test_debugprint_nested_scans():
     Inner graphs:
 
     Scan{scan_fn, while_loop=False, inplace=none} [id E]
-     → *0-<TensorType(float64, ())> [id Y] -> [id U] (inner_in_seqs-0)
-     → *1-<TensorType(int64, ())> [id Z] -> [id W] (inner_in_seqs-1)
-     → *2-<TensorType(float64, (?,))> [id BA] -> [id C] (inner_in_non_seqs-0)
-     → *3-<TensorType(int32, ())> [id BB] -> [id B] (inner_in_non_seqs-1)
+     → *0-<Scalar(float64, shape=())> [id Y] -> [id U] (inner_in_seqs-0)
+     → *1-<Scalar(int64, shape=())> [id Z] -> [id W] (inner_in_seqs-1)
+     → *2-<Vector(float64, shape=(?,))> [id BA] -> [id C] (inner_in_non_seqs-0)
+     → *3-<Scalar(int32, shape=())> [id BB] -> [id B] (inner_in_non_seqs-1)
      ← Mul [id BC] (inner_out_nit_sot-0)
         ├─ ExpandDims{axis=0} [id BD]
-        │  └─ *0-<TensorType(float64, ())> [id Y] (inner_in_seqs-0)
+        │  └─ *0-<Scalar(float64, shape=())> [id Y] (inner_in_seqs-0)
         └─ Pow [id BE]
            ├─ Subtensor{i} [id BF]
            │  ├─ Subtensor{start:} [id BG]
            │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id BH] (outer_out_sit_sot-0)
-           │  │  │  ├─ *3-<TensorType(int32, ())> [id BB] (inner_in_non_seqs-1) (n_steps)
+           │  │  │  ├─ *3-<Scalar(int32, shape=())> [id BB] (inner_in_non_seqs-1) (n_steps)
            │  │  │  ├─ SetSubtensor{:stop} [id BI] (outer_in_sit_sot-0)
            │  │  │  │  ├─ AllocEmpty{dtype='float64'} [id BJ]
            │  │  │  │  │  ├─ Add [id BK]
-           │  │  │  │  │  │  ├─ *3-<TensorType(int32, ())> [id BB] (inner_in_non_seqs-1)
+           │  │  │  │  │  │  ├─ *3-<Scalar(int32, shape=())> [id BB] (inner_in_non_seqs-1)
            │  │  │  │  │  │  └─ Subtensor{i} [id BL]
            │  │  │  │  │  │     ├─ Shape [id BM]
            │  │  │  │  │  │     │  └─ Unbroadcast{0} [id BN]
            │  │  │  │  │  │     │     └─ ExpandDims{axis=0} [id BO]
            │  │  │  │  │  │     │        └─ Second [id BP]
-           │  │  │  │  │  │     │           ├─ *2-<TensorType(float64, (?,))> [id BA] (inner_in_non_seqs-0)
+           │  │  │  │  │  │     │           ├─ *2-<Vector(float64, shape=(?,))> [id BA] (inner_in_non_seqs-0)
            │  │  │  │  │  │     │           └─ ExpandDims{axis=0} [id BQ]
            │  │  │  │  │  │     │              └─ TensorConstant{1.0} [id BR]
            │  │  │  │  │  │     └─ ScalarConstant{0} [id BS]
@@ -391,18 +391,18 @@ def test_debugprint_nested_scans():
            │  │  │  │  └─ ScalarFromTensor [id BW]
            │  │  │  │     └─ Subtensor{i} [id BL]
            │  │  │  │        └─ ···
-           │  │  │  └─ *2-<TensorType(float64, (?,))> [id BA] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
+           │  │  │  └─ *2-<Vector(float64, shape=(?,))> [id BA] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
            │  │  └─ ScalarConstant{1} [id BX]
            │  └─ ScalarConstant{-1} [id BY]
            └─ ExpandDims{axis=0} [id BZ]
-              └─ *1-<TensorType(int64, ())> [id Z] (inner_in_seqs-1)
+              └─ *1-<Scalar(int64, shape=())> [id Z] (inner_in_seqs-1)
 
     Scan{scan_fn, while_loop=False, inplace=none} [id BH]
-     → *0-<TensorType(float64, (?,))> [id CA] -> [id BI] (inner_in_sit_sot-0)
-     → *1-<TensorType(float64, (?,))> [id CB] -> [id BA] (inner_in_non_seqs-0)
+     → *0-<Vector(float64, shape=(?,))> [id CA] -> [id BI] (inner_in_sit_sot-0)
+     → *1-<Vector(float64, shape=(?,))> [id CB] -> [id BA] (inner_in_non_seqs-0)
      ← Mul [id CC] (inner_out_sit_sot-0)
-        ├─ *0-<TensorType(float64, (?,))> [id CA] (inner_in_sit_sot-0)
-        └─ *1-<TensorType(float64, (?,))> [id CB] (inner_in_non_seqs-0)"""
+        ├─ *0-<Vector(float64, shape=(?,))> [id CA] (inner_in_sit_sot-0)
+        └─ *1-<Vector(float64, shape=(?,))> [id CB] (inner_in_non_seqs-0)"""
 
     for truth, out in zip(expected_output.split("\n"), lines):
         assert truth.strip() == out.strip()
@@ -440,7 +440,7 @@ def test_debugprint_mitsot():
      │  │  │  │     └─ Subtensor{i} [id H]
      │  │  │  │        ├─ Shape [id I]
      │  │  │  │        │  └─ Subtensor{:stop} [id J]
-     │  │  │  │        │     ├─ <TensorType(int64, (?,))> [id K]
+     │  │  │  │        │     ├─ <Vector(int64, shape=(?,))> [id K]
      │  │  │  │        │     └─ ScalarConstant{2} [id L]
      │  │  │  │        └─ ScalarConstant{0} [id M]
      │  │  │  ├─ Subtensor{:stop} [id J]
@@ -455,7 +455,7 @@ def test_debugprint_mitsot():
      │  │     │     └─ Subtensor{i} [id R]
      │  │     │        ├─ Shape [id S]
      │  │     │        │  └─ Subtensor{:stop} [id T]
-     │  │     │        │     ├─ <TensorType(int64, (?,))> [id U]
+     │  │     │        │     ├─ <Vector(int64, shape=(?,))> [id U]
      │  │     │        │     └─ ScalarConstant{2} [id V]
      │  │     │        └─ ScalarConstant{0} [id W]
      │  │     ├─ Subtensor{:stop} [id T]
@@ -473,11 +473,11 @@ def test_debugprint_mitsot():
 
     Scan{scan_fn, while_loop=False, inplace=none} [id C]
      ← Add [id BB] (inner_out_mit_sot-0)
-        ├─ *1-<TensorType(int64, ())> [id BC] -> [id E] (inner_in_mit_sot-0-1)
-        └─ *0-<TensorType(int64, ())> [id BD] -> [id E] (inner_in_mit_sot-0-0)
+        ├─ *1-<Scalar(int64, shape=())> [id BC] -> [id E] (inner_in_mit_sot-0-1)
+        └─ *0-<Scalar(int64, shape=())> [id BD] -> [id E] (inner_in_mit_sot-0-0)
      ← Add [id BE] (inner_out_mit_sot-1)
-        ├─ *3-<TensorType(int64, ())> [id BF] -> [id O] (inner_in_mit_sot-1-1)
-        └─ *2-<TensorType(int64, ())> [id BG] -> [id O] (inner_in_mit_sot-1-0)"""
+        ├─ *3-<Scalar(int64, shape=())> [id BF] -> [id O] (inner_in_mit_sot-1-1)
+        └─ *2-<Scalar(int64, shape=())> [id BG] -> [id O] (inner_in_mit_sot-1-0)"""
 
     for truth, out in zip(expected_output.split("\n"), lines):
         assert truth.strip() == out.strip()
@@ -601,19 +601,19 @@ def test_debugprint_mitmot():
     Scan{grad_of_scan_fn, while_loop=False, inplace=none} [id B]
      ← Add [id CM] (inner_out_mit_mot-0-0)
         ├─ Mul [id CN]
-        │  ├─ *2-<TensorType(float64, (?,))> [id CO] -> [id BL] (inner_in_mit_mot-0-0)
-        │  └─ *5-<TensorType(float64, (?,))> [id CP] -> [id P] (inner_in_non_seqs-0)
-        └─ *3-<TensorType(float64, (?,))> [id CQ] -> [id BL] (inner_in_mit_mot-0-1)
+        │  ├─ *2-<Vector(float64, shape=(?,))> [id CO] -> [id BL] (inner_in_mit_mot-0-0)
+        │  └─ *5-<Vector(float64, shape=(?,))> [id CP] -> [id P] (inner_in_non_seqs-0)
+        └─ *3-<Vector(float64, shape=(?,))> [id CQ] -> [id BL] (inner_in_mit_mot-0-1)
      ← Add [id CR] (inner_out_sit_sot-0)
         ├─ Mul [id CS]
-        │  ├─ *2-<TensorType(float64, (?,))> [id CO] -> [id BL] (inner_in_mit_mot-0-0)
-        │  └─ *0-<TensorType(float64, (?,))> [id CT] -> [id Z] (inner_in_seqs-0)
-        └─ *4-<TensorType(float64, (?,))> [id CU] -> [id CE] (inner_in_sit_sot-0)
+        │  ├─ *2-<Vector(float64, shape=(?,))> [id CO] -> [id BL] (inner_in_mit_mot-0-0)
+        │  └─ *0-<Vector(float64, shape=(?,))> [id CT] -> [id Z] (inner_in_seqs-0)
+        └─ *4-<Vector(float64, shape=(?,))> [id CU] -> [id CE] (inner_in_sit_sot-0)
 
     Scan{scan_fn, while_loop=False, inplace=none} [id F]
      ← Mul [id CV] (inner_out_sit_sot-0)
-        ├─ *0-<TensorType(float64, (?,))> [id CT] -> [id H] (inner_in_sit_sot-0)
-        └─ *1-<TensorType(float64, (?,))> [id CW] -> [id P] (inner_in_non_seqs-0)"""
+        ├─ *0-<Vector(float64, shape=(?,))> [id CT] -> [id H] (inner_in_sit_sot-0)
+        └─ *1-<Vector(float64, shape=(?,))> [id CW] -> [id P] (inner_in_non_seqs-0)"""
 
     for truth, out in zip(expected_output.split("\n"), lines):
         assert truth.strip() == out.strip()
@@ -643,13 +643,13 @@ def test_debugprint_compiled_fn():
 
     expected_output = """Scan{scan_fn, while_loop=False, inplace=all} [id A] 2 (outer_out_sit_sot-0)
      ├─ TensorConstant{20000} [id B] (n_steps)
-     ├─ TensorConstant{[    0    ..998 19999]} [id C] (outer_in_seqs-0)
+     ├─ TensorConstant{[    0 ... 998 19999]} [id C] (outer_in_seqs-0)
      ├─ SetSubtensor{:stop} [id D] 1 (outer_in_sit_sot-0)
      │  ├─ AllocEmpty{dtype='int64'} [id E] 0
      │  │  └─ TensorConstant{20000} [id B]
      │  ├─ TensorConstant{(1,) of 0} [id F]
      │  └─ ScalarConstant{1} [id G]
-     └─ <TensorType(float64, (20000, 2, 2))> [id H] (outer_in_non_seqs-0)
+     └─ <Tensor3(float64, shape=(20000, 2, 2))> [id H] (outer_in_non_seqs-0)
 
     Inner graphs:
 
@@ -657,11 +657,11 @@ def test_debugprint_compiled_fn():
      ← Composite{switch(lt(i0, i1), i2, i0)} [id I] (inner_out_sit_sot-0)
         ├─ TensorConstant{0} [id J]
         ├─ Subtensor{i, j, k} [id K]
-        │  ├─ *2-<TensorType(float64, (20000, 2, 2))> [id L] -> [id H] (inner_in_non_seqs-0)
+        │  ├─ *2-<Tensor3(float64, shape=(20000, 2, 2))> [id L] -> [id H] (inner_in_non_seqs-0)
         │  ├─ ScalarFromTensor [id M]
-        │  │  └─ *0-<TensorType(int64, ())> [id N] -> [id C] (inner_in_seqs-0)
+        │  │  └─ *0-<Scalar(int64, shape=())> [id N] -> [id C] (inner_in_seqs-0)
         │  ├─ ScalarFromTensor [id O]
-        │  │  └─ *1-<TensorType(int64, ())> [id P] -> [id D] (inner_in_sit_sot-0)
+        │  │  └─ *1-<Scalar(int64, shape=())> [id P] -> [id D] (inner_in_sit_sot-0)
         │  └─ ScalarConstant{0} [id Q]
         └─ TensorConstant{1} [id R]
 

--- a/tests/scan/test_printing.py
+++ b/tests/scan/test_printing.py
@@ -654,7 +654,7 @@ def test_debugprint_compiled_fn():
     Inner graphs:
 
     forall_inplace,cpu,scan_fn} [id A]
-     ← Elemwise{Composite} [id I] (inner_out_sit_sot-0)
+     ← Elemwise{Composite{Switch(LT(i0, i1), i2, i0)}} [id I] (inner_out_sit_sot-0)
         ├─ TensorConstant{0} [id J]
         ├─ Subtensor{int64, int64, uint8} [id K]
         │  ├─ *2-<TensorType(float64, (20000, 2, 2))> [id L] -> [id H] (inner_in_non_seqs-0)
@@ -665,13 +665,13 @@ def test_debugprint_compiled_fn():
         │  └─ ScalarConstant{0} [id Q]
         └─ TensorConstant{1} [id R]
 
-    Elemwise{Composite} [id I]
-     ← Switch [id S]
+    Elemwise{Composite{Switch(LT(i0, i1), i2, i0)}} [id I]
+     ← Switch [id S] 'o0'
         ├─ LT [id T]
-        │  ├─ <int64> [id U]
-        │  └─ <float64> [id V]
-        ├─ <int64> [id W]
-        └─ <int64> [id U]
+        │  ├─ i0 [id U]
+        │  └─ i1 [id V]
+        ├─ i2 [id W]
+        └─ i0 [id U]
     """
 
     output_str = debugprint(out, file="str", print_op_info=True)

--- a/tests/scan/test_printing.py
+++ b/tests/scan/test_printing.py
@@ -41,21 +41,21 @@ def test_debugprint_sitsot():
      │  │  │  │  │     │        └─ Second [id L]
      │  │  │  │  │     │           ├─ A [id M]
      │  │  │  │  │     │           └─ ExpandDims{axis=0} [id N]
-     │  │  │  │  │     │              └─ TensorConstant{1.0} [id O]
-     │  │  │  │  │     └─ ScalarConstant{0} [id P]
+     │  │  │  │  │     │              └─ 1.0 [id O]
+     │  │  │  │  │     └─ 0 [id P]
      │  │  │  │  └─ Subtensor{i} [id Q]
      │  │  │  │     ├─ Shape [id R]
      │  │  │  │     │  └─ Unbroadcast{0} [id J]
      │  │  │  │     │     └─ ···
-     │  │  │  │     └─ ScalarConstant{1} [id S]
+     │  │  │  │     └─ 1 [id S]
      │  │  │  ├─ Unbroadcast{0} [id J]
      │  │  │  │  └─ ···
      │  │  │  └─ ScalarFromTensor [id T]
      │  │  │     └─ Subtensor{i} [id H]
      │  │  │        └─ ···
      │  │  └─ A [id M] (outer_in_non_seqs-0)
-     │  └─ ScalarConstant{1} [id U]
-     └─ ScalarConstant{-1} [id V]
+     │  └─ 1 [id U]
+     └─ -1 [id V]
 
     Inner graphs:
 
@@ -99,21 +99,21 @@ def test_debugprint_sitsot_no_extra_info():
      │  │  │  │  │     │        └─ Second [id L]
      │  │  │  │  │     │           ├─ A [id M]
      │  │  │  │  │     │           └─ ExpandDims{axis=0} [id N]
-     │  │  │  │  │     │              └─ TensorConstant{1.0} [id O]
-     │  │  │  │  │     └─ ScalarConstant{0} [id P]
+     │  │  │  │  │     │              └─ 1.0 [id O]
+     │  │  │  │  │     └─ 0 [id P]
      │  │  │  │  └─ Subtensor{i} [id Q]
      │  │  │  │     ├─ Shape [id R]
      │  │  │  │     │  └─ Unbroadcast{0} [id J]
      │  │  │  │     │     └─ ···
-     │  │  │  │     └─ ScalarConstant{1} [id S]
+     │  │  │  │     └─ 1 [id S]
      │  │  │  ├─ Unbroadcast{0} [id J]
      │  │  │  │  └─ ···
      │  │  │  └─ ScalarFromTensor [id T]
      │  │  │     └─ Subtensor{i} [id H]
      │  │  │        └─ ···
      │  │  └─ A [id M]
-     │  └─ ScalarConstant{1} [id U]
-     └─ ScalarConstant{-1} [id V]
+     │  └─ 1 [id U]
+     └─ -1 [id V]
 
     Inner graphs:
 
@@ -154,17 +154,17 @@ def test_debugprint_nitsot():
         │  │  ├─ Shape [id E]
         │  │  │  └─ Subtensor{start:} [id F] 'coefficients[0:]'
         │  │  │     ├─ coefficients [id G]
-        │  │  │     └─ ScalarConstant{0} [id H]
-        │  │  └─ ScalarConstant{0} [id I]
+        │  │  │     └─ 0 [id H]
+        │  │  └─ 0 [id I]
         │  └─ Subtensor{i} [id J]
         │     ├─ Shape [id K]
         │     │  └─ Subtensor{start:} [id L]
         │     │     ├─ ARange{dtype='int64'} [id M]
-        │     │     │  ├─ TensorConstant{0} [id N]
-        │     │     │  ├─ TensorConstant{10000} [id O]
-        │     │     │  └─ TensorConstant{1} [id P]
-        │     │     └─ ScalarConstant{0} [id Q]
-        │     └─ ScalarConstant{0} [id R]
+        │     │     │  ├─ 0 [id N]
+        │     │     │  ├─ 10000 [id O]
+        │     │     │  └─ 1 [id P]
+        │     │     └─ 0 [id Q]
+        │     └─ 0 [id R]
         ├─ Subtensor{:stop} [id S] (outer_in_seqs-0)
         │  ├─ Subtensor{start:} [id F] 'coefficients[0:]'
         │  │  └─ ···
@@ -232,17 +232,17 @@ def test_debugprint_nested_scans():
         │  │  ├─ Shape [id E]
         │  │  │  └─ Subtensor{start:} [id F] 'c[0:]'
         │  │  │     ├─ c [id G]
-        │  │  │     └─ ScalarConstant{0} [id H]
-        │  │  └─ ScalarConstant{0} [id I]
+        │  │  │     └─ 0 [id H]
+        │  │  └─ 0 [id I]
         │  └─ Subtensor{i} [id J]
         │     ├─ Shape [id K]
         │     │  └─ Subtensor{start:} [id L]
         │     │     ├─ ARange{dtype='int64'} [id M]
-        │     │     │  ├─ TensorConstant{0} [id N]
-        │     │     │  ├─ TensorConstant{10} [id O]
-        │     │     │  └─ TensorConstant{1} [id P]
-        │     │     └─ ScalarConstant{0} [id Q]
-        │     └─ ScalarConstant{0} [id R]
+        │     │     │  ├─ 0 [id N]
+        │     │     │  ├─ 10 [id O]
+        │     │     │  └─ 1 [id P]
+        │     │     └─ 0 [id Q]
+        │     └─ 0 [id R]
         ├─ Subtensor{:stop} [id S] (outer_in_seqs-0)
         │  ├─ Subtensor{start:} [id F] 'c[0:]'
         │  │  └─ ···
@@ -282,21 +282,21 @@ def test_debugprint_nested_scans():
            │  │  │  │  │  │     │        └─ Second [id BN]
            │  │  │  │  │  │     │           ├─ *2-<Vector(float64, shape=(?,))> [id BO] -> [id W] (inner_in_non_seqs-0)
            │  │  │  │  │  │     │           └─ ExpandDims{axis=0} [id BP]
-           │  │  │  │  │  │     │              └─ TensorConstant{1.0} [id BQ]
-           │  │  │  │  │  │     └─ ScalarConstant{0} [id BR]
+           │  │  │  │  │  │     │              └─ 1.0 [id BQ]
+           │  │  │  │  │  │     └─ 0 [id BR]
            │  │  │  │  │  └─ Subtensor{i} [id BS]
            │  │  │  │  │     ├─ Shape [id BT]
            │  │  │  │  │     │  └─ Unbroadcast{0} [id BL]
            │  │  │  │  │     │     └─ ···
-           │  │  │  │  │     └─ ScalarConstant{1} [id BU]
+           │  │  │  │  │     └─ 1 [id BU]
            │  │  │  │  ├─ Unbroadcast{0} [id BL]
            │  │  │  │  │  └─ ···
            │  │  │  │  └─ ScalarFromTensor [id BV]
            │  │  │  │     └─ Subtensor{i} [id BJ]
            │  │  │  │        └─ ···
            │  │  │  └─ *2-<Vector(float64, shape=(?,))> [id BO] -> [id W] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
-           │  │  └─ ScalarConstant{1} [id BW]
-           │  └─ ScalarConstant{-1} [id BX]
+           │  │  └─ 1 [id BW]
+           │  └─ -1 [id BX]
            └─ ExpandDims{axis=0} [id BY]
               └─ *1-<Scalar(int64, shape=())> [id BZ] -> [id U] (inner_in_seqs-1)
 
@@ -325,17 +325,17 @@ def test_debugprint_nested_scans():
         │  │  ├─ Shape [id H] 5
         │  │  │  └─ Subtensor{start:} [id I] 'c[0:]' 4
         │  │  │     ├─ c [id A]
-        │  │  │     └─ ScalarConstant{0} [id J]
-        │  │  └─ ScalarConstant{0} [id K]
+        │  │  │     └─ 0 [id J]
+        │  │  └─ 0 [id K]
         │  └─ Subtensor{i} [id L] 3
         │     ├─ Shape [id M] 2
         │     │  └─ Subtensor{start:} [id N] 1
         │     │     ├─ ARange{dtype='int64'} [id O] 0
-        │     │     │  ├─ TensorConstant{0} [id P]
-        │     │     │  ├─ TensorConstant{10} [id Q]
-        │     │     │  └─ TensorConstant{1} [id R]
-        │     │     └─ ScalarConstant{0} [id S]
-        │     └─ ScalarConstant{0} [id T]
+        │     │     │  ├─ 0 [id P]
+        │     │     │  ├─ 10 [id Q]
+        │     │     │  └─ 1 [id R]
+        │     │     └─ 0 [id S]
+        │     └─ 0 [id T]
         ├─ Subtensor{:stop} [id U] 11 (outer_in_seqs-0)
         │  ├─ Subtensor{start:} [id I] 'c[0:]' 4
         │  │  └─ ···
@@ -379,21 +379,21 @@ def test_debugprint_nested_scans():
            │  │  │  │  │  │     │        └─ Second [id BP]
            │  │  │  │  │  │     │           ├─ *2-<Vector(float64, shape=(?,))> [id BA] (inner_in_non_seqs-0)
            │  │  │  │  │  │     │           └─ ExpandDims{axis=0} [id BQ]
-           │  │  │  │  │  │     │              └─ TensorConstant{1.0} [id BR]
-           │  │  │  │  │  │     └─ ScalarConstant{0} [id BS]
+           │  │  │  │  │  │     │              └─ 1.0 [id BR]
+           │  │  │  │  │  │     └─ 0 [id BS]
            │  │  │  │  │  └─ Subtensor{i} [id BT]
            │  │  │  │  │     ├─ Shape [id BU]
            │  │  │  │  │     │  └─ Unbroadcast{0} [id BN]
            │  │  │  │  │     │     └─ ···
-           │  │  │  │  │     └─ ScalarConstant{1} [id BV]
+           │  │  │  │  │     └─ 1 [id BV]
            │  │  │  │  ├─ Unbroadcast{0} [id BN]
            │  │  │  │  │  └─ ···
            │  │  │  │  └─ ScalarFromTensor [id BW]
            │  │  │  │     └─ Subtensor{i} [id BL]
            │  │  │  │        └─ ···
            │  │  │  └─ *2-<Vector(float64, shape=(?,))> [id BA] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
-           │  │  └─ ScalarConstant{1} [id BX]
-           │  └─ ScalarConstant{-1} [id BY]
+           │  │  └─ 1 [id BX]
+           │  └─ -1 [id BY]
            └─ ExpandDims{axis=0} [id BZ]
               └─ *1-<Scalar(int64, shape=())> [id Z] (inner_in_seqs-1)
 
@@ -432,17 +432,17 @@ def test_debugprint_mitsot():
     expected_output = """Add [id A]
      ├─ Subtensor{start:} [id B]
      │  ├─ Scan{scan_fn, while_loop=False, inplace=none}.0 [id C] (outer_out_mit_sot-0)
-     │  │  ├─ TensorConstant{5} [id D] (n_steps)
+     │  │  ├─ 5 [id D] (n_steps)
      │  │  ├─ SetSubtensor{:stop} [id E] (outer_in_mit_sot-0)
      │  │  │  ├─ AllocEmpty{dtype='int64'} [id F]
      │  │  │  │  └─ Add [id G]
-     │  │  │  │     ├─ TensorConstant{5} [id D]
+     │  │  │  │     ├─ 5 [id D]
      │  │  │  │     └─ Subtensor{i} [id H]
      │  │  │  │        ├─ Shape [id I]
      │  │  │  │        │  └─ Subtensor{:stop} [id J]
      │  │  │  │        │     ├─ <Vector(int64, shape=(?,))> [id K]
-     │  │  │  │        │     └─ ScalarConstant{2} [id L]
-     │  │  │  │        └─ ScalarConstant{0} [id M]
+     │  │  │  │        │     └─ 2 [id L]
+     │  │  │  │        └─ 0 [id M]
      │  │  │  ├─ Subtensor{:stop} [id J]
      │  │  │  │  └─ ···
      │  │  │  └─ ScalarFromTensor [id N]
@@ -451,23 +451,23 @@ def test_debugprint_mitsot():
      │  │  └─ SetSubtensor{:stop} [id O] (outer_in_mit_sot-1)
      │  │     ├─ AllocEmpty{dtype='int64'} [id P]
      │  │     │  └─ Add [id Q]
-     │  │     │     ├─ TensorConstant{5} [id D]
+     │  │     │     ├─ 5 [id D]
      │  │     │     └─ Subtensor{i} [id R]
      │  │     │        ├─ Shape [id S]
      │  │     │        │  └─ Subtensor{:stop} [id T]
      │  │     │        │     ├─ <Vector(int64, shape=(?,))> [id U]
-     │  │     │        │     └─ ScalarConstant{2} [id V]
-     │  │     │        └─ ScalarConstant{0} [id W]
+     │  │     │        │     └─ 2 [id V]
+     │  │     │        └─ 0 [id W]
      │  │     ├─ Subtensor{:stop} [id T]
      │  │     │  └─ ···
      │  │     └─ ScalarFromTensor [id X]
      │  │        └─ Subtensor{i} [id R]
      │  │           └─ ···
-     │  └─ ScalarConstant{2} [id Y]
+     │  └─ 2 [id Y]
      └─ Subtensor{start:} [id Z]
         ├─ Scan{scan_fn, while_loop=False, inplace=none}.1 [id C] (outer_out_mit_sot-1)
         │  └─ ···
-        └─ ScalarConstant{2} [id BA]
+        └─ 2 [id BA]
 
     Inner graphs:
 
@@ -519,28 +519,28 @@ def test_debugprint_mitmot():
      │  │  │  │     │  │  │     │        └─ Second [id O]
      │  │  │  │     │  │  │     │           ├─ A [id P]
      │  │  │  │     │  │  │     │           └─ ExpandDims{axis=0} [id Q]
-     │  │  │  │     │  │  │     │              └─ TensorConstant{1.0} [id R]
-     │  │  │  │     │  │  │     └─ ScalarConstant{0} [id S]
+     │  │  │  │     │  │  │     │              └─ 1.0 [id R]
+     │  │  │  │     │  │  │     └─ 0 [id S]
      │  │  │  │     │  │  └─ Subtensor{i} [id T]
      │  │  │  │     │  │     ├─ Shape [id U]
      │  │  │  │     │  │     │  └─ Unbroadcast{0} [id M]
      │  │  │  │     │  │     │     └─ ···
-     │  │  │  │     │  │     └─ ScalarConstant{1} [id V]
+     │  │  │  │     │  │     └─ 1 [id V]
      │  │  │  │     │  ├─ Unbroadcast{0} [id M]
      │  │  │  │     │  │  └─ ···
      │  │  │  │     │  └─ ScalarFromTensor [id W]
      │  │  │  │     │     └─ Subtensor{i} [id K]
      │  │  │  │     │        └─ ···
      │  │  │  │     └─ A [id P] (outer_in_non_seqs-0)
-     │  │  │  └─ ScalarConstant{0} [id X]
-     │  │  └─ TensorConstant{1} [id Y]
+     │  │  │  └─ 0 [id X]
+     │  │  └─ 1 [id Y]
      │  ├─ Subtensor{:stop} [id Z] (outer_in_seqs-0)
      │  │  ├─ Subtensor{::step} [id BA]
      │  │  │  ├─ Subtensor{:stop} [id BB]
      │  │  │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  └─ ···
-     │  │  │  │  └─ ScalarConstant{-1} [id BC]
-     │  │  │  └─ ScalarConstant{-1} [id BD]
+     │  │  │  │  └─ -1 [id BC]
+     │  │  │  └─ -1 [id BD]
      │  │  └─ ScalarFromTensor [id BE]
      │  │     └─ Sub [id C]
      │  │        └─ ···
@@ -549,8 +549,8 @@ def test_debugprint_mitmot():
      │  │  │  ├─ Subtensor{::step} [id BH]
      │  │  │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  └─ ···
-     │  │  │  │  └─ ScalarConstant{-1} [id BI]
-     │  │  │  └─ ScalarConstant{-1} [id BJ]
+     │  │  │  │  └─ -1 [id BI]
+     │  │  │  └─ -1 [id BJ]
      │  │  └─ ScalarFromTensor [id BK]
      │  │     └─ Sub [id C]
      │  │        └─ ···
@@ -560,41 +560,41 @@ def test_debugprint_mitmot():
      │  │  │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  └─ ···
      │  │  │  │  └─ ExpandDims{axes=[0, 1]} [id BO]
-     │  │  │  │     └─ TensorConstant{0.0} [id BP]
+     │  │  │  │     └─ 0.0 [id BP]
      │  │  │  ├─ IncSubtensor{i} [id BQ]
      │  │  │  │  ├─ Second [id BR]
      │  │  │  │  │  ├─ Subtensor{start:} [id BS]
      │  │  │  │  │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  │  │  └─ ···
-     │  │  │  │  │  │  └─ ScalarConstant{1} [id BT]
+     │  │  │  │  │  │  └─ 1 [id BT]
      │  │  │  │  │  └─ ExpandDims{axes=[0, 1]} [id BU]
-     │  │  │  │  │     └─ TensorConstant{0.0} [id BV]
+     │  │  │  │  │     └─ 0.0 [id BV]
      │  │  │  │  ├─ Second [id BW]
      │  │  │  │  │  ├─ Subtensor{i} [id BX]
      │  │  │  │  │  │  ├─ Subtensor{start:} [id BS]
      │  │  │  │  │  │  │  └─ ···
-     │  │  │  │  │  │  └─ ScalarConstant{-1} [id BY]
+     │  │  │  │  │  │  └─ -1 [id BY]
      │  │  │  │  │  └─ ExpandDims{axis=0} [id BZ]
      │  │  │  │  │     └─ Second [id CA]
      │  │  │  │  │        ├─ Sum{axes=None} [id CB]
      │  │  │  │  │        │  └─ Subtensor{i} [id BX]
      │  │  │  │  │        │     └─ ···
-     │  │  │  │  │        └─ TensorConstant{1.0} [id CC]
-     │  │  │  │  └─ ScalarConstant{-1} [id BY]
-     │  │  │  └─ ScalarConstant{1} [id BT]
-     │  │  └─ ScalarConstant{-1} [id CD]
+     │  │  │  │  │        └─ 1.0 [id CC]
+     │  │  │  │  └─ -1 [id BY]
+     │  │  │  └─ 1 [id BT]
+     │  │  └─ -1 [id CD]
      │  ├─ Alloc [id CE] (outer_in_sit_sot-0)
-     │  │  ├─ TensorConstant{0.0} [id CF]
+     │  │  ├─ 0.0 [id CF]
      │  │  ├─ Add [id CG]
      │  │  │  ├─ Sub [id C]
      │  │  │  │  └─ ···
-     │  │  │  └─ TensorConstant{1} [id CH]
+     │  │  │  └─ 1 [id CH]
      │  │  └─ Subtensor{i} [id CI]
      │  │     ├─ Shape [id CJ]
      │  │     │  └─ A [id P]
-     │  │     └─ ScalarConstant{0} [id CK]
+     │  │     └─ 0 [id CK]
      │  └─ A [id P] (outer_in_non_seqs-0)
-     └─ ScalarConstant{-1} [id CL]
+     └─ -1 [id CL]
 
     Inner graphs:
 
@@ -642,28 +642,28 @@ def test_debugprint_compiled_fn():
     out = pytensor.function([M], out, updates=updates, mode="FAST_RUN")
 
     expected_output = """Scan{scan_fn, while_loop=False, inplace=all} [id A] 2 (outer_out_sit_sot-0)
-     ├─ TensorConstant{20000} [id B] (n_steps)
-     ├─ TensorConstant{[    0 ... 998 19999]} [id C] (outer_in_seqs-0)
+     ├─ 20000 [id B] (n_steps)
+     ├─ [    0 ... 998 19999] [id C] (outer_in_seqs-0)
      ├─ SetSubtensor{:stop} [id D] 1 (outer_in_sit_sot-0)
      │  ├─ AllocEmpty{dtype='int64'} [id E] 0
-     │  │  └─ TensorConstant{20000} [id B]
-     │  ├─ TensorConstant{(1,) of 0} [id F]
-     │  └─ ScalarConstant{1} [id G]
+     │  │  └─ 20000 [id B]
+     │  ├─ [0] [id F]
+     │  └─ 1 [id G]
      └─ <Tensor3(float64, shape=(20000, 2, 2))> [id H] (outer_in_non_seqs-0)
 
     Inner graphs:
 
     Scan{scan_fn, while_loop=False, inplace=all} [id A]
      ← Composite{switch(lt(i0, i1), i2, i0)} [id I] (inner_out_sit_sot-0)
-        ├─ TensorConstant{0} [id J]
+        ├─ 0 [id J]
         ├─ Subtensor{i, j, k} [id K]
         │  ├─ *2-<Tensor3(float64, shape=(20000, 2, 2))> [id L] -> [id H] (inner_in_non_seqs-0)
         │  ├─ ScalarFromTensor [id M]
         │  │  └─ *0-<Scalar(int64, shape=())> [id N] -> [id C] (inner_in_seqs-0)
         │  ├─ ScalarFromTensor [id O]
         │  │  └─ *1-<Scalar(int64, shape=())> [id P] -> [id D] (inner_in_sit_sot-0)
-        │  └─ ScalarConstant{0} [id Q]
-        └─ TensorConstant{1} [id R]
+        │  └─ 0 [id Q]
+        └─ 1 [id R]
 
     Composite{switch(lt(i0, i1), i2, i0)} [id I]
      ← Switch [id S] 'o0'

--- a/tests/tensor/rewriting/test_basic.py
+++ b/tests/tensor/rewriting/test_basic.py
@@ -12,6 +12,7 @@ from pytensor.compile.function import function
 from pytensor.compile.mode import get_default_mode, get_mode
 from pytensor.compile.ops import DeepCopyOp, deep_copy_op
 from pytensor.configdefaults import config
+from pytensor.graph.basic import equal_computations
 from pytensor.graph.fg import FunctionGraph
 from pytensor.graph.rewriting.basic import check_stack_trace, out2in
 from pytensor.graph.rewriting.db import RewriteDatabaseQuery
@@ -1410,31 +1411,28 @@ class TestLiftTransposeThroughDot:
 
     def test_matrix_matrix(self):
         a, b = matrices("ab")
-        g = self.simple_rewrite(FunctionGraph([a, b], [dot(a, b).T]))
-        sg = "FunctionGraph(dot(InplaceDimShuffle{1,0}(b), InplaceDimShuffle{1,0}(a)))"
-        assert str(g) == sg, (str(g), sg)
+        g = self.simple_rewrite(FunctionGraph([a, b], [dot(a, b).T], clone=False))
+        assert equal_computations(g.outputs, [dot(b.T, a.T)])
         assert check_stack_trace(g, ops_to_check="all")
 
     def test_row_matrix(self):
         a = vector("a")
         b = matrix("b")
         g = rewrite(
-            FunctionGraph([a, b], [dot(a.dimshuffle("x", 0), b).T]),
+            FunctionGraph([a, b], [dot(a.dimshuffle("x", 0), b).T], clone=False),
             level="stabilize",
         )
-        sg = "FunctionGraph(dot(InplaceDimShuffle{1,0}(b), InplaceDimShuffle{0,x}(a)))"
-        assert str(g) == sg, (str(g), sg)
+        assert equal_computations(g.outputs, [dot(b.T, a.dimshuffle(0, "x"))])
         assert check_stack_trace(g, ops_to_check="all")
 
     def test_matrix_col(self):
         a = vector("a")
         b = matrix("b")
         g = rewrite(
-            FunctionGraph([a, b], [dot(b, a.dimshuffle(0, "x")).T]),
+            FunctionGraph([a, b], [dot(b, a.dimshuffle(0, "x")).T], clone=False),
             level="stabilize",
         )
-        sg = "FunctionGraph(dot(InplaceDimShuffle{x,0}(a), InplaceDimShuffle{1,0}(b)))"
-        assert str(g) == sg, (str(g), sg)
+        assert equal_computations(g.outputs, [dot(a.dimshuffle("x", 0), b.T)])
         assert check_stack_trace(g, ops_to_check="all")
 
 

--- a/tests/tensor/rewriting/test_elemwise.py
+++ b/tests/tensor/rewriting/test_elemwise.py
@@ -12,7 +12,7 @@ from pytensor.compile.function import function
 from pytensor.compile.mode import Mode, get_default_mode
 from pytensor.configdefaults import config
 from pytensor.gradient import grad
-from pytensor.graph.basic import Constant
+from pytensor.graph.basic import Constant, equal_computations
 from pytensor.graph.fg import FunctionGraph
 from pytensor.graph.rewriting.basic import check_stack_trace, out2in
 from pytensor.graph.rewriting.db import RewriteDatabaseQuery
@@ -86,113 +86,66 @@ def inputs(xbc=(0, 0), ybc=(0, 0), zbc=(0, 0)):
 
 class TestDimshuffleLift:
     def test_double_transpose(self):
-        x, y, z = inputs()
+        x, *_ = inputs()
         e = ds(ds(x, (1, 0)), (1, 0))
-        g = FunctionGraph([x], [e])
-        # TODO FIXME: Construct these graphs and compare them.
-        assert (
-            str(g) == "FunctionGraph(InplaceDimShuffle{1,0}(InplaceDimShuffle{1,0}(x)))"
-        )
+        g = FunctionGraph([x], [e], clone=False)
+        assert isinstance(g.outputs[0].owner.op, DimShuffle)
         dimshuffle_lift.rewrite(g)
-        assert str(g) == "FunctionGraph(x)"
+        assert g.outputs[0] is x
         # no need to check_stack_trace as graph is supposed to be empty
 
     def test_merge2(self):
-        x, y, z = inputs()
+        x, *_ = inputs()
         e = ds(ds(x, (1, "x", 0)), (2, 0, "x", 1))
-        g = FunctionGraph([x], [e])
-        # TODO FIXME: Construct these graphs and compare them.
-        assert (
-            str(g)
-            == "FunctionGraph(InplaceDimShuffle{2,0,x,1}(InplaceDimShuffle{1,x,0}(x)))"
-        ), str(g)
+        g = FunctionGraph([x], [e], clone=False)
+        assert len(g.apply_nodes) == 2
         dimshuffle_lift.rewrite(g)
-        assert str(g) == "FunctionGraph(InplaceDimShuffle{0,1,x,x}(x))", str(g)
+        assert equal_computations(g.outputs, [x.dimshuffle(0, 1, "x", "x")])
         # Check stacktrace was copied over correctly after rewrite was applied
         assert check_stack_trace(g, ops_to_check="all")
 
     def test_elim3(self):
         x, y, z = inputs()
         e = ds(ds(ds(x, (0, "x", 1)), (2, 0, "x", 1)), (1, 0))
-        g = FunctionGraph([x], [e])
-        # TODO FIXME: Construct these graphs and compare them.
-        assert str(g) == (
-            "FunctionGraph(InplaceDimShuffle{1,0}(InplaceDimShuffle{2,0,x,1}"
-            "(InplaceDimShuffle{0,x,1}(x))))"
-        ), str(g)
+        g = FunctionGraph([x], [e], clone=False)
+        assert isinstance(g.outputs[0].owner.op, DimShuffle)
         dimshuffle_lift.rewrite(g)
-        assert str(g) == "FunctionGraph(x)", str(g)
+        assert g.outputs[0] is x
         # no need to check_stack_trace as graph is supposed to be empty
 
     def test_lift(self):
         x, y, z = inputs([False] * 1, [False] * 2, [False] * 3)
         e = x + y + z
-        g = FunctionGraph([x, y, z], [e])
-
-        # TODO FIXME: Construct these graphs and compare them.
-        # It does not really matter if the DimShuffles are inplace
-        # or not.
-        init_str_g_inplace = (
-            "FunctionGraph(Elemwise{add,no_inplace}(InplaceDimShuffle{x,0,1}"
-            "(Elemwise{add,no_inplace}(InplaceDimShuffle{x,0}(x), y)), z))"
-        )
-        init_str_g_noinplace = (
-            "FunctionGraph(Elemwise{add,no_inplace}(DimShuffle{x,0,1}"
-            "(Elemwise{add,no_inplace}(DimShuffle{x,0}(x), y)), z))"
-        )
-        assert str(g) in (init_str_g_inplace, init_str_g_noinplace), str(g)
-
-        rewrite_str_g_inplace = (
-            "FunctionGraph(Elemwise{add,no_inplace}(Elemwise{add,no_inplace}"
-            "(InplaceDimShuffle{x,x,0}(x), InplaceDimShuffle{x,0,1}(y)), z))"
-        )
-        rewrite_str_g_noinplace = (
-            "FunctionGraph(Elemwise{add,no_inplace}(Elemwise{add,no_inplace}"
-            "(DimShuffle{x,x,0}(x), DimShuffle{x,0,1}(y)), z))"
-        )
+        g = FunctionGraph([x, y, z], [e], clone=False)
         dimshuffle_lift.rewrite(g)
-        assert str(g) in (rewrite_str_g_inplace, rewrite_str_g_noinplace), str(g)
+        assert equal_computations(
+            g.outputs,
+            [(x.dimshuffle("x", "x", 0) + y.dimshuffle("x", 0, 1)) + z],
+        )
         # Check stacktrace was copied over correctly after rewrite was applied
         assert check_stack_trace(g, ops_to_check="all")
 
     def test_recursive_lift(self):
-        v = vector(dtype="float64")
-        m = matrix(dtype="float64")
+        v = vector("v", dtype="float64")
+        m = matrix("m", dtype="float64")
         out = ((v + 42) * (m + 84)).T
-        g = FunctionGraph([v, m], [out])
-        # TODO FIXME: Construct these graphs and compare them.
-        init_str_g = (
-            "FunctionGraph(InplaceDimShuffle{1,0}(Elemwise{mul,no_inplace}"
-            "(InplaceDimShuffle{x,0}(Elemwise{add,no_inplace}"
-            "(<TensorType(float64, (?,))>, "
-            "InplaceDimShuffle{x}(TensorConstant{42}))), "
-            "Elemwise{add,no_inplace}"
-            "(<TensorType(float64, (?, ?))>, "
-            "InplaceDimShuffle{x,x}(TensorConstant{84})))))"
+        g = FunctionGraph([v, m], [out], clone=False)
+        new_out = local_dimshuffle_lift.transform(g, g.outputs[0].owner)
+        assert equal_computations(
+            new_out,
+            [(v.dimshuffle(0, "x") + 42) * (m.T + 84)],
         )
-        assert str(g) == init_str_g
-        new_out = local_dimshuffle_lift.transform(g, g.outputs[0].owner)[0]
-        new_g = FunctionGraph(g.inputs, [new_out])
-        rewrite_str_g = (
-            "FunctionGraph(Elemwise{mul,no_inplace}(Elemwise{add,no_inplace}"
-            "(InplaceDimShuffle{0,x}(<TensorType(float64, (?,))>), "
-            "InplaceDimShuffle{x,x}(TensorConstant{42})), "
-            "Elemwise{add,no_inplace}(InplaceDimShuffle{1,0}"
-            "(<TensorType(float64, (?, ?))>), "
-            "InplaceDimShuffle{x,x}(TensorConstant{84}))))"
-        )
-        assert str(new_g) == rewrite_str_g
         # Check stacktrace was copied over correctly after rewrite was applied
+        new_g = FunctionGraph(g.inputs, new_out, clone=False)
         assert check_stack_trace(new_g, ops_to_check="all")
 
     def test_useless_dimshuffle(self):
-        x, _, _ = inputs()
+        x, *_ = inputs()
         e = ds(x, (0, 1))
-        g = FunctionGraph([x], [e])
-        # TODO FIXME: Construct these graphs and compare them.
-        assert str(g) == "FunctionGraph(InplaceDimShuffle{0,1}(x))"
+        g = FunctionGraph([x], [e], clone=False)
+        assert isinstance(g.outputs[0].owner.op, DimShuffle)
         dimshuffle_lift.rewrite(g)
-        assert str(g) == "FunctionGraph(x)"
+        assert g.outputs[0] is x
         # Check stacktrace was copied over correctly after rewrite was applied
         assert hasattr(g.outputs[0].tag, "trace")
 
@@ -203,17 +156,10 @@ class TestDimshuffleLift:
         ds_y = ds(y, (2, 1, 0))  # useless
         ds_z = ds(z, (2, 1, 0))  # useful
         ds_u = ds(u, ("x"))  # useful
-        g = FunctionGraph([x, y, z, u], [ds_x, ds_y, ds_z, ds_u])
-        # TODO FIXME: Construct these graphs and compare them.
-        assert (
-            str(g)
-            == "FunctionGraph(InplaceDimShuffle{0,x}(x), InplaceDimShuffle{2,1,0}(y), InplaceDimShuffle{2,1,0}(z), InplaceDimShuffle{x}(TensorConstant{1}))"
-        )
+        g = FunctionGraph([x, y, z, u], [ds_x, ds_y, ds_z, ds_u], clone=False)
+        assert len(g.apply_nodes) == 4
         dimshuffle_lift.rewrite(g)
-        assert (
-            str(g)
-            == "FunctionGraph(x, y, InplaceDimShuffle{2,1,0}(z), InplaceDimShuffle{x}(TensorConstant{1}))"
-        )
+        assert equal_computations(g.outputs, [x, y, z.T, u.dimshuffle("x")])
         # Check stacktrace was copied over correctly after rewrite was applied
         assert hasattr(g.outputs[0].tag, "trace")
 
@@ -237,34 +183,32 @@ def test_local_useless_dimshuffle_in_reshape():
             reshape_dimshuffle_row,
             reshape_dimshuffle_col,
         ],
+        clone=False,
     )
-
-    # TODO FIXME: Construct these graphs and compare them.
-    assert str(g) == (
-        "FunctionGraph(Reshape{1}(InplaceDimShuffle{x,0}(vector), Shape(vector)), "
-        "Reshape{2}(InplaceDimShuffle{x,0,x,1}(mat), Shape(mat)), "
-        "Reshape{2}(InplaceDimShuffle{1,x}(row), Shape(row)), "
-        "Reshape{2}(InplaceDimShuffle{0}(col), Shape(col)))"
-    )
+    assert len(g.apply_nodes) == 4 * 3
     useless_dimshuffle_in_reshape = out2in(local_useless_dimshuffle_in_reshape)
     useless_dimshuffle_in_reshape.rewrite(g)
-    assert str(g) == (
-        "FunctionGraph(Reshape{1}(vector, Shape(vector)), "
-        "Reshape{2}(mat, Shape(mat)), "
-        "Reshape{2}(row, Shape(row)), "
-        "Reshape{2}(col, Shape(col)))"
+    assert equal_computations(
+        g.outputs,
+        [
+            reshape(vec, vec.shape),
+            reshape(mat, mat.shape),
+            reshape(row, row.shape),
+            reshape(col, col.shape),
+        ],
     )
-
     # Check stacktrace was copied over correctly after rewrite was applied
     assert check_stack_trace(g, ops_to_check="all")
 
     # Check that the rewrite does not get applied when the order
     # of dimensions has changed.
     reshape_dimshuffle_mat2 = reshape(mat.dimshuffle("x", 1, "x", 0), mat.shape)
-    h = FunctionGraph([mat], [reshape_dimshuffle_mat2])
-    str_h = str(h)
+    h = FunctionGraph([mat], [reshape_dimshuffle_mat2], clone=False)
+    assert len(h.apply_nodes) == 3
     useless_dimshuffle_in_reshape.rewrite(h)
-    assert str(h) == str_h
+    assert equal_computations(
+        h.outputs, [reshape(mat.dimshuffle("x", 1, "x", 0), mat.shape)]
+    )
 
 
 class TestFusion:

--- a/tests/tensor/test_elemwise.py
+++ b/tests/tensor/test_elemwise.py
@@ -676,14 +676,9 @@ class TestCAReduce(unittest_tools.InferShapeTester):
 
     def test_str(self):
         op = CAReduce(aes.add, axis=None)
-        assert str(op) == "CAReduce{add}"
+        assert str(op) == "CAReduce{add, axes=None}"
         op = CAReduce(aes.add, axis=(1,))
-        assert str(op) == "CAReduce{add}{axis=[1]}"
-
-        op = CAReduce(aes.add, axis=None, acc_dtype="float64")
-        assert str(op) == "CAReduce{add}{acc_dtype=float64}"
-        op = CAReduce(aes.add, axis=(1,), acc_dtype="float64")
-        assert str(op) == "CAReduce{add}{axis=[1], acc_dtype=float64}"
+        assert str(op) == "CAReduce{add, axis=1}"
 
     def test_repeated_axis(self):
         x = vector("x")
@@ -802,10 +797,8 @@ class TestElemwise(unittest_tools.InferShapeTester):
         self.check_input_dimensions_match(Mode(linker="c"))
 
     def test_str(self):
-        op = Elemwise(aes.add, inplace_pattern=None, name=None)
-        assert str(op) == "Elemwise{add}"
         op = Elemwise(aes.add, inplace_pattern={0: 0}, name=None)
-        assert str(op) == "Elemwise{add}[(0, 0)]"
+        assert str(op) == "Add"
         op = Elemwise(aes.add, inplace_pattern=None, name="my_op")
         assert str(op) == "my_op"
 

--- a/tests/tensor/test_type.py
+++ b/tests/tensor/test_type.py
@@ -252,7 +252,7 @@ def test_fixed_shape_basic():
     assert t1.shape == (2, 3)
     assert t1.broadcastable == (False, False)
 
-    assert str(t1) == "TensorType(float64, (2, 3))"
+    assert str(t1) == "Matrix(float64, shape=(2, 3))"
 
     t1 = TensorType("float64", shape=(1,))
     assert t1.shape == (1,)

--- a/tests/tensor/test_var.py
+++ b/tests/tensor/test_var.py
@@ -213,7 +213,7 @@ def test_print_constant():
     c = pytensor.tensor.constant(1, name="const")
     assert str(c) == "const{1}"
     d = pytensor.tensor.constant(1)
-    assert str(d) == "TensorConstant{1}"
+    assert str(d) == "1"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -145,12 +145,12 @@ def test_debugprint():
     reference = dedent(
         r"""
         Elemwise{add,no_inplace} [id 0]
-         |Elemwise{add,no_inplace} [id 1] 'C'
-         | |A [id 2]
-         | |B [id 3]
-         |Elemwise{add,no_inplace} [id 4]
-           |D [id 5]
-           |E [id 6]
+         ├─ Elemwise{add,no_inplace} [id 1] 'C'
+         │  ├─ A [id 2]
+         │  └─ B [id 3]
+         └─ Elemwise{add,no_inplace} [id 4]
+            ├─ D [id 5]
+            └─ E [id 6]
         """
     ).lstrip()
 
@@ -163,12 +163,12 @@ def test_debugprint():
     reference = dedent(
         r"""
         Elemwise{add,no_inplace} [id A]
-         |Elemwise{add,no_inplace} [id B] 'C'
-         | |A [id C]
-         | |B [id D]
-         |Elemwise{add,no_inplace} [id E]
-           |D [id F]
-           |E [id G]
+         ├─ Elemwise{add,no_inplace} [id B] 'C'
+         │  ├─ A [id C]
+         │  └─ B [id D]
+         └─ Elemwise{add,no_inplace} [id E]
+            ├─ D [id F]
+            └─ E [id G]
         """
     ).lstrip()
 
@@ -181,10 +181,11 @@ def test_debugprint():
     reference = dedent(
         r"""
         Elemwise{add,no_inplace} [id A]
-         |Elemwise{add,no_inplace} [id B] 'C'
-         |Elemwise{add,no_inplace} [id C]
-           |D [id D]
-           |E [id E]
+         ├─ Elemwise{add,no_inplace} [id B] 'C'
+         │  └─ ···
+         └─ Elemwise{add,no_inplace} [id C]
+            ├─ D [id D]
+            └─ E [id E]
         """
     ).lstrip()
 
@@ -196,12 +197,12 @@ def test_debugprint():
     reference = dedent(
         r"""
         Elemwise{add,no_inplace}
-         |Elemwise{add,no_inplace} 'C'
-         | |A
-         | |B
-         |Elemwise{add,no_inplace}
-           |D
-           |E
+         ├─ Elemwise{add,no_inplace} 'C'
+         │  ├─ A
+         │  └─ B
+         └─ Elemwise{add,no_inplace}
+            ├─ D
+            └─ E
         """
     ).lstrip()
 
@@ -213,10 +214,10 @@ def test_debugprint():
     reference = dedent(
         r"""
         Elemwise{add,no_inplace} 0 [None]
-         |A [None]
-         |B [None]
-         |D [None]
-         |E [None]
+         ├─ A [None]
+         ├─ B [None]
+         ├─ D [None]
+         └─ E [None]
         """
     ).lstrip()
 
@@ -231,10 +232,10 @@ def test_debugprint():
     reference = dedent(
         r"""
         Elemwise{add,no_inplace} 0 [None]
-         |A [None]
-         |B [None]
-         |D [None]
-         |E [None]
+         ├─ A [None]
+         ├─ B [None]
+         ├─ D [None]
+         └─ E [None]
         """
     ).lstrip()
 
@@ -249,10 +250,10 @@ def test_debugprint():
     reference = dedent(
         r"""
         Elemwise{add,no_inplace} 0 [None]
-         |A [None]
-         |B [None]
-         |D [None]
-         |E [None]
+         ├─ A [None]
+         ├─ B [None]
+         ├─ D [None]
+         └─ E [None]
         """
     ).lstrip()
 
@@ -274,26 +275,26 @@ def test_debugprint():
     exp_res = dedent(
         r"""
         Elemwise{Composite} 4
-         |InplaceDimShuffle{x,0} v={0: [0]} 3
-         | |CGemv{inplace} d={0: [0]} 2
-         |   |AllocEmpty{dtype='float64'} 1
-         |   | |Shape_i{0} 0
-         |   |   |B
-         |   |TensorConstant{1.0}
-         |   |B
-         |   |<TensorType(float64, (?,))>
-         |   |TensorConstant{0.0}
-         |D
-         |A
+         ├─ InplaceDimShuffle{x,0} v={0: [0]} 3
+         │  └─ CGemv{inplace} d={0: [0]} 2
+         │     ├─ AllocEmpty{dtype='float64'} 1
+         │     │  └─ Shape_i{0} 0
+         │     │     └─ B
+         │     ├─ TensorConstant{1.0}
+         │     ├─ B
+         │     ├─ <TensorType(float64, (?,))>
+         │     └─ TensorConstant{0.0}
+         ├─ D
+         └─ A
 
         Inner graphs:
 
         Elemwise{Composite}
-         >add
-         > |<float64>
-         > |sub
-         >   |<float64>
-         >   |<float64>
+         ← add
+            ├─ <float64>
+            └─ sub
+               ├─ <float64>
+               └─ <float64>
         """
     ).lstrip()
 
@@ -314,10 +315,10 @@ def test_debugprint_id_type():
     s = s.getvalue()
 
     exp_res = f"""Elemwise{{add,no_inplace}} [id {e_at.auto_name}]
- |dot [id {d_at.auto_name}]
- | |<TensorType(float64, (?, ?))> [id {b_at.auto_name}]
- | |<TensorType(float64, (?,))> [id {a_at.auto_name}]
- |<TensorType(float64, (?,))> [id {a_at.auto_name}]
+ ├─ dot [id {d_at.auto_name}]
+ │  ├─ <TensorType(float64, (?, ?))> [id {b_at.auto_name}]
+ │  └─ <TensorType(float64, (?,))> [id {a_at.auto_name}]
+ └─ <TensorType(float64, (?,))> [id {a_at.auto_name}]
     """
 
     assert [l.strip() for l in s.split("\n")] == [
@@ -351,15 +352,15 @@ def test_debugprint_inner_graph():
     lines = output_str.split("\n")
 
     exp_res = """MyInnerGraphOp [id A]
- |3 [id B]
- |4 [id C]
+ ├─ 3 [id B]
+ └─ 4 [id C]
 
 Inner graphs:
 
 MyInnerGraphOp [id A]
- >op2 [id D] 'igo1'
- > |*0-<MyType()> [id E]
- > |*1-<MyType()> [id F]
+ ← op2 [id D] 'igo1'
+    ├─ *0-<MyType()> [id E]
+    └─ *1-<MyType()> [id F]
     """
 
     for exp_line, res_line in zip(exp_res.split("\n"), lines):
@@ -375,19 +376,19 @@ MyInnerGraphOp [id A]
     lines = output_str.split("\n")
 
     exp_res = """MyInnerGraphOp [id A]
- |5 [id B]
+ └─ 5 [id B]
 
 Inner graphs:
 
 MyInnerGraphOp [id A]
- >MyInnerGraphOp [id C]
- > |*0-<MyType()> [id D]
- > |*1-<MyType()> [id E]
+ ← MyInnerGraphOp [id C]
+    ├─ *0-<MyType()> [id D]
+    └─ *1-<MyType()> [id E]
 
 MyInnerGraphOp [id C]
- >op2 [id F] 'igo1'
- > |*0-<MyType()> [id D]
- > |*1-<MyType()> [id E]
+ ← op2 [id F] 'igo1'
+    ├─ *0-<MyType()> [id D]
+    └─ *1-<MyType()> [id E]
     """
 
     for exp_line, res_line in zip(exp_res.split("\n"), lines):

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -274,7 +274,7 @@ def test_debugprint():
     s = s.getvalue()
     exp_res = dedent(
         r"""
-        Elemwise{Composite} 4
+        Elemwise{Composite{(i2 + (i0 - i1))}} 4
          ├─ InplaceDimShuffle{x,0} v={0: [0]} 3
          │  └─ CGemv{inplace} d={0: [0]} 2
          │     ├─ AllocEmpty{dtype='float64'} 1
@@ -289,12 +289,12 @@ def test_debugprint():
 
         Inner graphs:
 
-        Elemwise{Composite}
-         ← add
-            ├─ <float64>
+        Elemwise{Composite{(i2 + (i0 - i1))}}
+         ← add 'o0'
+            ├─ i2
             └─ sub
-               ├─ <float64>
-               └─ <float64>
+               ├─ i0
+               └─ i1
         """
     ).lstrip()
 

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -280,10 +280,10 @@ def test_debugprint():
          │     ├─ AllocEmpty{dtype='float64'} 1
          │     │  └─ Shape_i{0} 0
          │     │     └─ B
-         │     ├─ TensorConstant{1.0}
+         │     ├─ 1.0
          │     ├─ B
          │     ├─ <Vector(float64, shape=(?,))>
-         │     └─ TensorConstant{0.0}
+         │     └─ 0.0
          ├─ D
          └─ A
 

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -275,7 +275,7 @@ def test_debugprint():
     exp_res = dedent(
         r"""
         Elemwise{Composite{(i2 + (i0 - i1))}} 4
-         ├─ InplaceDimShuffle{x,0} v={0: [0]} 3
+         ├─ ExpandDims{axis=0} v={0: [0]} 3
          │  └─ CGemv{inplace} d={0: [0]} 2
          │     ├─ AllocEmpty{dtype='float64'} 1
          │     │  └─ Shape_i{0} 0

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -282,7 +282,7 @@ def test_debugprint():
          │     │     └─ B
          │     ├─ TensorConstant{1.0}
          │     ├─ B
-         │     ├─ <TensorType(float64, (?,))>
+         │     ├─ <Vector(float64, shape=(?,))>
          │     └─ TensorConstant{0.0}
          ├─ D
          └─ A
@@ -316,9 +316,9 @@ def test_debugprint_id_type():
 
     exp_res = f"""Add [id {e_at.auto_name}]
  ├─ dot [id {d_at.auto_name}]
- │  ├─ <TensorType(float64, (?, ?))> [id {b_at.auto_name}]
- │  └─ <TensorType(float64, (?,))> [id {a_at.auto_name}]
- └─ <TensorType(float64, (?,))> [id {a_at.auto_name}]
+ │  ├─ <Matrix(float64, shape=(?, ?))> [id {b_at.auto_name}]
+ │  └─ <Vector(float64, shape=(?,))> [id {a_at.auto_name}]
+ └─ <Vector(float64, shape=(?,))> [id {a_at.auto_name}]
     """
 
     assert [l.strip() for l in s.split("\n")] == [
@@ -329,7 +329,7 @@ def test_debugprint_id_type():
 def test_pprint():
     x = dvector()
     y = x[1]
-    assert pp(y) == "<TensorType(float64, (?,))>[1]"
+    assert pp(y) == "<Vector(float64, shape=(?,))>[1]"
 
 
 def test_debugprint_inner_graph():

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -106,9 +106,9 @@ def test_min_informative_str():
 
     mis = min_informative_str(G).replace("\t", "        ")
 
-    reference = """A. Elemwise{add,no_inplace}
+    reference = """A. Add
  B. C
- C. Elemwise{add,no_inplace}
+ C. Add
   D. D
   E. E"""
 
@@ -144,11 +144,11 @@ def test_debugprint():
     s = s.getvalue()
     reference = dedent(
         r"""
-        Elemwise{add,no_inplace} [id 0]
-         ├─ Elemwise{add,no_inplace} [id 1] 'C'
+        Add [id 0]
+         ├─ Add [id 1] 'C'
          │  ├─ A [id 2]
          │  └─ B [id 3]
-         └─ Elemwise{add,no_inplace} [id 4]
+         └─ Add [id 4]
             ├─ D [id 5]
             └─ E [id 6]
         """
@@ -162,11 +162,11 @@ def test_debugprint():
     # The additional white space are needed!
     reference = dedent(
         r"""
-        Elemwise{add,no_inplace} [id A]
-         ├─ Elemwise{add,no_inplace} [id B] 'C'
+        Add [id A]
+         ├─ Add [id B] 'C'
          │  ├─ A [id C]
          │  └─ B [id D]
-         └─ Elemwise{add,no_inplace} [id E]
+         └─ Add [id E]
             ├─ D [id F]
             └─ E [id G]
         """
@@ -180,10 +180,10 @@ def test_debugprint():
     # The additional white space are needed!
     reference = dedent(
         r"""
-        Elemwise{add,no_inplace} [id A]
-         ├─ Elemwise{add,no_inplace} [id B] 'C'
+        Add [id A]
+         ├─ Add [id B] 'C'
          │  └─ ···
-         └─ Elemwise{add,no_inplace} [id C]
+         └─ Add [id C]
             ├─ D [id D]
             └─ E [id E]
         """
@@ -196,11 +196,11 @@ def test_debugprint():
     s = s.getvalue()
     reference = dedent(
         r"""
-        Elemwise{add,no_inplace}
-         ├─ Elemwise{add,no_inplace} 'C'
+        Add
+         ├─ Add 'C'
          │  ├─ A
          │  └─ B
-         └─ Elemwise{add,no_inplace}
+         └─ Add
             ├─ D
             └─ E
         """
@@ -213,7 +213,7 @@ def test_debugprint():
     s = s.getvalue()
     reference = dedent(
         r"""
-        Elemwise{add,no_inplace} 0 [None]
+        Add 0 [None]
          ├─ A [None]
          ├─ B [None]
          ├─ D [None]
@@ -231,7 +231,7 @@ def test_debugprint():
     s = s.getvalue()
     reference = dedent(
         r"""
-        Elemwise{add,no_inplace} 0 [None]
+        Add 0 [None]
          ├─ A [None]
          ├─ B [None]
          ├─ D [None]
@@ -249,7 +249,7 @@ def test_debugprint():
     s = s.getvalue()
     reference = dedent(
         r"""
-        Elemwise{add,no_inplace} 0 [None]
+        Add 0 [None]
          ├─ A [None]
          ├─ B [None]
          ├─ D [None]
@@ -274,7 +274,7 @@ def test_debugprint():
     s = s.getvalue()
     exp_res = dedent(
         r"""
-        Elemwise{Composite{(i2 + (i0 - i1))}} 4
+        Composite{(i2 + (i0 - i1))} 4
          ├─ ExpandDims{axis=0} v={0: [0]} 3
          │  └─ CGemv{inplace} d={0: [0]} 2
          │     ├─ AllocEmpty{dtype='float64'} 1
@@ -289,7 +289,7 @@ def test_debugprint():
 
         Inner graphs:
 
-        Elemwise{Composite{(i2 + (i0 - i1))}}
+        Composite{(i2 + (i0 - i1))}
          ← add 'o0'
             ├─ i2
             └─ sub
@@ -314,7 +314,7 @@ def test_debugprint_id_type():
     debugprint(e_at, id_type="auto", file=s)
     s = s.getvalue()
 
-    exp_res = f"""Elemwise{{add,no_inplace}} [id {e_at.auto_name}]
+    exp_res = f"""Add [id {e_at.auto_name}]
  ├─ dot [id {d_at.auto_name}]
  │  ├─ <TensorType(float64, (?, ?))> [id {b_at.auto_name}]
  │  └─ <TensorType(float64, (?,))> [id {a_at.auto_name}]


### PR DESCRIPTION
**Please if you can: try with some examples of your own and give feedback** Specially if you have suggestions for Ops that have awful names that could be rendered better. I only tackled some I could think from memory.

Closes #313 
Closes #196 

Example from the issue:
```python
import pytensor
import pytensor.tensor as pt

x = pt.scalar("x")
y = pt.vector("y")
z = x + pt.exp(y)

pytensor.dprint(z)
```
Before:
```
Elemwise{add,no_inplace} [id A]
 |InplaceDimShuffle{x} [id B]
 | |x [id C]
 |Elemwise{exp,no_inplace} [id D]
   |y [id E]
```

After:
```
Add [id A]
 ├─ ExpandDims{axis=0} [id B]
 │  └─ x [id C]
 └─ Exp [id D]
    └─ y [id E]
```

Before with `print_type=True`
```
Elemwise{add,no_inplace} [id A] <TensorType(float64, (?,))>
 |InplaceDimShuffle{x} [id B] <TensorType(float64, (1,))>
 | |x [id C] <TensorType(float64, ())>
 |Elemwise{exp,no_inplace} [id D] <TensorType(float64, (?,))>
   |y [id E] <TensorType(float64, (?,))>
```

After with `print_type=True`
```
Add [id A] <Vector(float64, shape=(?,))>
 ├─ ExpandDims{axis=0} [id B] <Vector(float64, shape=(1,))>
 │  └─ x [id C] <Scalar(float64, shape=())>
 └─ Exp [id D] <Vector(float64, shape=(?,))>
    └─ y [id E] <Vector(float64, shape=(?,))>
```

A more crazy one:
```python
import pytensor
import pytensor.tensor as pt

x = pt.vector()
y = pt.matrix("y")
z = x + pt.exp(y)
out1 = pt.squeeze(z[None, None, None, None][:1, 0, None, 0, 1, 2])
out2 = z.T
out3 = z.dimshuffle((1, "x", 0)).sum((0, 1, 2))
outs = [out1, out2, out3]

pytensor.dprint(outs)
```
Before:
```
InplaceDimShuffle{2} [id A]
 |Subtensor{:int64:, int64, ::, int64, int64, int64} [id B]
   |InplaceDimShuffle{0,1,x,2,3,4,5} [id C]
   | |InplaceDimShuffle{x,x,x,x,0,1} [id D]
   |   |Elemwise{add,no_inplace} [id E]
   |     |InplaceDimShuffle{x,0} [id F]
   |     | |<TensorType(float64, (?,))> [id G]
   |     |Elemwise{exp,no_inplace} [id H]
   |       |y [id I]
   |ScalarConstant{1} [id J]
   |ScalarConstant{0} [id K]
   |ScalarConstant{0} [id L]
   |ScalarConstant{1} [id M]
   |ScalarConstant{2} [id N]
InplaceDimShuffle{1,0} [id O]
 |Elemwise{add,no_inplace} [id E]
Sum{axis=[0, 1, 2], acc_dtype=float64} [id P]
 |InplaceDimShuffle{1,x,0} [id Q]
   |Elemwise{add,no_inplace} [id E]
```
After:
```
DropDims{axes=[0, 1]} [id A]
 └─ Subtensor{:stop, i, :, j, k, ii} [id B]
    ├─ ExpandDims{axis=2} [id C]
    │  └─ ExpandDims{axes=[0, 1, 2, 3]} [id D]
    │     └─ Add [id E]
    │        ├─ ExpandDims{axis=0} [id F]
    │        │  └─ <Vector(float64, shape=(?,))> [id G]
    │        └─ Exp [id H]
    │           └─ y [id I]
    ├─ 1 [id J]
    ├─ 0 [id K]
    ├─ 0 [id L]
    ├─ 1 [id M]
    └─ 2 [id N]
Transpose{axes=[1, 0]} [id O]
 └─ Add [id E]
    └─ ···
Sum{axes=[0, 1, 2]} [id P]
 └─ DimShuffle{order=[1,x,0]} [id Q]
    └─ Add [id E]
       └─ ···
```

Something with inner graphs
```python
import pytensor
import pytensor.tensor as pt

x = pt.scalar("x")
y = pt.vector("y")
z = x + pt.exp(y)
w = z + 2

fn = pytensor.function([x, y], [z, w])
pytensor.dprint(fn)
```
Before:
```
Elemwise{Composite}.0 [id A] 1
 |y [id B]
 |InplaceDimShuffle{x} [id C] 0
 | |x [id D]
 |TensorConstant{(1,) of 2.0} [id E]
Elemwise{Composite}.1 [id A] 1

Inner graphs:

Elemwise{Composite}.0 [id A]
 >add [id F]
 > |<float64> [id G]
 > |exp [id H]
 >   |<float64> [id I]
 >add [id J]
 > |<float64> [id K]
 > |<float64> [id G]
 > |exp [id H]
Elemwise{Composite}.1 [id A]
 >add [id F]
 >add [id J]
```

After:
```
Composite{...}.0 [id A] 1
 ├─ y [id B]
 ├─ ExpandDims{axis=0} [id C] 0
 │  └─ x [id D]
 └─ [2.] [id E]
Composite{...}.1 [id A] 1
 └─ ···
Inner graphs:
Composite{...} [id A]
 ← add [id F] 'o0'
    ├─ i1 [id G]
    └─ exp [id H] 't0'
       └─ i0 [id I]
 ← add [id J] 'o1'
    ├─ i2 [id K]
    ├─ i1 [id G]
    └─ exp [id H] 't0'
       └─ ···
```