### PR TITLE
Correctly report the elemwise output type in Numba

### DIFF
--- a/pytensor/link/numba/dispatch/elemwise.py
+++ b/pytensor/link/numba/dispatch/elemwise.py
@@ -604,12 +604,16 @@ def _vectorized(
             builder, sig.return_type, [out._getvalue() for out in outputs]
         )
 
-    ret_type = types.Tuple(
-        [
-            types.Array(numba.from_dtype(np.dtype(dtype)), ndim, "C")
-            for dtype in output_dtypes
-        ]
-    )
+    ret_types = [
+        types.Array(numba.from_dtype(np.dtype(dtype)), ndim, "C")
+        for dtype in output_dtypes
+    ]
+
+    for output_idx, input_idx in inplace_pattern:
+        ret_types[output_idx] = input_types[input_idx]
+
+    ret_type = types.Tuple(ret_types)
+
     if len(output_dtypes) == 1:
         ret_type = ret_type.types[0]
     sig = ret_type(*arg_types)

--- a/tests/link/numba/test_elemwise.py
+++ b/tests/link/numba/test_elemwise.py
@@ -605,3 +605,18 @@ def test_fused_elemwise_benchmark(benchmark):
     # JIT compile first
     func()
     benchmark(func)
+
+
+def test_elemwise_out_type():
+    # Create a graph with an elemwise
+    # Ravel failes if the elemwise output type is reported incorrectly
+    x = at.matrix()
+    y = (2 * x).ravel()
+
+    # Pass in the input as mutable, to trigger the inplace rewrites
+    func = pytensor.function([pytensor.In(x, mutable=True)], y, mode="NUMBA")
+
+    # Apply it to a numpy array that is neither C or F contigous
+    x_val = np.broadcast_to(np.zeros((3,)), (6, 3))
+
+    assert func(x_val).shape == (18,)


### PR DESCRIPTION
Fix a bug where inplace operations in numba mode could lead to a mismatch between reported and actual numba types, which then lead to errors like the following:


```python
import pymc as pm
import pytensor
import numpy as np

with pm.Model() as model:
    pm.ZeroSumNormal("x", shape=(3, 7))

dlogp = model.dlogp()
func_fail = pytensor.function(model.value_vars, [dlogp], mode=pytensor.compile.mode.NUMBA)

func_fail(np.zeros((3, 6)))
```

```
---------------------------------------------------------------------------
NotImplementedError                       Traceback (most recent call last)
File ~/git/pytensor/pytensor/link/utils.py:202, in streamline.<locals>.streamline_default_f()
    199 for thunk, node, old_storage in zip(
    200     thunks, order, post_thunk_old_storage
    201 ):
--> 202     thunk()
    203     for old_s in old_storage:

File ~/git/pytensor/pytensor/link/basic.py:669, in JITLinker.create_jitable_thunk.<locals>.thunk(fgraph, fgraph_jit, thunk_inputs, thunk_outputs)
    663 def thunk(
    664     fgraph=self.fgraph,
    665     fgraph_jit=fgraph_jit,
    666     thunk_inputs=thunk_inputs,
    667     thunk_outputs=thunk_outputs,
    668 ):
--> 669     outputs = fgraph_jit(*[x[0] for x in thunk_inputs])
    671     for o_var, o_storage, o_val in zip(fgraph.outputs, thunk_outputs, outputs):

NotImplementedError: incompatible shape for array
...
```