### PR TITLE
Use static-only broadcasting rules to compute shape of broadcasting

### DIFF
--- a/tests/tensor/rewriting/test_basic.py
+++ b/tests/tensor/rewriting/test_basic.py
@@ -1703,8 +1703,12 @@ class TestLocalElemwiseAlloc:
         ],
     )
     def test_basic(self, expr, x_shape, y_shape):
-        x = at.tensor(dtype="int64", shape=(None,) * len(x_shape), name="x")
-        y = at.tensor(dtype="int64", shape=(None,) * len(y_shape), name="y")
+        x = at.tensor(
+            dtype="int64", shape=(1 if val == 1 else None for val in x_shape), name="x"
+        )
+        y = at.tensor(
+            dtype="int64", shape=(1 if val == 1 else None for val in y_shape), name="y"
+        )
         z = expr(x, y)
 
         z_opt = pytensor.function(
@@ -1878,7 +1882,8 @@ class TestLocalElemwiseAlloc:
             mode=self.fast_run_mode,
         )
         self.verify_op_count(func, 0, Alloc)
-        self.verify_op_count(func, 1, Assert)
+        # The second assert is from the shape check...
+        self.verify_op_count(func, 2, Assert)
 
     def test_misc(self):
         x = row(dtype=self.dtype)

--- a/tests/unittest_tools.py
+++ b/tests/unittest_tools.py
@@ -255,7 +255,7 @@ class InferShapeTester:
         # Check that the Op is removed from the compiled function.
         if check_topo:
             topo_shape = shapes_function.maker.fgraph.toposort()
-            assert not any(isinstance(t.op, cls) for t in topo_shape)
+            assert not any(t in outputs for t in topo_shape)
         topo_out = outputs_function.maker.fgraph.toposort()
         assert any(isinstance(t.op, cls) for t in topo_out)
         # Check that the shape produced agrees with the actual shape.


