### PR TITLE
Update index.ipynb

### DIFF
--- a/doc/library/d3viz/index.ipynb
+++ b/doc/library/d3viz/index.ipynb
@@ -19,8 +19,7 @@
    "metadata": {},
    "source": [
     "``d3viz`` requires the [pydot](https://pypi.python.org/pypi/pydot)\n",
-    "package. [pydot-ng](https://github.com/pydot/pydot-ng) fork is better\n",
-    "maintained, and it works both in Python 2.x and 3.x. Install it with pip::"
+    "package. Install it with pip::"
    ]
   },
   {
@@ -31,7 +30,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install pydot-ng"
+    "!pip install pydot"
    ]
   },
   {


### PR DESCRIPTION
Following the update of `index.rst`, see https://github.com/pymc-devs/pytensor/pull/336 (where the `pydot-ng` recommendation was removed because `pydot-ng` is officially archived in favor of pydot: https://github.com/pydot/pydot-ng), a corresponding update of `index.ipynb` is necessary. I am sorry that I did not commit those changes together.
