### PR TITLE
Extend cholesky of triangular dot rewrite to matmul Ops

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -49,7 +49,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.0
+        uses: pypa/cibuildwheel@v2.14.1
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Also restrict to 2D Dot cases

Also reverts #455 