### PR TITLE
Rename `add` `inc_subtensor` helper method to `inc`

### DIFF
--- a/pytensor/tensor/variable.py
+++ b/pytensor/tensor/variable.py
@@ -835,7 +835,7 @@ class _tensor_py_operators:
         """
         return at.subtensor.set_subtensor(self[idx], y, **kwargs)
 
-    def add(self, idx, y, **kwargs):
+    def inc(self, idx, y, **kwargs):
         """Return a copy of self with the indexed values incremented by y.
 
         Equivalent to inc_subtensor(self[idx], y). See docstrings for kwargs.
@@ -846,7 +846,7 @@ class _tensor_py_operators:
         >>> import pytensor.tensor as pt
         >>>
         >>> x = pt.ones((3,))
-        >>> out = x.add(1, 2)
+        >>> out = x.inc(1, 2)
         >>> out.eval()  # array([1., 3., 1.])
         """
         return at.inc_subtensor(self[idx], y, **kwargs)

--- a/tests/tensor/test_variable.py
+++ b/tests/tensor/test_variable.py
@@ -433,13 +433,13 @@ class TestTensorInstanceMethods:
         # Test equivalent advanced indexing
         assert_array_equal(X[:, indices].eval({X: x}), x[:, indices])
 
-    def test_set_add(self):
+    def test_set_inc(self):
         x = matrix("x")
         idx = [0]
         y = 5
 
         assert equal_computations([x.set(idx, y)], [set_subtensor(x[idx], y)])
-        assert equal_computations([x.add(idx, y)], [inc_subtensor(x[idx], y)])
+        assert equal_computations([x.inc(idx, y)], [inc_subtensor(x[idx], y)])
 
     def test_set_item_error(self):
         x = matrix("x")


### PR DESCRIPTION
For consistency with the existing name. I also think it's more intuitive.