### PR TITLE
Explicitly prevent Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ name = "pytensor"
 dynamic = [
   'version'
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.12"
 authors = [
     {name = "pymc-devs", email = "pymc.devs@gmail.com"}
 ]


### PR DESCRIPTION
To discuss: If we don't support 3.12, maybe we should enforce this here in `pyproject.toml`?

I'm not convinced that this is the right move since it might slightly hinder testing. But if we are explicit, then this seems to me like the correct place for it.

<!-- !! Thank your for opening a PR !! -->

### Motivation for these changes
Source: <https://github.com/pymc-devs/pytensor/issues/441#issuecomment-1752718880>

### Checklist
+ [X] Explain motivation and implementation 👆
+ [X] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [X] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [X] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [ ] Are the changes covered by tests and docstrings?
+ [X] Fill out the short summary sections 👇


## Major / Breaking Changes
- ...

## New features
- ...

## Bugfixes
- ...

## Documentation
- ...

## Maintenance
- Put explicit Python version upper-bound

