### PR TITLE
Deprecate ScalarSharedVariable

### DIFF
--- a/pytensor/tensor/sharedvar.py
+++ b/pytensor/tensor/sharedvar.py
@@ -9,6 +9,18 @@ from pytensor.tensor.type import TensorType
 from pytensor.tensor.variable import _tensor_py_operators
 
 
+def __getattr__(name):
+    if name == "ScalarSharedVariable":
+        warnings.warn(
+            "The class `ScalarSharedVariable` has been deprecated. "
+            "Use `TensorSharedVariable` instead and check for `ndim==0`.",
+            FutureWarning,
+        )
+        return TensorSharedVariable
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 def load_shared_variable(val):
     """
     This function is only here to keep some pickles loading
@@ -94,10 +106,6 @@ def tensor_constructor(
     )
 
 
-class ScalarSharedVariable(TensorSharedVariable):
-    pass
-
-
 @shared_constructor.register(np.number)
 @shared_constructor.register(float)
 @shared_constructor.register(int)
@@ -132,7 +140,7 @@ def scalar_constructor(
 
     # Do not pass the dtype to asarray because we want this to fail if
     # strict is True and the types do not match.
-    rval = ScalarSharedVariable(
+    rval = TensorSharedVariable(
         type=tensor_type,
         value=np.array(value, copy=True),
         name=name,

--- a/pytensor/tensor/sharedvar.py
+++ b/pytensor/tensor/sharedvar.py
@@ -65,7 +65,6 @@ def tensor_constructor(
     allow_downcast=None,
     borrow=False,
     shape=None,
-    target="cpu",
     broadcastable=None,
 ):
     r"""`SharedVariable` constructor for `TensorType`\s.
@@ -86,9 +85,6 @@ def tensor_constructor(
             DeprecationWarning,
         )
         shape = broadcastable
-
-    if target != "cpu":
-        raise TypeError("not for cpu")
 
     # If no shape is given, then the default is to assume that the value might
     # be resized in any dimension in the future.
@@ -111,7 +107,7 @@ def tensor_constructor(
 @shared_constructor.register(int)
 @shared_constructor.register(complex)
 def scalar_constructor(
-    value, name=None, strict=False, allow_downcast=None, borrow=False, target="cpu"
+    value, name=None, strict=False, allow_downcast=None, borrow=False
 ):
     """`SharedVariable` constructor for scalar values.
 
@@ -126,9 +122,6 @@ def scalar_constructor(
     borrow, as it is a hint to PyTensor that we can reuse it.
 
     """
-    if target != "cpu":
-        raise TypeError("not for cpu")
-
     try:
         dtype = value.dtype
     except AttributeError:

--- a/tests/tensor/test_sharedvar.py
+++ b/tests/tensor/test_sharedvar.py
@@ -10,7 +10,7 @@ from pytensor.misc.may_share_memory import may_share_memory
 from pytensor.tensor import get_vector_length
 from pytensor.tensor.basic import MakeVector
 from pytensor.tensor.shape import Shape_i, specify_shape
-from pytensor.tensor.sharedvar import ScalarSharedVariable, TensorSharedVariable
+from pytensor.tensor.sharedvar import TensorSharedVariable
 from tests import unittest_tools as utt
 
 
@@ -679,10 +679,15 @@ def test_tensor_shared_zero():
 
 def test_scalar_shared_options():
     res = pytensor.shared(value=np.float32(0.0), name="lk", borrow=True)
-    assert isinstance(res, ScalarSharedVariable)
+    assert isinstance(res, TensorSharedVariable) and res.type.ndim == 0
     assert res.type.dtype == "float32"
     assert res.name == "lk"
     assert res.type.shape == ()
+
+
+def test_scalar_shared_deprecated():
+    with pytest.warns(FutureWarning, match=".*deprecated.*"):
+        pytensor.tensor.sharedvar.ScalarSharedVariable
 
 
 def test_get_vector_length():


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
As explained in the related issue this class is messy because it internally upcasts the values to 0d arrays, so that `shared(shared(5).get_value())` belongs to a different class than `shared(5)` but are exactly the same objects otherwise!

This was a source of bugs in PyMC. The way you create an object shouldn't matter for type checks, only what you actually ended up creating!
 
There is a proper ScalarSharedVariable if someone really wants to work with scalar types

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #396

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
