### PR TITLE
Add JAX support for SortOp

### DIFF
--- a/pytensor/link/jax/dispatch/tensor_basic.py
+++ b/pytensor/link/jax/dispatch/tensor_basic.py
@@ -22,6 +22,7 @@ from pytensor.tensor.basic import (
 )
 from pytensor.tensor.exceptions import NotScalarConstantError
 from pytensor.tensor.shape import Shape_i
+from pytensor.tensor.sort import SortOp
 
 
 ARANGE_CONCRETE_VALUE_ERROR = """JAX requires the arguments of `jax.numpy.arange`
@@ -205,3 +206,11 @@ def jax_funcify_Tri(op, node, **kwargs):
         return jnp.tri(*args, dtype=op.dtype)
 
     return tri
+
+
+@jax_funcify.register(SortOp)
+def jax_funcify_Sort(op, **kwargs):
+    def sort(arr, *args):
+        return jnp.sort(arr, *args)
+
+    return sort

--- a/pytensor/link/jax/dispatch/tensor_basic.py
+++ b/pytensor/link/jax/dispatch/tensor_basic.py
@@ -210,7 +210,7 @@ def jax_funcify_Tri(op, node, **kwargs):
 
 @jax_funcify.register(SortOp)
 def jax_funcify_Sort(op, **kwargs):
-    def sort(arr, *args):
-        return jnp.sort(arr, *args)
+    def sort(arr, axis):
+        return jnp.sort(arr, axis=axis)
 
     return sort

--- a/tests/link/jax/test_tensor_basic.py
+++ b/tests/link/jax/test_tensor_basic.py
@@ -218,6 +218,14 @@ def test_tri():
     compare_jax_and_py(fgraph, [])
 
 
+def test_sort():
+    x = matrix("x")
+    out = pytensor.tensor.sort(x)
+    fgraph = FunctionGraph([x], [out])
+    arr = np.array([[1.0, 4.0], [5.0, 2.0]])
+    compare_jax_and_py(fgraph, [arr])
+
+
 def test_tri_nonconcrete():
     """JAX cannot JIT-compile `jax.numpy.tri` when arguments are not concrete values."""
 

--- a/tests/link/jax/test_tensor_basic.py
+++ b/tests/link/jax/test_tensor_basic.py
@@ -218,9 +218,10 @@ def test_tri():
     compare_jax_and_py(fgraph, [])
 
 
-def test_sort():
-    x = matrix("x")
-    out = pytensor.tensor.sort(x)
+@pytest.mark.parametrize("axis", [None, -1])
+def test_sort(axis):
+    x = matrix("x", shape=(2, 2), dtype="float64")
+    out = pytensor.tensor.sort(x, axis=axis)
     fgraph = FunctionGraph([x], [out])
     arr = np.array([[1.0, 4.0], [5.0, 2.0]])
     compare_jax_and_py(fgraph, [arr])


### PR DESCRIPTION
<!-- !! Thank you for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
Implement JAX conversion for SortOp

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #595 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] Maintenance
