### PR TITLE
Use empty blas_ldflags if no cxx is configured

### DIFF
--- a/pytensor/link/c/cmodule.py
+++ b/pytensor/link/c/cmodule.py
@@ -2731,6 +2731,15 @@ def default_blas_ldflags():
             shell=True,
         )
         (stdout, stderr) = p.communicate(input=b"")
+        if p.returncode != 0:
+            warnings.warn(
+                "Pytensor cxx failed to communicate its search dirs. As a consequence, "
+                "it might not be possible to automatically determine the blas link flags to use.\n"
+                f"Command that was run: {config.cxx} -print-search-dirs\n"
+                f"Output printed to stderr: {stderr.decode(sys.stderr.encoding)}"
+            )
+            return []
+
         maybe_lib_dirs = [
             [pathlib.Path(p).resolve() for p in line[len("libraries: =") :].split(":")]
             for line in stdout.decode(sys.stdout.encoding).splitlines()

--- a/pytensor/link/c/cmodule.py
+++ b/pytensor/link/c/cmodule.py
@@ -2773,6 +2773,9 @@ def default_blas_ldflags():
         else:
             raise RuntimeError(f"Supplied flags {flags} failed to compile")
 
+    # If no compiler is available we default to empty ldflags
+    if not config.cxx:
+        return ""
     _std_lib_dirs = std_lib_dirs()
     if len(_std_lib_dirs) > 0:
         rpath = _std_lib_dirs[0]

--- a/tests/link/c/test_cmodule.py
+++ b/tests/link/c/test_cmodule.py
@@ -226,6 +226,11 @@ def test_default_blas_ldflags(
             )
 
 
+def test_default_blas_ldflags_no_cxx():
+    with pytensor.config.change_flags(cxx=""):
+        assert default_blas_ldflags() == ""
+
+
 @patch(
     "os.listdir", return_value=["mkl_core.1.dll", "mkl_rt.1.0.dll", "mkl_rt.1.1.lib"]
 )


### PR DESCRIPTION
Closes #504 



## Major / Breaking Changes
- ...

## New features
- ...

## Bugfixes
- Default blas_ldflags are empty if no compiler is configured

## Documentation
- ...

## Maintenance
- ...

