### PR TITLE
Replace pre-commit linters (flake8, isort, black, ...) with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,14 @@ repos:
     hooks:
       - id: pyupgrade
         args: [--py39-plus]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.7
+    hooks:
+      # Run the linter
+      - id: ruff
+        args: [ --fix ]
+      # Run the formatter
+      - id: ruff-format
   - repo: https://github.com/psf/black
     rev: 23.1.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,35 +32,35 @@ repos:
         args: [ --fix ]
       # Run the formatter
       - id: ruff-format
-  - repo: https://github.com/psf/black
-    rev: 23.1.0
-    hooks:
-      - id: black
-        language_version: python3
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-comprehensions
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-  - repo: https://github.com/humitos/mirrors-autoflake.git
-    rev: v1.1
-    hooks:
-      - id: autoflake
-        exclude: |
-          (?x)^(
-              .*/?__init__\.py|
-              pytensor/graph/toolbox\.py|
-              pytensor/link/jax/jax_dispatch\.py|
-              pytensor/link/jax/jax_linker\.py|
-              pytensor/scalar/basic_scipy\.py|
-              pytensor/tensor/linalg\.py
-          )$
-        args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']
+  # - repo: https://github.com/psf/black
+  #   rev: 23.1.0
+  #   hooks:
+  #     - id: black
+  #       language_version: python3
+  # - repo: https://github.com/pycqa/flake8
+  #   rev: 6.0.0
+  #   hooks:
+  #     - id: flake8
+  #       additional_dependencies:
+  #         - flake8-comprehensions
+  # - repo: https://github.com/pycqa/isort
+  #   rev: 5.12.0
+  #   hooks:
+  #     - id: isort
+  # - repo: https://github.com/humitos/mirrors-autoflake.git
+  #   rev: v1.1
+  #   hooks:
+  #     - id: autoflake
+  #       exclude: |
+  #         (?x)^(
+  #             .*/?__init__\.py|
+  #             pytensor/graph/toolbox\.py|
+  #             pytensor/link/jax/jax_dispatch\.py|
+  #             pytensor/link/jax/jax_linker\.py|
+  #             pytensor/scalar/basic_scipy\.py|
+  #             pytensor/tensor/linalg\.py
+  #         )$
+  #       args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.0.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,13 +173,16 @@ skip = "pytensor/version.py"
 skip_glob = "**/*.pyx"
 
 [tool.ruff]
-select=["C","E","F","W"]
+select=["C","E","F","W","I"]
 ignore=["E501","E741","C408","C901"]
 exclude = [
     "doc/",
     "pytensor/_version.py",
     "bin/pytensor_cache.py",
 ]
+
+[tool.ruff.isort]
+lines-after-imports = 2
 
 [tool.ruff.per-file-ignores]
 # TODO: Get rid of these:

--- a/pytensor/compile/debugmode.py
+++ b/pytensor/compile/debugmode.py
@@ -1359,7 +1359,7 @@ class _Linker(LocalLinker):
         if no_recycling is None:
             no_recycling = []
         if self.fgraph is not None and self.fgraph is not fgraph:
-            assert type(self) is _Linker
+            assert isinstance(self, _Linker)
             return type(self)(maker=self.maker).accept(fgraph, no_recycling, profile)
         self.fgraph = fgraph
         self.no_recycling: list = no_recycling
@@ -1866,7 +1866,7 @@ class _Linker(LocalLinker):
                 # Nothing should be in storage map after evaluating
                 # each the thunk (specifically the last one)
                 for r, s in storage_map.items():
-                    assert type(s) is list
+                    assert isinstance(s, list)
                     assert s[0] is None
 
                 # store our output variables to their respective storage lists

--- a/pytensor/link/vm.py
+++ b/pytensor/link/vm.py
@@ -1072,8 +1072,8 @@ class VMLinker(LocalLinker):
                 compute_map[vars_idx_inv[i]] for i in range(len(vars_idx_inv))
             ]
             if nodes:
-                assert type(storage_map_list[0]) is list
-                assert type(compute_map_list[0]) is list
+                assert isinstance(storage_map_list[0], list)
+                assert isinstance(compute_map_list[0], list)
 
             # Needed for allow_gc=True, profiling and storage_map reuse
             dependency_map = self.compute_gc_dependencies(storage_map)

