### PR TITLE
feat(jax): Allow boolean masks with constants

### DIFF
--- a/pytensor/link/jax/dispatch/subtensor.py
+++ b/pytensor/link/jax/dispatch/subtensor.py
@@ -37,6 +37,8 @@ def subtensor_assert_indices_jax_compatible(node, idx_list):
 
     ilist = indices_from_subtensor(node.inputs[1:], idx_list)
     for idx in ilist:
+        if isinstance(idx, Constant):
+            continue
         if isinstance(idx, TensorVariable):
             if idx.type.dtype == "bool":
                 raise NotImplementedError(BOOLEAN_MASK_ERROR)


### PR DESCRIPTION
Indexing with boolean arrays is problematic in jax, because it always needs to know the shape of the result. But this is the case if the mask is a constant, so we can allow that.

TODO needs a test...