### PR TITLE
Add `linalg.block_diag` and sparse equivalent 

### DIFF
--- a/pytensor/link/jax/dispatch/slinalg.py
+++ b/pytensor/link/jax/dispatch/slinalg.py
@@ -1,12 +1,7 @@
 import jax
 
 from pytensor.link.jax.dispatch.basic import jax_funcify
-from pytensor.tensor.slinalg import (
-    BlockDiagonalMatrix,
-    Cholesky,
-    Solve,
-    SolveTriangular,
-)
+from pytensor.tensor.slinalg import BlockDiagonal, Cholesky, Solve, SolveTriangular
 
 
 @jax_funcify.register(Cholesky)
@@ -52,7 +47,7 @@ def jax_funcify_SolveTriangular(op, **kwargs):
     return solve_triangular
 
 
-@jax_funcify.register(BlockDiagonalMatrix)
+@jax_funcify.register(BlockDiagonal)
 def jax_funcify_BlockDiagonalMatrix(op, **kwargs):
     def block_diag(*inputs):
         return jax.scipy.linalg.block_diag(*inputs)

--- a/pytensor/link/jax/dispatch/slinalg.py
+++ b/pytensor/link/jax/dispatch/slinalg.py
@@ -1,7 +1,12 @@
 import jax
 
 from pytensor.link.jax.dispatch.basic import jax_funcify
-from pytensor.tensor.slinalg import Cholesky, Solve, SolveTriangular
+from pytensor.tensor.slinalg import (
+    BlockDiagonalMatrix,
+    Cholesky,
+    Solve,
+    SolveTriangular,
+)
 
 
 @jax_funcify.register(Cholesky)
@@ -45,3 +50,11 @@ def jax_funcify_SolveTriangular(op, **kwargs):
         )
 
     return solve_triangular
+
+
+@jax_funcify.register(BlockDiagonalMatrix)
+def jax_funcify_BlockDiagonalMatrix(op, **kwargs):
+    def block_diag(*inputs):
+        return jax.scipy.linalg.block_diag(*inputs)
+
+    return block_diag

--- a/pytensor/link/numba/dispatch/slinalg.py
+++ b/pytensor/link/numba/dispatch/slinalg.py
@@ -9,7 +9,7 @@ from scipy import linalg
 
 from pytensor.link.numba.dispatch import basic as numba_basic
 from pytensor.link.numba.dispatch.basic import numba_funcify
-from pytensor.tensor.slinalg import BlockDiagonalMatrix, SolveTriangular
+from pytensor.tensor.slinalg import BlockDiagonal, SolveTriangular
 
 
 _PTR = ctypes.POINTER
@@ -275,8 +275,8 @@ def numba_funcify_SolveTriangular(op, node, **kwargs):
     return solve_triangular
 
 
-@numba_funcify.register(BlockDiagonalMatrix)
-def numba_funcify_BlockDiagonalMatrix(op, node, **kwargs):
+@numba_funcify.register(BlockDiagonal)
+def numba_funcify_BlockDiagonal(op, node, **kwargs):
     dtype = node.outputs[0].dtype
 
     # TODO: Why do we always inline all functions? It doesn't work with starred args, so can't use it in this case.

--- a/pytensor/link/numba/dispatch/slinalg.py
+++ b/pytensor/link/numba/dispatch/slinalg.py
@@ -282,9 +282,9 @@ def numba_funcify_BlockDiagonalMatrix(op, node, **kwargs):
     # TODO: Why do we always inline all functions? It doesn't work with starred args, so can't use it in this case.
     @numba_basic.numba_njit(inline="never")
     def block_diag(*arrs):
-        shapes = np.array([a.shape for a in arrs], dtype=dtype)
+        shapes = np.array([a.shape for a in arrs], dtype="int")
         out_shape = [int(s) for s in np.sum(shapes, axis=0)]
-        out = np.zeros((out_shape[0], out_shape[1]))
+        out = np.zeros((out_shape[0], out_shape[1]), dtype=dtype)
 
         r, c = 0, 0
         for arr, shape in zip(arrs, shapes):

