### PR TITLE
Prevent `local_sum_make_vector` from introducing forbidden `float64`

### DIFF
--- a/pytensor/tensor/rewriting/basic.py
+++ b/pytensor/tensor/rewriting/basic.py
@@ -28,7 +28,7 @@ from typing import Union
 import numpy as np
 
 import pytensor.scalar.basic as ps
-from pytensor import compile
+from pytensor import compile, config
 from pytensor.compile.ops import ViewOp
 from pytensor.graph import FunctionGraph
 from pytensor.graph.basic import Constant, Variable
@@ -941,6 +941,11 @@ def local_sum_make_vector(fgraph, node):
     elements = array.owner.inputs
     acc_dtype = node.op.acc_dtype
     out_dtype = node.op.dtype
+
+    # Skip rewrite if it would add unnecessary float64 to the graph
+    if acc_dtype=="float64" and out_dtype!="float64" and config.floatX != "float64":
+        return
+    
     if len(elements) == 0:
         element_sum = zeros(dtype=out_dtype, shape=())
     elif len(elements) == 1:

--- a/pytensor/tensor/rewriting/basic.py
+++ b/pytensor/tensor/rewriting/basic.py
@@ -943,9 +943,9 @@ def local_sum_make_vector(fgraph, node):
     out_dtype = node.op.dtype
 
     # Skip rewrite if it would add unnecessary float64 to the graph
-    if acc_dtype=="float64" and out_dtype!="float64" and config.floatX != "float64":
+    if acc_dtype == "float64" and out_dtype != "float64" and config.floatX != "float64":
         return
-    
+
     if len(elements) == 0:
         element_sum = zeros(dtype=out_dtype, shape=())
     elif len(elements) == 1:

