### PR TITLE
Deprecate `extract_diag` and `linalg.trace` in favor of numpy look-alikes

### DIFF
--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -3376,6 +3376,7 @@ def inverse_permutation(perm):
     )
 
 
+# TODO: optimization to insert ExtractDiag with view=True
 class ExtractDiag(Op):
     """
     Return specified diagonals.
@@ -3526,8 +3527,12 @@ class ExtractDiag(Op):
             self.axis2 = 1
 
 
-extract_diag = ExtractDiag()
-# TODO: optimization to insert ExtractDiag with view=True
+def extract_diag(x):
+    warnings.warn(
+        "pytensor.tensor.extract_diag is deprecated. Use pytensor.tensor.diagonal instead.",
+        FutureWarning,
+    )
+    return diagonal(x)
 
 
 def diagonal(a, offset=0, axis1=0, axis2=1):
@@ -3552,6 +3557,15 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
     a = as_tensor_variable(a)
     axis1, axis2 = normalize_axis_tuple((axis1, axis2), ndim=a.type.ndim)
     return ExtractDiag(offset, axis1, axis2)(a)
+
+
+def trace(a, offset=0, axis1=0, axis2=1):
+    """
+    Returns the sum along diagonals of the array.
+
+    Equivalent to `numpy.trace`
+    """
+    return diagonal(a, offset=offset, axis1=axis1, axis2=axis2).sum(-1)
 
 
 class AllocDiag(Op):
@@ -4254,6 +4268,7 @@ __all__ = [
     "full_like",
     "empty",
     "empty_like",
+    "trace",
     "tril_indices",
     "tril_indices_from",
     "triu_indices",

--- a/pytensor/tensor/nlinalg.py
+++ b/pytensor/tensor/nlinalg.py
@@ -1,3 +1,4 @@
+import warnings
 from functools import partial
 from typing import Tuple
 
@@ -9,7 +10,7 @@ from pytensor.graph.basic import Apply
 from pytensor.graph.op import Op
 from pytensor.tensor import basic as at
 from pytensor.tensor import math as tm
-from pytensor.tensor.basic import as_tensor_variable, extract_diag
+from pytensor.tensor.basic import as_tensor_variable, diagonal
 from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.type import dvector, lscalar, matrix, scalar, vector
 
@@ -175,7 +176,11 @@ def trace(X):
     """
     Returns the sum of diagonal elements of matrix X.
     """
-    return extract_diag(X).sum()
+    warnings.warn(
+        "pytensor.tensor.linalg.trace is deprecated. Use pytensor.tensor.trace instead.",
+        FutureWarning,
+    )
+    return diagonal(X).sum()
 
 
 class Det(Op):

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -77,6 +77,7 @@ from pytensor.tensor.basic import (
     tensor_copy,
     tensor_from_scalar,
     tile,
+    trace,
     tri,
     tril,
     tril_indices,
@@ -4489,3 +4490,23 @@ def test_oriented_stack_functions(func):
 
     with pytest.raises(ValueError):
         func(a, a)
+
+
+def test_trace():
+    x_val = np.ones((5, 4, 2))
+    x = at.as_tensor(x_val)
+
+    np.testing.assert_allclose(
+        trace(x).eval(),
+        np.trace(x_val),
+    )
+
+    np.testing.assert_allclose(
+        trace(x, offset=1, axis1=1, axis2=2).eval(),
+        np.trace(x_val, offset=1, axis1=1, axis2=2),
+    )
+
+    np.testing.assert_allclose(
+        trace(x, offset=-1, axis1=0, axis2=-1).eval(),
+        np.trace(x_val, offset=-1, axis1=0, axis2=-1),
+    )

--- a/tests/tensor/test_blockwise.py
+++ b/tests/tensor/test_blockwise.py
@@ -235,7 +235,11 @@ class BlockwiseOpTester:
                 )
                 pt_out = pt_func(*vec_inputs_testvals)
                 np_out = np_funcs[test_input_idx](*vec_inputs_testvals)
-                np.testing.assert_allclose(pt_out, np_out, atol=1e-6)
+                np.testing.assert_allclose(
+                    pt_out,
+                    np_out,
+                    atol=1e-6 if config.floatX == "float64" else 1e-5,
+                )
 
 
 class MatrixOpBlockwiseTester(BlockwiseOpTester):

--- a/tests/tensor/test_nlinalg.py
+++ b/tests/tensor/test_nlinalg.py
@@ -291,7 +291,8 @@ def test_slogdet():
 def test_trace():
     rng = np.random.default_rng(utt.fetch_seed())
     x = matrix()
-    g = trace(x)
+    with pytest.warns(FutureWarning):
+        g = trace(x)
     f = pytensor.function([x], g)
 
     for shp in [(2, 3), (3, 2), (3, 3)]:
@@ -302,7 +303,8 @@ def test_trace():
     xx = vector()
     ok = False
     try:
-        trace(xx)
+        with pytest.warns(FutureWarning):
+            trace(xx)
     except TypeError:
         ok = True
     except ValueError:

--- a/tests/tensor/test_variable.py
+++ b/tests/tensor/test_variable.py
@@ -351,7 +351,8 @@ class TestTensorInstanceMethods:
     def test_trace(self):
         X, _ = self.vars
         x, _ = self.vals
-        assert_array_equal(X.trace().eval({X: x}), x.trace())
+        with pytest.warns(FutureWarning):
+            assert_array_equal(X.trace().eval({X: x}), x.trace())
 
     def test_ravel(self):
         X, _ = self.vars


### PR DESCRIPTION
Provide the same function names and behavior as numpy to reduce confusion