### PR TITLE
Only invoke config.cxx if non-empty

### DIFF
--- a/pytensor/configdefaults.py
+++ b/pytensor/configdefaults.py
@@ -1437,12 +1437,16 @@ add_vm_configvars()
 add_numba_configvars()
 
 # TODO: `gcc_version_str` is used by other modules.. Should it become an immutable config var?
-try:
-    p_out = output_subprocess_Popen([config.cxx, "-dumpversion"])
-    gcc_version_str = p_out[0].strip().decode()
-except OSError:
-    # Typically means gcc cannot be found.
+if config.cxx != "":
+    try:
+        p_out = output_subprocess_Popen([config.cxx, "-dumpversion"])
+        gcc_version_str = p_out[0].strip().decode()
+    except OSError:
+        # Typically means gcc cannot be found.
+        gcc_version_str = "GCC_NOT_FOUND"
+else:
     gcc_version_str = "GCC_NOT_FOUND"
+
 # TODO: The caching dir resolution is a procedural mess of helper functions, local variables
 # and config definitions. And the result is also not particularly pretty..
 add_caching_dir_configvars()


### PR DESCRIPTION
## Description
Update configdefaults to only attempt to retrieve gcc_version_str iff config.cxx is non-empty.

## Related Issue
- [x] Closes #703
- [ ] Related to #

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)


## Type of change
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):

