### PR TITLE
Add missing "f" before format string (memory profiling)

### DIFF
--- a/pytensor/compile/profiling.py
+++ b/pytensor/compile/profiling.py
@@ -1402,7 +1402,7 @@ class ProfileStats:
             shapes = str(fct_shapes[fgraph][node])
 
             if all(hasattr(out.type, "get_size") for out in node.outputs):
-                size = "{node_outputs_size:9d}B"
+                size = f"{node_outputs_size:9d}B"
                 if node_outputs_size < config.profiling__min_memory_size:
                     N = idx
                     break


### PR DESCRIPTION
I think this self-explanatory :) Lazily tested by making the same change inplace in the installed package. Example output (the numbers in the first column were missing):

```
    <Sum apply outputs (bytes)> <Apply outputs shape> <created/inplace/view> <Apply node>

        195504B  [(24438,), (24438,)] c c Elemwise{Composite}(increments, playerDayRatingSDevs {[11.512925...14543837]}, TensorConstant{(1,) of -0.5}, TensorConstant{(1,) of 0...5175704956}, TensorConstant{[ 2.443470..1.9280028]})
        186496B  [(23312,), (23312,)] c c Elemwise{Composite}(Reshape{1}.0)
         97752B  [(24438,)] c Alloc(TensorConstant{0.0}, TensorConstant{24438})
         97752B  [(24438,)] i IncSubtensor{InplaceSet;int64:int64:}(extRatings, Subtensor{int64:int64:}.0, ScalarConstant{0}, ScalarConstant{2081})
...
```