### PR TITLE
Add numpy constants to pytensor.tensor scope

### DIFF
--- a/pytensor/tensor/__init__.py
+++ b/pytensor/tensor/__init__.py
@@ -148,5 +148,8 @@ from pytensor.tensor.type import *  # noqa
 from pytensor.tensor.type_other import *  # noqa
 from pytensor.tensor.var import TensorConstant, TensorVariable  # noqa
 
+# Allow accessing numpy constants from pytensor.tensor
+from numpy import e, euler_gamma, inf, infty, nan, newaxis, pi  # noqa
+
 
 __all__ = ["random"]  # noqa: F405


### PR DESCRIPTION
One can thus write:

```python
import pytensor.tensor as pt

x = pt.scalar("x")
y = x * pt.pi
```