--- a/pytensor/link/numba/dispatch/slinalg.py
+++ b/pytensor/link/numba/dispatch/slinalg.py
@@ -9,7 +9,7 @@ from scipy import linalg
 
 from pytensor.link.numba.dispatch import basic as numba_basic
 from pytensor.link.numba.dispatch.basic import numba_funcify
-from pytensor.tensor.slinalg import SolveTriangular
+from pytensor.tensor.slinalg import BlockDiagonalMatrix, SolveTriangular
 
 
 _PTR = ctypes.POINTER
@@ -273,3 +273,25 @@ def numba_funcify_SolveTriangular(op, node, **kwargs):
         return res
 
     return solve_triangular
+
+
+@numba_funcify.register(BlockDiagonalMatrix)
+def numba_funcify_BlockDiagonalMatrix(op, node, **kwargs):
+    dtype = node.outputs[0].dtype
+
+    # TODO: Why do we always inline all functions? It doesn't work with starred args, so can't use it in this case.
+    @numba_basic.numba_njit(inline="never")
+    def block_diag(*arrs):
+        shapes = np.array([a.shape for a in arrs], dtype=dtype)
+        out_shape = [int(s) for s in np.sum(shapes, axis=0)]
+        out = np.zeros((out_shape[0], out_shape[1]))
+
+        r, c = 0, 0
+        for arr, shape in zip(arrs, shapes):
+            rr, cc = shape
+            out[r : r + rr, c : c + cc] = arr
+            r += rr
+            c += cc
+        return out
+
+    return block_diag

--- a/pytensor/sparse/basic.py
+++ b/pytensor/sparse/basic.py
@@ -4261,10 +4261,11 @@ construct_sparse_from_list = ConstructSparseFromList()
 class SparseBlockDiagonalMatrix(BaseBlockDiagonal):
     __props__ = ("format",)
 
-    def __init__(self, format: Literal["csc", "csr"] = "csc"):
+    def __init__(self, n_inputs: int, format: Literal["csc", "csr"] = "csc"):
+        super().__init__(n_inputs)
         self.format = format
 
-    def make_node(self, *matrices, name=None):
+    def make_node(self, *matrices):
         if not matrices:
             raise ValueError("no matrices to allocate")
         dtype = largest_common_dtype(matrices)
@@ -4273,7 +4274,7 @@ class SparseBlockDiagonalMatrix(BaseBlockDiagonal):
         if any(mat.type.ndim != 2 for mat in matrices):
             raise TypeError("all data arguments must be matrices")
 
-        out_type = matrix(format=self.format, dtype=dtype, name=name)
+        out_type = matrix(format=self.format, dtype=dtype)
         return Apply(self, matrices, [out_type])
 
     def perform(self, node, inputs, output_storage, params=None):
