### PR TITLE
Don't try to infer support shape of multivariate RVs by default

### DIFF
--- a/pytensor/tensor/random/basic.py
+++ b/pytensor/tensor/random/basic.py
@@ -5,10 +5,13 @@ import numpy as np
 import scipy.stats as stats
 
 import pytensor
-from pytensor.tensor.basic import as_tensor_variable
-from pytensor.tensor.random.op import RandomVariable, default_supp_shape_from_params
+from pytensor.tensor.basic import as_tensor_variable, arange
+from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.random.type import RandomGeneratorType, RandomStateType
-from pytensor.tensor.random.utils import broadcast_params
+from pytensor.tensor.random.utils import (
+    broadcast_params,
+    supp_shape_from_ref_param_shape,
+)
 from pytensor.tensor.random.var import (
     RandomGeneratorSharedVariable,
     RandomStateSharedVariable,
@@ -855,6 +858,14 @@ class MvNormalRV(RandomVariable):
     dtype = "floatX"
     _print_name = ("MultivariateNormal", "\\operatorname{MultivariateNormal}")
 
+    def _supp_shape_from_params(self, dist_params, param_shapes=None):
+        return supp_shape_from_ref_param_shape(
+            ndim_supp=self.ndim_supp,
+            dist_params=dist_params,
+            param_shapes=param_shapes,
+            ref_param_idx=0,
+        )
+
     def __call__(self, mean=None, cov=None, size=None, **kwargs):
         r""" "Draw samples from a multivariate normal distribution.
 
@@ -932,6 +943,14 @@ class DirichletRV(RandomVariable):
     ndims_params = [1]
     dtype = "floatX"
     _print_name = ("Dirichlet", "\\operatorname{Dirichlet}")
+
+    def _supp_shape_from_params(self, dist_params, param_shapes=None):
+        return supp_shape_from_ref_param_shape(
+            ndim_supp=self.ndim_supp,
+            dist_params=dist_params,
+            param_shapes=param_shapes,
+            ref_param_idx=0,
+        )
 
     def __call__(self, alphas, size=None, **kwargs):
         r"""Draw samples from a dirichlet distribution.
@@ -1776,9 +1795,12 @@ class MultinomialRV(RandomVariable):
         """
         return super().__call__(n, p, size=size, **kwargs)
 
-    def _supp_shape_from_params(self, dist_params, rep_param_idx=1, param_shapes=None):
-        return default_supp_shape_from_params(
-            self.ndim_supp, dist_params, rep_param_idx, param_shapes
+    def _supp_shape_from_params(self, dist_params, param_shapes=None):
+        return supp_shape_from_ref_param_shape(
+            ndim_supp=self.ndim_supp,
+            dist_params=dist_params,
+            param_shapes=param_shapes,
+            ref_param_idx=1,
         )
 
     @classmethod

--- a/pytensor/tensor/random/utils.py
+++ b/pytensor/tensor/random/utils.py
@@ -323,7 +323,7 @@ def supp_shape_from_ref_param_shape(
         raise ValueError("ndim_supp must be greater than 0")
     if param_shapes is not None:
         ref_param = param_shapes[ref_param_idx]
-        return (ref_param[-ndim_supp],)
+        return tuple(ref_param[i] for i in range(-ndim_supp, 0))
     else:
         ref_param = dist_params[ref_param_idx]
         if ref_param.ndim < ndim_supp:

--- a/tests/tensor/random/test_basic.py
+++ b/tests/tensor/random/test_basic.py
@@ -1413,6 +1413,14 @@ def test_permutation_samples():
     compare_sample_values(permutation, np.array([1.0, 2.0, 3.0], dtype=config.floatX))
 
 
+def test_permutation_shape():
+    assert tuple(permutation(5).shape.eval()) == (5,)
+    assert tuple(permutation(np.arange(5)).shape.eval()) == (5,)
+    assert tuple(permutation(np.arange(10).reshape(2, 5)).shape.eval()) == (2, 5)
+    assert tuple(permutation(5, size=(2, 3)).shape.eval()) == (2, 3, 5)
+    assert tuple(permutation(np.arange(5), size=(2, 3)).shape.eval()) == (2, 3, 5)
+
+
 @config.change_flags(compute_test_value="off")
 def test_pickle():
     # This is an interesting `Op` case, because it has `None` types and a

--- a/tests/tensor/random/test_op.py
+++ b/tests/tensor/random/test_op.py
@@ -6,12 +6,7 @@ from pytensor import config, function
 from pytensor.gradient import NullTypeGradError, grad
 from pytensor.raise_op import Assert
 from pytensor.tensor.math import eq
-from pytensor.tensor.random.op import (
-    RandomState,
-    RandomVariable,
-    default_rng,
-    default_supp_shape_from_params,
-)
+from pytensor.tensor.random.op import RandomState, RandomVariable, default_rng
 from pytensor.tensor.shape import specify_shape
 from pytensor.tensor.type import all_dtypes, iscalar, tensor
 
@@ -20,29 +15,6 @@ from pytensor.tensor.type import all_dtypes, iscalar, tensor
 def set_pytensor_flags():
     with config.change_flags(cxx="", compute_test_value="raise"):
         yield
-
-
-def test_default_supp_shape_from_params():
-    with pytest.raises(ValueError, match="^ndim_supp*"):
-        default_supp_shape_from_params(0, (np.array([1, 2]), 0))
-
-    res = default_supp_shape_from_params(
-        1, (np.array([1, 2]), np.eye(2)), rep_param_idx=0
-    )
-    assert res == (2,)
-
-    res = default_supp_shape_from_params(
-        1, (np.array([1, 2]), 0), param_shapes=((2,), ())
-    )
-    assert res == (2,)
-
-    with pytest.raises(ValueError, match="^Reference parameter*"):
-        default_supp_shape_from_params(1, (np.array(1),), rep_param_idx=0)
-
-    res = default_supp_shape_from_params(
-        2, (np.array([1, 2]), np.ones((2, 3, 4))), rep_param_idx=1
-    )
-    assert res == (3, 4)
 
 
 def test_RandomVariable_basics():

--- a/tests/tensor/random/test_utils.py
+++ b/tests/tensor/random/test_utils.py
@@ -313,3 +313,11 @@ def test_supp_shape_from_ref_param_shape():
         ref_param_idx=1,
     )
     assert res == (3, 4)
+
+    res = supp_shape_from_ref_param_shape(
+        ndim_supp=2,
+        dist_params=(np.array([1, 2]), np.ones((2, 3, 4))),
+        param_shapes=((2,), (2, 3, 4)),
+        ref_param_idx=1,
+    )
+    assert res == (3, 4)

--- a/tests/tensor/rewriting/test_linalg.py
+++ b/tests/tensor/rewriting/test_linalg.py
@@ -94,7 +94,8 @@ def test_generic_solve_to_solve_triangular():
     b2 = solve(U, x)
     f = pytensor.function([A, x], b1)
 
-    X = np.random.normal(size=(10, 10)).astype(config.floatX)
+    rng = np.random.default_rng(97)
+    X = rng.normal(size=(10, 10)).astype(config.floatX)
     X = X @ X.T
     X_chol = np.linalg.cholesky(X)
     eye = np.eye(10, dtype=config.floatX)


### PR DESCRIPTION
The default method is not robust and can lead to cryptic error messages.

In a discussion with a user https://discourse.pymc.io/t/pm-sample-prior-predictive-fails-with-incorrect-size-info-passed-to-the-rng-fn-function-of-the-randomvariable/12513 , they were trying to fake a multivariate distribution as a univariate because of the cryptic error induced by the default method.

We now raise `NotImplementedError` by default, and include illustrative examples in the docstrings that should help users implementing this method.

Also fixed a couple of minor bugs.

The changes will break RVs that relied on the default implementation. This should be easy to fix and won't go unnoticed.