### PR TITLE
Fix mypy problem on Windows due to platform differences

### DIFF
--- a/pytensor/link/c/cmodule.py
+++ b/pytensor/link/c/cmodule.py
@@ -284,7 +284,11 @@ def add_gcc_dll_directory() -> None:
     if (sys.platform == "win32") & (hasattr(os, "add_dll_directory")):
         gcc_path = shutil.which("gcc")
         if gcc_path is not None:
-            os.add_dll_directory(os.path.dirname(gcc_path))  # type: ignore
+            # Since add_dll_directory is only defined on windows, we need
+            # the ignore[attr-defined] on non-Windows platforms.
+            # For Windows we need ignore[unused-ignore] since the ignore
+            # is unnecessary with that platform.
+            os.add_dll_directory(os.path.dirname(gcc_path))  # type: ignore[attr-defined,unused-ignore]
 
 
 def dlimport(fullpath, suffix=None):


### PR DESCRIPTION
## Description

As reported in <https://github.com/pymc-devs/pytensor/pull/678#issuecomment-2036674730>, mypy was failing on Windows due to an unnecessary `# type: ignore`. This fixes it by ignoring the `unused-ignore` so that Windows is covered.

I'm marking this as maintenance since it's not a runtime bugfix.

<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
Fixes an issue introduced and reported in #678.

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [X] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [X] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [X] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
