### PR TITLE
Add `shape_unsafe` tag to rewrites that can hide shape errors

### DIFF
--- a/pytensor/configdefaults.py
+++ b/pytensor/configdefaults.py
@@ -682,25 +682,7 @@ def add_traceback_configvars():
 
 
 def add_experimental_configvars():
-    config.add(
-        "experimental__local_alloc_elemwise",
-        "DEPRECATED: If True, enable the experimental"
-        " optimization local_alloc_elemwise."
-        " Generates error if not True. Use"
-        " optimizer_excluding=local_alloc_elemwise"
-        " to disable.",
-        BoolParam(True),
-        in_c_key=False,
-    )
-
-    # False could make the graph faster but not as safe.
-    config.add(
-        "experimental__local_alloc_elemwise_assert",
-        "When the local_alloc_elemwise is applied, add"
-        " an assert to highlight shape errors.",
-        BoolParam(True),
-        in_c_key=False,
-    )
+    return
 
 
 def add_error_and_warning_configvars():

--- a/pytensor/link/jax/dispatch/extra_ops.py
+++ b/pytensor/link/jax/dispatch/extra_ops.py
@@ -3,10 +3,8 @@ import warnings
 import jax.numpy as jnp
 
 from pytensor.link.jax.dispatch.basic import jax_funcify
