### PR TITLE
Fix failing CI in Python 3.8 and install numba/jax on specific runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,8 @@ jobs:
         python-version: ["3.8", "3.11"]
         fast-compile: [0,1]
         float32: [0,1]
-        install-numba: [1]
+        install-numba: [0]
+        install-jax: [0]
         part:
           - "tests --ignore=tests/tensor --ignore=tests/scan --ignore=tests/sparse"
           - "tests/scan"
@@ -93,6 +94,27 @@ jobs:
             part: "tests/tensor/test_math.py"
           - fast-compile: 1
             float32: 1
+        include:
+          - install-numba: 1
+            python-version: "3.8"
+            fast-compile: 0
+            float32: 0
+            part: "tests/link/numba"
+          - install-numba: 1
+            python-version: "3.11"
+            fast-compile: 0
+            float32: 0
+            part: "tests/link/numba"
+          - install-jax: 1
+            python-version: "3.8"
+            fast-compile: 0
+            float32: 0
+            part: "tests/link/jax"
+          - install-jax: 1
+            python-version: "3.11"
+            fast-compile: 0
+            float32: 0
+            part: "tests/link/jax"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -121,7 +143,7 @@ jobs:
 #          numba-scipy downgrades the installed scipy to 1.7.3 in Python 3.8, but not numpy, even though scipy 1.7 requires numpy<1.23. When installing PyTensor next, pip installs a lower version of numpy via the PyPI.
           if [[ $INSTALL_NUMBA == "1" ]] && [[ $PYTHON_VERSION == "3.8" ]]; then mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" "numpy<1.23" "numba>=0.57" numba-scipy; fi
           if [[ $INSTALL_NUMBA == "1" ]] && [[ $PYTHON_VERSION != "3.8" ]]; then mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" "numba>=0.57" numba-scipy; fi
-          mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" jax jaxlib numpyro
+          if [[ $INSTALL_JAX == "1" ]]; then mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" jax jaxlib numpyro; fi
           pip install -e ./
           mamba list && pip freeze
           python -c 'import pytensor; print(pytensor.config.__str__(print_doc=False))'
