### PR TITLE
Move register_canonicalize to graph.rewriting.utils, Adjust function signature, and enhance AttributeError handling 

### DIFF
--- a/pytensor/graph/rewriting/utils.py
+++ b/pytensor/graph/rewriting/utils.py
@@ -252,12 +252,7 @@ def register_canonicalize(
 
         return register
     else:
-        # Use getattr to handle cases where __name__ is not present
         name = kwargs.pop("name", None) or getattr(node_rewriter, "__name__", None)
-
-        # If name is still None, provide a default name or handle it as needed
-        if name is None:
-            name = "default_name"
 
         compile.optdb["canonicalize"].register(
             name, node_rewriter, "fast_run", "fast_compile", *tags, **kwargs

--- a/pytensor/tensor/rewriting/basic.py
+++ b/pytensor/tensor/rewriting/basic.py
@@ -41,6 +41,7 @@ from pytensor.graph.rewriting.basic import (
     node_rewriter,
 )
 from pytensor.graph.rewriting.db import RewriteDatabase
+from pytensor.graph.rewriting.utils import register_canonicalize
 from pytensor.raise_op import Assert, CheckAndRaise, assert_op
 from pytensor.tensor.basic import (
     Alloc,
@@ -149,23 +150,6 @@ def register_useless(
 
         compile.mode.local_useless.register(
             name, node_rewriter, "fast_run", *tags, position="last", **kwargs
-        )
-        return node_rewriter
-
-
-def register_canonicalize(
-    node_rewriter: Union[RewriteDatabase, NodeRewriter, str], *tags: str, **kwargs
-):
-    if isinstance(node_rewriter, str):
-
-        def register(inner_rewriter: Union[RewriteDatabase, Rewriter]):
-            return register_canonicalize(inner_rewriter, node_rewriter, *tags, **kwargs)
-
-        return register
-    else:
-        name = kwargs.pop("name", None) or node_rewriter.__name__
-        compile.optdb["canonicalize"].register(
-            name, node_rewriter, "fast_run", "fast_compile", *tags, **kwargs
         )
         return node_rewriter
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
### 1.Function Relocation:
The `register_canonicalize` function has been relocated from` tensor.rewriting.basic` to `graph.rewriting.utils`. The move encompasses all necessary imports to ensure seamless functionality in the new location.However, during this transition, issues were identified specifically related to implementation which I tried to fix and are described below.

### 2.Type Mismatch Error Resolution:
The function signature of `register` function inside `register_canonicalize` was causing a type mismatch error. This was addressed by changing the input type to `Union[RewriteDatabase, NodeRewriter]` from `Union[RewriteDatabase, Rewriter`]
Before:
```
    if isinstance(node_rewriter, str):

        def register(inner_rewriter: Union[RewriteDatabase, Rewriter]):
            return register_canonicalize(inner_rewriter, node_rewriter, *tags, **kwargs)

        return register
```
**Error:**
```
pytensor\graph\rewriting\utils.py:251: error: Argument 1 to "register_canonicalize" has incompatible type "RewriteDatabase | 
Rewriter"; expected "RewriteDatabase | NodeRewriter | str"
```
After:
```
  if isinstance(node_rewriter, str):
        def register(inner_rewriter: Union[RewriteDatabase, NodeRewriter]):
            return register_canonicalize(inner_rewriter, node_rewriter, *tags, **kwargs)
        return register
```
### 3.AttributeError Fix:
In `register_canonicalize`, there were errors related to missing `__name__ `attributes for `node_rewriter:Union[RewriteDatabase, NodeRewriter, str]`
This was resolved by using `getattr()` to handle cases where `__name__ `is not present .In cases where the attribute is not available, `Name=None`. (We can think of implementing default name )
before:
`name = kwargs.pop("name", None) or node_rewriter.__name__`

**Error:**
```
pytensor\graph\rewriting\utils.py:255: error: Item "RewriteDatabase" of "RewriteDatabase | NodeRewriter" has no attribute "__name__"
pytensor\graph\rewriting\utils.py:255: error: Item "NodeRewriter" of "RewriteDatabase | NodeRewriter" has no attribute "__name__"

```
after:
`name = kwargs.pop("name", None) or getattr(node_rewriter, "__name__", None)`

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #323 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [x] refactor 
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
