### PR TITLE
Don't include `local_uint_constant_indices` rewrite in JAX mode due to XLA bug

### DIFF
--- a/pytensor/compile/mode.py
+++ b/pytensor/compile/mode.py
@@ -451,7 +451,14 @@ JAX = Mode(
     JAXLinker(),
     RewriteDatabaseQuery(
         include=["fast_run", "jax"],
-        exclude=["cxx_only", "BlasOpt", "fusion", "inplace"],
+        # TODO: "local_uint_constant_indices" can be reintroduced once https://github.com/google/jax/issues/16836 is fixed.
+        exclude=[
+            "cxx_only",
+            "BlasOpt",
+            "fusion",
+            "inplace",
+            "local_uint_constant_indices",
+        ],
     ),
 )
 NUMBA = Mode(


### PR DESCRIPTION
Temporarily minimizes #395 

Graphs may still fail if users explicitly create `uint` indexes but that's not very likely, and anyway it's a JAX bug.

