### PR TITLE
Fix PyPy by eliminating deprecated library detection code

### DIFF
--- a/pytensor/link/c/cmodule.py
+++ b/pytensor/link/c/cmodule.py
@@ -1751,30 +1751,23 @@ def std_lib_dirs_and_libs() -> Optional[tuple[list[str], ...]]:
     elif sys.platform == "darwin":
         std_lib_dirs_and_libs.data = [], []
     else:
-        if platform.python_implementation() == "PyPy":
-            # Assume Linux (note: Ubuntu doesn't ship this .so)
-            libname = "pypy3-c"
-            # Unfortunately the only convention of this .so is that it appears
-            # next to the location of the interpreter binary.
-            libdir = os.path.dirname(os.path.realpath(sys.executable))
-        else:
-            # Assume Linux
-            # Typical include directory: /usr/include/python2.6
+        # Assume Linux
+        # Typical include directory: /usr/include/python2.6
 
-            # get the name of the python library (shared object)
+        # get the name of the python library (shared object)
 
-            libname = str(get_config_var("LDLIBRARY"))
+        libname = str(get_config_var("LDLIBRARY"))
 
-            if libname.startswith("lib"):
-                libname = libname[3:]
+        if libname.startswith("lib"):
+            libname = libname[3:]
 
-            # remove extension if present
-            if libname.endswith(".so"):
-                libname = libname[:-3]
-            elif libname.endswith(".a"):
-                libname = libname[:-2]
+        # remove extension if present
+        if libname.endswith(".so"):
+            libname = libname[:-3]
+        elif libname.endswith(".a"):
+            libname = libname[:-2]
 
-            libdir = str(get_config_var("LIBDIR"))
+        libdir = str(get_config_var("LIBDIR"))
 
         std_lib_dirs_and_libs.data = [libname], [libdir]
 


### PR DESCRIPTION


<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->

I tested PyTensor with PyPy and it fails with:

```
ld: cannot find -lpypy3-c: No such file or directory
```

The problem is this code that handles PyPy as a special case.

For example, the correct value for libname may be `"pypy3.9-c"` and can be inferred from `LDLIBRARY`, but setting it to `"pypy3-c"` leads to the aforementioned failure.



## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [X] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [X] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [X] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
