### PR TITLE
Use Dimshuffle for `expand_dims`

### DIFF
--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -4009,10 +4009,10 @@ def expand_dims(
     out_ndim = len(axis) + a.ndim
     axis = np.core.numeric.normalize_axis_tuple(axis, out_ndim)
 
-    shape_it = iter(a.shape)
-    shape = [1 if ax in axis else next(shape_it) for ax in range(out_ndim)]
+    dim_it = iter(range(a.ndim))
+    pattern = ["x" if ax in axis else next(dim_it) for ax in range(out_ndim)]
 
-    return a.reshape(shape)
+    return a.dimshuffle(pattern)
 
 
 def _make_along_axis_idx(arr_shape, indices, axis):

--- a/pytensor/tensor/extra_ops.py
+++ b/pytensor/tensor/extra_ops.py
@@ -708,7 +708,10 @@ class Repeat(Op):
             shape = [x.shape[k] for k in range(x.ndim)]
             shape.insert(axis, repeats)
 
-            return [gz.reshape(shape, x.ndim + 1).sum(axis=axis), DisconnectedType()()]
+            return [
+                gz.reshape(shape, ndim=x.ndim + 1).sum(axis=axis),
+                DisconnectedType()(),
+            ]
         elif repeats.ndim == 1:
             # For this implementation, we would need to specify the length
             # of repeats in order to split gz in the right way to sum

--- a/pytensor/tensor/math.py
+++ b/pytensor/tensor/math.py
@@ -2196,7 +2196,7 @@ def _tensordot_as_dot(a, b, axes, dot, batched):
         b_reshaped = b.reshape(b_shape)
 
         out_reshaped = dot(a_reshaped, b_reshaped)
-        out = out_reshaped.reshape(outshape, outndim)
+        out = out_reshaped.reshape(outshape, ndim=outndim)
         # Make sure the broadcastable pattern of the result is correct,
         # since some shape information can be lost in the reshapes.
         if out.type.broadcastable != outbcast:

--- a/pytensor/tensor/rewriting/elemwise.py
+++ b/pytensor/tensor/rewriting/elemwise.py
@@ -422,7 +422,12 @@ def local_dimshuffle_lift(fgraph, node):
     inp = node.inputs[0]
     inode = inp.owner
     new_order = op.new_order
-    if inode and isinstance(inode.op, Elemwise) and (len(fgraph.clients[inp]) == 1):
+    if (
+        inode
+        and isinstance(inode.op, Elemwise)
+        and len(inode.outputs) == 1
+        and (len(fgraph.clients[inp]) == 1)
+    ):
         # Don't use make_node to have tag.test_value set.
         new_inputs = []
         for inp in inode.inputs:

--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -155,7 +155,7 @@ def transform_take(a, indices, axis):
 
     ndim = a.ndim + indices.ndim - 1
 
-    return transform_take(a, indices.flatten(), axis).reshape(shape, ndim)
+    return transform_take(a, indices.flatten(), axis).reshape(shape, ndim=ndim)
 
 
 def is_full_slice(x):

--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -580,7 +580,7 @@ def kron(a, b):
             f"You passed {int(a.ndim)} and {int(b.ndim)}."
         )
     o = atm.outer(a, b)
-    o = o.reshape(at.concatenate((a.shape, b.shape)), a.ndim + b.ndim)
+    o = o.reshape(at.concatenate((a.shape, b.shape)), ndim=a.ndim + b.ndim)
     shf = o.dimshuffle(0, 2, 1, *list(range(3, o.ndim)))
     if shf.ndim == 3:
         shf = o.dimshuffle(1, 0, 2)

--- a/pytensor/tensor/var.py
+++ b/pytensor/tensor/var.py
@@ -286,7 +286,7 @@ class _tensor_py_operators:
     #                     "Variable) due to Python restriction. You can use "
     #                     "PyTensorVariable.shape[0] instead.")
 
-    def reshape(self, shape, ndim=None):
+    def reshape(self, shape, *, ndim=None):
         """Return a reshaped view/copy of this variable.
 
         Parameters


### PR DESCRIPTION
This makes more sense as the rest of the codebase prioritizes `dimshuffle` over other reshape operations, and most rewrites target those.

There is even a rewrite to use expand_dims from reshape when safe.