### PR TITLE
Faster `infer_static_shape`

### DIFF
--- a/pytensor/tensor/rewriting/basic.py
+++ b/pytensor/tensor/rewriting/basic.py
@@ -58,6 +58,7 @@ from pytensor.tensor.basic import (
     get_underlying_scalar_constant_value,
     join,
     ones_like,
+    register_infer_shape,
     switch,
     tensor_copy,
     zeros,
@@ -420,6 +421,7 @@ compile.optdb.register(
 )
 
 
+@register_infer_shape
 @register_canonicalize("fast_compile", "shape_unsafe")
 @register_useless("shape_unsafe")
 @node_rewriter([fill])
@@ -441,6 +443,7 @@ def local_useless_fill(fgraph, node):
         return [v]
 
 
+@register_infer_shape
 @register_specialize("shape_unsafe")
 @register_stabilize("shape_unsafe")
 @register_canonicalize("shape_unsafe")
@@ -530,6 +533,7 @@ compile.optdb.register(
 )
 
 
+@register_infer_shape
 @register_useless
 @register_canonicalize("fast_compile")
 @register_specialize
@@ -806,6 +810,7 @@ compile.optdb["useless"].register(
 )
 
 
+@register_infer_shape
 @register_specialize
 @register_canonicalize
 @register_useless
@@ -826,6 +831,7 @@ def local_join_1(fgraph, node):
 
 
 # TODO: merge in local_useless_join
+@register_infer_shape
 @register_useless
 @register_specialize
 @register_canonicalize
@@ -1066,6 +1072,7 @@ def local_merge_switch_same_cond(fgraph, node):
     ]
 
 
+@register_infer_shape
 @register_useless
 @register_canonicalize
 @register_specialize
@@ -1149,6 +1156,7 @@ register_stabilize(topo_constant_folding, "fast_compile", final_rewriter=True)
 register_specialize(topo_constant_folding, "fast_compile", final_rewriter=True)
 
 
+@register_infer_shape
 @register_canonicalize("fast_compile")
 @register_useless("fast_compile")
 @node_rewriter(None)
@@ -1157,6 +1165,7 @@ def local_view_op(fgraph, node):
         return node.inputs
 
 
+@register_infer_shape
 @register_useless
 @register_canonicalize
 @register_stabilize

--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -32,6 +32,7 @@ from pytensor.tensor.basic import (
     extract_constant,
     get_underlying_scalar_constant_value,
     ones_like,
+    register_infer_shape,
     switch,
     zeros_like,
 )
@@ -1745,6 +1746,7 @@ def local_reduce_join(fgraph, node):
         return [ret]
 
 
+@register_infer_shape
 @register_canonicalize("fast_compile", "local_cut_useless_reduce")
 @register_useless("local_cut_useless_reduce")
 @node_rewriter(ALL_REDUCE)

--- a/pytensor/tensor/rewriting/shape.py
+++ b/pytensor/tensor/rewriting/shape.py
@@ -25,6 +25,7 @@ from pytensor.tensor.basic import (
     constant,
     extract_constant,
     get_underlying_scalar_constant_value,
+    register_infer_shape,
     stack,
 )
 from pytensor.tensor.elemwise import DimShuffle, Elemwise
@@ -964,6 +965,7 @@ def local_reshape_lift(fgraph, node):
         return [e]
 
 
+@register_infer_shape
 @register_useless
 @register_canonicalize
 @node_rewriter([SpecifyShape])
@@ -990,6 +992,17 @@ def local_merge_consecutive_specify_shape(fgraph, node):
     return [specify_shape(inner_obj, shape)]
 
 
+@register_infer_shape
+@node_rewriter([Shape])
+def local_shape_ground(fgraph, node):
+    """Rewrite shape(x) -> make_vector(x.type.shape) when this is constant."""
+    [x] = node.inputs
+    static_shape = x.type.shape
+    if not any(dim is None for dim in static_shape):
+        return [stack([constant(dim, dtype="int64") for dim in static_shape])]
+
+
+@register_infer_shape
 @register_useless
 @register_canonicalize
 @node_rewriter([Shape])
@@ -1014,6 +1027,7 @@ def local_Shape_of_SpecifyShape(fgraph, node):
     return [stack(shape).astype(np.int64)]
 
 
+@register_infer_shape
 @register_canonicalize
 @register_specialize
 @node_rewriter([SpecifyShape])
@@ -1060,6 +1074,7 @@ def local_specify_shape_lift(fgraph, node):
         return new_out
 
 
+@register_infer_shape
 @register_useless
 @register_canonicalize
 @node_rewriter([Shape_i])
@@ -1079,6 +1094,7 @@ def local_Shape_i_ground(fgraph, node):
         return [as_tensor_variable(s_val, dtype=np.int64)]
 
 
+@register_infer_shape
 @register_specialize
 @register_canonicalize
 @node_rewriter([Shape])

--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -26,6 +26,7 @@ from pytensor.tensor.basic import (
     concatenate,
     extract_constant,
     get_underlying_scalar_constant_value,
+    register_infer_shape,
     switch,
 )
 from pytensor.tensor.elemwise import Elemwise
@@ -328,6 +329,7 @@ def local_subtensor_of_dot(fgraph, node):
     return [r]
 
 
+@register_infer_shape
 @register_useless
 @register_canonicalize
 @register_specialize
@@ -599,6 +601,7 @@ def local_subtensor_remove_broadcastable_index(fgraph, node):
         return [node.inputs[0].dimshuffle(tuple(remain_dim))]
 
 
+@register_infer_shape
 @register_useless
 @register_canonicalize
 @register_specialize
@@ -707,6 +710,7 @@ def local_subtensor_inc_subtensor(fgraph, node):
             return
 
 
+@register_infer_shape
 @register_specialize
 @register_canonicalize("fast_compile")
 @register_useless
@@ -785,6 +789,7 @@ def local_subtensor_make_vector(fgraph, node):
             pass
 
 
+@register_infer_shape
 @register_useless
 @register_canonicalize
 @register_specialize
@@ -1461,6 +1466,7 @@ def local_adv_sub1_adv_inc_sub1(fgraph, node):
     return [r2]
 
 
+@register_infer_shape
 @register_specialize
 @register_stabilize
 @register_canonicalize

--- a/scripts/mypy-failing.txt
+++ b/scripts/mypy-failing.txt
@@ -27,7 +27,6 @@ pytensor/tensor/random/basic.py
 pytensor/tensor/random/op.py
 pytensor/tensor/random/utils.py
 pytensor/tensor/rewriting/basic.py
-pytensor/tensor/shape.py
 pytensor/tensor/slinalg.py
 pytensor/tensor/subtensor.py
 pytensor/tensor/type.py


### PR DESCRIPTION
This method which is called every time we create an Alloc or RandomVariable Op, can be pretty slow, because it calls canonicalize + constant_folding on the shape graph, which can be pretty large sometimes. This can also be pretty wasteful if the shapes are already constant to begin with!

The utility is now much more targeted, using only rewrites that are directly relevant for static shape propagation. It also avoids doing costly C-compilation

This should result in much snappier creation of RandomVariables and rewrites