### PR TITLE
Extend ExtractDiag gradient and numba implementation to higher dimensional inputs

### DIFF
--- a/pytensor/link/jax/dispatch/tensor_basic.py
+++ b/pytensor/link/jax/dispatch/tensor_basic.py
@@ -8,7 +8,6 @@ from pytensor.link.jax.dispatch.basic import jax_funcify
 from pytensor.tensor import get_vector_length
 from pytensor.tensor.basic import (
     Alloc,
-    AllocDiag,
     AllocEmpty,
     ARange,
     ExtractDiag,
@@ -30,16 +29,6 @@ by JAX. An example of a graph that can be compiled to JAX:
 >>> import pytensor.tensor basic
 >>> at.arange(1, 10, 2)
 """
-
-
-@jax_funcify.register(AllocDiag)
-def jax_funcify_AllocDiag(op, **kwargs):
-    offset = op.offset
-
-    def allocdiag(v, offset=offset):
-        return jnp.diag(v, k=offset)
-
-    return allocdiag
 
 
 @jax_funcify.register(AllocEmpty)

--- a/pytensor/link/numba/dispatch/basic.py
+++ b/pytensor/link/numba/dispatch/basic.py
@@ -59,7 +59,6 @@ def global_numba_func(func):
 
 
 def numba_njit(*args, **kwargs):
-    kwargs = kwargs.copy()
     kwargs.setdefault("cache", config.numba__cache)
 
     if len(args) > 0 and callable(args[0]):

--- a/pytensor/link/numba/dispatch/tensor_basic.py
+++ b/pytensor/link/numba/dispatch/tensor_basic.py
@@ -7,7 +7,6 @@ from pytensor.link.numba.dispatch.basic import create_tuple_string, numba_funcif
 from pytensor.link.utils import compile_function_src, unique_name_generator
 from pytensor.tensor.basic import (
     Alloc,
-    AllocDiag,
     AllocEmpty,
     ARange,
     ExtractDiag,
@@ -91,17 +90,6 @@ def alloc(val, {", ".join(shape_var_names)}):
     alloc_fn = compile_function_src(alloc_def_src, "alloc", {**globals(), **global_env})
 
     return numba_basic.numba_njit(alloc_fn)
-
-
-@numba_funcify.register(AllocDiag)
-def numba_funcify_AllocDiag(op, **kwargs):
-    offset = op.offset
-
-    @numba_basic.numba_njit(inline="always")
-    def allocdiag(v):
-        return np.diag(v, k=offset)
-
-    return allocdiag
 
 
 @numba_funcify.register(ARange)

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -3630,7 +3630,7 @@ def diag(v, k=0):
     A helper function for two ops: `ExtractDiag` and
     `AllocDiag`. The name `diag` is meant to keep it consistent
     with numpy. It both accepts tensor vector and tensor matrix.
-    While the passed tensor variable `v` has `v.ndim>=2`, it builds a
+    While the passed tensor variable `v` has `v.ndim==2`, it builds a
     `ExtractDiag` instance, and returns a vector with its entries equal to
     `v`'s main diagonal; otherwise if `v.ndim` is `1`, it builds an `AllocDiag`
     instance, and returns a matrix with `v` at its k-th diaogonal.
@@ -3651,10 +3651,10 @@ def diag(v, k=0):
 
     if _v.ndim == 1:
         return AllocDiag(k)(_v)
-    elif _v.ndim >= 2:
+    elif _v.ndim == 2:
         return diagonal(_v, offset=k)
     else:
-        raise ValueError("Number of dimensions of `v` must be greater than one.")
+        raise ValueError("Input must be 1- or 2-d.")
 
 
 def stacklists(arg):

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -3408,6 +3408,12 @@ class ExtractDiag(Op):
         if self.view:
             self.view_map = {0: [0]}
         self.offset = offset
+        if axis1 < 0 or axis2 < 0:
+            raise NotImplementedError(
+                "ExtractDiag does not support negative axis. Use pytensor.tensor.diagonal instead."
+            )
+        if axis1 == axis2:
+            raise ValueError("axis1 and axis2 cannot be the same")
         self.axis1 = axis1
         self.axis2 = axis2
 
@@ -3502,6 +3508,8 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
     tensor : symbolic tensor
 
     """
+    a = as_tensor_variable(a)
+    axis1, axis2 = normalize_axis_tuple((axis1, axis2), ndim=a.type.ndim)
     return ExtractDiag(offset, axis1, axis2)(a)
 
 
@@ -3529,6 +3537,10 @@ class AllocDiag(Op):
             the diagonals will be allocated.  Defaults to second axis (i.e. 1).
         """
         self.offset = offset
+        if axis1 < 0 or axis2 < 0:
+            raise NotImplementedError("AllocDiag does not support negative axis")
+        if axis1 == axis2:
+            raise ValueError("axis1 and axis2 cannot be the same")
         self.axis1 = axis1
         self.axis2 = axis2
 

--- a/tests/link/jax/test_slinalg.py
+++ b/tests/link/jax/test_slinalg.py
@@ -85,7 +85,7 @@ def test_jax_basic():
         ],
     )
 
-    out = at.diag(at.specify_shape(b, shape=(10,)))
+    out = at.diag(b)
     out_fg = FunctionGraph([b], [out])
     compare_jax_and_py(out_fg, [np.arange(10).astype(config.floatX)])
 

--- a/tests/link/jax/test_slinalg.py
+++ b/tests/link/jax/test_slinalg.py
@@ -85,7 +85,7 @@ def test_jax_basic():
         ],
     )
 
-    out = at.diag(b)
+    out = at.diag(at.specify_shape(b, shape=(10,)))
     out_fg = FunctionGraph([b], [out])
     compare_jax_and_py(out_fg, [np.arange(10).astype(config.floatX)])
 

--- a/tests/link/jax/test_tensor_basic.py
+++ b/tests/link/jax/test_tensor_basic.py
@@ -63,6 +63,13 @@ def test_arange():
     compare_jax_and_py(fgraph, [])
 
 
+def test_arange_of_shape():
+    x = vector("x")
+    out = at.arange(1, x.shape[-1], 2)
+    fgraph = FunctionGraph([x], [out])
+    compare_jax_and_py(fgraph, [np.zeros((5,))])
+
+
 def test_arange_nonconcrete():
     """JAX cannot JIT-compile `jax.numpy.arange` when arguments are not concrete values."""
 

--- a/tests/link/numba/test_tensor_basic.py
+++ b/tests/link/numba/test_tensor_basic.py
@@ -58,28 +58,6 @@ def test_AllocEmpty():
 
 
 @pytest.mark.parametrize(
-    "v, offset",
-    [
-        (set_test_value(at.vector(), np.arange(10, dtype=config.floatX)), 0),
-        (set_test_value(at.vector(), np.arange(10, dtype=config.floatX)), 1),
-        (set_test_value(at.vector(), np.arange(10, dtype=config.floatX)), -1),
-    ],
-)
-def test_AllocDiag(v, offset):
-    g = atb.AllocDiag(offset=offset)(v)
-    g_fg = FunctionGraph(outputs=[g])
-
-    compare_numba_and_py(
-        g_fg,
-        [
-            i.tag.test_value
-            for i in g_fg.inputs
-            if not isinstance(i, (SharedVariable, Constant))
-        ],
-    )
-
-
-@pytest.mark.parametrize(
     "v", [set_test_value(aes.float64(), np.array(1.0, dtype="float64"))]
 )
 def test_TensorFromScalar(v):

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -3714,6 +3714,14 @@ class TestAllocDiag:
                 assert np.all(true_grad_input == grad_input)
 
 
+def test_diagonal_negative_axis():
+    x = np.arange(2 * 3 * 3).reshape((2, 3, 3))
+    np.testing.assert_allclose(
+        at.diagonal(x, axis1=-1, axis2=-2).eval(),
+        np.diagonal(x, axis1=-1, axis2=-2),
+    )
+
+
 def test_transpose():
     x1 = dvector("x1")
     x2 = dmatrix("x2")

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -3593,16 +3593,17 @@ class TestDiag:
             # The right matrix is created
             assert (r == v).all()
 
-        # Test scalar input
-        xx = scalar()
-        with pytest.raises(ValueError):
-            diag(xx)
-
         # Test passing a list
         xx = [[1, 2], [3, 4]]
         g = diag(xx)
         f = function([], g)
         assert np.array_equal(f(), np.diag(xx))
+
+    @pytest.mark.parametrize("inp", (scalar, tensor3))
+    def test_diag_invalid_input_ndim(self, inp):
+        x = inp()
+        with pytest.raises(ValueError, match="Input must be 1- or 2-d."):
+            diag(x)
 
 
 class TestExtractDiag:


### PR DESCRIPTION
* Extend ExtractDiag gradient to all cases
  * Fixes wrong gradient for negative offsets  
* Fix/extend ExtractDiag Numba implementation to all cases
* Deprecate AllocDiag Op and use symbolic graph instead
  * Gets rid of wrong Numba and JAX implementations 
  * Extra: do not raise in JAX dispatch of Arange, when a non-constant input comes from a shape