### PR TITLE
Implement numba overload for POTRF, LAPACK cholesky routine

### DIFF
--- a/pytensor/link/numba/dispatch/basic.py
+++ b/pytensor/link/numba/dispatch/basic.py
@@ -37,7 +37,7 @@ from pytensor.sparse import SparseTensorType
 from pytensor.tensor.blas import BatchedDot
 from pytensor.tensor.math import Dot
 from pytensor.tensor.shape import Reshape, Shape, Shape_i, SpecifyShape
-from pytensor.tensor.slinalg import Cholesky, Solve
+from pytensor.tensor.slinalg import Solve
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
     AdvancedIncSubtensor1,
@@ -809,39 +809,39 @@ def numba_funcify_Softplus(op, node, **kwargs):
     return softplus
 
 
-@numba_funcify.register(Cholesky)
-def numba_funcify_Cholesky(op, node, **kwargs):
-    lower = op.lower
-
-    out_dtype = node.outputs[0].type.numpy_dtype
-
-    if lower:
-        inputs_cast = int_to_float_fn(node.inputs, out_dtype)
-
-        @numba_njit
-        def cholesky(a):
-            return np.linalg.cholesky(inputs_cast(a)).astype(out_dtype)
-
-    else:
-        # TODO: Use SciPy's BLAS/LAPACK Cython wrappers.
-
-        warnings.warn(
-            (
-                "Numba will use object mode to allow the "
-                "`lower` argument to `scipy.linalg.cholesky`."
-            ),
-            UserWarning,
-        )
-
-        ret_sig = get_numba_type(node.outputs[0].type)
-
-        @numba_njit
-        def cholesky(a):
-            with numba.objmode(ret=ret_sig):
-                ret = scipy.linalg.cholesky(a, lower=lower).astype(out_dtype)
-            return ret
-
-    return cholesky
+# @numba_funcify.register(Cholesky)
+# def numba_funcify_Cholesky(op, node, **kwargs):
+#     lower = op.lower
+#
+#     out_dtype = node.outputs[0].type.numpy_dtype
+#
+#     if lower:
+#         inputs_cast = int_to_float_fn(node.inputs, out_dtype)
+#
+#         @numba_njit
+#         def cholesky(a):
+#             return np.linalg.cholesky(inputs_cast(a)).astype(out_dtype)
+#
+#     else:
+#         # TODO: Use SciPy's BLAS/LAPACK Cython wrappers.
+#
+#         warnings.warn(
+#             (
+#                 "Numba will use object mode to allow the "
+#                 "`lower` argument to `scipy.linalg.cholesky`."
+#             ),
+#             UserWarning,
+#         )
+#
+#         ret_sig = get_numba_type(node.outputs[0].type)
+#
+#         @numba_njit
+#         def cholesky(a):
+#             with numba.objmode(ret=ret_sig):
+#                 ret = scipy.linalg.cholesky(a, lower=lower).astype(out_dtype)
+#             return ret
+#
+#     return cholesky
 
 
 @numba_funcify.register(Solve)

--- a/pytensor/link/numba/dispatch/basic.py
+++ b/pytensor/link/numba/dispatch/basic.py
@@ -809,41 +809,6 @@ def numba_funcify_Softplus(op, node, **kwargs):
     return softplus
 
 
-# @numba_funcify.register(Cholesky)
-# def numba_funcify_Cholesky(op, node, **kwargs):
-#     lower = op.lower
-#
-#     out_dtype = node.outputs[0].type.numpy_dtype
-#
-#     if lower:
-#         inputs_cast = int_to_float_fn(node.inputs, out_dtype)
-#
-#         @numba_njit
-#         def cholesky(a):
-#             return np.linalg.cholesky(inputs_cast(a)).astype(out_dtype)
-#
-#     else:
-#         # TODO: Use SciPy's BLAS/LAPACK Cython wrappers.
-#
-#         warnings.warn(
-#             (
-#                 "Numba will use object mode to allow the "
-#                 "`lower` argument to `scipy.linalg.cholesky`."
-#             ),
-#             UserWarning,
-#         )
-#
-#         ret_sig = get_numba_type(node.outputs[0].type)
-#
-#         @numba_njit
-#         def cholesky(a):
-#             with numba.objmode(ret=ret_sig):
-#                 ret = scipy.linalg.cholesky(a, lower=lower).astype(out_dtype)
-#             return ret
-#
-#     return cholesky
-
-
 @numba_funcify.register(Solve)
 def numba_funcify_Solve(op, node, **kwargs):
     assume_a = op.assume_a

