### PR TITLE
Replace usage of `sys.stdout.encoding` with `sys.getdefaultencoding()`

### DIFF
--- a/pytensor/link/c/cmodule.py
+++ b/pytensor/link/c/cmodule.py
@@ -2743,7 +2743,7 @@ def default_blas_ldflags():
 
         maybe_lib_dirs = [
             [pathlib.Path(p).resolve() for p in line[len("libraries: =") :].split(":")]
-            for line in stdout.decode(sys.stdout.encoding).splitlines()
+            for line in stdout.decode(sys.getdefaultencoding()).splitlines()
             if line.startswith("libraries: =")
         ]
         if len(maybe_lib_dirs) > 0:


### PR DESCRIPTION
This fixes an error encountered when importing `pymc` in a rmarkdown document code chunk. 

In that context, `sys.stdout` is replaced with a `StringIO()` object to capture all output, and `sys.stdout.encoding` returns `None`, raising an exception.

closes https://github.com/rstudio/reticulate/issues/1508

<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes https://github.com/rstudio/reticulate/issues/1508
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
