### PR TITLE
Fix typo in profile summary printing function

### DIFF
--- a/pytensor/graph/rewriting/basic.py
+++ b/pytensor/graph/rewriting/basic.py
@@ -2640,7 +2640,7 @@ class EquilibriumGraphRewriter(NodeProcessingGraphRewriter):
         gf_rewrites = [
             o
             for o in (
-                rewrite.global_rewrites
+                rewrite.global_rewriters
                 + list(rewrite.final_rewriters)
                 + list(rewrite.cleanup_rewriters)
             )

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -459,3 +459,10 @@ def test_Print(capsys):
 
     stdout, stderr = capsys.readouterr()
     assert "hello" in stdout
+
+
+def test_summary():
+    old_profile_optimizer_config_value = pytensor.config.profile_optimizer = True
+    f = pytensor.function(inputs=[], outputs=[], profile=True)
+    f.profile.summary()
+    pytensor.config.profile_optimizer = old_profile_optimizer_config_value


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

The following fails on `main` because of a typo in an attribute name in the method `print_profile` of `EquilibriumGraphRewriter`:

``` python
import pytensor
pytensor.config.profile_optimizer = True
f = pytensor.function(inputs=[], outputs=[], profile=True)
f.profile.summary()
```


### Checklist
+ [x] Explain motivation and implementation 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇


## Major / Breaking Changes
- ...

## New features
- ...

## Bugfixes
- Fix optimization profile printing

## Documentation
- ...

## Maintenance
- ...

