### PR TITLE
Change default blas_info dictionary in cmodule

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ channels:
 dependencies:
   - python
   - compilers
-  - numpy>=1.17.0,<1.26.0
+  - numpy>=1.17.0
   - scipy>=0.14
   - filelock
   - etuples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ keywords = [
 dependencies = [
     "setuptools>=48.0.0",
     "scipy>=0.14",
-    "numpy>=1.17.0,<1.26",
+    "numpy>=1.17.0",
     "filelock",
     "etuples",
     "logical-unification",


### PR DESCRIPTION
Closes #441 

### Motivation for these changes

`numpy.__config__.get_info` has been deprecated and removed, so we have to set default link libraries some other way.

### Implementation details

This is a very rough first implementation. The idea is to use something like python's `sys.path` to look for libraries files (this would match a conda env lib folder and also the system level python lib folders, I still need to figure out what to do with venvs). Then look for some default libraries to link against, like mkl or openblas. I added LAPACK, but maybe the c code that is generated by `pytensor` doesn't have the proper includes to be able to link against that.

I haven't changed any other code yet, but the long term goal would be to remove most of the blas ldflag logic from the startup. In particular, I flagged a couple of platforms for deprecation (EPD and Canopy, which I think are no longer developed anyway)


### Checklist
+ [X] Explain motivation and implementation 👆
+ [X] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [X] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [X] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [x] Are the changes covered by tests and docstrings?
+ [X] Fill out the short summary sections 👇


## Major / Breaking Changes
- `default_blas_ldflags` has changed and might give different default link flags. It no longer looks at `numpy` for blas information, but rather searches some common system paths to try to find BLAS libraries to link against. The order of priorities is 1) MKL, 2) OPENBLAS, 3) LAPACK, 4) BLAS

## New features
- ...

## Bugfixes
- ...

## Documentation
- ...

## Maintenance
- ...

