### PR TITLE
Correct the example in the "Adding JAX and Numba support for Ops" doc

### DIFF
--- a/doc/extending/creating_a_numba_jax_op.rst
+++ b/doc/extending/creating_a_numba_jax_op.rst
@@ -105,7 +105,7 @@ Here’s an example for the `Eye`\ `Op`:
 
 
    @jax_funcify.register(Eye)
-   def jax_funcify_Eye(op):
+   def jax_funcify_Eye(op, **kwargs):
 
        # Obtain necessary "static" attributes from the Op being converted
        dtype = op.dtype


### PR DESCRIPTION
## Description
As it was written, this example demonstrating how to add JAX support for the `Eye` `Op` threw a type error, because it registered with JAX a function that only takes a single argument `op`, which is actually called with the keyword arguments `node` and `output_storage` as well.  Adding a `**kwargs` to the function signature resolves this, and is also what [the existing Jaxified Ops](https://github.com/pymc-devs/pytensor/blob/main/pytensor/link/jax/dispatch/basic.py) mostly seem to do.

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):

