### PR TITLE
Add name kwarg to Op.__call__

### DIFF
--- a/pytensor/graph/op.py
+++ b/pytensor/graph/op.py
@@ -291,10 +291,13 @@ class Op(MetaObject):
         return_list = kwargs.pop("return_list", False)
         name = kwargs.pop("name", None)
         node = self.make_node(*inputs, **kwargs)
-        name = kwargs.pop("name", None)
+        print(name, kwargs)
         if isinstance(node.outputs, list):
+            print('*'*7)
             for n in node.outputs:
+                # print(n.name)
                 n.name = name
+                print(n.name)
 
         if config.compute_test_value != "off":
             compute_test_value(node)

--- a/pytensor/graph/op.py
+++ b/pytensor/graph/op.py
@@ -291,7 +291,11 @@ class Op(MetaObject):
         return_list = kwargs.pop("return_list", False)
         name = kwargs.pop("name", None)
         node = self.make_node(*inputs, **kwargs)
-        node.outputs[0].name = name
+        if isinstance(node.outputs, list):
+            if len(node.outputs) >= 1:
+                node.outputs[0].name = name
+        else:
+            node.outputs.name = name
 
         if config.compute_test_value != "off":
             compute_test_value(node)

--- a/pytensor/graph/op.py
+++ b/pytensor/graph/op.py
@@ -289,7 +289,9 @@ class Op(MetaObject):
 
         """
         return_list = kwargs.pop("return_list", False)
+        name = kwargs.pop("name", None)
         node = self.make_node(*inputs, **kwargs)
+        node.outputs[0].name = name
 
         if config.compute_test_value != "off":
             compute_test_value(node)

--- a/pytensor/graph/op.py
+++ b/pytensor/graph/op.py
@@ -291,7 +291,7 @@ class Op(MetaObject):
         return_list = kwargs.pop("return_list", False)
         name = kwargs.pop("name", None)
         node = self.make_node(*inputs, **kwargs)
-        if isinstance(node.outputs, list):
+        if name is not None:
             if len(node.outputs) == 1:
                 node.outputs[0].name = name
             else:

--- a/pytensor/graph/op.py
+++ b/pytensor/graph/op.py
@@ -291,7 +291,6 @@ class Op(MetaObject):
         return_list = kwargs.pop("return_list", False)
         name = kwargs.pop("name", None)
         node = self.make_node(*inputs, **kwargs)
-        print(name, kwargs)
         if isinstance(node.outputs, list):
             for n in node.outputs:
                 n.name = name

--- a/pytensor/graph/op.py
+++ b/pytensor/graph/op.py
@@ -292,8 +292,11 @@ class Op(MetaObject):
         name = kwargs.pop("name", None)
         node = self.make_node(*inputs, **kwargs)
         if isinstance(node.outputs, list):
-            for n in node.outputs:
-                n.name = name
+            if len(node.outputs) == 1:
+                node.outputs[0].name = name
+            else:
+                for i, n in enumerate(node.outputs):
+                    n.name = f"{name}_{i}"
 
         if config.compute_test_value != "off":
             compute_test_value(node)

--- a/pytensor/graph/op.py
+++ b/pytensor/graph/op.py
@@ -293,11 +293,8 @@ class Op(MetaObject):
         node = self.make_node(*inputs, **kwargs)
         print(name, kwargs)
         if isinstance(node.outputs, list):
-            print('*'*7)
             for n in node.outputs:
-                # print(n.name)
                 n.name = name
-                print(n.name)
 
         if config.compute_test_value != "off":
             compute_test_value(node)

--- a/pytensor/graph/op.py
+++ b/pytensor/graph/op.py
@@ -246,7 +246,9 @@ class Op(MetaObject):
             )
         return Apply(self, inputs, [o() for o in self.otypes])
 
-    def __call__(self, *inputs: Any, **kwargs) -> Variable | list[Variable]:
+    def __call__(
+        self, *inputs: Any, name=None, return_list=False, **kwargs
+    ) -> Variable | list[Variable]:
         r"""Construct an `Apply` node using :meth:`Op.make_node` and return its outputs.
 
         This method is just a wrapper around :meth:`Op.make_node`.
@@ -288,12 +290,12 @@ class Op(MetaObject):
             the :attr:`Op.default_output` property.
 
         """
-        return_list = kwargs.pop("return_list", False)
-        name = kwargs.pop("name", None)
         node = self.make_node(*inputs, **kwargs)
         if name is not None:
             if len(node.outputs) == 1:
                 node.outputs[0].name = name
+            elif self.default_output is not None:
+                node.outputs[self.default_output].name = name
             else:
                 for i, n in enumerate(node.outputs):
                     n.name = f"{name}_{i}"

--- a/pytensor/graph/op.py
+++ b/pytensor/graph/op.py
@@ -291,11 +291,10 @@ class Op(MetaObject):
         return_list = kwargs.pop("return_list", False)
         name = kwargs.pop("name", None)
         node = self.make_node(*inputs, **kwargs)
+        name = kwargs.pop("name", None)
         if isinstance(node.outputs, list):
-            if len(node.outputs) >= 1:
-                node.outputs[0].name = name
-        else:
-            node.outputs.name = name
+            for n in node.outputs:
+                n.name = name
 
         if config.compute_test_value != "off":
             compute_test_value(node)

--- a/tests/graph/test_op.py
+++ b/tests/graph/test_op.py
@@ -232,3 +232,11 @@ def test_op_input_broadcastable():
 
     x = pt.TensorType(dtype="float64", shape=(1,))("x")
     assert SomeOp()(x).type == pt.dvector
+
+
+def test_op_name():
+    x = pt.vector("x")
+    y = pt.vector("y")
+    op_name = "op_name"
+    z = pt.add(x, y, name=op_name)
+    assert z.name == op_name

--- a/tests/graph/test_op.py
+++ b/tests/graph/test_op.py
@@ -238,5 +238,20 @@ def test_op_name():
     x = pt.vector("x")
     y = pt.vector("y")
     op_name = "op_name"
+
+    class MultiOutOp(Op):
+        def make_node(self, *inputs):
+            outputs = [pt.dmatrix(), pt.dmatrix()]
+            return Apply(self, list(inputs), outputs)
+
+        def perform(self, node, inputs, outputs):
+            outputs[0] = pt.matrix()
+            outputs[1] = pt.matrix()
+
+    multi_op = MultiOutOp()
+    res = multi_op(x, name=op_name)
+    for i, r in enumerate(res):
+        assert r.name == f"{op_name}_{i}"
+
     z = pt.add(x, y, name=op_name)
     assert z.name == op_name


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
Add `name` keyword in `Op.__call__` allowing arbitrary `Op`s to be given names
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #685 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Included tests that prove the fix is effective or that the new feature works


## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement