### PR TITLE
Fix bug in `local_dimshuffle_subtensor` rewrite

### DIFF
--- a/tests/tensor/rewriting/test_uncanonicalize.py
+++ b/tests/tensor/rewriting/test_uncanonicalize.py
@@ -214,3 +214,11 @@ def test_local_dimshuffle_subtensor():
     assert x[:, :, 0:3, ::-1].dimshuffle(0, 2, 3).eval(
         {x: np.ones((5, 1, 6, 7))}
     ).shape == (5, 3, 7)
+
+    # Test dropped sliced dimensions
+    x = matrix("x", shape=(5, 4), dtype="float64")
+
+    assert x[2:3, :-2].dimshuffle(1).eval({x: np.ones(x.type.shape)}).shape == (2,)
+    assert x[:1, 0:3].dimshuffle(1).eval({x: np.ones(x.type.shape)}).shape == (3,)
+    assert x[-1:, :].dimshuffle(1).eval({x: np.ones(x.type.shape)}).shape == (4,)
+    assert x[4:3:-1, 1:].dimshuffle(1).eval({x: np.ones(x.type.shape)}).shape == (3,)


### PR DESCRIPTION
This showed up now that we improved the static type of subtensors and there are more cases where we can "squeeze" degenerate dims coming out of subtensor operations.

Showed up in https://github.com/pymc-devs/pymc/pull/6897