### PR TITLE
Implementation of Maxwell RV

### DIFF
--- a/doc/library/tensor/random/basic.rst
+++ b/doc/library/tensor/random/basic.rst
@@ -124,6 +124,9 @@ PyTensor can produce :class:`RandomVariable`\s that draw samples from many diffe
 .. autoclass:: pytensor.tensor.random.basic.LogNormalRV
    :members: __call__
 
+.. autoclass:: pytensor.tensor.random.basic.MaxwellRV
+   :members: __call__
+
 .. autoclass:: pytensor.tensor.random.basic.MultinomialRV
    :members: __call__
 

--- a/pytensor/link/jax/dispatch/random.py
+++ b/pytensor/link/jax/dispatch/random.py
@@ -146,6 +146,7 @@ def jax_sample_fn_generic(op):
 @jax_sample_fn.register(aer.LogisticRV)
 @jax_sample_fn.register(aer.NormalRV)
 @jax_sample_fn.register(aer.StandardNormalRV)
+@jax_sample_fn.register(aer.MaxwellRV)
 def jax_sample_fn_loc_scale(op):
     """JAX implementation of random variables in the loc-scale families.
 

--- a/pytensor/link/numba/dispatch/random.py
+++ b/pytensor/link/numba/dispatch/random.py
@@ -194,6 +194,7 @@ def {sized_fn_name}({random_fn_input_names}):
 @numba_funcify.register(aer.BetaRV)
 @numba_funcify.register(aer.NormalRV)
 @numba_funcify.register(aer.LogNormalRV)
+@numba_funcify.register(aer.MaxwellRV)
 @numba_funcify.register(aer.GammaRV)
 @numba_funcify.register(aer.ChiSquareRV)
 @numba_funcify.register(aer.ParetoRV)

--- a/pytensor/tensor/random/basic.py
+++ b/pytensor/tensor/random/basic.py
@@ -419,6 +419,63 @@ class LogNormalRV(RandomVariable):
 lognormal = LogNormalRV()
 
 
+class MaxwellRV(ScipyRandomVariable):
+    r"""A Maxwellian continuous random variable.
+
+    The probability density function for `maxwell` in terms of its parameters :math:`\mu`
+    and :math:`\sigma` is:
+
+    .. math::
+
+        f(x; \mu, \sigma) = \sqrt{\frac{2}{\pi}}\frac{(x-\mu)^2 \exp\left\{-(x-\mu)^2/(2\sigma^2)\}}{\sigma^3}
+
+    for :math:`x \geq 0` and :math:`\sigma > 0`
+
+    """
+    name = "maxwell"
+    ndim_supp = 0
+    ndims_params = [0, 0]
+    dtype = "floatX"
+    _print_name = ("Maxwell", "\\operatorname{Maxwell}")
+
+    def __call__(self, loc, scale, size=None, **kwargs):
+        r"""Draw samples from a Maxwell distribution.
+
+        Signature
+        ---------
+
+        `(), () -> ()`
+
+        Parameters
+        ----------
+        loc
+            Location parameter :math:`\mu` of the distribution.
+        scale
+            Scale parameter :math:`\sigma` of the distribution. Must be
+            positive.
+        size
+            Sample shape. If the given size is, e.g. `(m, n, k)` then `m * n * k`
+            independent, identically distributed random variables are
+            returned. Default is `None` in which case a single random variable
+            is returned.
+
+        """
+        return super().__call__(loc, scale, size=size, **kwargs)
+
+    @classmethod
+    def rng_fn_scipy(
+        cls,
+        rng: Union[np.random.Generator, np.random.RandomState],
+        loc: Union[np.ndarray, float],
+        scale: Union[np.ndarray, float],
+        size: Optional[Union[List[int], int]],
+    ) -> np.ndarray:
+        return stats.maxwell.rvs(loc=loc, scale=scale, size=size, random_state=rng)
+
+
+maxwell = MaxwellRV()
+
+
 class GammaRV(ScipyRandomVariable):
     r"""A gamma continuous random variable.
 
