### PR TITLE
Fix bug in `tag_solve_triangular` rewrite

### DIFF
--- a/pytensor/tensor/rewriting/linalg.py
+++ b/pytensor/tensor/rewriting/linalg.py
@@ -50,7 +50,7 @@ def inv_as_solve(fgraph, node):
 @register_stabilize
 @register_canonicalize
 @node_rewriter([Solve])
-def tag_solve_triangular(fgraph, node):
+def generic_solve_to_solve_triangular(fgraph, node):
     """
     If any solve() is applied to the output of a cholesky op, then
     replace it with a triangular solve.

--- a/pytensor/tensor/rewriting/linalg.py
+++ b/pytensor/tensor/rewriting/linalg.py
@@ -11,7 +11,7 @@ from pytensor.tensor.rewriting.basic import (
     register_specialize,
     register_stabilize,
 )
-from pytensor.tensor.slinalg import Cholesky, Solve, cholesky, solve
+from pytensor.tensor.slinalg import Cholesky, Solve, SolveTriangular, cholesky, solve
 
 
 logger = logging.getLogger(__name__)
@@ -52,29 +52,28 @@ def inv_as_solve(fgraph, node):
 @node_rewriter([Solve])
 def tag_solve_triangular(fgraph, node):
     """
-    If a general solve() is applied to the output of a cholesky op, then
+    If any solve() is applied to the output of a cholesky op, then
     replace it with a triangular solve.
 
     """
     if isinstance(node.op, Solve):
-        if node.op.assume_a == "gen":
-            A, b = node.inputs  # result is solution Ax=b
-            if A.owner and isinstance(A.owner.op, Cholesky):
-                if A.owner.op.lower:
-                    return [Solve(assume_a="sym", lower=True)(A, b)]
+        A, b = node.inputs  # result is solution Ax=b
+        if A.owner and isinstance(A.owner.op, Cholesky):
+            if A.owner.op.lower:
+                return [SolveTriangular(lower=True)(A, b)]
+            else:
+                return [SolveTriangular(lower=False)(A, b)]
+        if (
+            A.owner
+            and isinstance(A.owner.op, DimShuffle)
+            and A.owner.op.new_order == (1, 0)
+        ):
+            (A_T,) = A.owner.inputs
+            if A_T.owner and isinstance(A_T.owner.op, Cholesky):
+                if A_T.owner.op.lower:
+                    return [SolveTriangular(lower=False)(A, b)]
                 else:
-                    return [Solve(assume_a="sym", lower=False)(A, b)]
-            if (
-                A.owner
-                and isinstance(A.owner.op, DimShuffle)
-                and A.owner.op.new_order == (1, 0)
-            ):
-                (A_T,) = A.owner.inputs
-                if A_T.owner and isinstance(A_T.owner.op, Cholesky):
-                    if A_T.owner.op.lower:
-                        return [Solve(assume_a="sym", lower=False)(A, b)]
-                    else:
-                        return [Solve(assume_a="sym", lower=True)(A, b)]
+                    return [SolveTriangular(lower=True)(A, b)]
 
 
 @register_canonicalize

--- a/tests/tensor/rewriting/test_linalg.py
+++ b/tests/tensor/rewriting/test_linalg.py
@@ -94,10 +94,10 @@ def test_tag_solve_triangular():
     b2 = solve(U, x)
     f = pytensor.function([A, x], b1)
 
-    X = np.random.normal(size=(10, 10))
+    X = np.random.normal(size=(10, 10)).astype(config.floatX)
     X = X @ X.T
     X_chol = np.linalg.cholesky(X)
-    eye = np.eye(10)
+    eye = np.eye(10, dtype=config.floatX)
 
     if config.mode != "FAST_COMPILE":
         toposort = f.maker.fgraph.toposort()

--- a/tests/tensor/rewriting/test_linalg.py
+++ b/tests/tensor/rewriting/test_linalg.py
@@ -106,7 +106,9 @@ def test_tag_solve_triangular():
         assert not any(isinstance(op, Solve) for op in op_list)
         assert any(isinstance(op, SolveTriangular) for op in op_list)
 
-        assert_allclose(f(X, eye) @ X_chol, eye, atol=1e-8 if config.floatX.endswith('64') else 1e-4)
+        assert_allclose(
+            f(X, eye) @ X_chol, eye, atol=1e-8 if config.floatX.endswith("64") else 1e-4
+        )
 
     f = pytensor.function([A, x], b2)
 
@@ -115,7 +117,11 @@ def test_tag_solve_triangular():
         op_list = [node.op for node in toposort]
         assert not any(isinstance(op, Solve) for op in op_list)
         assert any(isinstance(op, SolveTriangular) for op in op_list)
-        assert_allclose(f(X, eye).T @ X_chol, eye, atol=1e-8 if config.floatX.endswith('64') else 1e-4)
+        assert_allclose(
+            f(X, eye).T @ X_chol,
+            eye,
+            atol=1e-8 if config.floatX.endswith("64") else 1e-4,
+        )
 
 
 def test_matrix_inverse_solve():

--- a/tests/tensor/rewriting/test_linalg.py
+++ b/tests/tensor/rewriting/test_linalg.py
@@ -106,7 +106,7 @@ def test_tag_solve_triangular():
         assert not any(isinstance(op, Solve) for op in op_list)
         assert any(isinstance(op, SolveTriangular) for op in op_list)
 
-        assert_allclose(f(X, eye) @ X_chol, eye, atol=1e-8)
+        assert_allclose(f(X, eye) @ X_chol, eye, atol=1e-8 if config.floatX.endswith('64') else 1e-4)
 
     f = pytensor.function([A, x], b2)
 
@@ -115,7 +115,7 @@ def test_tag_solve_triangular():
         op_list = [node.op for node in toposort]
         assert not any(isinstance(op, Solve) for op in op_list)
         assert any(isinstance(op, SolveTriangular) for op in op_list)
-        assert_allclose(f(X, eye).T @ X_chol, eye, atol=1e-8)
+        assert_allclose(f(X, eye).T @ X_chol, eye, atol=1e-8 if config.floatX.endswith('64') else 1e-4)
 
 
 def test_matrix_inverse_solve():

--- a/tests/tensor/rewriting/test_linalg.py
+++ b/tests/tensor/rewriting/test_linalg.py
@@ -82,7 +82,7 @@ def test_transinv_to_invtrans():
                 assert node.inputs[0].name == "X"
 
 
-def test_tag_solve_triangular():
+def test_generic_solve_to_solve_triangular():
     cholesky_lower = Cholesky(lower=True)
     cholesky_upper = Cholesky(lower=False)
     A = matrix("A")


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

### Motivation for these changes
Currently, the `tag_solve_trangular` rewrite looks for graphs like this:

```python
import pytensor
import pytensor.tensor as pt
import numpy as np
from numpy.testing import assert_allclose

A = pt.dmatrix('A')
b = pt.dmatrix('b')
L = pt.linalg.cholesky(A)
L_inv = pt.linalg.solve(L, b, assume_a='gen')
f = pytensor.function([A, b], [L_inv])

pytensor.dprint(L_inv)

Solve{assume_a='gen', lower=True, check_finite=True} [id A]
 ├─ Cholesky{lower=True, destructive=False, on_error='raise'} [id B]
 │  └─ A [id C]
 └─ b [id D]
```

And replaces then with this:
```python
pytensor.dprint(f)

Solve{assume_a='sym', lower=True, check_finite=True} [id A] 1
 ├─ Cholesky{lower=True, destructive=False, on_error='raise'} [id B] 0
 │  └─ A [id C]
 └─ b [id D]
```

The `Solve(assume_a='sym', lower=True)` solver was incorrectly assumed to be a triangular solver. In fact, it is a symmetric solver that **decomposes** the symmetric `A` matrix into a triangular matrix. But given a triangular matrix, it produces incorrect results. This can be verified directly by testing `L @ L_inv = eye`:

```
n = 3
Z = np.random.normal(size=(n, n))
P = Z @ Z.T
P_chol = np.linalg.cholesky(P)
eye = np.eye(n)

assert_allclose(f(P, eye) @ P_chol, eye) # fails
```

Actually, even before the rewrite this code fails, so there's something deeper going on:
```
assert_allclose(f(L_inv.eval({A:P, b:eye}) @ P_chol, eye) # also fails
```

But one step at a time. This PR replaces `Solve(assume_a='sym', lower=True)` with `SolveTriangular` in the `tag_solve_triangular` rewrite, and adds a test for correct computation to the rewrite. That computational test can be put somewhere else once we track down what's going on with `Solve` more generally, but it's a good stop-gap for now.


### Checklist
+ [ ] Explain motivation and implementation 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [ ] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇


## Major / Breaking Changes
- ...

## New features
- ...

## Bugfixes
- Graphs with a `Cholesky` `Op` followed by a `Solve` op will no longer be incorrectly computed.

## Documentation
- ...

## Maintenance
- ...

Closes #382 

