### PR TITLE
Add rewrite for Sum(MakeVector)

### DIFF
--- a/pytensor/tensor/rewriting/basic.py
+++ b/pytensor/tensor/rewriting/basic.py
@@ -971,14 +971,18 @@ def local_sum_make_vector(fgraph, node):
     if not isinstance(array.owner.op, MakeVector):
         return
 
-    if node.op.axis not in [None, 0, -1]:
-        return
+    if node.op.axis == ():
+        return [array]
+
+    # If this is not the case the sum is invalid
+    assert node.op.axis is None or node.op.axis == (0,)
 
     elements = array.owner.inputs
-    dtype = node.op.acc_dtype
-    element_sum = add(*[cast(value, dtype) for value in elements])
+    acc_dtype = node.op.acc_dtype
+    out_dtype = node.op.dtype
+    element_sum = cast(add(*[cast(value, acc_dtype) for value in elements]), out_dtype)
 
-    return [as_tensor_variable(element_sum)]
+    return [element_sum]
 
 
 @register_useless("local_remove_switch_const_cond")

--- a/pytensor/tensor/rewriting/basic.py
+++ b/pytensor/tensor/rewriting/basic.py
@@ -975,12 +975,19 @@ def local_sum_make_vector(fgraph, node):
         return [array]
 
     # If this is not the case the sum is invalid
-    assert node.op.axis is None or node.op.axis == (0,)
+    assert node.op.axis is None or node.op.axis == (0,) or node.op.axis == (-1,)
 
     elements = array.owner.inputs
     acc_dtype = node.op.acc_dtype
     out_dtype = node.op.dtype
-    element_sum = cast(add(*[cast(value, acc_dtype) for value in elements]), out_dtype)
+    if len(elements) == 0:
+        element_sum = zeros(dtype=out_dtype, shape=())
+    elif len(elements) == 1:
+        element_sum = cast(elements[0], out_dtype)
+    else:
+        element_sum = cast(
+            add(*[cast(value, acc_dtype) for value in elements]), out_dtype
+        )
 
     return [element_sum]
 

--- a/tests/tensor/rewriting/test_basic.py
+++ b/tests/tensor/rewriting/test_basic.py
@@ -1321,6 +1321,23 @@ def test_local_sum_make_vector():
     for var in between:
         assert (var.owner is None) or (not isinstance(var.owner.op, Sum))
 
+    # Check empty MakeVector
+    mv = MakeVector(config.floatX)
+    output = mv().sum()
+
+    output = rewrite_graph(output)
+    between = vars_between([a, b, c], [output])
+    for var in between:
+        assert (var.owner is None) or (not isinstance(var.owner.op, Sum))
+
+    mv = MakeVector(config.floatX)
+    output = mv(a).sum()
+
+    output = rewrite_graph(output)
+    between = vars_between([a, b, c], [output])
+    for var in between:
+        assert (var.owner is None) or (not isinstance(var.owner.op, Sum))
+
 
 @pytest.mark.parametrize(
     "dtype",


### PR DESCRIPTION
I've seen graphs like these recently quite a bit, and we can avoid the allocation by removing the MakeVector call:

```
Sum{axes=None} [id A]
 └─ MakeVector{dtype='int64'} [id B]
    ├─ Subtensor{i} [id C]
    │  ├─ Shape [id D]
    │  │  └─ x [id E]
    │  └─ 0 [id F]
    └─ Add [id G]
       ├─ Subtensor{i} [id H]
       │  ├─ Shape [id I]
       │  │  └─ x [id E]
       │  └─ 1 [id J]
       └─ 1 [id K]
```

This now gets rewritten to
```
Add [id A] 2
 ├─ 1 [id B]
 ├─ Shape_i{0} [id C] 1
 │  └─ x [id D]
 └─ Shape_i{1} [id E] 0
    └─ x [id D]
```

In the same models I've also come across cases like this, that we could also rewrite, but this is not included here (there already is a rewrite for `Subtensor(MakeVector)`, but not for `IncSubtensor(MakeVector)`)
```
IncSubtensor{i} [id A] 4
 ├─ MakeVector{dtype='int64'} [id B] 3
 │  ├─ Shape_i{0} [id C] 2
 │  │  └─ x [id D]
 │  └─ Add [id E] 1
 │     ├─ 1 [id F]
 │     └─ Shape_i{1} [id G] 0
 │        └─ x [id D]
 ├─ 2 [id H]
 └─ 0 [id I]
```