@@ -2157,6 +2214,7 @@ __all__ = [
     "lognormal",
     "halfnormal",
     "normal",
+    "maxwell",
     "beta",
     "triangular",
     "uniform",

--- a/pytensor/tensor/random/basic.py
+++ b/pytensor/tensor/random/basic.py
@@ -427,7 +427,7 @@ class MaxwellRV(ScipyRandomVariable):
 
     .. math::
 
-        f(x; \mu, \sigma) = \sqrt{\frac{2}{\pi}}\frac{(x-\mu)^2 \exp\left\{-(x-\mu)^2/(2\sigma^2)\}}{\sigma^3}
+        f(x; \mu, \sigma) = \sqrt{\frac{2}{\pi}}\frac{(x-\mu)^2 e^{-(x-\mu)^2/(2\sigma^2)}}{\sigma^3}
 
     for :math:`x \geq 0` and :math:`\sigma > 0`
 

--- a/tests/link/jax/test_random.py
+++ b/tests/link/jax/test_random.py
@@ -214,6 +214,22 @@ def test_random_updates_input_storage_order():
             lambda mu, sigma: (sigma, 0, np.exp(mu)),
         ),
         (
+            aer.maxwell,
+            [
+                set_test_value(
+                    at.lvector(),
+                    np.array([1, 2], dtype=np.int64),
+                ),
+                set_test_value(
+                    at.dscalar(),
+                    np.array(1.0, dtype=np.float64),
+                ),
+            ],
+            (2,),
+            "maxwell",
+            lambda *args: args,
+        ),
+        (
             aer.normal,
             [
                 set_test_value(

--- a/tests/link/numba/test_random.py
+++ b/tests/link/numba/test_random.py
@@ -85,6 +85,22 @@ rng = np.random.default_rng(42849)
             ],
             at.as_tensor([3, 2]),
         ),
+        (
+            aer.maxwell,
+            [
+                set_test_value(
+                    at.dvector(),
+                    np.array([1.0, 2.0], dtype=np.float64),
+                ),
+                set_test_value(
+                    at.dscalar(),
+                    np.array(1.0, dtype=np.float64),
+                ),
+            ],
+            (2,),
+            "maxwell",
+            lambda *args: args,
+        ),
         pytest.param(
             aer.pareto,
             [

--- a/tests/tensor/random/test_basic.py
+++ b/tests/tensor/random/test_basic.py
@@ -40,6 +40,7 @@ from pytensor.tensor.random.basic import (
     laplace,
     logistic,
     lognormal,
+    maxwell,
     multinomial,
     multivariate_normal,
     nbinom,
@@ -336,6 +337,24 @@ def test_halfnormal_samples(mean, sigma, size):
 )
 def test_lognormal_samples(mean, sigma, size):
     compare_sample_values(lognormal, mean, sigma, size=size)
+
+
+@pytest.mark.parametrize(
+    "loc, sigma, size",
+    [
+        (np.array(0, dtype=config.floatX), np.array(1, dtype=config.floatX), None),
+        (np.array(0, dtype=config.floatX), np.array(1, dtype=config.floatX), []),
+        (
+            np.full((1, 2), 0, dtype=config.floatX),
+            np.array(1, dtype=config.floatX),
+            None,
+        ),
+    ],
+)
+def test_maxwell_samples(loc, sigma, size):
+    compare_sample_values(
+        maxwell, loc, sigma, size=size, test_fn=fixed_scipy_rvs("maxwell")
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

### Motivation for these changes
Following [this discussion](https://github.com/pymc-devs/pymc/discussions/6905), I have submitted this PR to implement a random variable (RV) that follows a [Maxwell distribution](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.maxwell.html). The Maxwell distribution appears often in physical systems and having access to it in `pymc` and `pytensor` would be generally useful.

### Implementation details
I have attempted to simply follow the style for other RV implementations that extend `ScipyRandomVariable`. I have also added tests to `tests/tensor/random/test_basic.py`, which is now running (slowly...).

I've added the relevant implementation and tests to `numba` and `jax`, but I would appreciate someone double checking what I've done since I was unsuccessful in running `tests/link/numba/test_random.py`, and `tests/link/jax/test_random.py` (the tests are skipped, probably because I don't have `jax`/`numba` set up in my environment).

### Checklist
+ [X] Explain motivation and implementation 👆
+ [X] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [X] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [X] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [X] Are the changes covered by tests and docstrings?
+ [X] Fill out the short summary sections 👇


## Major / Breaking Changes
- None

## New features
- New `MaxwellRV` implementation

## Bugfixes
- None

## Documentation
- Included docstrings as necessary

## Maintenance
- N/A

