### PR TITLE
Stop using deprecated `numpy.product`

### DIFF
--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -1895,7 +1895,7 @@ class Mul(ScalarOp):
     nfunc_variadic = "product"
 
     def impl(self, *inputs):
-        return np.product(inputs)
+        return np.prod(inputs)
 
     def c_code(self, node, name, inputs, outputs, sub):
         (z,) = outputs

--- a/tests/link/jax/test_extra_ops.py
+++ b/tests/link/jax/test_extra_ops.py
@@ -55,7 +55,7 @@ def test_extra_ops():
         fgraph = FunctionGraph([a], [out])
         compare_jax_and_py(fgraph, [get_test_value(i) for i in fgraph.inputs])
 
-    indices = np.arange(np.product((3, 4)))
+    indices = np.arange(np.prod((3, 4)))
     out = at_extra_ops.unravel_index(indices, (3, 4), order="C")
     fgraph = FunctionGraph([], out)
     compare_jax_and_py(
@@ -100,7 +100,7 @@ def test_extra_ops_omni():
     fgraph = FunctionGraph([], [out])
     compare_jax_and_py(fgraph, [get_test_value(i) for i in fgraph.inputs])
 
-    multi_index = np.unravel_index(np.arange(np.product((3, 4))), (3, 4))
+    multi_index = np.unravel_index(np.arange(np.prod((3, 4))), (3, 4))
     out = at_extra_ops.ravel_multi_index(multi_index, (3, 4))
     fgraph = FunctionGraph([], [out])
     compare_jax_and_py(

--- a/tests/tensor/test_extra_ops.py
+++ b/tests/tensor/test_extra_ops.py
@@ -925,7 +925,7 @@ class TestUnique(utt.InferShapeTester):
 class TestUnravelIndex(utt.InferShapeTester):
     def test_unravel_index(self):
         def check(shape, index_ndim, order):
-            indices = np.arange(np.product(shape))
+            indices = np.arange(np.prod(shape))
             # test with scalars and higher-dimensional indices
             if index_ndim == 0:
                 indices = indices[-1]
@@ -996,7 +996,7 @@ class TestRavelMultiIndex(utt.InferShapeTester):
     def test_ravel_multi_index(self):
         def check(shape, index_ndim, mode, order):
             multi_index = np.unravel_index(
-                np.arange(np.product(shape)), shape, order=order
+                np.arange(np.prod(shape)), shape, order=order
             )
             # create some invalid indices to test the mode
             if mode in ("wrap", "clip"):

--- a/tests/tensor/test_subtensor.py
+++ b/tests/tensor/test_subtensor.py
@@ -1151,7 +1151,7 @@ class TestSubtensor(utt.OptimizationTestMixin):
             for inplace in (False, True):
                 for data_shape in ((10,), (4, 5), (1, 2, 3), (4, 5, 6, 7)):
                     data_n_dims = len(data_shape)
-                    data_size = np.product(data_shape)
+                    data_size = np.prod(data_shape)
                     # Corresponding numeric variable.
                     data_num_init = np.arange(data_size, dtype=self.dtype)
                     data_num_init = data_num_init.reshape(data_shape)
@@ -1203,7 +1203,7 @@ class TestSubtensor(utt.OptimizationTestMixin):
                         # The param dtype is needed when inc_shape is empty.
                         # By default, it would return a float and rng.uniform
                         # with NumPy 1.10 will raise a Deprecation warning.
-                        inc_size = np.product(inc_shape, dtype="int")
+                        inc_size = np.prod(inc_shape, dtype="int")
                         # Corresponding numeric variable.
                         inc_num = rng.uniform(size=inc_size).astype(self.dtype)
                         inc_num = inc_num.reshape(inc_shape)


### PR DESCRIPTION
CI started failing in other PRs because of this deprecation