@@ -129,6 +151,7 @@ jobs:
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           INSTALL_NUMBA: ${{ matrix.install-numba }}
+          INSTALL_JAX: ${{ matrix.install-jax }}
 
       - name: Run tests
         shell: bash -l {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,7 +140,9 @@ jobs:
         shell: bash -l {0}
         run: |
           mamba install --yes -q "python~=${PYTHON_VERSION}=*_cpython" mkl numpy scipy pip mkl-service graphviz cython pytest coverage pytest-cov pytest-benchmark sympy
-#          numba-scipy downgrades the installed scipy to 1.7.3 in Python 3.8, but not numpy, even though scipy 1.7 requires numpy<1.23. When installing PyTensor next, pip installs a lower version of numpy via the PyPI.
+          # numba-scipy downgrades the installed scipy to 1.7.3 in Python 3.8, but
+          # not numpy, even though scipy 1.7 requires numpy<1.23. When installing
+          # PyTensor next, pip installs a lower version of numpy via the PyPI.
           if [[ $INSTALL_NUMBA == "1" ]] && [[ $PYTHON_VERSION == "3.8" ]]; then mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" "numpy<1.23" "numba>=0.57" numba-scipy; fi
           if [[ $INSTALL_NUMBA == "1" ]] && [[ $PYTHON_VERSION != "3.8" ]]; then mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" "numba>=0.57" numba-scipy; fi
           if [[ $INSTALL_JAX == "1" ]]; then mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" jax jaxlib numpyro; fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
           pip install -e ./
           mamba list && pip freeze
           python -c 'import pytensor; print(pytensor.config.__str__(print_doc=False))'
-          python -c 'import pytensor; assert(pytensor.config.blas__ldflags != "")'
+          python -c 'import pytensor; assert pytensor.config.blas__ldflags != "", "Blas flags are empty"'
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           INSTALL_NUMBA: ${{ matrix.install-numba }}
@@ -175,7 +175,7 @@ jobs:
             pip install -e ./
             mamba list && pip freeze
             python -c 'import pytensor; print(pytensor.config.__str__(print_doc=False))'
-            python -c 'import pytensor; assert(pytensor.config.blas__ldflags != "")'
+            python -c 'import pytensor; assert pytensor.config.blas__ldflags != "", "Blas flags are empty"'
           env:
             PYTHON_VERSION: 3.9
         - name: Download previous benchmark data

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,7 +118,9 @@ jobs:
         shell: bash -l {0}
         run: |
           mamba install --yes -q "python~=${PYTHON_VERSION}=*_cpython" mkl numpy scipy pip mkl-service graphviz cython pytest coverage pytest-cov pytest-benchmark sympy
-          if [[ $INSTALL_NUMBA == "1" ]]; then mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" "numba>=0.57" numba-scipy; fi
+#          numba-scipy downgrades the installed scipy to 1.7.3 in Python 3.8, but not numpy, even though scipy 1.7 requires numpy<1.23. When installing PyTensor next, pip installs a lower version of numpy via the PyPI.
+          if [[ $INSTALL_NUMBA == "1" ]] && [[ $PYTHON_VERSION == "3.8" ]]; then mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" "numpy<1.23" "numba>=0.57" numba-scipy; fi
+          if [[ $INSTALL_NUMBA == "1" ]] && [[ $PYTHON_VERSION != "3.8" ]]; then mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" "numba>=0.57" numba-scipy; fi
           mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" jax jaxlib numpyro
           pip install -e ./
           mamba list && pip freeze

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,8 @@ per-file-ignores =
     pytensor/link/jax/jax_dispatch.py:E402,F403,F401
     pytensor/link/jax/jax_linker.py:E402,F403,F401
     pytensor/sparse/sandbox/sp2.py:F401
+    tests/link/jax/*.py:E402
+    tests/link/numba/*.py:E402
     tests/tensor/test_math_scipy.py:E402
     tests/sparse/test_basic.py:E402
     tests/sparse/test_opt.py:E402

--- a/tests/link/jax/test_tensor_basic.py
+++ b/tests/link/jax/test_tensor_basic.py
@@ -1,6 +1,9 @@
-import jax.errors
 import numpy as np
 import pytest
+
+
+jax = pytest.importorskip("jax")
+import jax.errors
 
 import pytensor
 import pytensor.tensor.basic as at

--- a/tests/link/numba/test_basic.py
+++ b/tests/link/numba/test_basic.py
@@ -3,9 +3,11 @@ import inspect
 from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence, Tuple, Union
 from unittest import mock
 
-import numba
 import numpy as np
 import pytest
+
+
+numba = pytest.importorskip("numba")
 
 import pytensor.scalar as aes
 import pytensor.scalar.math as aesm

--- a/tests/link/numba/test_cython_support.py
+++ b/tests/link/numba/test_cython_support.py
@@ -1,6 +1,11 @@
 import numpy as np
 import pytest
 import scipy.special.cython_special
+
+
+numba = pytest.importorskip("numba")
+
+
 from numba.types import float32, float64, int32, int64
 
 from pytensor.link.numba.dispatch.cython_support import Signature, wrap_cython_function

--- a/tests/link/numba/test_performance.py
+++ b/tests/link/numba/test_performance.py
@@ -3,6 +3,9 @@ import timeit
 import numpy as np
 import pytest
 
+
+pytest.importorskip("numba")
+
 import pytensor.tensor as aet
 from pytensor import config
 from pytensor.compile.function import function
@@ -70,4 +73,5 @@ def test_careduce_performance(careduce_fn, numpy_fn, axis, inputs, input_vals):
     mean_numpy_time = np.mean(numpy_times)
     # mean_c_time = np.mean(c_times)
 
+    # FIXME: Why are we asserting >=? Numba could be doing worse than numpy!
     assert mean_numba_time / mean_numpy_time >= 0.75

--- a/tests/link/numba/test_sparse.py
+++ b/tests/link/numba/test_sparse.py
@@ -1,7 +1,10 @@
-import numba
 import numpy as np
 import pytest
 import scipy as sp
+
+
+numba = pytest.importorskip("numba")
+
 
 # Make sure the Numba customizations are loaded
 import pytensor.link.numba.dispatch.sparse  # noqa: F401


### PR DESCRIPTION
Also closes #322 even though the main goal was to fix the failing CI