### PR TITLE
Apply pyupgrade fixes missing from ruff

### DIFF
--- a/pytensor/compile/profiling.py
+++ b/pytensor/compile/profiling.py
@@ -1084,8 +1084,8 @@ class ProfileStats:
                     viewof_change = []
                     # Use to track view_of changes
 
-                    viewedby_add = defaultdict(lambda: [])
-                    viewedby_remove = defaultdict(lambda: [])
+                    viewedby_add = defaultdict(list)
+                    viewedby_remove = defaultdict(list)
                     # Use to track viewed_by changes
 
                     for var in node.outputs:

--- a/pytensor/graph/rewriting/basic.py
+++ b/pytensor/graph/rewriting/basic.py
@@ -950,8 +950,8 @@ class MetaNodeRewriter(NodeRewriter):
 
     def __init__(self):
         self.verbose = config.metaopt__verbose
-        self.track_dict = defaultdict(lambda: [])
-        self.tag_dict = defaultdict(lambda: [])
+        self.track_dict = defaultdict(list)
+        self.tag_dict = defaultdict(list)
         self._tracks = []
         self.rewriters = []
 

--- a/pytensor/link/utils.py
+++ b/pytensor/link/utils.py
@@ -818,7 +818,7 @@ def get_destroy_dependencies(fgraph: FunctionGraph) -> dict[Apply, list[Variable
     in destroy_dependencies.
     """
     order = fgraph.orderings()
-    destroy_dependencies = defaultdict(lambda: [])
+    destroy_dependencies = defaultdict(list)
     for node in fgraph.apply_nodes:
         for prereq in order.get(node, []):
             destroy_dependencies[node].extend(prereq.outputs)

--- a/pytensor/tensor/rewriting/elemwise.py
+++ b/pytensor/tensor/rewriting/elemwise.py
@@ -126,7 +126,7 @@ class InplaceElemwiseOptimizer(GraphRewriter):
             "nb_call_replace": 0,
             "nb_call_validate": 0,
             "nb_inconsistent": 0,
-            "ndim": defaultdict(lambda: 0),
+            "ndim": defaultdict(int),
         }
 
         check_each_change = config.tensor__insert_inplace_optimizer_validate_nb


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description

In the course of #586 we observed that newer versions of `pyupgrade` (the current latest `3.15.0` vs the outdated `3.3.1` configured in `.pre-commit-config.yaml`) caught a few more issues that `ruff` missed. I'm not sure why; perhaps `pyupgrade` is more up-to-date than `ruff`.

We can merge these particular fixes, but it's probably worth considering what to do here in general. Like should we still run `pyupgrade`, and perhaps also `flake8` in the CI to ensure that `ruff` isn't missing stuff?

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [X] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
