### PR TITLE
Don't run useless fusion and inplace rewrites in JAX mode

### DIFF
--- a/pytensor/compile/mode.py
+++ b/pytensor/compile/mode.py
@@ -454,7 +454,10 @@ else:
 
 JAX = Mode(
     JAXLinker(),
-    RewriteDatabaseQuery(include=["fast_run", "jax"], exclude=["cxx_only", "BlasOpt"]),
+    RewriteDatabaseQuery(
+        include=["fast_run", "jax"],
+        exclude=["cxx_only", "BlasOpt", "fusion", "inplace"],
+    ),
 )
 NUMBA = Mode(
     NumbaLinker(),


### PR DESCRIPTION
The inplace rewrites have no effect whatsoever, and neither do the fusion, since we were not dispatching it to any lower level XLA. 

JAX docs state that JAX has comprehensive fusion rewrites so I think we can safely leave it to their implementation. 

Closes #122