@@ -4338,5 +4339,7 @@ def block_diag(
     if len(matrices) == 1:
         return matrices
 
-    _sparse_block_diagonal = SparseBlockDiagonalMatrix(format=format)
-    return _sparse_block_diagonal(*matrices, name=name)
+    _sparse_block_diagonal = SparseBlockDiagonalMatrix(
+        n_inputs=len(matrices), format=format
+    )
+    return _sparse_block_diagonal(*matrices)

--- a/pytensor/sparse/basic.py
+++ b/pytensor/sparse/basic.py
@@ -4259,7 +4259,10 @@ construct_sparse_from_list = ConstructSparseFromList()
 
 
 class SparseBlockDiagonal(BaseBlockDiagonal):
-    __props__ = ("format",)
+    __props__ = (
+        "n_inputs",
+        "format",
+    )
 
     def __init__(self, n_inputs: int, format: Literal["csc", "csr"] = "csc"):
         super().__init__(n_inputs)

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -4269,6 +4269,25 @@ def take_along_axis(arr, indices, axis=0):
     return arr[_make_along_axis_idx(arr.shape, indices, axis)]
 
 
+def ix_(*args):
+    """
+    PyTensor np.ix_ analog
+
+    See numpy.lib.index_tricks.ix_ for reference
+    """
+    out = []
+    nd = len(args)
+    for k, new in enumerate(args):
+        if new is None:
+            out.append(slice(None))
+        new = as_tensor(new)
+        if new.ndim != 1:
+            raise ValueError("Cross index must be 1 dimensional")
+        new = new.reshape((1,) * k + (new.size,) + (1,) * (nd - k - 1))
+        out.append(new)
+    return tuple(out)
+
+
 __all__ = [
     "take_along_axis",
     "expand_dims",

--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -997,7 +997,7 @@ def block_diagonal(
         matrices = [pt.as_tensor_variable(mat) for mat in matrices]
         result = block_diagonal(matrices)
 
-        print(result)
+        print(result.eval())
         >>> Out: array([[1, 2, 0, 0],
         >>>             [3, 4, 0, 0],
         >>>             [0, 0, 5, 6],

--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -949,7 +949,7 @@ class BlockDiagonalMatrix(BaseBlockDiagonal):
         return Apply(self, matrices, [out_type])
 
     def perform(self, node, inputs, output_storage, params=None):
-        dtype = largest_common_dtype(inputs)
+        dtype = node.outputs[0].type.dtype
         output_storage[0][0] = scipy.linalg.block_diag(*inputs).astype(dtype)
 
 

--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -913,7 +913,7 @@ def _largest_common_dtype(tensors: typing.Sequence[TensorVariable]) -> np.dtype:
 
 
 class BaseBlockDiagonal(Op):
-    __props__ = ("gufunc_signature", "n_inputs")
+    __props__ = ("n_inputs",)
 
     def __init__(self, n_inputs):
         input_sig = ",".join([f"(m{i},n{i})" for i in range(n_inputs)])

--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -952,6 +952,8 @@ class BaseBlockDiagonal(Op):
 
 
 class BlockDiagonal(BaseBlockDiagonal):
+    __props__ = ("n_inputs",)
+
     def make_node(self, *matrices):
         matrices = self._validate_and_prepare_inputs(matrices, pt.as_tensor)
         dtype = _largest_common_dtype(matrices)

--- a/tests/link/jax/test_slinalg.py
+++ b/tests/link/jax/test_slinalg.py
@@ -138,8 +138,8 @@ def test_jax_block_diag():
     D = matrix("D")
 
     out = pt_slinalg.block_diag(A, B, C, D)
-
     out_fg = FunctionGraph([A, B, C, D], [out])
+
     compare_jax_and_py(
         out_fg,
         [
@@ -147,5 +147,19 @@ def test_jax_block_diag():
             np.random.normal(size=(3, 3)).astype(config.floatX),
             np.random.normal(size=(2, 2)).astype(config.floatX),
             np.random.normal(size=(4, 4)).astype(config.floatX),
+        ],
+    )
+
+
+def test_jax_block_diag_blockwise():
+    A = pt.tensor3("A")
+    B = pt.tensor3("B")
+    out = pt_slinalg.block_diag(A, B)
+    out_fg = FunctionGraph([A, B], [out])
+    compare_jax_and_py(
+        out_fg,
+        [
+            np.random.normal(size=(5, 5, 5)).astype(config.floatX),
+            np.random.normal(size=(5, 3, 3)).astype(config.floatX),
         ],
     )

--- a/tests/link/jax/test_slinalg.py
+++ b/tests/link/jax/test_slinalg.py
@@ -129,3 +129,23 @@ def test_jax_SolveTriangular(trans, lower, check_finite):
             np.arange(10).astype(config.floatX),
         ],
     )
+
+
+def test_jax_block_diag():
+    A = matrix("A")
+    B = matrix("B")
+    C = matrix("C")
+    D = matrix("D")
+
+    out = pt_slinalg.block_diag(A, B, C, D)
+
+    out_fg = FunctionGraph([A, B, C, D], [out])
+    compare_jax_and_py(
+        out_fg,
+        [
+            np.random.normal(size=(5, 5)).astype(config.floatX),
+            np.random.normal(size=(3, 3)).astype(config.floatX),
+            np.random.normal(size=(2, 2)).astype(config.floatX),
+            np.random.normal(size=(4, 4)).astype(config.floatX),
+        ],
+    )

--- a/tests/sparse/test_basic.py
+++ b/tests/sparse/test_basic.py
@@ -51,6 +51,7 @@ from pytensor.sparse import (
     add_s_s_data,
     as_sparse_or_tensor_variable,
     as_sparse_variable,
+    block_diag,
     cast,
     clean,
     construct_sparse_from_list,
@@ -3389,3 +3390,15 @@ class TestSamplingDot(utt.InferShapeTester):
 )
 class TestSharedOptions:
     pass
+
+
+@pytest.mark.parametrize("format", ["csc", "csr"], ids=["csc", "csr"])
+def test_block_diagonal(format):
+    from scipy.sparse import block_diag as scipy_block_diag
+
+    matrices = [np.array([[1.0, 2.0], [3.0, 4.0]]), np.array([[5.0, 6.0], [7.0, 8.0]])]
+    result = block_diag(*matrices, format=format, name="X")
+    sp_result = scipy_block_diag(matrices, format=format)
+
+    assert isinstance(result.eval(), type(sp_result))
+    np.testing.assert_allclose(result.eval().toarray(), sp_result.toarray())

--- a/tests/sparse/test_basic.py
+++ b/tests/sparse/test_basic.py
@@ -3393,11 +3393,14 @@ class TestSharedOptions:
 
 
 @pytest.mark.parametrize("format", ["csc", "csr"], ids=["csc", "csr"])
-def test_block_diagonal(format):
+@pytest.mark.parametrize("sparse_input", [True, False], ids=["sparse", "dense"])
+def test_block_diagonal(format, sparse_input):
     from scipy import sparse as sp_sparse
 
-    A = sp_sparse.csr_matrix([[1, 2], [3, 4]])
-    B = sp_sparse.csr_matrix([[5, 6], [7, 8]])
+    f_array = sp_sparse.csr_matrix if sparse_input else np.array
+    A = f_array([[1, 2], [3, 4]]).astype(config.floatX)
+    B = f_array([[5, 6], [7, 8]]).astype(config.floatX)
+
     result = block_diag(A, B, format=format, name="X")
     sp_result = sp_sparse.block_diag([A, B], format=format)
 

--- a/tests/sparse/test_basic.py
+++ b/tests/sparse/test_basic.py
@@ -3402,6 +3402,8 @@ def test_block_diagonal(format, sparse_input):
     B = f_array([[5, 6], [7, 8]]).astype(config.floatX)
 
     result = block_diag(A, B, format=format)
+    assert result.owner.op._props_dict() == {"n_inputs": 2, "format": format}
+
     sp_result = sp_sparse.block_diag([A, B], format=format)
 
     assert isinstance(result.eval(), type(sp_result))

--- a/tests/sparse/test_basic.py
+++ b/tests/sparse/test_basic.py
@@ -3394,11 +3394,12 @@ class TestSharedOptions:
 
 @pytest.mark.parametrize("format", ["csc", "csr"], ids=["csc", "csr"])
 def test_block_diagonal(format):
-    from scipy.sparse import block_diag as scipy_block_diag
+    from scipy import sparse as sp_sparse
 
-    matrices = [np.array([[1.0, 2.0], [3.0, 4.0]]), np.array([[5.0, 6.0], [7.0, 8.0]])]
-    result = block_diag(*matrices, format=format, name="X")
-    sp_result = scipy_block_diag(matrices, format=format)
+    A = sp_sparse.csr_matrix([[1, 2], [3, 4]])
+    B = sp_sparse.csr_matrix([[5, 6], [7, 8]])
+    result = block_diag(A, B, format=format, name="X")
+    sp_result = sp_sparse.block_diag([A, B], format=format)
 
     assert isinstance(result.eval(), type(sp_result))
     np.testing.assert_allclose(result.eval().toarray(), sp_result.toarray())

--- a/tests/sparse/test_basic.py
+++ b/tests/sparse/test_basic.py
@@ -3401,7 +3401,7 @@ def test_block_diagonal(format, sparse_input):
     A = f_array([[1, 2], [3, 4]]).astype(config.floatX)
     B = f_array([[5, 6], [7, 8]]).astype(config.floatX)
 
-    result = block_diag(A, B, format=format, name="X")
+    result = block_diag(A, B, format=format)
     sp_result = sp_sparse.block_diag([A, B], format=format)
 
     assert isinstance(result.eval(), type(sp_result))

--- a/tests/tensor/test_slinalg.py
+++ b/tests/tensor/test_slinalg.py
@@ -668,6 +668,8 @@ def test_block_diagonal():
     A = np.array([[1.0, 2.0], [3.0, 4.0]])
     B = np.array([[5.0, 6.0], [7.0, 8.0]])
     result = block_diag(A, B)
+    assert result.owner.op.core_op._props_dict() == {"n_inputs": 2}
+
     np.testing.assert_allclose(result.eval(), scipy.linalg.block_diag(A, B))
 
 

--- a/tests/tensor/test_slinalg.py
+++ b/tests/tensor/test_slinalg.py
@@ -671,6 +671,13 @@ def test_block_diagonal():
     np.testing.assert_allclose(result.eval(), scipy.linalg.block_diag(A, B))
 
 
+def test_block_diagonal_grad():
+    A = np.array([[1.0, 2.0], [3.0, 4.0]])
+    B = np.array([[5.0, 6.0], [7.0, 8.0]])
+
+    utt.verify_grad(block_diag, pt=[A, B], rng=np.random.default_rng())
+
+
 def test_block_diagonal_blockwise():
     batch_size = 5
     A = np.random.normal(size=(batch_size, 2, 2)).astype(config.floatX)
@@ -684,3 +691,9 @@ def test_block_diagonal_blockwise():
             atol=1e-4 if config.floatX == "float32" else 1e-8,
             rtol=1e-4 if config.floatX == "float32" else 1e-8,
         )
+
+    # Test broadcasting
+    A = np.random.normal(size=(10, batch_size, 2, 2)).astype(config.floatX)
+    B = np.random.normal(size=(1, batch_size, 4, 4)).astype(config.floatX)
+    result = block_diag(A, B).eval()
+    assert result.shape == (10, batch_size, 6, 6)

--- a/tests/tensor/test_slinalg.py
+++ b/tests/tensor/test_slinalg.py
@@ -671,5 +671,5 @@ def test_block_diagonal():
 
     result = block_diagonal(matrices, format="csr", sparse=True)
     sp_result = scipy.sparse.block_diag(matrices, format="csr")
-    assert isinstance(result.eval()),  type(sp_result))
+    assert isinstance(result.eval(), type(sp_result))
     np.testing.assert_allclose(result.eval().toarray(), sp_result.toarray())

--- a/tests/tensor/test_slinalg.py
+++ b/tests/tensor/test_slinalg.py
@@ -667,5 +667,20 @@ def test_solve_discrete_are_grad():
 def test_block_diagonal():
     A = np.array([[1.0, 2.0], [3.0, 4.0]])
     B = np.array([[5.0, 6.0], [7.0, 8.0]])
-    result = block_diag(A, B, name="X")
+    result = block_diag(A, B)
     np.testing.assert_allclose(result.eval(), scipy.linalg.block_diag(A, B))
+
+
+def test_block_diagonal_blockwise():
+    batch_size = 5
+    A = np.random.normal(size=(batch_size, 2, 2)).astype(config.floatX)
+    B = np.random.normal(size=(batch_size, 4, 4)).astype(config.floatX)
+    result = block_diag(A, B).eval()
+    assert result.shape == (batch_size, 6, 6)
+    for i in range(batch_size):
+        np.testing.assert_allclose(
+            result[i],
+            scipy.linalg.block_diag(A[i], B[i]),
+            atol=1e-4 if config.floatX == "float32" else 1e-8,
+            rtol=1e-4 if config.floatX == "float32" else 1e-8,
+        )

--- a/tests/tensor/test_slinalg.py
+++ b/tests/tensor/test_slinalg.py
@@ -665,6 +665,7 @@ def test_solve_discrete_are_grad():
 
 
 def test_block_diagonal():
-    matrices = [np.array([[1.0, 2.0], [3.0, 4.0]]), np.array([[5.0, 6.0], [7.0, 8.0]])]
-    result = block_diag(*matrices)
-    np.testing.assert_allclose(result.eval(), scipy.linalg.block_diag(*matrices))
+    A = np.array([[1.0, 2.0], [3.0, 4.0]])
+    B = np.array([[5.0, 6.0], [7.0, 8.0]])
+    result = block_diag(A, B, name="X")
+    np.testing.assert_allclose(result.eval(), scipy.linalg.block_diag(A, B))

--- a/tests/tensor/test_slinalg.py
+++ b/tests/tensor/test_slinalg.py
@@ -671,5 +671,5 @@ def test_block_diagonal():
 
     result = block_diagonal(matrices, format="csr", sparse=True)
     sp_result = scipy.sparse.block_diag(matrices, format="csr")
-    assert type(result.eval()) == type(sp_result)
+    assert isinstance(result.eval()),  type(sp_result))
     np.testing.assert_allclose(result.eval().toarray(), sp_result.toarray())

