### PR TITLE
Inline constants in composite graphs

### DIFF
--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -432,6 +432,12 @@ class ScalarType(CType, HasDataType, HasShape):
             return None
         if self.dtype == "bool":
             return "1" if data else "0"
+        if data == np.inf:
+            return "INFINITY"
+        if data == -np.inf:
+            return "-INFINITY"
+        if np.isnan(data):
+            return "NAN"
         return str(data)
 
     def c_declare(self, name, sub, check_input=True):

--- a/pytensor/scan/rewriting.py
+++ b/pytensor/scan/rewriting.py
@@ -69,7 +69,7 @@ from pytensor.tensor.subtensor import (
     get_slice_elements,
     set_subtensor,
 )
-from pytensor.tensor.var import TensorConstant, get_unique_value
+from pytensor.tensor.var import TensorConstant, get_unique_constant_value
 
 
 list_opt_slice = [
@@ -136,7 +136,7 @@ def remove_constants_and_unused_inputs_scan(fgraph, node):
         node_inp = node.inputs[idx + 1]
         if (
             isinstance(node_inp, TensorConstant)
-            and get_unique_value(node_inp) is not None
+            and get_unique_constant_value(node_inp) is not None
         ):
             try:
                 # This works if input is a constant that has all entries

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -62,7 +62,11 @@ from pytensor.tensor.type import (
     uint_dtypes,
     values_eq_approx_always_true,
 )
-from pytensor.tensor.var import TensorConstant, TensorVariable, get_unique_value
+from pytensor.tensor.var import (
+    TensorConstant,
+    TensorVariable,
+    get_unique_constant_value,
+)
 
 
 if TYPE_CHECKING:
@@ -323,7 +327,7 @@ def get_underlying_scalar_constant_value(
                 raise NotScalarConstantError()
 
         if isinstance(v, Constant):
-            unique_value = get_unique_value(v)
+            unique_value = get_unique_constant_value(v)
             if unique_value is not None:
                 data = unique_value
             else:

--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -1135,10 +1135,12 @@ class AlgebraicCanonizer(NodeRewriter):
         if new.type.dtype != out.type.dtype:
             new = cast(new, out.type.dtype)
 
-        if new.type != out.type:
+        if new.type.broadcastable != out.type.broadcastable:
             new = fill_chain(new, node.inputs)[0]
 
-        if new.type == out.type:
+        if (new.type.dtype == out.type.dtype) and (
+            new.type.broadcastable == out.type.broadcastable
+        ):
             new.tag.values_eq_approx = values_eq_approx_remove_inf_nan
             copy_stack_trace(out, new)
             return [new]

--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -101,7 +101,7 @@ from pytensor.tensor.type import (
     values_eq_approx_remove_inf_nan,
     values_eq_approx_remove_nan,
 )
-from pytensor.tensor.var import TensorConstant, get_unique_value
+from pytensor.tensor.var import TensorConstant, get_unique_constant_value
 
 
 def scalarconsts_rest(inputs, elemwise=True, only_process_constants=False):
@@ -133,7 +133,7 @@ def get_constant(v):
 
     """
     if isinstance(v, Constant):
-        unique_value = get_unique_value(v)
+        unique_value = get_unique_constant_value(v)
         if unique_value is not None:
             data = unique_value
         else:

--- a/pytensor/tensor/var.py
+++ b/pytensor/tensor/var.py
@@ -986,7 +986,7 @@ class TensorConstantSignature(tuple):
         return self._no_nan
 
 
-def get_unique_value(x: TensorVariable) -> Optional[Number]:
+def get_unique_constant_value(x: TensorVariable) -> Optional[Number]:
     """Return the unique value of a tensor, if there is one"""
     if isinstance(x, Constant):
         data = x.data

--- a/tests/tensor/rewriting/test_shape.py
+++ b/tests/tensor/rewriting/test_shape.py
@@ -491,6 +491,14 @@ def test_local_Shape_of_SpecifyShape_partial(s1):
     assert not any(isinstance(apply.op, SpecifyShape) for apply in fgraph.apply_nodes)
 
 
+def test_local_specify_shape_lift():
+    x = vector("x")
+    out = specify_shape([1.0] + x, shape=(5,))
+
+    new_out = rewrite_graph(out)
+    assert equal_computations([new_out], [[1.0] + specify_shape(x, shape=(5,))])
+
+
 def test_local_Shape_i_ground():
     x = tensor(dtype=np.float64, shape=(None, 2))
     s = Shape_i(1)(x)


### PR DESCRIPTION
This PR inlines constants in composite graphs, which reduces the number of variables that must be iterated over in the fused Elemwise graphs. I noticed some speedups when combined with `openmp` but not really otherwise. 

Would be interesting to check if `numba` benefits more from this. 

Regardless, this seems like a reasonable rewrite to include, if for nothing else that it also simplifies the debug_print of the final compiled graphs.

```python
import pytensor
import pytensor.tensor as pt

x = pt.vector("x")
out = pt.exp(x + 2)

fn = pytensor.function([x], out)
pytensor.dprint(fn)
```
```
Composite{exp((2.0 + i0))} [id A] 0
 └─ x [id B]

Inner graphs:

Composite{exp((2.0 + i0))} [id A]
 ← exp [id C] 'o0'
    └─ add [id D]
       ├─ 2.0 [id E]
       └─ i0 [id F]
```

There is no further constant folding triggered in the inner Composite graph. This shouldn't be needed for automatically introduced Composites, as those happen after constant folding. 

If users create their own Composite and pass constants, then they may have useless operations on constants inside the graph, but that's hopefully something compilers can optimize themselves?

Related to #107 