### PR TITLE
Add specialization rewrite for solve with batched b

### DIFF
--- a/tests/tensor/rewriting/test_linalg.py
+++ b/tests/tensor/rewriting/test_linalg.py
@@ -1,7 +1,6 @@
 from functools import partial
 
 import numpy as np
-import numpy.linalg
 import pytest
 import scipy.linalg
 from numpy.testing import assert_allclose
@@ -17,7 +16,16 @@ from pytensor.tensor.elemwise import DimShuffle
 from pytensor.tensor.math import _allclose, dot, matmul
 from pytensor.tensor.nlinalg import Det, MatrixInverse, matrix_inverse
 from pytensor.tensor.rewriting.linalg import inv_as_solve
-from pytensor.tensor.slinalg import Cholesky, Solve, SolveTriangular, cholesky, solve
+from pytensor.tensor.slinalg import (
+    Cholesky,
+    Solve,
+    SolveBase,
+    SolveTriangular,
+    cho_solve,
+    cholesky,
+    solve,
+    solve_triangular,
+)
 from pytensor.tensor.type import dmatrix, matrix, tensor, vector
 from tests import unittest_tools as utt
 from tests.test_rop import break_op
@@ -231,3 +239,70 @@ def test_local_det_chol():
     f = function([X], [L, det_X, X])
     nodes = f.maker.fgraph.toposort()
     assert not any(isinstance(node, Det) for node in nodes)
+
+
+class TestBatchedVectorBSolveToMatrixBSolve:
+    rewrite_name = "batched_vector_b_solve_to_matrix_b_solve"
+
+    @staticmethod
+    def any_vector_b_solve(fn):
+        return any(
+            (
+                isinstance(node.op, Blockwise)
+                and isinstance(node.op.core_op, SolveBase)
+                and node.op.core_op.b_ndim == 1
+            )
+            for node in fn.maker.fgraph.apply_nodes
+        )
+
+    @pytest.mark.parametrize("solve_op", (solve, solve_triangular, cho_solve))
+    def test_valid_cases(self, solve_op):
+        rng = np.random.default_rng(sum(map(ord, solve_op.__name__)))
+
+        a = tensor(shape=(None, None))
+        b = tensor(shape=(None, None, None))
+
+        if solve_op is cho_solve:
+            # cho_solves expects a tuple (a, lower) as the first input
+            out = solve_op((a, True), b, b_ndim=1)
+        else:
+            out = solve_op(a, b, b_ndim=1)
+
+        mode = get_default_mode().excluding(self.rewrite_name)
+        ref_fn = pytensor.function([a, b], out, mode=mode)
+        assert self.any_vector_b_solve(ref_fn)
+
+        mode = get_default_mode().including(self.rewrite_name)
+        opt_fn = pytensor.function([a, b], out, mode=mode)
+        assert not self.any_vector_b_solve(opt_fn)
+
+        test_a = rng.normal(size=(3, 3)).astype(config.floatX)
+        test_b = rng.normal(size=(7, 5, 3)).astype(config.floatX)
+        np.testing.assert_allclose(
+            opt_fn(test_a, test_b),
+            ref_fn(test_a, test_b),
+            rtol=1e-7 if config.floatX == "float64" else 1e-5,
+        )
+
+    def test_invalid_batched_a(self):
+        rng = np.random.default_rng(sum(map(ord, self.rewrite_name)))
+
+        # Rewrite is not applicable if a has batched dims
+        a = tensor(shape=(None, None, None))
+        b = tensor(shape=(None, None, None))
+
+        out = solve(a, b, b_ndim=1)
+
+        mode = get_default_mode().including(self.rewrite_name)
+        opt_fn = pytensor.function([a, b], out, mode=mode)
+        assert self.any_vector_b_solve(opt_fn)
+
+        ref_fn = np.vectorize(np.linalg.solve, signature="(m,m),(m)->(m)")
+
+        test_a = rng.normal(size=(5, 3, 3)).astype(config.floatX)
+        test_b = rng.normal(size=(7, 5, 3)).astype(config.floatX)
+        np.testing.assert_allclose(
+            opt_fn(test_a, test_b),
+            ref_fn(test_a, test_b),
+            rtol=1e-7 if config.floatX == "float64" else 1e-5,
+        )

--- a/tests/tensor/test_blockwise.py
+++ b/tests/tensor/test_blockwise.py
@@ -257,6 +257,8 @@ class BlockwiseOpTester:
             np.testing.assert_allclose(
                 pt_func(*vec_inputs_testvals),
                 np_func(*vec_inputs_testvals),
+                rtol=1e-7 if config.floatX == "float64" else 1e-5,
+                atol=1e-7 if config.floatX == "float64" else 1e-5,
             )
 
     def test_grad(self):
