### PR TITLE
Add `set` and `add` TensorVariable methods for `set_subtensor` and `inc_subtensor` operations`

### DIFF
--- a/pytensor/tensor/variable.py
+++ b/pytensor/tensor/variable.py
@@ -594,6 +594,11 @@ class _tensor_py_operators:
                     ),
                 )
 
+    def __setitem__(self, key, value):
+        raise TypeError(
+            "TensorVariable does not support item assignment. Use the output of `set` or `add` instead."
+        )
+
     def take(self, indices, axis=None, mode="raise"):
         return at.subtensor.take(self, indices, axis, mode)
 

--- a/pytensor/tensor/variable.py
+++ b/pytensor/tensor/variable.py
@@ -816,7 +816,9 @@ class _tensor_py_operators:
         return at.extra_ops.compress(self, a, axis=axis)
 
     def set(self, y, **kwargs):
-        """Set values to y, where y is the output of an index operation.
+        """Return a copy of a tensor with the indexed values set to y.
+
+        Self must be the output of an indexing operation.
 
         Equivalent to set_subtensor(self, y). See docstrings for kwargs.
 
@@ -829,9 +831,11 @@ class _tensor_py_operators:
         return at.subtensor.set_subtensor(self, y, **kwargs)
 
     def add(self, y, **kwargs):
-        """Add values to y, where y is the output of an index operation.
+        """Return a copy of a tensor with the indexed values incremented by y.
 
-        Equivalent to inc_subtensor(self, y). See docstrings for kwargs
+        Self must be the output of an indexing operation.
+
+        Equivalent to inc_subtensor(self, y). See docstrings for kwargs.
 
         Examples
         --------

--- a/pytensor/tensor/variable.py
+++ b/pytensor/tensor/variable.py
@@ -820,35 +820,36 @@ class _tensor_py_operators:
         """Return selected slices only."""
         return at.extra_ops.compress(self, a, axis=axis)
 
-    def set(self, y, **kwargs):
-        """Return a copy of a tensor with the indexed values set to y.
+    def set(self, idx, y, **kwargs):
+        """Return a copy of self with the indexed values set to y.
 
-        Self must be the output of an indexing operation.
+        Equivalent to set_subtensor(self[idx], y). See docstrings for kwargs.
 
-        Equivalent to set_subtensor(self, y). See docstrings for kwargs.
+        Examples
+        --------
+        >>> import pytensor.tensor as pt
+        >>>
+        >>> x = pt.ones((3,))
+        >>> out = x.set(1, 2)
+        >>> out.eval()  # array([1., 2., 1.])
+        """
+        return at.subtensor.set_subtensor(self[idx], y, **kwargs)
+
+    def add(self, idx, y, **kwargs):
+        """Return a copy of self with the indexed values incremented by y.
+
+        Equivalent to inc_subtensor(self[idx], y). See docstrings for kwargs.
 
         Examples
         --------
 
-        >>> x = matrix()
-        >>> out = x[0].set(5)
+        >>> import pytensor.tensor as pt
+        >>>
+        >>> x = pt.ones((3,))
+        >>> out = x.add(1, 2)
+        >>> out.eval()  # array([1., 3., 1.])
         """
-        return at.subtensor.set_subtensor(self, y, **kwargs)
-
-    def add(self, y, **kwargs):
-        """Return a copy of a tensor with the indexed values incremented by y.
-
-        Self must be the output of an indexing operation.
-
-        Equivalent to inc_subtensor(self, y). See docstrings for kwargs.
-
-        Examples
-        --------
-
-        >>> x = matrix()
-        >>> out = x[0].add(5)
-        """
-        return at.inc_subtensor(self, y, **kwargs)
+        return at.inc_subtensor(self[idx], y, **kwargs)
 
 
 class TensorVariable(

--- a/tests/tensor/test_variable.py
+++ b/tests/tensor/test_variable.py
@@ -438,14 +438,8 @@ class TestTensorInstanceMethods:
         idx = [0]
         y = 5
 
-        assert equal_computations([x[idx].set(y)], [set_subtensor(x[idx], y)])
-        assert equal_computations([x[idx].add(y)], [inc_subtensor(x[idx], y)])
-
-        msg = "must be the result of a subtensor operation"
-        with pytest.raises(TypeError, match=msg):
-            x.set(y)
-        with pytest.raises(TypeError, match=msg):
-            x.add(y)
+        assert equal_computations([x.set(idx, y)], [set_subtensor(x[idx], y)])
+        assert equal_computations([x.add(idx, y)], [inc_subtensor(x[idx], y)])
 
     def test_set_item_error(self):
         x = matrix("x")

--- a/tests/tensor/test_variable.py
+++ b/tests/tensor/test_variable.py
@@ -447,6 +447,15 @@ class TestTensorInstanceMethods:
         with pytest.raises(TypeError, match=msg):
             x.add(y)
 
+    def test_set_item_error(self):
+        x = matrix("x")
+
+        msg = "Use the output of `set` or `add` instead."
+        with pytest.raises(TypeError, match=msg):
+            x[0] = 5
+        with pytest.raises(TypeError, match=msg):
+            x[0] += 5
+
 
 def test_deprecated_import():
     with pytest.warns(


### PR DESCRIPTION
Changes #493 

New API:
```python
import pytensor.tensor as pt

x = pt.matrix()
y = x.set(0, 5)  # Equivalent to `y = pt.set_subtensor(x[0], 5)`
y = x.add(0, 5)  # Equivalent to `y = pt.inc_subtensor(x[0], 5)`
```