### PR TITLE
Extend sum of mul rewrite for multiple axis

### DIFF
--- a/tests/tensor/rewriting/test_elemwise.py
+++ b/tests/tensor/rewriting/test_elemwise.py
@@ -899,7 +899,7 @@ class TestFusion:
                 ),
                 (fx, fy),
                 (fxv, fyv),
-                3,
+                2,
                 (
                     np.sum(-((fxv - fyv) ** 2) / 2),
                     -(fxv - fyv),


### PR DESCRIPTION
Extend the Sum of Mul rewrite beyond the scalar case. We extract variables that have only degenerate dims along the reduced dimensions. In the case of a total sum only scalars can be pulled out, which was exactly the case supported by the old rewrite.

I am not so hot on the Prod of Mul rewrite, but since it was there already, we keep it. This actually fixes a bug when the prod only does a partial reduction, in which case the old logic of raising the extracted values to the power of the whole inner size was wrong. I added a test that failed in main in the first commit. The expanded rewrite comes up in the second commit, and fixes the failing test.

I also separated the rewrite for Sum(-mul) since it shares almost no logic with the larger rewrite. The usefulness of generalizing this rewrite showed up when exploring the grad of the batched MvNormal logp/dlogp in #482 .

And finally, I merged this with the nearly identical rewrite for sum of div, that already handled multiple axes