### PR TITLE
Add support for negative axis in `specify_broadcastable`

### DIFF
--- a/pytensor/tensor/shape.py
+++ b/pytensor/tensor/shape.py
@@ -4,7 +4,7 @@ from textwrap import dedent
 from typing import cast
 
 import numpy as np
-from numpy.core.numeric import normalize_axis_tuple
+from numpy.lib.array_utils import normalize_axis_tuple
 
 import pytensor
 from pytensor.gradient import DisconnectedType
@@ -995,12 +995,7 @@ def specify_broadcastable(x, *axes):
     if not axes:
         return x
 
-    if min(axes) < 0:
-        axes = list(normalize_axis_tuple(axes, x.type.ndim))
-
-    if max(axes) >= x.type.ndim:
-        raise ValueError("Trying to specify broadcastable of non-existent dimension")
-
+    axes = normalize_axis_tuple(axes, x.type.ndim)
     shape_info = [1 if i in axes else s for i, s in enumerate(x.type.shape)]
     return specify_shape(x, shape_info)
 

--- a/pytensor/tensor/shape.py
+++ b/pytensor/tensor/shape.py
@@ -4,6 +4,7 @@ from textwrap import dedent
 from typing import cast
 
 import numpy as np
+from numpy.core.numeric import normalize_axis_tuple
 
 import pytensor
 from pytensor.gradient import DisconnectedType
@@ -993,6 +994,9 @@ def specify_broadcastable(x, *axes):
 
     if not axes:
         return x
+
+    if min(axes)<0:
+        axes = list(normalize_axis_tuple(axes, x.type.ndim))
 
     if max(axes) >= x.type.ndim:
         raise ValueError("Trying to specify broadcastable of non-existent dimension")

--- a/pytensor/tensor/shape.py
+++ b/pytensor/tensor/shape.py
@@ -4,7 +4,7 @@ from textwrap import dedent
 from typing import cast
 
 import numpy as np
-from numpy.lib.array_utils import normalize_axis_tuple
+from numpy.core.numeric import normalize_axis_tuple
 
 import pytensor
 from pytensor.gradient import DisconnectedType

--- a/pytensor/tensor/shape.py
+++ b/pytensor/tensor/shape.py
@@ -995,7 +995,7 @@ def specify_broadcastable(x, *axes):
     if not axes:
         return x
 
-    if min(axes)<0:
+    if min(axes) < 0:
         axes = list(normalize_axis_tuple(axes, x.type.ndim))
 
     if max(axes) >= x.type.ndim:

--- a/pytensor/tensor/shape.py
+++ b/pytensor/tensor/shape.py
@@ -4,7 +4,7 @@ from textwrap import dedent
 from typing import cast
 
 import numpy as np
-from numpy.core.numeric import normalize_axis_tuple
+from numpy.core.numeric import normalize_axis_tuple  # type: ignore
 
 import pytensor
 from pytensor.gradient import DisconnectedType

--- a/scripts/mypy-failing.txt
+++ b/scripts/mypy-failing.txt
@@ -25,7 +25,6 @@ pytensor/tensor/random/basic.py
 pytensor/tensor/random/op.py
 pytensor/tensor/random/utils.py
 pytensor/tensor/rewriting/basic.py
-pytensor/tensor/shape.py
 pytensor/tensor/slinalg.py
 pytensor/tensor/subtensor.py
 pytensor/tensor/type.py

--- a/scripts/mypy-failing.txt
+++ b/scripts/mypy-failing.txt
@@ -25,6 +25,7 @@ pytensor/tensor/random/basic.py
 pytensor/tensor/random/op.py
 pytensor/tensor/random/utils.py
 pytensor/tensor/rewriting/basic.py
+pytensor/tensor/shape.py
 pytensor/tensor/slinalg.py
 pytensor/tensor/subtensor.py
 pytensor/tensor/type.py

--- a/tests/tensor/test_shape.py
+++ b/tests/tensor/test_shape.py
@@ -562,11 +562,13 @@ class TestSpecifyBroadcastable:
         x = matrix()
         assert specify_broadcastable(x, 0).type.shape == (1, None)
         assert specify_broadcastable(x, 1).type.shape == (None, 1)
+        assert specify_broadcastable(x, -1).type.shape == (None, 1)
         assert specify_broadcastable(x, 0, 1).type.shape == (1, 1)
 
         x = row()
         assert specify_broadcastable(x, 0) is x
         assert specify_broadcastable(x, 1) is not x
+        assert specify_broadcastable(x, -2) is x
 
     def test_validation(self):
         x = matrix()

--- a/tests/tensor/test_shape.py
+++ b/tests/tensor/test_shape.py
@@ -572,8 +572,12 @@ class TestSpecifyBroadcastable:
 
     def test_validation(self):
         x = matrix()
-        with pytest.raises(ValueError, match="^Trying to specify broadcastable of*"):
-            specify_broadcastable(x, 2)
+        axis = 2
+        with pytest.raises(
+            ValueError,
+            match=f"axis {axis} is out of bounds for array of dimension {axis}",
+        ):
+            specify_broadcastable(x, axis)
 
 
 class TestRopLop(RopLopChecker):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->

Normalized the axes argument in ```specify_broadcastable``` using ```normalize_axis_tuple``` from numpy. Also added tensor/shape.py to mypy-failing-list as import statements cause expected failure.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #698
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