-from pytensor.tensor.basic import infer_static_shape
 from pytensor.tensor.extra_ops import (
     Bartlett,
-    BroadcastTo,
     CumOp,
     FillDiagonal,
     FillDiagonalOffset,
@@ -100,18 +98,6 @@ def jax_funcify_RavelMultiIndex(op, **kwargs):
         return jnp.ravel_multi_index(multi_index, dims, mode=mode, order=order)
 
     return ravelmultiindex
-
-
-@jax_funcify.register(BroadcastTo)
-def jax_funcify_BroadcastTo(op, node, **kwargs):
-    shape = node.inputs[1:]
-    static_shape = infer_static_shape(shape)[1]
-
-    def broadcast_to(x, *shape):
-        shape = tuple(st if st is not None else s for s, st in zip(shape, static_shape))
-        return jnp.broadcast_to(x, shape)
-
-    return broadcast_to
 
 
 @jax_funcify.register(FillDiagonal)

--- a/pytensor/link/numba/dispatch/extra_ops.py
+++ b/pytensor/link/numba/dispatch/extra_ops.py
@@ -2,7 +2,6 @@ import warnings
 
 import numba
 import numpy as np
-from numba.misc.special import literal_unroll
 
 from pytensor import config
 from pytensor.link.numba.dispatch import basic as numba_basic
@@ -10,7 +9,6 @@ from pytensor.link.numba.dispatch.basic import get_numba_type, numba_funcify
 from pytensor.raise_op import CheckAndRaise
 from pytensor.tensor.extra_ops import (
     Bartlett,
-    BroadcastTo,
     CumOp,
     FillDiagonal,
     FillDiagonalOffset,
@@ -351,29 +349,6 @@ def numba_funcify_Searchsorted(op, node, **kwargs):
             return np.searchsorted(a, v, side)
 
     return searchsorted
-
-
-@numba_funcify.register(BroadcastTo)
-def numba_funcify_BroadcastTo(op, node, **kwargs):
-    create_zeros_tuple = numba_basic.create_tuple_creator(
-        lambda _: 0, len(node.inputs) - 1
-    )
-
-    # TODO broadcastable checks
-    @numba_basic.numba_njit
-    def broadcast_to(x, *shape):
-        scalars_shape = create_zeros_tuple()
-
-        i = 0
-        for s_i in literal_unroll(shape):
-            scalars_shape = numba_basic.tuple_setitem(
-                scalars_shape, i, numba_basic.to_scalar(s_i)
-            )
-            i += 1
-
-        return np.broadcast_to(x, scalars_shape)
-
-    return broadcast_to
 
 
 @numba_funcify.register(CheckAndRaise)

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -765,7 +765,12 @@ where = switch
 
 @scalar_elemwise
 def second(a, b):
-    """Create a matrix by filling the shape of a with b"""
+    """Create a matrix by filling the broadcasted shapes of a and b with the values of b
+
+    Equivalent to `np.broadcast_arrays(a, b)[1]`
+    Equivalent to `np.array(a).fill(b)` when b is a scalar value.
+
+    """
 
 
 fill = second

--- a/pytensor/tensor/extra_ops.py
+++ b/pytensor/tensor/extra_ops.py
@@ -23,7 +23,7 @@ from pytensor.scalar import int32 as int_t
 from pytensor.scalar import upcast
 from pytensor.tensor import as_tensor_variable
 from pytensor.tensor import basic as at
-from pytensor.tensor import get_vector_length
+from pytensor.tensor.basic import get_vector_length, second
 from pytensor.tensor.exceptions import NotScalarConstantError
 from pytensor.tensor.math import abs as pt_abs
 from pytensor.tensor.math import all as pt_all
@@ -1780,7 +1780,19 @@ def broadcast_arrays(*args: TensorVariable) -> Tuple[TensorVariable, ...]:
         The arrays to broadcast.
 
     """
-    return tuple(broadcast_to(a, broadcast_shape(*args)) for a in args)
+
+    def broadcast_with_others(a, others):
+        for other in others:
+            a = second(other, a)
+        return a
+
+    brodacasted_vars = []
+    for i, a in enumerate(args):
+        # We use indexing and not identity in case there are duplicated variables
+        others = [a for j, a in enumerate(args) if j != i]
+        brodacasted_vars.append(broadcast_with_others(a, others))
+
+    return brodacasted_vars
 
 
 __all__ = [

--- a/pytensor/tensor/extra_ops.py
+++ b/pytensor/tensor/extra_ops.py
@@ -23,7 +23,7 @@ from pytensor.scalar import int32 as int_t
 from pytensor.scalar import upcast
 from pytensor.tensor import as_tensor_variable
 from pytensor.tensor import basic as at
-from pytensor.tensor.basic import get_vector_length, second
+from pytensor.tensor.basic import alloc, second
 from pytensor.tensor.exceptions import NotScalarConstantError
 from pytensor.tensor.math import abs as pt_abs
 from pytensor.tensor.math import all as pt_all
@@ -1584,141 +1584,6 @@ def broadcast_shape_iter(
     return tuple(result_dims)
 
 
-class BroadcastTo(COp):
-    """An `Op` for `numpy.broadcast_to`."""
-
-    _output_type_depends_on_input_value = True
-
-    __props__ = ()
-
-    view_map = {0: [0]}
-
-    def __call__(self, a, shape, **kwargs):
-        return super().__call__(a, *shape, **kwargs)
-
-    def make_node(self, a, *shape):
-        a = at.as_tensor_variable(a)
-
-        shape, static_shape = at.infer_static_shape(shape)
-
-        if len(shape) < a.ndim:
-            raise ValueError(
-                f"Broadcast target shape has {len(shape)} dims, which is shorter than input with {a.ndim} dims"
-            )
-
-        out = TensorType(dtype=a.type.dtype, shape=static_shape)()
-
-        # Attempt to prevent in-place operations on this view-based output
-        out.tag.indestructible = True
-
-        return Apply(self, [a] + shape, [out])
-
-    def perform(self, node, inputs, output_storage):
-        a, *shape = inputs
-        z = output_storage[0]
-        z[0] = np.broadcast_to(a, shape)
-
-    def grad(self, inputs, outputs_gradients):
-        a, *shape = inputs
-        (dout,) = outputs_gradients
-
-        # Determine the dimensions that were added by broadcasting
-        new_dims = list(range(dout.ndim - a.ndim))
-
-        d_wrt_a = broadcast_to(dout, shape).sum(axis=new_dims)
-
-        # Determine the dimensions that were broadcast
-        _, static_shape = at.infer_static_shape(shape)
-
-        # TODO: This needs to be performed at run-time when static shape
-        # information isn't available.
-        bcast_sums = [
-            i
-            for i, (a_s, s_s) in enumerate(zip(a.type.shape, static_shape[-a.ndim :]))
-            if a_s == 1 and s_s != 1
-        ]
-
-        if bcast_sums:
-            d_wrt_a = d_wrt_a.sum(axis=bcast_sums, keepdims=True)
-
-        return [d_wrt_a] + [
-            grad_undefined(self, i, shp) for i, shp in enumerate(shape, 1)
-        ]
-
-    def infer_shape(self, fgraph, node, ins_shapes):
-        return [node.inputs[1:]]
-
-    def c_code(self, node, name, inputs, outputs, sub):
-        inp_dims = node.inputs[0].ndim
-        out_dims = node.outputs[0].ndim
-        new_dims = out_dims - inp_dims
-
-        (x, *shape) = inputs
-        (out,) = outputs
-        fail = sub["fail"]
-
-        # TODO: Could just use `PyArray_Return`, no?
-        dims_array = ", ".join(
-            [
-                f"((dtype_{shape}*)(PyArray_DATA({shape})))[0]"
-                for i, shape in enumerate(shape)
-            ]
-        )
-
-        src = (
-            """
-            npy_intp itershape[%(out_dims)s] = {%(dims_array)s};
-
-            NpyIter *iter;
-            PyArrayObject *ops[1] = {%(x)s};
-            npy_uint32 flags = NPY_ITER_MULTI_INDEX | NPY_ITER_REFS_OK | NPY_ITER_ZEROSIZE_OK;
-            npy_uint32 op_flags[1] = {NPY_ITER_READONLY};
-            PyArray_Descr *op_dtypes[1] = {NULL};
-            int oa_ndim = %(out_dims)s;
-            int* op_axes[1] = {NULL};
-            npy_intp buffersize = 0;
-
-            for(int i = 0; i < %(inp_dims)s; i++)
-            {
-                if ((PyArray_DIMS(%(x)s)[i] != 1) && (PyArray_DIMS(%(x)s)[i] != itershape[i + %(new_dims)s]))
-                {
-                    PyErr_Format(PyExc_ValueError,
-                                 "Shape mismatch in broadcast_to: target shape[%%i] = %%lld is incompatible with input shape = %%lld.",
-                                 i,
-                                 (long long int) itershape[i + %(new_dims)s],
-                                 (long long int) PyArray_DIMS(%(x)s)[i]
-                    );
-                    %(fail)s
-                }
-            }
-
-            iter = NpyIter_AdvancedNew(
-                1, ops, flags, NPY_CORDER, NPY_NO_CASTING, op_flags, op_dtypes, oa_ndim, op_axes, itershape, buffersize
-            );
-            %(out)s = NpyIter_GetIterView(iter, 0);
-
-            if(%(out)s == NULL){
-                NpyIter_Deallocate(iter);
-                %(fail)s;
-            }
-
-            if (NpyIter_Deallocate(iter) != NPY_SUCCEED) {
-                %(fail)s;
-            }
-
-            """
-            % locals()
-        )
-
-        return src
-
-    def c_code_cache_version(self):
-        return (2,)
-
-
-broadcast_to_ = BroadcastTo()
-
-
 def geomspace(start, end, steps, base=10.0):
     from pytensor.tensor.math import log
 
@@ -1762,13 +1627,7 @@ def broadcast_to(
         broadcasted array may refer to a single memory location.
 
     """
-    x = at.as_tensor(x)
-    shape_len = get_vector_length(shape)
-
-    if x.ndim == 0 and shape_len == 0:
-        return x
-
-    return broadcast_to_(x, shape)
+    return alloc(x, *shape)
 
 
 def broadcast_arrays(*args: TensorVariable) -> Tuple[TensorVariable, ...]:

--- a/pytensor/tensor/rewriting/basic.py
+++ b/pytensor/tensor/rewriting/basic.py
@@ -256,7 +256,7 @@ def local_scalar_tensor_scalar(fgraph, node):
             return [s]
 
 
-@register_specialize("local_alloc_elemwise")
+@register_specialize("shape_unsafe")
 @node_rewriter([Elemwise])
 def local_elemwise_alloc(fgraph, node):
     r"""Remove unnecessary `Alloc`\s that occur as inputs of `Elemwise` `Op`\s.
@@ -377,7 +377,7 @@ def local_elemwise_alloc(fgraph, node):
     return ret
 
 
-@register_canonicalize
+@register_canonicalize("shape_unsafe")
 @node_rewriter([Elemwise])
 def local_fill_sink(fgraph, node):
     """
@@ -428,8 +428,8 @@ def local_fill_sink(fgraph, node):
     return replacements
 
 
-@register_specialize
-@register_stabilize
+@register_specialize("shape_unsafe")
+@register_stabilize("shape_unsafe")
 @node_rewriter([fill])
 def local_fill_to_alloc(fgraph, node):
     r"""Remove `fill`\s or replace them with `Alloc`\s.
@@ -479,8 +479,8 @@ compile.optdb.register(
 )
 
 
-@register_canonicalize("fast_compile")
-@register_useless
+@register_canonicalize("fast_compile", "shape_unsafe")
+@register_useless("shape_unsafe")
 @node_rewriter([fill])
 def local_useless_fill(fgraph, node):
     """fill(s,v) -> v
@@ -500,10 +500,10 @@ def local_useless_fill(fgraph, node):
         return [v]
 
 
-@register_specialize
-@register_stabilize
-@register_canonicalize
-@register_useless
+@register_specialize("shape_unsafe")
+@register_stabilize("shape_unsafe")
+@register_canonicalize("shape_unsafe")
+@register_useless("shape_unsafe")
 @node_rewriter([Alloc])
 def local_useless_alloc(fgraph, node):
     """

--- a/pytensor/tensor/rewriting/elemwise.py
+++ b/pytensor/tensor/rewriting/elemwise.py
@@ -34,7 +34,7 @@ from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
 from pytensor.tensor.exceptions import NotScalarConstantError
 from pytensor.tensor.math import exp
 from pytensor.tensor.rewriting.basic import (
-    broadcast_like,
+    alloc_like,
     register_canonicalize,
     register_specialize,
 )
@@ -1242,7 +1242,7 @@ def local_inline_composite_constants(fgraph, node):
     # Some of the inlined constants were broadcasting the output shape
     if node.outputs[0].type.broadcastable != new_outputs[0].type.broadcastable:
         new_outputs = [
-            broadcast_like(new_out, template=node.outputs[0], fgraph=fgraph)
+            alloc_like(new_out, template=node.outputs[0], fgraph=fgraph)
             for new_out in new_outputs
         ]
 

--- a/pytensor/tensor/rewriting/extra_ops.py
+++ b/pytensor/tensor/rewriting/extra_ops.py
@@ -2,7 +2,7 @@ import pytensor.scalar.basic as aes
 from pytensor.graph.rewriting.basic import node_rewriter
 from pytensor.tensor.basic import Alloc, as_tensor_variable
 from pytensor.tensor.elemwise import Elemwise
-from pytensor.tensor.extra_ops import BroadcastTo, Repeat, Unique
+from pytensor.tensor.extra_ops import Repeat, Unique
 from pytensor.tensor.rewriting.basic import register_canonicalize, register_useless
 
 
@@ -54,39 +54,6 @@ def local_Unique_Alloc_lift(fgraph, node):
     alloced_var, *alloc_shape = alloc_var.owner.inputs
 
     new_unique, *_ = node.op.make_node(alloced_var).outputs
-
-    old_out = node.outputs[0]
-    new_x = as_tensor_variable(new_unique, ndim=old_out.ndim, dtype=old_out.dtype)
-    return [new_x]
-
-
-@register_useless
-@register_canonicalize
-@node_rewriter([Unique])
-def local_Unique_BroadcastTo_lift(fgraph, node):
-    """Convert ``unique(broadcast_to(x, ...), axis=None)`` to ``unique(x, axis=None)``.
-
-    This isn't really so much a lift as a "reduction/consumption".
-    """
-    if not isinstance(node.op, Unique):
-        return False
-
-    if (
-        node.op.return_index
-        or node.op.return_inverse
-        or node.op.return_counts
-        or node.op.axis is not None
-    ):
-        return False
-
-    bcast_var = node.inputs[0]
-
-    if not (bcast_var.owner and isinstance(bcast_var.owner.op, BroadcastTo)):
-        return False
-
-    bcasted_var, *bcast_shape = bcast_var.owner.inputs
-
-    new_unique, *_ = node.op.make_node(bcasted_var).outputs
 
     old_out = node.outputs[0]
     new_x = as_tensor_variable(new_unique, ndim=old_out.ndim, dtype=old_out.dtype)
@@ -161,16 +128,3 @@ def local_Unique_second(fgraph, node):
     old_out = node.outputs[0]
     new_x = as_tensor_variable(new_unique, ndim=old_out.ndim, dtype=old_out.dtype)
     return [new_x]
-
-
-@register_useless
-@register_canonicalize
-@node_rewriter([BroadcastTo])
-def local_remove_scalar_BroadcastTo(fgraph, node):
-    bcast_shape = node.inputs[1:]
-
-    if not bcast_shape:
-        bcasted_var = node.inputs[0]
-        # If this isn't true, the graph is invalid
-        assert bcasted_var.ndim == 0
-        return [bcasted_var]

--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -84,7 +84,7 @@ from pytensor.tensor.math import (
 from pytensor.tensor.math import sum as at_sum
 from pytensor.tensor.math import true_div
 from pytensor.tensor.rewriting.basic import (
-    broadcast_like,
+    alloc_like,
     broadcasted_by,
     local_fill_sink,
     register_canonicalize,
@@ -1973,7 +1973,7 @@ def local_div_to_reciprocal(fgraph, node):
             new_out = cast(new_out, dtype=out.dtype)
         # The ones could have forced a specific length
         if not out.type.is_super(new_out.type):
-            new_out = broadcast_like(new_out, out, fgraph)
+            new_out = alloc_like(new_out, out, fgraph)
         return [new_out]
     else:
         return False
@@ -1994,9 +1994,9 @@ def local_pow_canonicalize(fgraph, node):
     if node.op == at_pow:
         cst = get_constant(node.inputs[1])
         if cst == 0:
-            return [broadcast_like(1, node.outputs[0], fgraph)]
+            return [alloc_like(1, node.outputs[0], fgraph)]
         if cst == 1:
-            return [broadcast_like(node.inputs[0], node.outputs[0], fgraph)]
+            return [alloc_like(node.inputs[0], node.outputs[0], fgraph)]
     else:
         return False
 
@@ -2033,7 +2033,7 @@ def local_zero_div(fgraph, node):
         node.op.scalar_op, (aes.IntDiv, aes.TrueDiv)
     ):
         if get_constant(node.inputs[0]) == 0:
-            ret = broadcast_like(0, node.outputs[0], fgraph)
+            ret = alloc_like(0, node.outputs[0], fgraph)
             ret.tag.values_eq_approx = values_eq_approx_remove_nan
             return [ret]
 
@@ -2184,7 +2184,7 @@ def local_mul_specialize(fgraph, node):
                 has_neg ^= True  # toggles
             elif y == 0.0:
                 # if we find any zero, we just return right away
-                return [broadcast_like(0, node.outputs[0], fgraph)]
+                return [alloc_like(0, node.outputs[0], fgraph)]
             else:
                 new_inputs.append(inp)
 
@@ -2209,14 +2209,14 @@ def local_mul_specialize(fgraph, node):
                         new_inputs = [m1] + new_inputs
                     rval = mul(*new_inputs)
 
-                return [broadcast_like(rval, node.outputs[0], fgraph)]
+                return [alloc_like(rval, node.outputs[0], fgraph)]
             else:
                 # there are no variable inputs to mul
                 # N.B. this could have been constant-folded...
                 if has_neg:
-                    return [broadcast_like(-1, node.outputs[0], fgraph)]
+                    return [alloc_like(-1, node.outputs[0], fgraph)]
                 else:
-                    return [broadcast_like(1, node.outputs[0], fgraph)]
+                    return [alloc_like(1, node.outputs[0], fgraph)]
 
 
 @register_specialize

--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -85,7 +85,7 @@ from pytensor.tensor.math import sum as at_sum
 from pytensor.tensor.math import true_div
 from pytensor.tensor.rewriting.basic import (
     broadcast_like,
-    encompasses_broadcastable,
+    broadcasted_by,
     local_fill_sink,
     register_canonicalize,
     register_specialize,
@@ -2049,9 +2049,7 @@ def local_pow_specialize(fgraph, node):
         xsym = node.inputs[0]
         ysym = node.inputs[1]
         y = get_constant(ysym)
-        if (y is not None) and encompasses_broadcastable(
-            xsym.type.broadcastable, ysym.type.broadcastable
-        ):
+        if (y is not None) and not broadcasted_by(xsym, ysym):
             rval = None
 
             if np.all(y == 2):
@@ -2107,9 +2105,7 @@ def local_pow_to_nested_squaring(fgraph, node):
                 y = y[0]
             except IndexError:
                 pass
-        if (y is not None) and encompasses_broadcastable(
-            xsym.type.broadcastable, ysym.type.broadcastable
-        ):
+        if (y is not None) and not broadcasted_by(xsym, ysym):
             rval = None
             # 512 is too small for the cpu and too big for some gpu!
             if abs(y) == int(abs(y)) and abs(y) <= 512:

--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -1176,7 +1176,7 @@ def mul_calculate(num, denum, aslist=False, out_type=None):
 local_mul_canonizer = AlgebraicCanonizer(
     mul, true_div, reciprocal, mul_calculate, False
 )
-register_canonicalize(local_mul_canonizer, name="local_mul_canonizer")
+register_canonicalize(local_mul_canonizer, "shape_unsafe", name="local_mul_canonizer")
 
 
 @register_canonicalize
@@ -2493,7 +2493,7 @@ add_canonizer = in2out(
 )
 
 
-register_canonicalize(local_add_canonizer, name="local_add_canonizer")
+register_canonicalize(local_add_canonizer, "shape_unsafe", name="local_add_canonizer")
 
 
 def distribute_greedy(pos_pairs, neg_pairs, num, denum, out_type, minscore=0):

--- a/tests/link/jax/test_extra_ops.py
+++ b/tests/link/jax/test_extra_ops.py
@@ -7,7 +7,7 @@ from pytensor.configdefaults import config
 from pytensor.graph.fg import FunctionGraph
 from pytensor.graph.op import get_test_value
 from pytensor.tensor import extra_ops as at_extra_ops
-from pytensor.tensor.type import matrix, vector
+from pytensor.tensor.type import matrix
 from tests.link.jax.test_basic import compare_jax_and_py
 
 
@@ -61,29 +61,6 @@ def test_extra_ops():
     compare_jax_and_py(
         fgraph, [get_test_value(i) for i in fgraph.inputs], must_be_device_array=False
     )
-
-
-@pytest.mark.parametrize(
-    "x, shape",
-    [
-        (
-            set_test_value(
-                vector("x"), np.random.random(size=(2,)).astype(config.floatX)
-            ),
-            [at.as_tensor(3, dtype=np.int64), at.as_tensor(2, dtype=np.int64)],
-        ),
-        (
-            set_test_value(
-                vector("x"), np.random.random(size=(2,)).astype(config.floatX)
-            ),
-            [at.as_tensor(3, dtype=np.int8), at.as_tensor(2, dtype=np.int64)],
-        ),
-    ],
-)
-def test_BroadcastTo(x, shape):
-    out = at_extra_ops.broadcast_to(x, shape)
-    fgraph = FunctionGraph(outputs=[out])
-    compare_jax_and_py(fgraph, [get_test_value(i) for i in fgraph.inputs])
 
 
 @pytest.mark.xfail(

--- a/tests/link/numba/test_extra_ops.py
+++ b/tests/link/numba/test_extra_ops.py
@@ -37,41 +37,6 @@ def test_Bartlett(val):
 
 
 @pytest.mark.parametrize(
-    "x, shape",
-    [
-        (
-            set_test_value(at.vector(), rng.random(size=(2,)).astype(config.floatX)),
-            [set_test_value(at.lscalar(), np.array(v)) for v in [3, 2]],
-        ),
-        (
-            set_test_value(at.vector(), rng.random(size=(2,)).astype(config.floatX)),
-            [at.as_tensor(3, dtype=np.int64), at.as_tensor(2, dtype=np.int64)],
-        ),
-        (
-            set_test_value(at.vector(), rng.random(size=(2,)).astype(config.floatX)),
-            at.as_tensor([set_test_value(at.lscalar(), np.array(v)) for v in [3, 2]]),
-        ),
-        (
-            set_test_value(at.vector(), rng.random(size=(2,)).astype(config.floatX)),
-            [at.as_tensor(3, dtype=np.int8), at.as_tensor(2, dtype=np.int64)],
-        ),
-    ],
-)
-def test_BroadcastTo(x, shape):
-    g = extra_ops.BroadcastTo()(x, shape)
-    g_fg = FunctionGraph(outputs=[g])
-
-    compare_numba_and_py(
-        g_fg,
-        [
-            i.tag.test_value
-            for i in g_fg.inputs
-            if not isinstance(i, (SharedVariable, Constant))
-        ],
-    )
-
-
-@pytest.mark.parametrize(
     "val, axis, mode",
     [
         (

--- a/tests/tensor/rewriting/test_basic.py
+++ b/tests/tensor/rewriting/test_basic.py
@@ -272,27 +272,6 @@ class TestLocalCanonicalizeAlloc:
     def setup_method(self):
         self.rng = np.random.default_rng(utt.fetch_seed())
 
-    def test_inconsistent_constant(self):
-        x = at.as_tensor(self.rng.standard_normal((3, 7)))
-        a = at.alloc(x, 6, 7)
-
-        assert a.owner and isinstance(a.owner.op, Alloc)
-
-        # `local_useless_alloc` should attempt to replace the `Alloc` with an
-        # `Assert` and fail when the static shape information conflicts.
-        with pytest.raises(TypeError):
-            f = function([], a, mode=rewrite_mode)
-
-        x = at.as_tensor(self.rng.standard_normal((6, 7)))
-        a = at.alloc(x, 6, 7)
-
-        f = function([], a, mode=rewrite_mode)
-
-        # The rewrite should then be applied, and remove Alloc
-        assert not any(
-            isinstance(node.op, (Alloc, Assert)) for node in f.maker.fgraph.toposort()
-        )
-
     def test_inconsistent_shared(self):
         # These shapes don't match!
         x = shared(self.rng.standard_normal((3, 7)))

--- a/tests/tensor/rewriting/test_basic.py
+++ b/tests/tensor/rewriting/test_basic.py
@@ -1933,3 +1933,17 @@ class TestLocalElemwiseAlloc:
         x_val = np.random.random((1, 5)).astype(self.dtype)
         exp_res = np.broadcast_to(x_val, (5, 5))[..., None] + y_val
         assert np.array_equal(func(y_val, x_val), exp_res)
+
+
+def test_shape_unsafe_tag():
+    mode = get_mode("FAST_RUN")
+    x = vector("x")
+    y = vector("y")
+    out = x * y / y
+
+    fn = function([x, y], out, mode=mode)
+    np.testing.assert_equal(fn([0, 1], [2, 3, 4]), [0, 1])
+
+    fn = function([x, y], out, mode=mode.excluding("shape_unsafe"))
+    with pytest.raises(ValueError):
+        fn([0, 1], [2, 3, 4]), [0, 1]

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -835,6 +835,22 @@ class TestAlloc:
         assert y_new.shape.eval({x_new: x_new_test}) == (100,)
         assert y_new.eval({x_new: x_new_test}).shape == (100,)
 
+    def test_static_shape(self):
+        x = tensor(shape=(None, 1, 5))
+        d0 = scalar("d0", dtype=int)
+        d1 = scalar("d1", dtype=int)
+        assert at.alloc(x, 3, 1, 5).type.shape == (3, 1, 5)
+        assert at.alloc(x, 3, 4, 5).type.shape == (3, 4, 5)
+        assert at.alloc(x, d0, d1, 5).type.shape == (None, None, 5)
+        assert at.alloc(x, d0, 1, d1).type.shape == (None, 1, 5)
+
+        msg = "Alloc static input type and target shape are incompatible"
+        with pytest.raises(ValueError, match=msg):
+            at.alloc(x, 3, 1, 1)
+
+        with pytest.raises(ValueError, match=msg):
+            at.alloc(x, 3, 1, 6)
+
 
 def test_infer_shape():
     with pytest.raises(TypeError, match="^Shapes must be scalar integers.*"):


### PR DESCRIPTION
* Remove `BroadcastTo` in favor of `Alloc`
* Address spoken inconsistencies between Second / Alloc in rewrites
* Add tag to easily exclude rewrites that can hide shape errors
* Simplify such rewrites
* Improve static shape of Alloc

Note that from a user standpoint, providing static shapes (via `vector("x", shape=(5,))` or `specify_shapes`) will many times reveal shape errors immediately (this is the case for 99% of PyMC models). In this case users should feel pretty safe about "shape_unsafe" rewrites because they aren't really masking anything that wasn't checked before already. 

`Alloc.make_node` now also raises early when it can see the provided shape is inconsistent. Alloc and Elemwise make up all of the tagged "shape_unsafe" rewrites so far.

With this PR, users can also do `mode=get_default_mode().excluding("shape_unsafe")` or add `shape_unsafe` to the `excluding` config to skip these rewrites at the cost of less optimizations.

Closes #367 

