### PR TITLE
Add codecov_token env variable to upload coverage report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -259,7 +259,8 @@ jobs:
           path: coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: ./coverage/
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Closes #714

From looking at [this failed coverage report upload](https://github.com/pymc-devs/pytensor/actions/runs/8637210115/job/23914548773#step:6:116), the codecov action was saying that we were not using the upload token when we tried to upload the coverage reports. To be honest, I have no idea why we were ever able to upload the reports without setting the token. I've added the token as an action secret and placed it as an env variable for that step of the upload job.