### PR DESCRIPTION
### Motivation for these changes
As discussed [here](https://github.com/pymc-devs/pytensor/discussions/100) we want to go back to static broadcasting only, and one this simplifies the rules for the expected shapes of broadcasted arrays quite a bit. This PR changes the broadcast_shape function to take advantage of this, which then simplifies a lot of graphs significantly.

### Implementation details
I'm not sure yet how we should code the condition that triggers the assert for arrays that aren't compatible.
The current code contains an implementation that uses Elemwise, and one that uses scalar expressions.
The scalar expressions seem a bit more reasonable to me (not tensors and no allocations), but since most rewrites only work on Elemwise, this can prevent a lot of optimizations right now.

### Checklist
+ [x] Explain motivation and implementation 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇


## Major / Breaking Changes
This can lead to dynamic assertion failures for code that relied on the (never fully implemented) support for dynamic broadcasting.


## Example of before and after

```python
import pytensor.tensor as pt
import pytensor
import pymc as pm
import numpy as np

trafo = pm.distributions.multivariate.ZeroSumTransform([1])

x = pt.dmatrix("x")
y = trafo.backward(x)
grad = pt.grad(y.sum(), x)

func = pytensor.function([x], grad)
```

### Before

<details>

```
Add [id A] 27
 ├─ Split{2}.0 [id B] 15
 │  ├─ Alloc [id C] 13
 │  │  ├─ [[1.]] [id D]
 │  │  ├─ TensorFromScalar [id E] 11
 │  │  │  └─ Assert{msg=Could not broadcast dimensions} [id F] 9
 │  │  │     ├─ Composite{Abs(maximum(Switch(EQ(i0, 1), (-1), i0), Switch(EQ(i1, 1), (-1), i1)))} [id G] 7
 │  │  │     │  ├─ ScalarFromTensor [id H] 4
 │  │  │     │  │  └─ Shape_i{0} [id I] 1
 │  │  │     │  │     └─ x [id J]
 │  │  │     │  └─ ScalarFromTensor [id H] 4
 │  │  │     │     └─ ···
 │  │  │     └─ Composite{...} [id K] 6
 │  │  │        ├─ ScalarFromTensor [id H] 4
 │  │  │        │  └─ ···
 │  │  │        └─ ScalarFromTensor [id H] 4
 │  │  │           └─ ···
 │  │  └─ Add [id L] 8
 │  │     ├─ Shape_i{1} [id M] 0
 │  │     │  └─ x [id J]
 │  │     └─ 1 [id N]
 │  ├─ 1 [id O]
 │  └─ MakeVector{dtype='int64'} [id P] 2
 │     ├─ Shape_i{1} [id M] 0
 │     │  └─ ···
 │     └─ 1 [id N]
 ├─ Composite{((i0 + i1) / i2)} [id Q] 25
 │  ├─ SpecifyShape [id R] 17
 │  │  ├─ Split{2}.1 [id B] 15
 │  │  │  └─ ···
 │  │  ├─ NoneConst{None} [id S]
 │  │  └─ 1 [id O]
 │  ├─ BroadcastTo [id T] 24
 │  │  ├─ Composite{cast{float64}((-i0))} [id U] 12
 │  │  │  └─ ExpandDims{axes=[0, 1]} [id V] 10
 │  │  │     └─ Add [id L] 8
 │  │  │        └─ ···
 │  │  ├─ TensorFromScalar [id W] 23
 │  │  │  └─ Assert{msg=Could not broadcast dimensions} [id X] 22
 │  │  │     ├─ Composite{Abs(maximum(Switch(EQ(i0, 1), (-1), i0), Switch(EQ(i1, 1), (-1), i1)))} [id Y] 21
 │  │  │     │  ├─ ScalarFromTensor [id Z] 19
 │  │  │     │  │  └─ Subtensor{i} [id BA] 18
 │  │  │     │  │     ├─ SetSubtensor{i} [id BB] 16
 │  │  │     │  │     │  ├─ MakeVector{dtype='int64'} [id BC] 14
 │  │  │     │  │     │  │  ├─ TensorFromScalar [id E] 11
 │  │  │     │  │     │  │  │  └─ ···
 │  │  │     │  │     │  │  └─ Add [id L] 8
 │  │  │     │  │     │  │     └─ ···
 │  │  │     │  │     │  ├─ 1 [id N]
 │  │  │     │  │     │  └─ 1 [id BD]
 │  │  │     │  │     └─ 0 [id BE]
 │  │  │     │  └─ Assert{msg=Could not broadcast dimensions} [id F] 9
 │  │  │     │     └─ ···
 │  │  │     └─ Composite{...} [id BF] 20
 │  │  │        ├─ ScalarFromTensor [id Z] 19
 │  │  │        │  └─ ···
 │  │  │        └─ Assert{msg=Could not broadcast dimensions} [id F] 9
 │  │  │           └─ ···
 │  │  └─ 1 [id N]
 │  └─ Composite{...}.1 [id BG] 5
 │     ├─ [[1]] [id BH]
 │     ├─ ExpandDims{axes=[0, 1]} [id BI] 3
 │     │  └─ Shape_i{1} [id M] 0
 │     │     └─ ···
 │     └─ [[1.]] [id D]
 └─ Composite{((-i0) / i1)} [id BJ] 26
    ├─ SpecifyShape [id R] 17
    │  └─ ···
    └─ Composite{...}.0 [id BG] 5
       └─ ···

Inner graphs:

Composite{Abs(maximum(Switch(EQ(i0, 1), (-1), i0), Switch(EQ(i1, 1), (-1), i1)))} [id G]
 ← Abs [id BK] 'o0'
    └─ maximum [id BL]
       ├─ Switch [id BM]
       │  ├─ EQ [id BN]
       │  │  ├─ i0 [id BO]
       │  │  └─ t8{1} [id BP]
       │  ├─ neg [id BQ] 't1'
       │  │  └─ 1 [id BR]
       │  └─ i0 [id BO]
       └─ Switch [id BS]
          ├─ EQ [id BT]
          │  ├─ i1 [id BU]
          │  └─ t8{1} [id BP]
          ├─ neg [id BQ] 't1'
          │  └─ ···
          └─ i1 [id BU]

Composite{...} [id K]
 ← AND [id BV] 'o0'
    ├─ OR [id BW]
    │  ├─ EQ [id BX]
    │  │  ├─ Switch [id BY] 't10'
    │  │  │  ├─ EQ [id BZ]
    │  │  │  │  ├─ i0 [id CA]
    │  │  │  │  └─ t8{1} [id BP]
    │  │  │  ├─ neg [id CB] 't15'
    │  │  │  │  └─ 1 [id BR]
    │  │  │  └─ i0 [id CA]
    │  │  └─ neg [id CB] 't15'
    │  │     └─ ···
    │  └─ EQ [id CC]
    │     ├─ Switch [id BY] 't10'
    │     │  └─ ···
    │     └─ Composite{Abs(maximum(Switch(EQ(i0, 1), (-1), i0), Switch(EQ(i1, 1), (-1), i1)))} [id CD] 't12'
    │        ├─ i0 [id CA]
    │        └─ i1 [id CE]
    └─ OR [id CF]
       ├─ EQ [id CG]
       │  ├─ Switch [id CH] 't0'
       │  │  ├─ EQ [id CI]
       │  │  │  ├─ i1 [id CE]
       │  │  │  └─ t8{1} [id BP]
       │  │  ├─ neg [id CB] 't15'
       │  │  │  └─ ···
       │  │  └─ i1 [id CE]
       │  └─ neg [id CB] 't15'
       │     └─ ···
       └─ EQ [id CJ]
          ├─ Switch [id CH] 't0'
          │  └─ ···
          └─ Composite{Abs(maximum(Switch(EQ(i0, 1), (-1), i0), Switch(EQ(i1, 1), (-1), i1)))} [id CD] 't12'
             └─ ···

Composite{((i0 + i1) / i2)} [id Q]
 ← true_div [id CK] 'o0'
    ├─ add [id CL]
    │  ├─ i0 [id CM]
    │  └─ i1 [id CN]
    └─ i2 [id CO]

Composite{cast{float64}((-i0))} [id U]
 ← Cast{float64} [id CP] 'o0'
    └─ neg [id CQ]
       └─ i0 [id CR]

Composite{Abs(maximum(Switch(EQ(i0, 1), (-1), i0), Switch(EQ(i1, 1), (-1), i1)))} [id Y]
 ← Abs [id CS] 'o0'
    └─ maximum [id CT]
       ├─ Switch [id CU]
       │  ├─ EQ [id CV]
       │  │  ├─ i0 [id CW]
       │  │  └─ t8{1} [id CX]
       │  ├─ neg [id CY] 't1'
       │  │  └─ 1 [id CZ]
       │  └─ i0 [id CW]
       └─ Switch [id DA]
          ├─ EQ [id DB]
          │  ├─ i1 [id DC]
          │  └─ t8{1} [id CX]
          ├─ neg [id CY] 't1'
          │  └─ ···
          └─ i1 [id DC]

Composite{...} [id BF]
 ← AND [id DD] 'o0'
    ├─ OR [id DE]
    │  ├─ EQ [id DF]
    │  │  ├─ Switch [id DG] 't6'
    │  │  │  ├─ EQ [id DH]
    │  │  │  │  ├─ i0 [id DI]
    │  │  │  │  └─ t8{1} [id CX]
    │  │  │  ├─ neg [id DJ] 't3'
    │  │  │  │  └─ 1 [id CZ]
    │  │  │  └─ i0 [id DI]
    │  │  └─ neg [id DJ] 't3'
    │  │     └─ ···
    │  └─ EQ [id DK]
    │     ├─ Switch [id DG] 't6'
    │     │  └─ ···
    │     └─ Composite{Abs(maximum(Switch(EQ(i0, 1), (-1), i0), Switch(EQ(i1, 1), (-1), i1)))} [id DL] 't16'
    │        ├─ i0 [id DI]
    │        └─ i1 [id DM]
    └─ OR [id DN]
       ├─ EQ [id DO]
       │  ├─ Switch [id DP] 't15'
       │  │  ├─ EQ [id DQ]
       │  │  │  ├─ i1 [id DM]
       │  │  │  └─ t8{1} [id CX]
       │  │  ├─ neg [id DJ] 't3'
       │  │  │  └─ ···
       │  │  └─ i1 [id DM]
       │  └─ neg [id DJ] 't3'
       │     └─ ···
       └─ EQ [id DR]
          ├─ Switch [id DP] 't15'
          │  └─ ···
          └─ Composite{Abs(maximum(Switch(EQ(i0, 1), (-1), i0), Switch(EQ(i1, 1), (-1), i1)))} [id DL] 't16'
             └─ ···

Composite{...} [id BG]
 ← sqrt [id DS] 'o0'
    └─ add [id DT]
       ├─ i0 [id DU]
       └─ i1 [id DV]
 ← add [id DW] 'o1'
    ├─ i2 [id DX]
    ├─ sqrt [id DS] 'o0'
    │  └─ ···
    └─ i1 [id DV]

Composite{((-i0) / i1)} [id BJ]
 ← true_div [id DY] 'o0'
    ├─ neg [id DZ]
    │  └─ i0 [id EA]
    └─ i1 [id EB]

Composite{Abs(maximum(Switch(EQ(i0, 1), (-1), i0), Switch(EQ(i1, 1), (-1), i1)))} [id CD]
 ← Abs [id BK] 'o0'
    └─ ···

Composite{Abs(maximum(Switch(EQ(i0, 1), (-1), i0), Switch(EQ(i1, 1), (-1), i1)))} [id DL]
 ← Abs [id CS] 'o0'
    └─ ···
```

</details>

### After

<details>

```
Add [id A] 19
 ├─ Split{2}.0 [id B] 9
 │  ├─ Alloc [id C] 6
 │  │  ├─ [[1.]] [id D]
 │  │  ├─ Shape_i{0} [id E] 1
 │  │  │  └─ x [id F]
 │  │  └─ Add [id G] 5
 │  │     ├─ Shape_i{1} [id H] 0
 │  │     │  └─ x [id F]
 │  │     └─ 1 [id I]
 │  ├─ 1 [id J]
 │  └─ MakeVector{dtype='int64'} [id K] 2
 │     ├─ Shape_i{1} [id H] 0
 │     │  └─ ···
 │     └─ 1 [id I]
 ├─ Composite{((i0 + i1) / i2)} [id L] 17
 │  ├─ SpecifyShape [id M] 12
 │  │  ├─ Split{2}.1 [id B] 9
 │  │  │  └─ ···
 │  │  ├─ NoneConst{None} [id N]
 │  │  └─ 1 [id J]
 │  ├─ BroadcastTo [id O] 16
 │  │  ├─ Composite{cast{float64}((-i0))} [id P] 11
 │  │  │  └─ ExpandDims{axes=[0, 1]} [id Q] 8
 │  │  │     └─ Add [id G] 5
 │  │  │        └─ ···
 │  │  ├─ Assert{msg=Could not dynamically broadcast dimensions.} [id R] 15
 │  │  │  ├─ Subtensor{i} [id S] 13
 │  │  │  │  ├─ SetSubtensor{i} [id T] 10
 │  │  │  │  │  ├─ MakeVector{dtype='int64'} [id U] 7
 │  │  │  │  │  │  ├─ Shape_i{0} [id E] 1
 │  │  │  │  │  │  │  └─ ···
 │  │  │  │  │  │  └─ Add [id G] 5
 │  │  │  │  │  │     └─ ···
 │  │  │  │  │  ├─ 1 [id I]
 │  │  │  │  │  └─ 1 [id V]
 │  │  │  │  └─ 0 [id W]
 │  │  │  └─ Eq [id X] 14
 │  │  │     ├─ Subtensor{i} [id S] 13
 │  │  │     │  └─ ···
 │  │  │     └─ Shape_i{0} [id E] 1
 │  │  │        └─ ···
 │  │  └─ 1 [id I]
 │  └─ Composite{...}.1 [id Y] 4
 │     ├─ [[1]] [id Z]
 │     ├─ ExpandDims{axes=[0, 1]} [id BA] 3
 │     │  └─ Shape_i{1} [id H] 0
 │     │     └─ ···
 │     └─ [[1.]] [id D]
 └─ Composite{((-i0) / i1)} [id BB] 18
    ├─ SpecifyShape [id M] 12
    │  └─ ···
    └─ Composite{...}.0 [id Y] 4
       └─ ···

Inner graphs:

Composite{((i0 + i1) / i2)} [id L]
 ← true_div [id BC] 'o0'
    ├─ add [id BD]
    │  ├─ i0 [id BE]
    │  └─ i1 [id BF]
    └─ i2 [id BG]

Composite{cast{float64}((-i0))} [id P]
 ← Cast{float64} [id BH] 'o0'
    └─ neg [id BI]
       └─ i0 [id BJ]

Composite{...} [id Y]
 ← sqrt [id BK] 'o0'
    └─ add [id BL]
       ├─ i0 [id BM]
       └─ i1 [id BN]
 ← add [id BO] 'o1'
    ├─ i2 [id BP]
    ├─ sqrt [id BK] 'o0'
    │  └─ ···
    └─ i1 [id BN]

Composite{((-i0) / i1)} [id BB]
 ← true_div [id BQ] 'o0'
    ├─ neg [id BR]
    │  └─ i0 [id BS]
    └─ i1 [id BT]
```

</details>