--- a/tests/tensor/test_slinalg.py
+++ b/tests/tensor/test_slinalg.py
@@ -15,6 +15,7 @@ from pytensor.tensor.slinalg import (
     Solve,
     SolveBase,
     SolveTriangular,
+    block_diagonal,
     cho_solve,
     cholesky,
     eigvalsh,
@@ -661,3 +662,14 @@ def test_solve_discrete_are_grad():
         rng=rng,
         abs_tol=atol,
     )
+
+
+def test_block_diagonal():
+    matrices = [np.array([[1.0, 2.0], [3.0, 4.0]]), np.array([[5.0, 6.0], [7.0, 8.0]])]
+    result = block_diagonal(matrices)
+    np.testing.assert_allclose(result.eval(), scipy.linalg.block_diag(*matrices))
+
+    result = block_diagonal(matrices, format="csr", sparse=True)
+    sp_result = scipy.sparse.block_diag(matrices, format="csr")
+    assert type(result.eval()) == type(sp_result)
+    np.testing.assert_allclose(result.eval().toarray(), sp_result.toarray())

--- a/tests/tensor/test_slinalg.py
+++ b/tests/tensor/test_slinalg.py
@@ -15,7 +15,7 @@ from pytensor.tensor.slinalg import (
     Solve,
     SolveBase,
     SolveTriangular,
-    block_diagonal,
+    block_diag,
     cho_solve,
     cholesky,
     eigvalsh,
@@ -666,10 +666,5 @@ def test_solve_discrete_are_grad():
 
 def test_block_diagonal():
     matrices = [np.array([[1.0, 2.0], [3.0, 4.0]]), np.array([[5.0, 6.0], [7.0, 8.0]])]
-    result = block_diagonal(matrices)
+    result = block_diag(*matrices)
     np.testing.assert_allclose(result.eval(), scipy.linalg.block_diag(*matrices))
-
-    result = block_diagonal(matrices, format="csr", sparse=True)
-    sp_result = scipy.sparse.block_diag(matrices, format="csr")
-    assert isinstance(result.eval(), type(sp_result))
-    np.testing.assert_allclose(result.eval().toarray(), sp_result.toarray())


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
There are a number of generic math-type operations in `pymc.math` that make more sense in `pytensor`. This PR moves one of them -- `block_diag`, to `pytensor.tensor.slinalg`. There are others that could likely be moved as well.

`block_diag` uses a few support functions that also present opportunities to implement some missing numpy functions in pytensor. I re-wrote `largest_common_dtype` to use `np.promote_types`, but there should probably be a `pt.promote_types` and `pt.result_type`. The latter should just replace this helper function entirely.

There was also a function `ix`, which is an implementation of `np.ix_`. We're missing all of these numpy quick constructors: `np.r_`, `np.c_`, `np.ogrid`, `np.mgrid`. Plus `np.meshgrid`, which is an actual function people use.

`floatX` and `intX` should probably also be pytensor functions instead of PyMC functions.

I tagged this as relevant to #573 because I'm interested in experimenting with linear algebra rewrites out of the `block_diag` `Op`.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #573 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
