### PR TITLE
Do not invert Gamma rate and fix JAX implementation of Gamma and Pareto

### DIFF
--- a/pytensor/link/jax/dispatch/random.py
+++ b/pytensor/link/jax/dispatch/random.py
@@ -216,21 +216,20 @@ def jax_sample_fn_uniform(op):
 
 @jax_sample_fn.register(aer.ParetoRV)
 @jax_sample_fn.register(aer.GammaRV)
-def jax_sample_fn_shape_rate(op):
-    """JAX implementation of random variables in the shape-rate family.
+def jax_sample_fn_shape_scale(op):
+    """JAX implementation of random variables in the shape-scale family.
 
     JAX only implements the standard version of random variables in the
-    shape-rate family. We thus need to rescale the results manually.
+    shape-scale family. We thus need to rescale the results manually.
 
     """
     name = op.name
     jax_op = getattr(jax.random, name)
 
-    def sample_fn(rng, size, dtype, *parameters):
+    def sample_fn(rng, size, dtype, shape, scale):
         rng_key = rng["jax_state"]
         rng_key, sampling_key = jax.random.split(rng_key, 2)
-        (shape, rate) = parameters
-        sample = jax_op(sampling_key, shape, size, dtype) / rate
+        sample = jax_op(sampling_key, shape, size, dtype) * scale
         rng["jax_state"] = rng_key
         return (rng, sample)
 

--- a/tests/link/jax/test_random.py
+++ b/tests/link/jax/test_random.py
@@ -4,7 +4,7 @@ import scipy.stats as stats
 
 import pytensor
 import pytensor.tensor as at
-import pytensor.tensor.random as aer
+import pytensor.tensor.random.basic as aer
 from pytensor.compile.function import function
 from pytensor.compile.sharedvalue import SharedVariable, shared
 from pytensor.graph.basic import Constant
@@ -140,15 +140,15 @@ def test_random_updates_input_storage_order():
             lambda *args: (0, args[0]),
         ),
         (
-            aer.gamma,
+            aer._gamma,
             [
                 set_test_value(
                     at.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
                 set_test_value(
-                    at.dscalar(),
-                    np.array(1.0, dtype=np.float64),
+                    at.dvector(),
+                    np.array([0.5, 3.0], dtype=np.float64),
                 ),
             ],
             (2,),
@@ -235,11 +235,15 @@ def test_random_updates_input_storage_order():
                 set_test_value(
                     at.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
-                )
+                ),
+                set_test_value(
+                    at.dvector(),
+                    np.array([2.0, 10.0], dtype=np.float64),
+                ),
             ],
             (2,),
             "pareto",
-            lambda *args: args,
+            lambda shape, scale: (shape, 0.0, scale),
         ),
         (
             aer.poisson,

--- a/tests/link/numba/test_random.py
+++ b/tests/link/numba/test_random.py
@@ -92,6 +92,10 @@ rng = np.random.default_rng(42849)
                     at.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
+                set_test_value(
+                    at.dvector(),
+                    np.array([2.0, 10.0], dtype=np.float64),
+                ),
             ],
             at.as_tensor([3, 2]),
             marks=pytest.mark.xfail(reason="Not implemented"),
@@ -316,15 +320,15 @@ def test_aligned_RandomVariable(rv_op, dist_args, size):
             lambda *args: args,
         ),
         (
-            aer.gamma,
+            aer._gamma,
             [
                 set_test_value(
                     at.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
                 set_test_value(
-                    at.dscalar(),
-                    np.array(1.0, dtype=np.float64),
+                    at.dvector(),
+                    np.array([0.5, 3.0], dtype=np.float64),
                 ),
             ],
             (2,),


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

### Motivation for these changes
The current implementation of `GammaRV` inverts the passed `rate` (`beta`) parameter upon each call. This breaks functionality in `pymc` [as described in this bug report](https://github.com/pymc-devs/pymc/issues/6931). ~~This PR changes the parameterization so that we only invert `beta` when we draw samples. Along with [this pytensor PR](https://github.com/pymc-devs/pymc/pull/6934), the bug is fixed.~~ This PR changes the parameterization to store `scale` (`1/beta`) and adds a helper function to convert `rate` to `scale` and warn the use that `rate` is deprecated.

### Implementation details
No changes to API.


### Checklist
+ [X] Explain motivation and implementation 👆
+ [X] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [X] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [X] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [X] Are the changes covered by tests and docstrings?
+ [X] Fill out the short summary sections 👇


## Major / Breaking Changes
- ~~Store `beta` directly rather than its inverse.~~ Store `scale` directly. There are no changes to the API.

## New features
- N/A

## Bugfixes
- [Fixes this bug](https://github.com/pymc-devs/pymc/issues/6931)

## Documentation
- N/A

## Maintenance
- N/A

