### PR TITLE
Fix Overly Broad Regular Expression Ranges

### DIFF
--- a/pytensor/link/c/cmodule.py
+++ b/pytensor/link/c/cmodule.py
@@ -2622,7 +2622,7 @@ class GCC_compiler(Compiler):
             tf.write(compile_stderr)
             tf.close()
             print("\nYou can find the C code in this temporary file: " + tf.name)
-            not_found_libraries = re.findall('-l["."-_a-zA-Z0-9]*', compile_stderr)
+            not_found_libraries = re.findall('-l[a-zA-Z0-9]*', compile_stderr)
             for nf_lib in not_found_libraries:
                 print("library " + nf_lib[2:] + " is not found.")
                 if re.search('-lPYTHON["."0-9]*', nf_lib, re.IGNORECASE):

--- a/pytensor/link/c/cmodule.py
+++ b/pytensor/link/c/cmodule.py
@@ -2622,7 +2622,7 @@ class GCC_compiler(Compiler):
             tf.write(compile_stderr)
             tf.close()
             print("\nYou can find the C code in this temporary file: " + tf.name)
-            not_found_libraries = re.findall('-l[a-zA-Z0-9]*', compile_stderr)
+            not_found_libraries = re.findall("-l[a-zA-Z0-9]*", compile_stderr)
             for nf_lib in not_found_libraries:
                 print("library " + nf_lib[2:] + " is not found.")
                 if re.search('-lPYTHON["."0-9]*', nf_lib, re.IGNORECASE):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->
### Motivation for these changes
These changes make the regular expressions unambiguous and ensure that they match only the expected characters.
### Implementation details

***The specific regular expressions causing the problem are:***

-l["."-_a-zA-Z0-9]* in the re.findall function

***The proposed changes in this PR are:***

Change -l["."-_a-zA-Z0-9]* to -l[a-zA-Z0-9]* in the re.findall function

The regex I addressed is -l["."-_a-zA-Z0-9]*, used within a re.findall function. Originally, it had a character range of ["."-_a-zA-Z0-9] which was overly broad, including characters such as quotes and periods, among others. My proposed modification narrows down this range to [a-zA-Z0-9], which means the regex now matches any lowercase or uppercase alphanumeric character. This refines the regex's behavior, ensuring that it will only capture sequences that start with '-l' followed by alphanumeric characters.

### Checklist
+ [x] Explain motivation and implementation 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇


## Major / Breaking Changes
-l["."-_a-zA-Z0-9]* in the re.findall function

## New features
Change -l["."-_a-zA-Z0-9]* to -l[a-zA-Z0-9]* in the re.findall function

## Bugfixes
#364 

