### PR TITLE
prevent `log10` `L_op` from upcasting

### DIFF
--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -3030,7 +3030,7 @@ class Log10(UnaryScalarOp):
             else:
                 return [x.zeros_like()]
 
-        return (gz / (x * np.log(10.0)),)
+        return (gz / (x * np.asarray(math.log(10.0)).astype(x.dtype)),)
 
     def c_code(self, node, name, inputs, outputs, sub):
         (x,) = inputs

--- a/tests/scalar/test_basic.py
+++ b/tests/scalar/test_basic.py
@@ -544,3 +544,14 @@ def test_shape():
     assert b.shape.type.ndim == 1
     assert b.shape.type.shape == (0,)
     assert b.shape.type.dtype == "int64"
+
+
+def test_grad_log10():
+    # Ensure that log10 does not upcast gradient
+    # This is a regression test for
+    # https://github.com/pymc-devs/pytensor/issues/667
+    a = float32("log10_a")
+    b = log10(a)
+    b_grad = pytensor.gradient.grad(b, a)
+    assert b.dtype == "float32"
+    assert b_grad.dtype == "float32"


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
Prevent `log10` `L_op` from upcasting.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [X] Closes https://github.com/pymc-devs/pytensor/issues/667

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [X] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [X] Included tests that prove the fix is effective or that the new feature works
- [X] Added necessary documentation (docstrings and/or example notebooks)
- [X] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [X] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
