### PR TITLE
Remove incorrect `solve` usage in `psd_solve_with_chol` rewrite

### DIFF
--- a/pytensor/tensor/rewriting/linalg.py
+++ b/pytensor/tensor/rewriting/linalg.py
@@ -215,8 +215,8 @@ def psd_solve_with_chol(fgraph, node):
             # N.B. this can be further reduced to a yet-unwritten cho_solve Op
             #     __if__ no other Op makes use of the L matrix during the
             #     stabilization
-            Li_b = solve(L, b, assume_a="sym", lower=True, b_ndim=2)
-            x = solve(_T(L), Li_b, assume_a="sym", lower=False, b_ndim=2)
+            Li_b = solve_triangular(L, b, lower=True, b_ndim=2)
+            x = solve_triangular(_T(L), Li_b, lower=False, b_ndim=2)
             return [x]
 
 

--- a/tests/tensor/rewriting/test_linalg.py
+++ b/tests/tensor/rewriting/test_linalg.py
@@ -260,7 +260,12 @@ def test_psd_solve_with_chol():
     L = rng.normal(size=(5, 5)).astype(config.floatX)
     X_psd = L @ L.T
     X_psd_inv = f(X_psd)
-    assert_allclose(X_psd_inv, np.linalg.inv(X_psd))
+    assert_allclose(
+        X_psd_inv,
+        np.linalg.inv(X_psd),
+        atol=1e-4 if config.floatX == "float32" else 1e-8,
+        rtol=1e-4 if config.floatX == "float32" else 1e-8,
+    )
 
 
 class TestBatchedVectorBSolveToMatrixBSolve:

--- a/tests/tensor/rewriting/test_linalg.py
+++ b/tests/tensor/rewriting/test_linalg.py
@@ -246,7 +246,7 @@ def test_psd_solve_with_chol():
     X.tag.psd = True
     X_inv = pt.linalg.solve(X, pt.identity_like(X))
 
-    f = function([X], X_inv)
+    f = function([X], X_inv, mode="FAST_RUN")
 
     nodes = f.maker.fgraph.apply_nodes
 
@@ -255,7 +255,9 @@ def test_psd_solve_with_chol():
     assert any(isinstance(node.op, SolveTriangular) for node in nodes)
 
     # Numeric test
-    L = np.random.randn(5, 5).astype(config.floatX)
+    rng = np.random.default_rng(sum(map(ord, "test_psd_solve_with_chol")))
+
+    L = rng.normal(size=(5, 5)).astype(config.floatX)
     X_psd = L @ L.T
     X_psd_inv = f(X_psd)
     assert_allclose(X_psd_inv, np.linalg.inv(X_psd))


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
To invert a positive semi-definite matrix, it is faster to first cholesky factorize the matrix then use two triangular solves rather than directly using solve. Here's a lazy benchmark:

 ```python
import numpy as np
from scipy import linalg

N = 10_000
Z = np.random.normal(size=(N, N))
X = Z @ Z.T

def direct_solve(X, N):
    return linalg.solve(X, np.eye(N), assume_a='pos')

def tri_solve(X, N):
    L = linalg.cholesky(X, lower=True)
    b = np.eye(N)
    Li_b = linalg.solve_triangular(L, b, lower=True)
    x = linalg.solve_triangular(L.T, Li_b, lower=False)
    return x

direct_time = %timeit -o direct_solve(X, N)
tri_time = %timeit -o tri_solve(X, N)

12.7 s ± 369 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
11.5 s ± 165 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

The triangular method is about 1s faster. I've read it also more numerically stable too, but I don't know how to demonstrate that.

Anyway, there's a rewrite to change `pt.linalg.solve` to something like the `tri_solve` function above if the `A` matrix has a `"psd"` tag. This rewrite is actually useless -- as far as I can tell, the psd is never used in the code base. But it is potentially useful in light of #573. It's also currently wrong: as pointed out in #382, `solve(tri_A, b, assume_a='sym', lower=True)` does NOT use the correct algorithm to solve a triangular matrix, and results in an incorrect computation.

This PR corrects the rewrite to use the correct computations, but does nothing else to make it used anywhere in the code base.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #382 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
