### PR TITLE
feat(useless-rewrite): Useless rewrite from `log1mexp(log1mexp(x))` to `x`

### DIFF
--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -332,6 +332,7 @@ def local_exp_log_nan_switch(fgraph, node):
 
     node_is_exp = isinstance(node_op, aes.Exp)
     node_is_expm1 = isinstance(node_op, aes.Expm1)
+    node_is_log1mexp = isinstance(node_op, aes_math.Log1mexp)
 
     def nan_switch(*, if_, substitute) -> list:
         """Reused inner function because these cases all have the same fallback."""
@@ -362,6 +363,9 @@ def local_exp_log_nan_switch(fgraph, node):
         elif node_is_expm1:
             # Case for expm1(log1mexp(x)) -> -exp(x)
             return nan_switch(if_=le(x, 0), substitute=neg(exp(x)))
+        elif node_is_log1mexp:
+            # Case for log1mexp(log1mexp(x)) -> x
+            return nan_switch(if_=ge(x, 0), substitute=x)
 
 
 @register_canonicalize


### PR DESCRIPTION
### Motivation for these changes

Picking up this ticket on the PyData Global 2023 OSS sprint :runner: 

- #471

The motivating issue concerned an issue using PyMC's `Censored` functionality which was traced back to the need for a "useless rewrite":

- replacing a $log(1 - exp(x))$ within another $log(1 - exp(x))$
  - i.e. a $log(1 - exp(log(1 - exp(x))))$
- by just an $x$.

### Implementation details

1. :broom: **refactor(nan switch): DRY out nan switch rewrite function, easier to follow important parts** :broom: 
- The first change is in preparation for adding a new case, which is to simplify the case handling (avoid repetition).
- This is achieved by putting an "inner function" (function within a function) that captures the `x` and `node` from the function body in its scope, meaning we don't need to pass them as parameters, so the body of each case becomes simpler
- Every case has a "nan switch", so this trick lets us avoid repeating ourselves but retaining clarity about the variables we're using.

2. :writing_hand:   **Add new useless rewrite case** :writing_hand: 

- The previous operation and the node operation are both going to be `log1mexp` for this case
- The condition for the case is that x >= 0 (**confirm?**)

### Checklist
+ [x] Explain motivation and implementation 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇


## Major / Breaking Changes
- N/A

## New features
- "Useless rewrite" to optimise $log(1 - exp(log(1 - exp(x))))$ into just $x$

## Bugfixes
- Would resolve #471

## Documentation
- ...

## Maintenance
- Took an opportunity to tidy up the 'nan switch' cases into a dict, which is clearer to read than the repetitive if blocks