--- a/tests/tensor/rewriting/test_basic.py
+++ b/tests/tensor/rewriting/test_basic.py
@@ -31,7 +31,6 @@ from pytensor.tensor.basic import (
 )
 from pytensor.tensor.elemwise import DimShuffle, Elemwise
 from pytensor.tensor.math import (
-    Sum,
     add,
     bitwise_and,
     bitwise_or,
@@ -1325,7 +1324,7 @@ def test_local_sum_make_vector():
     output = rewrite_graph(output)
     between = vars_between([a, b, c], [output])
     for var in between:
-        assert (var.owner is None)
+        assert var.owner is None
 
     # Check single element
     mv = MakeVector(config.floatX)
@@ -1334,7 +1333,7 @@ def test_local_sum_make_vector():
     output = rewrite_graph(output)
     between = vars_between([a, b, c], [output])
     for var in between:
-        assert (var.owner is None)
+        assert var.owner is None
 
     # This is a regression test for #653. Ensure that rewrite is not
     # applied when user requests float32

--- a/tests/tensor/rewriting/test_basic.py
+++ b/tests/tensor/rewriting/test_basic.py
@@ -1320,8 +1320,9 @@ def test_local_sum_make_vector():
     mv = MakeVector(config.floatX)
     output = mv(a, b, c).sum(axis=[])
     rewrite_output = rewrite_graph(output)
+    expected_output = mv(a, b, c)
     # check rewrite
-    assert isinstance(rewrite_output.owner.op, MakeVector)
+    assert equal_computations([expected_output], [rewrite_output])
     # check logic
     np.testing.assert_almost_equal(output.eval(point), rewrite_output.eval(point))
 
@@ -1340,12 +1341,13 @@ def test_local_sum_make_vector():
     mv = MakeVector(config.floatX)
     output = mv(a).sum()
     rewrite_output = rewrite_graph(output)
+    expected_output = cast(a, config.floatX)
     # check rewrite
-    assert rewrite_output == a
+    assert equal_computations([expected_output], [rewrite_output])
     # check logic
     np.testing.assert_almost_equal(output.eval(point), rewrite_output.eval(point))
 
-    # This is a regression test for #653. Ensure that rewrite is not
+    # This is a regression test for #653. Ensure that rewrite is NOT
     # applied when user requests float32
     with config.change_flags(floatX="float32", warn_float64="raise"):
         a, b, c = scalars("abc")

--- a/tests/tensor/rewriting/test_basic.py
+++ b/tests/tensor/rewriting/test_basic.py
@@ -1301,51 +1301,36 @@ def test_local_sum_make_vector():
     # To check that rewrite is applied, we must enforce dtype to
     # allow rewrite to occur even if floatX != "float64"
     a, b, c = scalars("abc")
-    point = {a: 1.0, b: 2.0, c: 3.0}
     mv = MakeVector(config.floatX)
     output = mv(a, b, c).sum(dtype="float64")
     rewrite_output = rewrite_graph(output)
     expected_output = cast(
         add(*[cast(value, "float64") for value in [a, b, c]]), dtype="float64"
     )
-    # check rewrite
     assert equal_computations([expected_output], [rewrite_output])
-    # check logic
-    np.testing.assert_almost_equal(output.eval(point), rewrite_output.eval(point))
 
     # Empty axes should return input vector since no sum is applied
     a, b, c = scalars("abc")
-    point = {a: 1.0, b: 2.0, c: 3.0}
     mv = MakeVector(config.floatX)
     output = mv(a, b, c).sum(axis=[])
     rewrite_output = rewrite_graph(output)
     expected_output = mv(a, b, c)
-    # check rewrite
     assert equal_computations([expected_output], [rewrite_output])
-    # check logic
-    np.testing.assert_almost_equal(output.eval(point), rewrite_output.eval(point))
 
     # Empty input should return 0
     mv = MakeVector(config.floatX)
     output = mv().sum()
     rewrite_output = rewrite_graph(output)
     expected_output = pt.as_tensor(0, dtype=config.floatX)
-    # check rewrite
     assert equal_computations([expected_output], [rewrite_output])
-    # check logic
-    np.testing.assert_almost_equal(output.eval(), rewrite_output.eval())
 
     # Single element input should return element value
     a = scalars("a")
-    point = {a: 1.0}
     mv = MakeVector(config.floatX)
     output = mv(a).sum()
     rewrite_output = rewrite_graph(output)
     expected_output = cast(a, config.floatX)
-    # check rewrite
     assert equal_computations([expected_output], [rewrite_output])
-    # check logic
-    np.testing.assert_almost_equal(output.eval(point), rewrite_output.eval(point))
 
     # This is a regression test for #653. Ensure that rewrite is NOT
     # applied when user requests float32

--- a/tests/tensor/rewriting/test_basic.py
+++ b/tests/tensor/rewriting/test_basic.py
@@ -105,7 +105,6 @@ from pytensor.tensor.type import (
     values_eq_approx_remove_nan,
     vector,
 )
-from pytensor.tensor.variable import TensorConstant
 from tests import unittest_tools as utt
 
 
@@ -1330,8 +1329,9 @@ def test_local_sum_make_vector():
     mv = MakeVector(config.floatX)
     output = mv().sum()
     rewrite_output = rewrite_graph(output)
+    expected_output = pt.as_tensor(0, dtype=config.floatX)
     # check rewrite
-    assert isinstance(rewrite_output, TensorConstant)
+    assert equal_computations([expected_output], [rewrite_output])
     # check logic
     np.testing.assert_almost_equal(output.eval(), rewrite_output.eval())
 

--- a/tests/tensor/rewriting/test_basic.py
+++ b/tests/tensor/rewriting/test_basic.py
@@ -26,6 +26,7 @@ from pytensor.tensor.basic import (
     ScalarFromTensor,
     Split,
     TensorFromScalar,
+    cast,
     join,
     tile,
 )
@@ -1305,8 +1306,11 @@ def test_local_sum_make_vector():
     mv = MakeVector(config.floatX)
     output = mv(a, b, c).sum(dtype="float64")
     rewrite_output = rewrite_graph(output)
+    expected_output = cast(
+        add(*[cast(value, "float64") for value in [a, b, c]]), dtype="float64"
+    )
     # check rewrite
-    assert not equal_computations([output], [rewrite_output])
+    assert equal_computations([expected_output], [rewrite_output])
     # check logic
     np.testing.assert_almost_equal(output.eval(point), rewrite_output.eval(point))
 

--- a/tests/tensor/rewriting/test_basic.py
+++ b/tests/tensor/rewriting/test_basic.py
@@ -1297,15 +1297,16 @@ def test_local_join_make_vector():
 
 
 def test_local_sum_make_vector():
-    # Check that rewrite is applied
+    # Check that rewrite is applied. Enforce dtype to allow rewrite
+    # even if floatX != "float64"
     a, b, c = scalars("abc")
     mv = MakeVector(config.floatX)
-    output = mv(a, b, c).sum()
+    output = mv(a, b, c).sum(dtype="float64")
 
     output = rewrite_graph(output)
     between = vars_between([a, b, c], [output])
     for var in between:
-        assert (var.owner is None) or (isinstance(var.owner.op, ps.Add))
+        assert (var.owner is None) or (isinstance(var.owner.op, Elemwise))
 
     # Check for empty sum
     a, b, c = scalars("abc")


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
This PR changes the behavior of `local_sum_make_vector` to skip rewriting whenever the internal accumulator is more precise than both the input/output data and `config.floatX`. Otherwise, the internal accumulator is added to the graph, which can introduce forbidden `float64` to the graph when the user requests `config.floatX="float32"`.

Replaces PR https://github.com/pymc-devs/pytensor/pull/655 and https://github.com/pymc-devs/pytensor/pull/656

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [X] Closes https://github.com/pymc-devs/pytensor/issues/653

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [X] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [X] Included tests that prove the fix is effective or that the new feature works
- [X] Added necessary documentation (docstrings and/or example notebooks)
- [X] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [X] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
