### PR TITLE
Cleanup fusion rewrite database

### DIFF
--- a/pytensor/compile/mode.py
+++ b/pytensor/compile/mode.py
@@ -248,11 +248,6 @@ optdb.register("specialize", EquilibriumDB(), "fast_run", "fast_compile", positi
 # misc special cases for speed that break canonicalization
 optdb.register("uncanonicalize", EquilibriumDB(), "fast_run", position=3)
 
-# misc special cases for speed that are dependent on the device.
-optdb.register(
-    "specialize_device", EquilibriumDB(), "fast_compile", "fast_run", position=48.6
-)  # must be after gpu stuff at 48.5
-
 # especially constant merge
 optdb.register("merge2", MergeOptimizer(), "fast_run", "merge", position=49)
 

--- a/pytensor/configdefaults.py
+++ b/pytensor/configdefaults.py
@@ -640,16 +640,6 @@ def add_tensor_configvars():
         in_c_key=False,
     )
 
-    config.add(
-        "tensor__local_elemwise_fusion",
-        (
-            "Enable or not in fast_run mode(fast_run optimization) the elemwise "
-            "fusion optimization"
-        ),
-        BoolParam(True),
-        in_c_key=False,
-    )
-
     # http://developer.amd.com/CPU/LIBRARIES/LIBM/Pages/default.aspx
     config.add(
         "lib__amblibm",

--- a/pytensor/tensor/rewriting/basic.py
+++ b/pytensor/tensor/rewriting/basic.py
@@ -205,25 +205,6 @@ def register_uncanonicalize(
         return node_rewriter
 
 
-def register_specialize_device(
-    node_rewriter: Union[RewriteDatabase, Rewriter, str], *tags: str, **kwargs
-):
-    if isinstance(node_rewriter, str):
-
-        def register(inner_rewriter: Union[RewriteDatabase, Rewriter]):
-            return register_specialize_device(
-                inner_rewriter, node_rewriter, *tags, **kwargs
-            )
-
-        return register
-    else:
-        name = (kwargs and kwargs.pop("name", None)) or node_rewriter.__name__
-        compile.optdb["specialize_device"].register(
-            name, node_rewriter, "fast_run", *tags, **kwargs
-        )
-        return node_rewriter
-
-
 @register_canonicalize
 @register_specialize
 @node_rewriter([TensorFromScalar])

--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -88,7 +88,6 @@ from pytensor.tensor.rewriting.basic import (
     local_fill_sink,
     register_canonicalize,
     register_specialize,
-    register_specialize_device,
     register_stabilize,
     register_uncanonicalize,
     register_useless,
@@ -2078,12 +2077,14 @@ def local_pow_specialize(fgraph, node):
         return False
 
 
-@register_specialize_device
+@register_specialize
 @node_rewriter([at_pow])
-def local_pow_specialize_device(fgraph, node):
+def local_pow_to_nested_squaring(fgraph, node):
+    """Convert a large power exponent to multiple squaring operations.
+
+    Note: This sounds like the kind of thing any half-decent compiler can do by itself?
     """
-    This rewrite is not the same on all device. We do it only on cpu here.
-    """
+
     if node.op == at_pow:
         # the idea here is that we have pow(x, y)
         odtype = node.outputs[0].dtype

--- a/tests/tensor/rewriting/test_elemwise.py
+++ b/tests/tensor/rewriting/test_elemwise.py
@@ -1425,39 +1425,40 @@ class TestCompositeCodegen:
         fval = f([1, 2, 3])
         assert np.all(fval == [6, 12, 18])
 
-    def test_local_useless_composite(self):
-        x = aes.float32()
-        y = aes.float32()
-        z = aes.float32()
-        c = aes.Composite([x, y, z], [x + 1, y - 1])
-        X = matrix("X")
-        Y = matrix("Y")
-        Z = matrix("Z")
-        o1, o2 = Elemwise(scalar_op=c)(X, Y, Z)
-        mode = get_default_mode().including("local_useless_composite")
 
-        f = function([X, Y, Z], [o1, o2], mode=mode)
-        topo = f.maker.fgraph.toposort()
-        assert len(topo) == 1
-        assert len(topo[0].inputs) == 2
-        assert len(topo[0].outputs) == 2
-        res1, res2 = f([[1.0]], [[1.0]], [[np.nan]])
-        utt.assert_allclose(res1, [[2.0]])
-        utt.assert_allclose(res2, [[0.0]])
+def test_local_useless_composite_outputs():
+    x = aes.float32()
+    y = aes.float32()
+    z = aes.float32()
+    c = aes.Composite([x, y, z], [x + 1, y - 1])
+    X = matrix("X")
+    Y = matrix("Y")
+    Z = matrix("Z")
+    o1, o2 = Elemwise(scalar_op=c)(X, Y, Z)
+    mode = get_default_mode().including("local_useless_composite")
 
-        f = function([X, Y, Z], o1, mode=mode)
-        topo = f.maker.fgraph.toposort()
-        assert len(topo) == 1
-        assert len(topo[0].inputs) == 1
-        assert len(topo[0].outputs) == 1
-        utt.assert_allclose(f([[1.0]], [[np.nan]], [[np.nan]]), [[2.0]])
+    f = function([X, Y, Z], [o1, o2], mode=mode)
+    topo = f.maker.fgraph.toposort()
+    assert len(topo) == 1
+    assert len(topo[0].inputs) == 2
+    assert len(topo[0].outputs) == 2
+    res1, res2 = f([[1.0]], [[1.0]], [[np.nan]])
+    utt.assert_allclose(res1, [[2.0]])
+    utt.assert_allclose(res2, [[0.0]])
 
-        f = function([X, Y, Z], o2, mode=mode)
-        topo = f.maker.fgraph.toposort()
-        assert len(topo) == 1
-        assert len(topo[0].inputs) == 1
-        assert len(topo[0].outputs) == 1
-        utt.assert_allclose(f([[np.nan]], [[1.0]], [[np.nan]]), [[0.0]])
+    f = function([X, Y, Z], o1, mode=mode)
+    topo = f.maker.fgraph.toposort()
+    assert len(topo) == 1
+    assert len(topo[0].inputs) == 1
+    assert len(topo[0].outputs) == 1
+    utt.assert_allclose(f([[1.0]], [[np.nan]], [[np.nan]]), [[2.0]])
+
+    f = function([X, Y, Z], o2, mode=mode)
+    topo = f.maker.fgraph.toposort()
+    assert len(topo) == 1
+    assert len(topo[0].inputs) == 1
+    assert len(topo[0].outputs) == 1
+    utt.assert_allclose(f([[np.nan]], [[1.0]], [[np.nan]]), [[0.0]])
 
 
 def test_local_useless_dimshuffle_makevector():

--- a/tests/tensor/rewriting/test_math.py
+++ b/tests/tensor/rewriting/test_math.py
@@ -1672,12 +1672,12 @@ def test_local_pow_specialize():
     utt.assert_allclose(f(val_no0), val_no0 ** (-0.5))
 
 
-def test_local_pow_specialize_device_more_aggressive_on_cpu():
+def test_local_pow_to_nested_squaring():
     mode = config.mode
     if mode == "FAST_COMPILE":
         mode = "FAST_RUN"
     mode = get_mode(mode)
-    mode = mode.excluding("fusion").excluding("gpu")
+    mode = mode.excluding("fusion")
 
     v = vector()
     val = np.arange(10, dtype=config.floatX)


### PR DESCRIPTION
* Fix a couple of bugs in the careduce_fusion rewrite. These are very much related to some discussion on
https://github.com/pymc-devs/pytensor/pull/346 about tricky aspects of the CAReduce Ops. This rewrite was accidentally rarely used because it was registered outside the fusion database, and ran before the fusion rewrites. This explains why the failures where hidden for so long. It is now included in the same database, which is also related to the next point:
* Remove the flag to create the fusion database. This unnecessarily complicated the codebase logic, and the flag was not even "mutable". The same behavior can be done by excluding "fusion" tags from the compilation mode.
* Remove specialize_device database. This seems to be a left-over from the time Theano supported GPU. Only one rewrite (of dubious value) existed in it, which I have moved into the standard specialize database.

Spinoff from #361 