@@ -288,6 +290,7 @@ class BlockwiseOpTester:
                 np.testing.assert_allclose(
                     pt_out,
                     np_out,
+                    rtol=1e-7 if config.floatX == "float64" else 1e-5,
                     atol=1e-6 if config.floatX == "float64" else 1e-5,
                 )
 

--- a/tests/tensor/test_blockwise.py
+++ b/tests/tensor/test_blockwise.py
@@ -88,7 +88,7 @@ def test_runtime_broadcast(mode):
     check_blockwise_runtime_broadcasting(mode)
 
 
-class TestOp(Op):
+class MyTestOp(Op):
     def make_node(self, *inputs):
         return Apply(self, inputs, [i.type() for i in inputs])
 
@@ -96,7 +96,7 @@ class TestOp(Op):
         raise NotImplementedError("Test Op should not be present in final graph")
 
 
-test_op = TestOp()
+test_op = MyTestOp()
 
 
 def test_vectorize_node_default_signature():
@@ -106,12 +106,12 @@ def test_vectorize_node_default_signature():
 
     vect_node = vectorize_node(node, mat, mat)
     assert isinstance(vect_node.op, Blockwise) and isinstance(
-        vect_node.op.core_op, TestOp
+        vect_node.op.core_op, MyTestOp
     )
     assert vect_node.op.signature == ("(i00),(i10,i11)->(o00),(o10,o11)")
 
     with pytest.raises(
-        ValueError, match="Signature not provided nor found in core_op TestOp"
+        ValueError, match="Signature not provided nor found in core_op MyTestOp"
     ):
         Blockwise(test_op)
 
@@ -138,7 +138,7 @@ def test_blockwise_shape():
 
     shape_fn = pytensor.function([inp], out.shape)
     assert not any(
-        isinstance(getattr(n.op, "core_op", n.op), TestOp)
+        isinstance(getattr(n.op, "core_op", n.op), MyTestOp)
         for n in shape_fn.maker.fgraph.apply_nodes
     )
     assert tuple(shape_fn(inp_test)) == (5, 3, 4)
@@ -150,13 +150,13 @@ def test_blockwise_shape():
 
     shape_fn = pytensor.function([inp], out.shape)
     assert any(
-        isinstance(getattr(n.op, "core_op", n.op), TestOp)
+        isinstance(getattr(n.op, "core_op", n.op), MyTestOp)
         for n in shape_fn.maker.fgraph.apply_nodes
     )
 
     shape_fn = pytensor.function([inp], out.shape[:-1])
     assert not any(
-        isinstance(getattr(n.op, "core_op", n.op), TestOp)
+        isinstance(getattr(n.op, "core_op", n.op), MyTestOp)
         for n in shape_fn.maker.fgraph.apply_nodes
     )
     assert tuple(shape_fn(inp_test)) == (5, 4)
@@ -174,20 +174,20 @@ def test_blockwise_shape():
 
     shape_fn = pytensor.function([inp1, inp2], [out.shape for out in outs])
     assert any(
-        isinstance(getattr(n.op, "core_op", n.op), TestOp)
+        isinstance(getattr(n.op, "core_op", n.op), MyTestOp)
         for n in shape_fn.maker.fgraph.apply_nodes
     )
 
     shape_fn = pytensor.function([inp1, inp2], outs[0].shape)
     assert not any(
-        isinstance(getattr(n.op, "core_op", n.op), TestOp)
+        isinstance(getattr(n.op, "core_op", n.op), MyTestOp)
         for n in shape_fn.maker.fgraph.apply_nodes
     )
     assert tuple(shape_fn(inp1_test, inp2_test)) == (7, 5, 3, 4)
 
     shape_fn = pytensor.function([inp1, inp2], [outs[0].shape, outs[1].shape[:-1]])
     assert not any(
-        isinstance(getattr(n.op, "core_op", n.op), TestOp)
+        isinstance(getattr(n.op, "core_op", n.op), MyTestOp)
         for n in shape_fn.maker.fgraph.apply_nodes
     )
     assert tuple(shape_fn(inp1_test, inp2_test)[0]) == (7, 5, 3, 4)


### PR DESCRIPTION
Related to https://github.com/pymc-devs/pymc/issues/6993 and https://discourse.pymc.io/t/version-dependant-slowing-down-of-gaussian-mixture-sampling-in-ubuntu-20-04/13219

This PR adds a rewrite that optimizes solve when there is a batched vector b (b_ndim=1) and a single a. 
This form was previously used for the logp of MvNormal in PyMC and is potentially much faster when the batched dimensions of b are large. More importantly the grad will look better. 

I have a couple of other PRs that improve the blockwise grads for the truly new supported cases, but that it's slower work.

PS: Obviously we should also implement the JAX Ops https://github.com/pymc-devs/pytensor/issues/430, but this looks like a nice optimization, specially if it solves the regression described in the discourse issue above.