### PR TITLE
[471] adding case for log1mexp(log1mexp(x)) -> x

### DIFF
--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -362,6 +362,13 @@ def local_exp_log_nan_switch(fgraph, node):
         old_out = node.outputs[0]
         new_out = switch(le(x, 0), sub(1, exp(x)), np.asarray(np.nan, old_out.dtype))
         return [new_out]
+    
+    # Case for log1mexp(log1mexp(x)) -> x
+    if isinstance(prev_op, aes_math.Log1mexp) and isinstance(node_op, aes_math.Log1mexp):
+        x = x.owner.inputs[0]
+        old_out = node.outputs[0]
+        new_out = switch(le(x, 0), x, np.asarray(np.nan, old_out.dtype))
+        return [new_out]
 
     # Case for expm1(log1mexp(x)) -> -exp(x)
     if isinstance(prev_op, aes_math.Log1mexp) and isinstance(node_op, aes.Expm1):


### PR DESCRIPTION
### Small rewrite changes to allow pytensor to cancel iterative applications of the log1mexp() function as it caused  issues  in the application of pm.Censored on the Weibull distribution: https://github.com/pymc-devs/pymc-examples/pull/580

...

I've added a new case to the existing math re-write functions as discussed with @ricardoV94 
...


### Checklist
+ [ ] Explain motivation and implementation 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [ ] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [ ] Are the changes covered by tests and docstrings?
+ [X] Fill out the short summary sections 👇


## Major / Breaking Changes

NA
- ...

## New features

NA
- ...

## Bugfixes

NA
- ...

## Documentation

NA
- ...

## Maintenance
NA