--- a/pytensor/scan/op.py
+++ b/pytensor/scan/op.py
@@ -1625,7 +1625,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
 
                 if hasattr(self.fn.maker, "profile"):
                     profile = self.fn.maker.profile
-                    if type(profile) is not bool and profile:
+                    if not isinstance(profile, bool) and profile:
                         profile.vm_call_time += t_fn
                         profile.callcount += 1
                         profile.nbsteps += n_steps

--- a/tests/link/jax/test_scalar.py
+++ b/tests/link/jax/test_scalar.py
@@ -31,7 +31,7 @@ from tests.link.jax.test_basic import compare_jax_and_py
 
 
 jax = pytest.importorskip("jax")
-from pytensor.link.jax.dispatch import jax_funcify
+from pytensor.link.jax.dispatch import jax_funcify  # noqa: E402
 
 
 try:

--- a/tests/link/jax/test_tensor_basic.py
+++ b/tests/link/jax/test_tensor_basic.py
@@ -5,16 +5,16 @@ from pytensor.compile import get_mode
 
 
 jax = pytest.importorskip("jax")
-import jax.errors
+import jax.errors  # noqa: E402
 
-import pytensor
-import pytensor.tensor.basic as at
-from pytensor.configdefaults import config
-from pytensor.graph.fg import FunctionGraph
-from pytensor.graph.op import get_test_value
-from pytensor.tensor.type import iscalar, matrix, scalar, vector
-from tests.link.jax.test_basic import compare_jax_and_py
-from tests.tensor.test_basic import TestAlloc
+import pytensor  # noqa: E402
+import pytensor.tensor.basic as at  # noqa: E402
+from pytensor.configdefaults import config  # noqa: E402
+from pytensor.graph.fg import FunctionGraph  # noqa: E402
+from pytensor.graph.op import get_test_value  # noqa: E402
+from pytensor.tensor.type import iscalar, matrix, scalar, vector  # noqa: E402
+from tests.link.jax.test_basic import compare_jax_and_py  # noqa: E402
+from tests.tensor.test_basic import TestAlloc  # noqa: E402
 
 
 def test_jax_Alloc():

--- a/tests/link/numba/test_basic.py
+++ b/tests/link/numba/test_basic.py
@@ -10,31 +10,31 @@ import pytest
 
 numba = pytest.importorskip("numba")
 
-import pytensor.scalar as aes
-import pytensor.scalar.math as aesm
-import pytensor.tensor as at
-import pytensor.tensor.math as aem
-from pytensor import config, shared
-from pytensor.compile.builders import OpFromGraph
-from pytensor.compile.function import function
-from pytensor.compile.mode import Mode
-from pytensor.compile.ops import ViewOp
-from pytensor.compile.sharedvalue import SharedVariable
-from pytensor.graph.basic import Apply, Constant
-from pytensor.graph.fg import FunctionGraph
-from pytensor.graph.op import Op, get_test_value
-from pytensor.graph.rewriting.db import RewriteDatabaseQuery
-from pytensor.graph.type import Type
-from pytensor.ifelse import ifelse
-from pytensor.link.numba.dispatch import basic as numba_basic
-from pytensor.link.numba.dispatch import numba_typify
-from pytensor.link.numba.linker import NumbaLinker
-from pytensor.raise_op import assert_op
-from pytensor.scalar.basic import ScalarOp, as_scalar
-from pytensor.tensor import blas
-from pytensor.tensor import subtensor as at_subtensor
-from pytensor.tensor.elemwise import Elemwise
-from pytensor.tensor.shape import Reshape, Shape, Shape_i, SpecifyShape
+import pytensor.scalar as aes  # noqa: E402
+import pytensor.scalar.math as aesm  # noqa: E402
+import pytensor.tensor as at  # noqa: E402
+import pytensor.tensor.math as aem  # noqa: E402
+from pytensor import config, shared  # noqa: E402
+from pytensor.compile.builders import OpFromGraph  # noqa: E402
+from pytensor.compile.function import function  # noqa: E402
+from pytensor.compile.mode import Mode  # noqa: E402
+from pytensor.compile.ops import ViewOp  # noqa: E402
+from pytensor.compile.sharedvalue import SharedVariable  # noqa: E402
+from pytensor.graph.basic import Apply, Constant  # noqa: E402
+from pytensor.graph.fg import FunctionGraph  # noqa: E402
+from pytensor.graph.op import Op, get_test_value  # noqa: E402
+from pytensor.graph.rewriting.db import RewriteDatabaseQuery  # noqa: E402
+from pytensor.graph.type import Type  # noqa: E402
+from pytensor.ifelse import ifelse  # noqa: E402
+from pytensor.link.numba.dispatch import basic as numba_basic  # noqa: E402
+from pytensor.link.numba.dispatch import numba_typify  # noqa: E402
+from pytensor.link.numba.linker import NumbaLinker  # noqa: E402
+from pytensor.raise_op import assert_op  # noqa: E402
+from pytensor.scalar.basic import ScalarOp, as_scalar  # noqa: E402
+from pytensor.tensor import blas  # noqa: E402
+from pytensor.tensor import subtensor as at_subtensor  # noqa: E402
+from pytensor.tensor.elemwise import Elemwise  # noqa: E402
+from pytensor.tensor.shape import Reshape, Shape, Shape_i, SpecifyShape  # noqa: E402
 
 
 if TYPE_CHECKING:

--- a/tests/link/numba/test_cython_support.py
+++ b/tests/link/numba/test_cython_support.py
@@ -6,9 +6,12 @@ import scipy.special.cython_special
 numba = pytest.importorskip("numba")
 
 
-from numba.types import float32, float64, int32, int64
+from numba.types import float32, float64, int32, int64  # noqa: E402
 
-from pytensor.link.numba.dispatch.cython_support import Signature, wrap_cython_function
+from pytensor.link.numba.dispatch.cython_support import (  # noqa: E402
+    Signature,
+    wrap_cython_function,
+)
 
 
 @pytest.mark.parametrize(

--- a/tests/link/numba/test_performance.py
+++ b/tests/link/numba/test_performance.py
@@ -6,13 +6,13 @@ import pytest
 
 pytest.importorskip("numba")
 
-import pytensor.tensor as aet
-from pytensor import config
-from pytensor.compile.function import function
-from pytensor.compile.mode import Mode
-from pytensor.graph.rewriting.db import RewriteDatabaseQuery
-from pytensor.link.numba.linker import NumbaLinker
-from pytensor.tensor.math import Max
+import pytensor.tensor as aet  # noqa: E402
+from pytensor import config  # noqa: E402
+from pytensor.compile.function import function  # noqa: E402
+from pytensor.compile.mode import Mode  # noqa: E402
+from pytensor.graph.rewriting.db import RewriteDatabaseQuery  # noqa: E402
+from pytensor.link.numba.linker import NumbaLinker  # noqa: E402
+from pytensor.tensor.math import Max  # noqa: E402
 
 
 opts = RewriteDatabaseQuery(include=[None], exclude=["cxx_only", "BlasOpt"])

--- a/tests/link/numba/test_sparse.py
+++ b/tests/link/numba/test_sparse.py
@@ -7,10 +7,10 @@ numba = pytest.importorskip("numba")
 
 
 # Make sure the Numba customizations are loaded
-import pytensor.link.numba.dispatch.sparse  # noqa: F401
-from pytensor import config
-from pytensor.sparse import Dot, SparseTensorType
-from tests.link.numba.test_basic import compare_numba_and_py
+import pytensor.link.numba.dispatch.sparse  # noqa: E402,F401
+from pytensor import config  # noqa: E402
+from pytensor.sparse import Dot, SparseTensorType  # noqa: E402
+from tests.link.numba.test_basic import compare_numba_and_py  # noqa: E402
 
 
 pytestmark = pytest.mark.filterwarnings("error")

--- a/tests/link/numba/test_tensor_basic.py
+++ b/tests/link/numba/test_tensor_basic.py
@@ -20,7 +20,7 @@ from tests.tensor.test_basic import TestAlloc
 
 
 pytest.importorskip("numba")
-from pytensor.link.numba.dispatch import numba_funcify
+from pytensor.link.numba.dispatch import numba_funcify # noqa: E402
 
 
 rng = np.random.default_rng(42849)

--- a/tests/tensor/rewriting/test_basic.py
+++ b/tests/tensor/rewriting/test_basic.py
@@ -846,7 +846,7 @@ class TestLocalSwitchSink:
                 f = self.function_remove_nan(
                     [condition[0], x[0], c], [y], mode=self.mode
                 )
-                if type(condition[1]) is list:
+                if isinstance(condition[1], list):
                     for i in range(len(condition[1])):
                         res = f(condition[1][i], x[1], -1)
                         assert (
@@ -886,7 +886,7 @@ class TestLocalSwitchSink:
                 f = self.function_remove_nan(
                     [condition[0], x[0], c], [y], mode=self.mode
                 )
-                if type(condition[1]) is list:
+                if isinstance(condition[1], list):
                     for i in range(len(condition[1])):
                         res = f(condition[1][i], x[1], -1)
                         assert (

--- a/tests/tensor/rewriting/test_math.py
+++ b/tests/tensor/rewriting/test_math.py
@@ -2092,7 +2092,7 @@ class TestLocalSwitchSink:
                 f = self.function_remove_nan(
                     [condition[0], x[0], c], [y], mode=self.mode
                 )
-                if type(condition[1]) is list:
+                if isinstance(condition[1], list):
                     for i in range(len(condition[1])):
                         res = f(condition[1][i], x[1], -1)
                         assert (
@@ -2132,7 +2132,7 @@ class TestLocalSwitchSink:
                 f = self.function_remove_nan(
                     [condition[0], x[0], c], [y], mode=self.mode
                 )
-                if type(condition[1]) is list:
+                if isinstance(condition[1], list):
                     for i in range(len(condition[1])):
                         res = f(condition[1][i], x[1], -1)
                         assert (


### PR DESCRIPTION
### Motivation for these changes

As requested in #298 by @ricardoV94 and co-signed by @jessegrabowski and @cluhmann on the PyData Global code sprint Thursday call tonight

It looks like the previous PR to "add support for ruff" (#295) only fixed the issues raised by ruff, this PR will put it in the pre-commit.

### Implementation details

- I added the pre-commit hook and got errors, it looks like ones not found by flake8
- I fixed all the errors I got from `ruff check` by adding `noqa` for unavoidable/'structural' ones (like import orders with dynamic imports) and fixed some to do with not duck typing (`type(...) is ...` -> `isinstance(..., ...)`)

#### Timing comparison

Here's the time it takes to run pre-commit (run on a low spec netbook!)

**Total time** 78 seconds

```
debug statements (python)................................................Passed
- hook id: debug-statements
- duration: 1.34s
check for merge conflicts................................................Passed
- hook id: check-merge-conflict
- duration: 0.13s
pyupgrade................................................................Passed
- hook id: pyupgrade
- duration: 7.96s
black....................................................................Failed
- hook id: black
- duration: 17.81s
- files were modified by this hook

reformatted tests/link/numba/test_tensor_basic.py

All done! ✨ 🍰 ✨
1 file reformatted, 355 files left unchanged.

flake8...................................................................Passed
- hook id: flake8
- duration: 28.38s
isort....................................................................Passed
- hook id: isort
- duration: 2.67s

Skipped 2 files

autoflake................................................................Passed
- hook id: autoflake
- duration: 9.02s
mypy.....................................................................Passed
- hook id: mypy
- duration: 10.37s

<-- Bunch of verbose output removed here -->

153/187 files pass as expected.
```

Here's the timing for pre-commit with ruff instead of black, flake8, and isort hooks.

**Total time** 20 seconds

- 

```
debug statements (python)................................................Passed
- hook id: debug-statements
- duration: 1.29s
check for merge conflicts................................................Passed
- hook id: check-merge-conflict
- duration: 0.09s
pyupgrade................................................................Passed
- hook id: pyupgrade
- duration: 7.37s
ruff.....................................................................Passed
- hook id: ruff
- duration: 0.17s
ruff-format..............................................................Passed
- hook id: ruff-format
- duration: 0.03s

356 files left unchanged

mypy.....................................................................Passed
- hook id: mypy
- duration: 10.6s

153/187 files pass as expected.
```

### Checklist
+ [x] Explain motivation and implementation 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues, preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [ ] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). Note that if they don't, we will [rewrite/rebase/squash the git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) before merging.
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇


## Major / Breaking Changes
- Pretty big upgrade but by definition non-breaking

## New features
- Powerful new linter, fast and a 'Swiss army knife' (functionality of many existing tools provided in one)

## Bugfixes
- Resolves #298
- CI/local development improvement: the pre-commit suite initial setup time will fall (fewer tools to install environments for)

## Documentation
- N/A (?)

## Maintenance
- N/A