--- a/pytensor/link/numba/dispatch/slinalg.py
+++ b/pytensor/link/numba/dispatch/slinalg.py
@@ -311,6 +311,10 @@ def cholesky_impl(A, lower=0, overwrite_a=False, check_finite=True):
     ensure_lapack()
     _check_scipy_linalg_matrix(A, "cholesky")
     dtype = A.dtype
+    if str(dtype).startswith("complex"):
+        raise ValueError(
+            "Complex inputs not currently supported by cholesky in Numba mode"
+        )
     w_type = _get_underlying_float(dtype)
     numba_potrf = _LAPACK().numba_xpotrf(dtype)
 

--- a/pytensor/link/numba/dispatch/slinalg.py
+++ b/pytensor/link/numba/dispatch/slinalg.py
@@ -353,6 +353,12 @@ def cholesky_impl(A, lower=0, overwrite_a=False, check_finite=True):
 
 @numba_funcify.register(Cholesky)
 def numba_funcify_Cholesky(op, node, **kwargs):
+    """
+    Overload scipy.linalg.cholesky with a numba function.
+
+    Note that np.linalg.cholesky is already implemented in numba, but it does not support additional keyword arguments.
+    In particular, the `inplace` argument is not supported, which is why we choose to implement our own version.
+    """
     lower = op.lower
     overwrite_a = False
     check_finite = op.check_finite

--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -132,7 +132,7 @@ class Cholesky(Op):
             return [grad]
 
 
-def cholesky(x, lower=True, on_error="raise", check_finite=True):
+def cholesky(x, lower=True, on_error="raise", check_finite=False):
     return Blockwise(
         Cholesky(lower=lower, on_error=on_error, check_finite=check_finite)
     )(x)

--- a/tests/link/numba/test_nlinalg.py
+++ b/tests/link/numba/test_nlinalg.py
@@ -15,57 +15,6 @@ rng = np.random.default_rng(42849)
 
 
 @pytest.mark.parametrize(
-    "x, lower, exc",
-    [
-        (
-            set_test_value(
-                pt.dmatrix(),
-                (lambda x: x.T.dot(x))(rng.random(size=(3, 3)).astype("float64")),
-            ),
-            True,
-            None,
-        ),
-        (
-            set_test_value(
-                pt.lmatrix(),
-                (lambda x: x.T.dot(x))(
-                    rng.integers(1, 10, size=(3, 3)).astype("int64")
-                ),
-            ),
-            True,
-            None,
-        ),
-        (
-            set_test_value(
-                pt.dmatrix(),
-                (lambda x: x.T.dot(x))(rng.random(size=(3, 3)).astype("float64")),
-            ),
-            False,
-            UserWarning,
-        ),
-    ],
-)
-def test_Cholesky(x, lower, exc):
-    g = slinalg.Cholesky(lower=lower)(x)
-
-    if isinstance(g, list):
-        g_fg = FunctionGraph(outputs=g)
-    else:
-        g_fg = FunctionGraph(outputs=[g])
-
-    cm = contextlib.suppress() if exc is None else pytest.warns(exc)
-    with cm:
-        compare_numba_and_py(
-            g_fg,
-            [
-                i.tag.test_value
-                for i in g_fg.inputs
-                if not isinstance(i, (SharedVariable, Constant))
-            ],
-        )
-
-
-@pytest.mark.parametrize(
     "A, x, lower, exc",
     [
         (

--- a/tests/link/numba/test_slinalg.py
+++ b/tests/link/numba/test_slinalg.py
@@ -103,7 +103,7 @@ def test_solve_triangular_raises_on_nan_inf(value):
 
     with pytest.raises(
         np.linalg.LinAlgError,
-        match=re.escape("Non-numeric values (nan or inf) returned "),
+        match=re.escape("Non-numeric values"),
     ):
         f(A_tri, b)
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
Tests are failing on #577 for the numba overloaded cholesky routine and I realized we didn't have a real one, so here it is. Now fully compatible with all the scipy keyword arguments. In addition, it will no longer drop numba into object mode. 

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #577

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->