### PR TITLE
Fix gradient of `OpFromGraph` with disconnected/related outputs

### DIFF
--- a/pytensor/compile/builders.py
+++ b/pytensor/compile/builders.py
@@ -413,7 +413,10 @@ class OpFromGraph(Op, HasInnerGraph):
                 FutureWarning,
             )
             self._lop_op_interface = False
-        self._lop_op_cache: Callable | None = None
+        # Dictionary where we cache OpFromGraph that represent the L_op
+        # A distinct OpFromGraph is needed to represent each pattern of output_grads connection
+        # It also returns a tuple that indicates which input_gradients are disconnected
+        self._lop_op_cache: dict[tuple[bool, ...], Callable] = {}
         self._rop_op_cache: Callable | None = None
 
         self._connection_pattern = connection_pattern
@@ -475,24 +478,30 @@ class OpFromGraph(Op, HasInnerGraph):
         return outputs
 
     @config.change_flags(compute_test_value="off")
-    def _build_and_cache_lop_op(self) -> Callable:
-        """converts lop_overrides (or grad_overrides) from user supplied form to type(self) instance.
+    def _build_and_cache_lop_op(
+        self, disconnected_output_grads: tuple[bool, ...]
+    ) -> Callable:
+        """converts lop_overrides (or grad_overrides) from user supplied form to type(self) instance,
+        specialized for the pattern of disconnected_output_grads
 
         Results are cached in self._lop_op_cache
         """
-        if self._lop_op_cache is not None:
-            return self._lop_op_cache
+        try:
+            return self._lop_op_cache[disconnected_output_grads]
+        except KeyError:
+            pass
 
         inner_inputs = self.inner_inputs
         inner_outputs = self.inner_outputs
         nin = len(inner_inputs)
+        nout = len(inner_outputs)
         lop_overrides = (
             self.lop_overrides if self._lop_op_interface else self.grad_overrides
         )
 
         if isinstance(lop_overrides, OpFromGraph):
             if self._lop_op_interface:
-                self._lop_op_cache = lop_overrides
+                self._lop_op_cache[disconnected_output_grads] = lop_overrides
                 lop_overrides.kwargs["on_unused_input"] = "ignore"
                 return lop_overrides
 
@@ -502,20 +511,42 @@ class OpFromGraph(Op, HasInnerGraph):
                 def lop_overrides(inps, grads):
                     return self.grad_overrides(*inps, *grads)
 
-        output_grads = [out_t() for out_t in self.output_types]
+        # We try to compute the gradient with respect to connected outputs only
+        connected_inner_outputs = [
+            # We add an identity operation(copy) so that we don't override indirect
+            # gradient contributions to an inner output coming from other inner outputs
+            inner_out.copy()
+            for inner_out, disconnected in zip(
+                inner_outputs, disconnected_output_grads, strict=True
+            )
+            if not disconnected
+        ]
+        connected_output_grads = [
+            out_t()
+            for out_t, disconnected in zip(
+                self.output_types, disconnected_output_grads, strict=True
+            )
+            if not disconnected
+        ]
         fn_grad = partial(
             grad,
             cost=None,
             disconnected_inputs="ignore",
             return_disconnected="disconnected",
             null_gradients="return",
-            known_grads=dict(zip(inner_outputs, output_grads)),
+            known_grads=dict(
+                zip(connected_inner_outputs, connected_output_grads, strict=True)
+            ),
         )
 
         if self._lop_op_interface:
-            callable_args = (inner_inputs, inner_outputs, output_grads)
+            callable_args = (
+                inner_inputs,
+                connected_inner_outputs,
+                connected_output_grads,
+            )
         else:
-            callable_args = (inner_inputs, output_grads)
+            callable_args = (inner_inputs, connected_output_grads)
 
         # we need to convert _lop_op into an OfG instance
         if lop_overrides is None:
@@ -539,14 +570,15 @@ class OpFromGraph(Op, HasInnerGraph):
         else:
             input_grads = self._call_custom_override(lop_overrides, callable_args, nin)
 
-        # Filter out disconnected input and output gradients
+        # Filter out disconnected/null input generated from the inner graph grad
+        # We append them in the outer wrapper function below
         connected_input_grads = [
             inp_grad
             for inp_grad in input_grads
             if not isinstance(inp_grad.type, DisconnectedType | NullType)
         ]
         lop_op = type(self)(
-            inputs=inner_inputs + inner_outputs + output_grads,
+            inputs=inner_inputs + connected_inner_outputs + connected_output_grads,
             outputs=connected_input_grads,
             inline=self.is_inline,
             name=(None if self.name is None else f"{self.name}_LOp"),
@@ -554,9 +586,27 @@ class OpFromGraph(Op, HasInnerGraph):
             on_unused_input="ignore",
         )
 
-        # Return a wrapper that combines connected and disconnected input gradients
+        # Return a wrapper that combines connected and disconnected/null input gradients
+        # And also filters out disconnected/null output gradients
         def wrapper(*inputs: Variable, **kwargs) -> list[Variable]:
-            connected_input_grads = iter(lop_op(*inputs, **kwargs))
+            inputs, outputs, output_grads = (
+                inputs[: -nout * 2],
+                inputs[-nout * 2 : -nout],
+                inputs[-nout:],
+            )
+            connected_outputs = [
+                output
+                for output, output_grad in zip(outputs, output_grads, strict=True)
+                if not isinstance(output_grad.type, DisconnectedType | NullType)
+            ]
+            connected_output_grads = [
+                output_grad
+                for output_grad in output_grads
+                if not isinstance(output_grad.type, DisconnectedType)
+            ]
+            connected_input_grads = iter(
+                lop_op(*inputs, *connected_outputs, *connected_output_grads, **kwargs)
+            )
             return [
                 input_grad
                 if isinstance(input_grad.type, DisconnectedType | NullType)
@@ -564,7 +614,7 @@ class OpFromGraph(Op, HasInnerGraph):
                 for input_grad in input_grads
             ]
 
-        self._lop_op_cache = wrapper
+        self._lop_op_cache[disconnected_output_grads] = wrapper
         return wrapper
 
     @config.change_flags(compute_test_value="off")
@@ -647,7 +697,10 @@ class OpFromGraph(Op, HasInnerGraph):
         return wrapper
 
     def L_op(self, inputs, outputs, output_grads):
-        lop_op = self._build_and_cache_lop_op()
+        disconnected_output_grads = tuple(
+            isinstance(og.type, DisconnectedType) for og in output_grads
+        )
+        lop_op = self._build_and_cache_lop_op(disconnected_output_grads)
         return lop_op(*inputs, *outputs, *output_grads, return_list=True)
 
     def R_op(self, inputs, eval_points):

--- a/pytensor/compile/builders.py
+++ b/pytensor/compile/builders.py
@@ -1,13 +1,11 @@
 """Define new Ops from existing Ops"""
 
 import warnings
-from collections import OrderedDict
 from collections.abc import Callable, Sequence
 from copy import copy
 from functools import partial
 from typing import Union, cast
 
-import pytensor.tensor as pt
 from pytensor.compile.function import function
 from pytensor.compile.function.pfunc import rebuild_collect_shared
 from pytensor.compile.mode import optdb
@@ -248,57 +246,6 @@ class OpFromGraph(Op, HasInnerGraph):
 
     """
 
-    TYPE_ERR_MSG = (
-        "L_op/gradient override should be (single or list of)"
-        "None | OpFromGraph | callable | Variable "
-        "with NullType or DisconnectedType, got %s"
-    )
-    STYPE_ERR_MSG = (
-        "Overriding Variable instance can only have type"
-        " of DisconnectedType or NullType, got %s"
-    )
-    LOP_TYPE_ERR_MSG = 'L_op type can only be "grad" or "lop", got %s.'
-    OV_INP_LEN_ERR_MSG = "expect overrider with %d inputs, got %d"
-
-    @staticmethod
-    def _filter_grad_var(grad, inp):
-        # Returns (filtered_var, overrider_var)
-        # Args:
-        #     grad: gradient Variable
-        #     inp: the corresponding input of gradient Variable
-        #
-        # a grad() call could return instance of NullType() or DisconnectedType()
-        # which cannot be directly used in OfG
-        #
-        # Since we always use an OfG instance as self._lop_op, the current
-        # workaround is to "remember" the special cases of the gradient and
-        # replace them after self._lop_op is called.
-        #
-        # This helper function changes invalid types into a filtered_var,
-        # and provides a overrider_var to be replaced at grad() call
-        #
-        # For now, this converts NullType or DisconnectedType into zeros_like.
-        # other types are unmodified: overrider_var -> None
-        if isinstance(grad.type, NullType | DisconnectedType):
-            if hasattr(inp, "zeros_like"):
-                return inp.zeros_like(), grad
-            else:
-                return pt.constant(0.0), grad
-        else:
-            return grad, None
-
-    @staticmethod
-    def _filter_rop_var(inpJ, out):
-        # mostly similar to _filter_grad_var
-        if isinstance(inpJ.type, NullType):
-            return out.zeros_like(), inpJ
-        if isinstance(inpJ.type, DisconnectedType):
-            # since R_op does not have DisconnectedType yet, we will just
-            # make them zeros.
-            return out.zeros_like(), None
-        else:
-            return inpJ, None
-
     def __init__(
         self,
         inputs: list[Variable],
@@ -318,8 +265,10 @@ class OpFromGraph(Op, HasInnerGraph):
         ----------
         inputs
             The inputs to the graph.
+
         outputs
             The outputs to the graph.
+
         inline
             Defaults to ``False``
 
@@ -328,6 +277,7 @@ class OpFromGraph(Op, HasInnerGraph):
             graph but rather its internal graph.
 
             ``False`` : will use a pre-compiled function inside.
+
         grad_overrides
             Defaults to ``None``.
             This argument is mutually exclusive with ``lop_overrides``.
@@ -341,6 +291,7 @@ class OpFromGraph(Op, HasInnerGraph):
             `callable`: Should take two args: ``inputs`` and ``output_grads``.
             Each argument is expected to be a list of :class:`Variable `.
             Must return list of :class:`Variable `.
+
         lop_overrides
             Defaults to ``None``.
 
@@ -359,10 +310,6 @@ class OpFromGraph(Op, HasInnerGraph):
             `callable`: Should take three args: ``inputs``, ``outputs`` and ``output_grads``.
             Each argument is expected to be a list of :class:`Variable`.
             Must return list of :class:`Variable`.
-
-            `NullType` instance: Treat as non-differentiable
-            `DisconnectedType` instance: Treat as disconnected gradient,
-            numerically gives zero
 
             ``list``: Each `OpFromGraph`/callable must return a single
             :class:`Variable`. Each list element corresponds to gradient of
@@ -383,10 +330,6 @@ class OpFromGraph(Op, HasInnerGraph):
             Each argument is expected to be a list of :class:`Variable`.  Must
             return list of :class:`Variable`.
 
-            `NullType` instance: Treat as non-differentiable `DisconnectedType`
-            instance: Treat as zero since `DisconnectedType` is not yet supported
-            in :meth:`Op.R_op`.
-
             ``list``:
             Each :class:`OpFromGraph`/callable must return a single
             :class:`Variable <pytensor.graph.basic.Variable>`. Each list element
@@ -394,12 +337,15 @@ class OpFromGraph(Op, HasInnerGraph):
             must be equal to number of outputs.  connection_pattern If not
             ``None``, this will be used as the connection_pattern for this
             :class:`Op`.
+
         strict: bool, default False
             If true, it raises when any variables needed to compute the inner graph
             are not provided as explici inputs. This can only happen for graphs with
             shared variables.
+
         name
             A name for debugging purposes.
+
         kwargs
             Check :func:`pytensor.function` for more arguments, only works when not
             inline.
@@ -456,26 +402,19 @@ class OpFromGraph(Op, HasInnerGraph):
         self.grad_overrides = grad_overrides
         self.rop_overrides = rop_overrides
 
-        if lop_overrides is not None:
-            if grad_overrides is not None:
+        self._lop_op_interface = True
+        if grad_overrides is not None:
+            if lop_overrides is not None:
                 raise ValueError(
                     "lop_overrides and grad_overrides are mutually exclusive"
                 )
-            else:
-                self.set_lop_overrides(lop_overrides)
-                self._lop_type = "lop"
-        elif grad_overrides is not None:
             warnings.warn(
                 "grad_overrides is deprecated in favor of lop_overrides. Using it will lead to an error in the future.",
                 FutureWarning,
             )
-            self.set_lop_overrides(grad_overrides)
-            self._lop_type = "grad"
-        else:
-            self.set_lop_overrides(None)
-            self._lop_type = "lop"
-
-        self.set_rop_overrides(rop_overrides)
+            self._lop_op_interface = False
+        self._lop_op_cache: Callable | None = None
+        self._rop_op_cache: Callable | None = None
 
         self._connection_pattern = connection_pattern
 
@@ -496,307 +435,224 @@ class OpFromGraph(Op, HasInnerGraph):
         is_inline = self.is_inline
         return "{name}{{inline={is_inline}}}".format(**locals())
 
-    @config.change_flags(compute_test_value="off")
-    def _recompute_lop_op(self):
-        """
-        converts self._lop_op from user supplied form to type(self) instance
+    def _combine_list_overrides(self, default_outs, custom_outs, callable_args):
+        """Combines default and custom overrides into a single list of outputs."""
+        default_out_iter = iter(default_outs)
+        combined_outs = []
+        for custom_out in custom_outs:
+            if custom_out is None:
+                combined_outs.append(next(default_out_iter))
+            elif isinstance(custom_out, Variable):
+                if not isinstance(custom_out.type, NullType | DisconnectedType):
+                    raise ValueError(
+                        f"Override list can only contain NullType or DisconnectedType Variable instances, got {custom_out.type}"
+                    )
+                combined_outs.append(custom_out)
+            elif callable(custom_out):
+                combined_outs.append(custom_out(*callable_args))
+            else:
+                raise ValueError(
+                    f"Override list should contain None, Variable or callable, got {type(custom_out)}"
+                )
+        return combined_outs
 
-        """
-        local_inputs = self.inner_inputs
-        local_outputs = self.inner_outputs
-        inp_len = len(local_inputs)
-        lop_op = self._lop_op
-
-        if isinstance(lop_op, OpFromGraph):
-            if self._lop_op_is_cached:
-                return
-            assert self._lop_type in ("lop", "grad"), (
-                self.LOP_TYPE_ERR_MSG % self._lop_type
+    def _call_custom_override(self, op_overrides, callable_args, nout):
+        """Calls custom override function and provides informative error messages."""
+        if not callable(op_overrides):
+            raise TypeError(
+                f"L_op/R_op override should be None, a list or a Callable, got {type(op_overrides)}"
             )
-            if self._lop_type == "grad":
-                needed_ninps = inp_len + len(local_outputs)
-                ninps = len(lop_op.inner_inputs)
-                if needed_ninps != ninps:
-                    raise ValueError(self.OV_INP_LEN_ERR_MSG % (needed_ninps, ninps))
-                # make a wrapper callable
+        outputs = op_overrides(*callable_args)
+        if not isinstance(outputs, list):
+            raise TypeError(
+                f"Lop/Rop overriding function should return a list, got {type(outputs)}"
+            )
+        if len(outputs) != nout:
+            raise ValueError(
+                f"Lop/Rop overriding function {self.rop_overrides} should return "
+                f"a list of {nout} outputs, got {len(outputs)}"
+            )
+        return outputs
 
-                def lop_op(inps, grads):
-                    return self._lop_op(*(inps + grads))
+    @config.change_flags(compute_test_value="off")
+    def _build_and_cache_lop_op(self) -> Callable:
+        """converts lop_overrides (or grad_overrides) from user supplied form to type(self) instance.
 
-            elif self._lop_type == "lop":
-                # OfG can be directly used in L_op format
-                needed_ninps = inp_len + 2 * len(local_outputs)
-                ninps = len(lop_op.inner_inputs)
-                if needed_ninps != ninps:
-                    raise ValueError(self.OV_INP_LEN_ERR_MSG % (needed_ninps, ninps))
-                self._lop_op_is_cached = True
-                self._lop_op_stypes_l = [None] * inp_len
-                self._lop_op.kwargs["on_unused_input"] = "ignore"
-                return
+        Results are cached in self._lop_op_cache
+        """
+        if self._lop_op_cache is not None:
+            return self._lop_op_cache
+
+        inner_inputs = self.inner_inputs
+        inner_outputs = self.inner_outputs
+        nin = len(inner_inputs)
+        lop_overrides = (
+            self.lop_overrides if self._lop_op_interface else self.grad_overrides
+        )
+
+        if isinstance(lop_overrides, OpFromGraph):
+            if self._lop_op_interface:
+                self._lop_op_cache = lop_overrides
+                lop_overrides.kwargs["on_unused_input"] = "ignore"
+                return lop_overrides
+
+            else:
+                # We need to add a wrapper for the different input signature
+                # TODO: Remove this once the grad interface is gone
+                def lop_overrides(inps, grads):
+                    return self.grad_overrides(*inps, *grads)
 
         output_grads = [out_t() for out_t in self.output_types]
         fn_grad = partial(
             grad,
             cost=None,
             disconnected_inputs="ignore",
-            return_disconnected="Disconnected",
+            return_disconnected="disconnected",
             null_gradients="return",
-            known_grads=OrderedDict(zip(local_outputs, output_grads)),
+            known_grads=dict(zip(inner_outputs, output_grads)),
         )
 
-        assert self._lop_type in ("lop", "grad"), self.LOP_TYPE_ERR_MSG % self._lop_type
-        if self._lop_type == "lop":
-            callable_args = (local_inputs, local_outputs, output_grads)
-        elif self._lop_type == "grad":
-            callable_args = (local_inputs, output_grads)
+        if self._lop_op_interface:
+            callable_args = (inner_inputs, inner_outputs, output_grads)
+        else:
+            callable_args = (inner_inputs, output_grads)
 
         # we need to convert _lop_op into an OfG instance
-        if lop_op is None:
-            gdefaults_l = fn_grad(wrt=local_inputs)
-            all_grads_l, all_grads_ov_l = zip(
-                *[
-                    OpFromGraph._filter_grad_var(grad, inp)
-                    for grad, inp in zip(gdefaults_l, local_inputs)
-                ]
-            )
-            all_grads_l = list(all_grads_l)
-            all_grads_ov_l = list(all_grads_ov_l)
-        elif isinstance(lop_op, list):
-            goverrides_l = lop_op
-            if len(goverrides_l) != inp_len:
+        if lop_overrides is None:
+            input_grads = fn_grad(wrt=inner_inputs)
+        elif isinstance(lop_overrides, list):
+            custom_input_grads = lop_overrides
+            if len(custom_input_grads) != nin:
                 raise ValueError(
-                    f"Need to override {int(inp_len)} gradients, got {len(goverrides_l)}",
-                    goverrides_l,
+                    f"Need to override {nin} gradients, got {len(custom_input_grads)}",
+                    custom_input_grads,
                 )
             # compute non-overriding downsteam grads from upstreams grads
             # it's normal some input may be disconnected, thus the 'ignore'
-            wrt_l = [lin for lin, gov in zip(local_inputs, goverrides_l) if gov is None]
-            gdefaults = iter(fn_grad(wrt=wrt_l) if wrt_l else [])
-            # combine overriding gradients
-            all_grads_l = []
-            all_grads_ov_l = []
-            for inp, fn_gov in zip(local_inputs, goverrides_l):
-                if fn_gov is None:
-                    gnext, gnext_ov = OpFromGraph._filter_grad_var(next(gdefaults), inp)
-                    all_grads_l.append(gnext)
-                    all_grads_ov_l.append(gnext_ov)
-                elif isinstance(fn_gov, Variable):
-                    if isinstance(fn_gov.type, DisconnectedType | NullType):
-                        all_grads_l.append(inp.zeros_like())
-                        all_grads_ov_l.append(fn_gov.type())
-                    else:
-                        raise ValueError(self.STYPE_ERR_MSG % fn_gov.type)
-                else:
-                    if not callable(fn_gov):
-                        raise TypeError(self.TYPE_ERR_MSG % fn_gov)
-                    gov, gov_ov = OpFromGraph._filter_grad_var(
-                        fn_gov(*callable_args), inp
-                    )
-                    all_grads_l.append(gov)
-                    all_grads_ov_l.append(gov_ov)
-        else:
-            # callable case
-            if not callable(lop_op):
-                raise TypeError(self.TYPE_ERR_MSG % lop_op)
-            goverrides_l = lop_op(*callable_args)
-            if not isinstance(goverrides_l, list):
-                raise TypeError(
-                    "Gradient/L_op overriding function should return a list, "
-                    f'got "{type(goverrides_l)}"'
-                )
-            all_grads_l, all_grads_ov_l = zip(
-                *[
-                    OpFromGraph._filter_grad_var(grad, inp)
-                    for grad, inp in zip(goverrides_l, local_inputs)
-                ]
+            wrt = [
+                lin for lin, gov in zip(inner_inputs, custom_input_grads) if gov is None
+            ]
+            default_input_grads = fn_grad(wrt=wrt) if wrt else []
+            input_grads = self._combine_list_overrides(
+                default_input_grads, custom_input_grads, callable_args
             )
-            if len(all_grads_l) != len(local_inputs):
-                raise ValueError(
-                    "Gradient/L_op overriding function should return list of "
-                    f"{int(inp_len)} outputs, got {len(all_grads_l)}"
-                )
-        all_grads_l = list(all_grads_l)
-        all_grads_ov_l = list(all_grads_ov_l)
-        self._lop_op = type(self)(
-            inputs=local_inputs + local_outputs + output_grads,
-            outputs=all_grads_l,
+        else:
+            input_grads = self._call_custom_override(lop_overrides, callable_args, nin)
+
+        # Filter out disconnected input and output gradients
+        connected_input_grads = [
+            inp_grad
+            for inp_grad in input_grads
+            if not isinstance(inp_grad.type, DisconnectedType | NullType)
+        ]
+        lop_op = type(self)(
+            inputs=inner_inputs + inner_outputs + output_grads,
+            outputs=connected_input_grads,
             inline=self.is_inline,
-            name=(None if self.name is None else self.name + "_" + self._lop_type),
+            name=(None if self.name is None else f"{self.name}_LOp"),
+            # TODO: We can be eager here and exclude unused inputs in the OFG
             on_unused_input="ignore",
         )
-        self._lop_op_stypes_l = all_grads_ov_l
-        self._lop_op_is_cached = True
-        self._lop_type = "lop"
+
+        # Return a wrapper that combines connected and disconnected input gradients
+        def wrapper(*inputs: Variable, **kwargs) -> list[Variable]:
+            connected_input_grads = iter(lop_op(*inputs, **kwargs))
+            return [
+                input_grad
+                if isinstance(input_grad.type, DisconnectedType | NullType)
+                else next(connected_input_grads)
+                for input_grad in input_grads
+            ]
+
+        self._lop_op_cache = wrapper
+        return wrapper
 
     @config.change_flags(compute_test_value="off")
-    def _recompute_rop_op(self):
-        """
-        converts self._rop_op from user supplied form to type(self) instance
+    def _build_and_cache_rop_op(self):
+        """Converts rop_overrides from user supplied form to type(self) instance.
 
+        Results are cached in self._rop_op_cache
         """
-        local_inputs = self.inner_inputs
-        local_outputs = self.inner_outputs
-        out_len = len(local_outputs)
-        rop_op = self._rop_op
+        if self._rop_op_cache is not None:
+            return self._rop_op_cache
 
-        if isinstance(rop_op, OpFromGraph):
-            if not self._rop_op_is_cached:
-                self._rop_op_is_cached = True
-                self._rop_op_stypes_l = [None] * out_len
-            return
+        inner_inputs = self.inner_inputs
+        inner_outputs = self.inner_outputs
+        nout = len(inner_outputs)
+        rop_overrides = self.rop_overrides
+
+        if isinstance(rop_overrides, OpFromGraph):
+            self._rop_op_cache = rop_overrides
+            return rop_overrides
 
         eval_points = [inp_t() for inp_t in self.input_types]
-        fn_rop = partial(Rop, wrt=local_inputs, eval_points=eval_points)
-        TYPE_ERR_MSG = (
-            "R_op overrides should be (single or list of)"
-            "OpFromGraph, None, a list or a callable, got %s"
-        )
-        STYPE_ERR_MSG = (
-            "Overriding Variable instance can only have type"
-            " of DisconnectedType or NullType, got %s"
-        )
-        if rop_op is None:
-            rdefaults_l = fn_rop(f=local_outputs)
-            all_rops_l, all_rops_ov_l = zip(
-                *[
-                    OpFromGraph._filter_rop_var(rop, out)
-                    for rop, out in zip(rdefaults_l, local_outputs)
-                ]
-            )
-            all_rops_l = list(all_rops_l)
-            all_rops_ov_l = list(all_rops_ov_l)
-        elif isinstance(rop_op, list):
-            roverrides_l = rop_op
-            if len(roverrides_l) != out_len:
+        fn_rop = partial(Rop, wrt=inner_inputs, eval_points=eval_points)
+
+        callable_args = (inner_inputs, eval_points)
+        if rop_overrides is None:
+            output_grads = fn_rop(f=inner_outputs)
+        elif isinstance(rop_overrides, list):
+            custom_output_grads = rop_overrides
+            if len(custom_output_grads) != nout:
                 raise ValueError(
-                    f"Need to override {int(out_len)} Rop, got {len(roverrides_l)}",
-                    roverrides_l,
+                    f"Need to override {int(nout)} Rop, got {len(custom_output_grads)}",
+                    custom_output_grads,
                 )
             # get outputs that does not have Rop override
-            odefaults_l = [
-                lo for lo, rov in zip(local_outputs, roverrides_l) if rov is None
+            f = [
+                output
+                for output, custom_output_grad in zip(
+                    inner_outputs, custom_output_grads
+                )
+                if custom_output_grad is None
             ]
-            rdefaults_l = fn_rop(f=odefaults_l)
-            rdefaults = iter(rdefaults_l if odefaults_l else [])
-            # combine overriding Rops
-            all_rops_l = []
-            all_rops_ov_l = []
-            for out, fn_rov in zip(local_outputs, roverrides_l):
-                if fn_rov is None:
-                    rnext, rnext_ov = OpFromGraph._filter_rop_var(next(rdefaults), out)
-                    all_rops_l.append(rnext)
-                    all_rops_ov_l.append(rnext_ov)
-                elif isinstance(fn_rov, Variable):
-                    if isinstance(fn_rov.type, NullType):
-                        all_rops_l.append(out.zeros_like())
-                        all_rops_ov_l.append(fn_rov.type())
-                    if isinstance(fn_rov.type, DisconnectedType):
-                        all_rops_l.append(out.zeros_like())
-                        all_rops_ov_l.append(None)
-                    else:
-                        raise ValueError(STYPE_ERR_MSG % fn_rov.type)
-                else:
-                    if not callable(fn_rov):
-                        raise TypeError(TYPE_ERR_MSG % fn_rov)
-                    rov, rov_ov = OpFromGraph._filter_rop_var(
-                        fn_rov(local_inputs, eval_points), out
-                    )
-                    all_rops_l.append(rov)
-                    all_rops_ov_l.append(rov_ov)
-        else:
-            if not callable(rop_op):
-                raise TypeError(TYPE_ERR_MSG % rop_op)
-            roverrides_l = rop_op(local_inputs, eval_points)
-            if not isinstance(roverrides_l, list):
-                raise TypeError(
-                    "Rop overriding function should return a list, "
-                    f'got "{type(roverrides_l)}"'
-                )
-            all_rops_l, all_rops_ov_l = zip(
-                *[
-                    OpFromGraph._filter_rop_var(rop, out)
-                    for rop, out in zip(roverrides_l, local_outputs)
-                ]
+            default_output_grads = fn_rop(f=f) if f else []
+            output_grads = self._combine_list_overrides(
+                default_output_grads, custom_output_grads, callable_args
             )
-            if len(all_rops_l) != out_len:
-                raise ValueError(
-                    (
-                        f"Rop overriding function {self._rop_op} should return list of "
-                        f"{int(out_len)} outputs, got {len(all_rops_l)}",
-                    ),
-                    rop_op,
-                )
-            all_rops_l = list(all_rops_l)
-            all_rops_ov_l = list(all_rops_ov_l)
-        self._rop_op = type(self)(
-            inputs=local_inputs + eval_points,
-            outputs=all_rops_l,
+        else:
+            output_grads = self._call_custom_override(
+                rop_overrides, callable_args, nout
+            )
+
+        # Filter out disconnected output gradients
+        filtered_output_grads = [
+            out_grad
+            for out_grad in output_grads
+            if not isinstance(out_grad.type, DisconnectedType | NullType)
+        ]
+        rop_op = type(self)(
+            inputs=inner_inputs + eval_points,
+            outputs=filtered_output_grads,
             inline=self.is_inline,
             name=(None if self.name is None else self.name + "_rop"),
             on_unused_input="ignore",
         )
-        self._rop_op_stypes_l = all_rops_ov_l
-        self._rop_op_is_cached = True
 
-    def get_lop_op(self):
-        if not self._lop_op_is_cached:
-            self._recompute_lop_op()
-        return self._lop_op
+        # Return a wrapper that combines connected and disconnected output gradients
+        def wrapper(*inputs: Variable, **kwargs) -> list[Variable | None]:
+            connected_output_grads = iter(rop_op(*inputs, **kwargs))
+            all_output_grads = []
+            for out_grad in output_grads:
+                if isinstance(out_grad.type, DisconnectedType):
+                    # R_Op does not have DisconnectedType yet, None should be used instead
+                    all_output_grads.append(None)
+                elif isinstance(out_grad.type, NullType):
+                    all_output_grads.append(out_grad)
+                else:
+                    all_output_grads.append(next(connected_output_grads))
+            return all_output_grads
 
-    def get_rop_op(self):
-        if not self._rop_op_is_cached:
-            self._recompute_rop_op()
-        return self._rop_op
-
-    def set_grad_overrides(self, grad_overrides):
-        """
-        Set gradient overrides.
-        This will completely remove any previously set L_op/gradient overrides
-
-        """
-        self._lop_op = grad_overrides
-        self._lop_op_is_cached = False
-        self._lop_type = "grad"
-
-    def set_lop_overrides(self, lop_overrides):
-        """
-        Set L_op overrides
-        This will completely remove any previously set L_op/gradient overrides
-
-        """
-        self._lop_op = lop_overrides
-        self._lop_op_is_cached = False
-        self._lop_type = "lop"
-
-    def set_rop_overrides(self, rop_overrides):
-        """
-        Set R_op overrides
-        This will completely remove any previously set R_op overrides
-
-        """
-        self._rop_op = rop_overrides
-        self._rop_op_is_cached = False
+        self._rop_op_cache = wrapper
+        return wrapper
 
     def L_op(self, inputs, outputs, output_grads):
-        if not self._lop_op_is_cached:
-            self._recompute_lop_op()
-        inps = list(inputs) + list(outputs) + list(output_grads)
-        ret_ofg_l = self._lop_op(*inps, return_list=True)
-        ret_l = [
-            ret_ofg if ov is None else ov
-            for ret_ofg, ov in zip(ret_ofg_l, self._lop_op_stypes_l)
-        ]
-        return ret_l
+        lop_op = self._build_and_cache_lop_op()
+        return lop_op(*inputs, *outputs, *output_grads, return_list=True)
 
     def R_op(self, inputs, eval_points):
-        if not self._rop_op_is_cached:
-            self._recompute_rop_op()
-        ret_ofg_l = self._rop_op(*(list(inputs) + list(eval_points)), return_list=True)
-        ret_l = [
-            ret_ofg if ov is None else ov
-            for ret_ofg, ov in zip(ret_ofg_l, self._rop_op_stypes_l)
-        ]
-        return ret_l
+        rop_op = self._build_and_cache_rop_op()
+        return rop_op(*inputs, *eval_points, return_list=True)
 
     def __call__(self, *inputs, **kwargs):
         # The user interface doesn't expect the shared variable inputs of the

--- a/pytensor/compile/builders.py
+++ b/pytensor/compile/builders.py
@@ -159,16 +159,9 @@ class OpFromGraph(Op, HasInnerGraph):
     Currently does not support ``updates`` or ``givens`` argument.
 
     .. TODO:
-        - examples for a multi-layer mlp. where?
-        - __hash__, __eq__ otherwise won't merge, try
-          is_same_graph_with_merge(op1.local_outputs, op2,
-          local_outputs)
-        - c_code() to remove the double overhead?
-        - grad() make it support DisconnectedType and the new interface
-        - add support for NullType and DisconnectedType when R_op supports them
-        - check how it works with updates.
+        - Allow / test merging of OpFromGraph nodes
+        - Add support for NullType and DisconnectedType when R_op supports them
         - Add support to pickle this Op.
-        - Add support/test with random generator
         - Add optimization to removing unused inputs/outputs
         - Add optimization to work inplace on inputs when not inline
 

--- a/pytensor/compile/builders.py
+++ b/pytensor/compile/builders.py
@@ -884,30 +884,9 @@ class OpFromGraph(Op, HasInnerGraph):
         if self._connection_pattern is not None:
             return self._connection_pattern
 
-        inp_len = len(self.inner_inputs)
-        out_len = len(self.inner_outputs)
-        cpmat_self = io_connection_pattern(self.inner_inputs, self.inner_outputs)
-
-        lop_op = self.get_lop_op()
-        cpmat_grad = io_connection_pattern(
-            lop_op.inner_inputs[inp_len:], lop_op.inner_outputs
-        )
-
-        # cpmat_self |= cpmat_grad.T
-        # cpmat_self &= out_is_disconnected
-        for i, t in enumerate(self._lop_op_stypes_l):
-            if t is not None:
-                if isinstance(t.type, DisconnectedType):
-                    for o in range(out_len):
-                        cpmat_self[i][o] = False
-            for o in range(out_len):
-                cpmat_self[i][o] |= cpmat_grad[o][i]
-
-        # TODO in case DisconnectedType is implemented for R_op,
-        # self._rop_op_stypes_l self._rop_op should considered for
-        # connection_pattern
-
-        return list(map(list, cpmat_self))
+        ret = io_connection_pattern(self.inner_inputs, self.inner_outputs)
+        self._connection_pattern = ret
+        return ret
 
     def infer_shape(self, fgraph, node, shapes):
         # TODO: Use `fgraph.shape_feature` to do this instead.

--- a/pytensor/compile/builders.py
+++ b/pytensor/compile/builders.py
@@ -2,10 +2,10 @@
 
 import warnings
 from collections import OrderedDict
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from copy import copy
 from functools import partial
-from typing import cast
+from typing import Union, cast
 
 import pytensor.tensor as pt
 from pytensor.compile.function import function
@@ -222,7 +222,7 @@ class OpFromGraph(Op, HasInnerGraph):
         e2 = op(x, y, z) + op(z, y, x)
         fn = function([x, y, z], [e2])
 
-    Example 3 override L_op
+    Example 3 override second output of L_op
 
     .. code-block:: python
 
@@ -238,7 +238,7 @@ class OpFromGraph(Op, HasInnerGraph):
         op = OpFromGraph(
             [x, y, z],
             [e],
-            lop_overrides=['default', rescale_dy, 'default'],
+            lop_overrides=[None, rescale_dy, None],
         )
         e2 = op(x, y, z)
         dx, dy, dz = grad(e2, [x, y, z])
@@ -250,7 +250,7 @@ class OpFromGraph(Op, HasInnerGraph):
 
     TYPE_ERR_MSG = (
         "L_op/gradient override should be (single or list of)"
-        "'default' | OpFromGraph | callable | Variable "
+        "None | OpFromGraph | callable | Variable "
         "with NullType or DisconnectedType, got %s"
     )
     STYPE_ERR_MSG = (
@@ -305,9 +305,9 @@ class OpFromGraph(Op, HasInnerGraph):
         outputs: list[Variable],
         *,
         inline: bool = False,
-        lop_overrides: str = "default",
-        grad_overrides: str = "default",
-        rop_overrides: str = "default",
+        lop_overrides: Union[Callable, "OpFromGraph", None] = None,
+        grad_overrides: Union[Callable, "OpFromGraph", None] = None,
+        rop_overrides: Union[Callable, "OpFromGraph", None] = None,
         connection_pattern: list[list[bool]] | None = None,
         strict: bool = False,
         name: str | None = None,
@@ -329,10 +329,10 @@ class OpFromGraph(Op, HasInnerGraph):
 
             ``False`` : will use a pre-compiled function inside.
         grad_overrides
-            Defaults to ``'default'``.
+            Defaults to ``None``.
             This argument is mutually exclusive with ``lop_overrides``.
 
-            ``'default'`` : Do not override, use default grad() result
+            ``None`` : Do not override, use default grad() result
 
             `OpFromGraph`: Override with another `OpFromGraph`, should
             accept inputs as the same order and types of ``inputs`` and ``output_grads``
@@ -342,14 +342,14 @@ class OpFromGraph(Op, HasInnerGraph):
             Each argument is expected to be a list of :class:`Variable `.
             Must return list of :class:`Variable `.
         lop_overrides
-            Defaults to ``'default'``.
+            Defaults to ``None``.
 
             This argument is mutually exclusive with ``grad_overrides``.
 
             These options are similar to the ``grad_overrides`` above, but for
             the :meth:`Op.L_op` method.
 
-            ``'default'``: Do not override, use the default :meth:`Op.L_op` result
+            ``None``: Do not override, use the default :meth:`Op.L_op` result
 
             `OpFromGraph`: Override with another `OpFromGraph`, should
             accept inputs as the same order and types of ``inputs``,
@@ -369,11 +369,11 @@ class OpFromGraph(Op, HasInnerGraph):
             a specific input, length of list must be equal to number of inputs.
 
         rop_overrides
-            One of ``{'default', OpFromGraph, callable, Variable}``.
+            One of ``{None, OpFromGraph, callable, Variable}``.
 
-            Defaults to ``'default'``.
+            Defaults to ``None``.
 
-            ``'default'``: Do not override, use the default :meth:`Op.R_op` result
+            ``None``: Do not override, use the default :meth:`Op.R_op` result
 
             `OpFromGraph`: Override with another `OpFromGraph`, should
             accept inputs as the same order and types of ``inputs`` and ``eval_points``
@@ -442,19 +442,29 @@ class OpFromGraph(Op, HasInnerGraph):
         self.input_types = [inp.type for inp in inputs]
         self.output_types = [out.type for out in outputs]
 
+        for override in (lop_overrides, grad_overrides, rop_overrides):
+            if override == "default":
+                raise ValueError(
+                    "'default' is no longer a valid value for overrides. Use None instead."
+                )
+            if isinstance(override, Variable):
+                raise TypeError(
+                    "Variables are no longer valid types for overrides. Return them in a list for each output instead"
+                )
+
         self.lop_overrides = lop_overrides
         self.grad_overrides = grad_overrides
         self.rop_overrides = rop_overrides
 
-        if lop_overrides != "default":
-            if grad_overrides != "default":
+        if lop_overrides is not None:
+            if grad_overrides is not None:
                 raise ValueError(
                     "lop_overrides and grad_overrides are mutually exclusive"
                 )
             else:
                 self.set_lop_overrides(lop_overrides)
                 self._lop_type = "lop"
-        elif grad_overrides != "default":
+        elif grad_overrides is not None:
             warnings.warn(
                 "grad_overrides is deprecated in favor of lop_overrides. Using it will lead to an error in the future.",
                 FutureWarning,
@@ -462,7 +472,7 @@ class OpFromGraph(Op, HasInnerGraph):
             self.set_lop_overrides(grad_overrides)
             self._lop_type = "grad"
         else:
-            self.set_lop_overrides("default")
+            self.set_lop_overrides(None)
             self._lop_type = "lop"
 
         self.set_rop_overrides(rop_overrides)
@@ -541,7 +551,7 @@ class OpFromGraph(Op, HasInnerGraph):
             callable_args = (local_inputs, output_grads)
 
         # we need to convert _lop_op into an OfG instance
-        if lop_op == "default":
+        if lop_op is None:
             gdefaults_l = fn_grad(wrt=local_inputs)
             all_grads_l, all_grads_ov_l = zip(
                 *[
@@ -551,12 +561,6 @@ class OpFromGraph(Op, HasInnerGraph):
             )
             all_grads_l = list(all_grads_l)
             all_grads_ov_l = list(all_grads_ov_l)
-        elif isinstance(lop_op, Variable):
-            if isinstance(lop_op.type, DisconnectedType | NullType):
-                all_grads_l = [inp.zeros_like() for inp in local_inputs]
-                all_grads_ov_l = [lop_op.type() for _ in range(inp_len)]
-            else:
-                raise ValueError(self.STYPE_ERR_MSG % lop_op.type)
         elif isinstance(lop_op, list):
             goverrides_l = lop_op
             if len(goverrides_l) != inp_len:
@@ -566,15 +570,13 @@ class OpFromGraph(Op, HasInnerGraph):
                 )
             # compute non-overriding downsteam grads from upstreams grads
             # it's normal some input may be disconnected, thus the 'ignore'
-            wrt_l = [
-                lin for lin, gov in zip(local_inputs, goverrides_l) if gov == "default"
-            ]
+            wrt_l = [lin for lin, gov in zip(local_inputs, goverrides_l) if gov is None]
             gdefaults = iter(fn_grad(wrt=wrt_l) if wrt_l else [])
             # combine overriding gradients
             all_grads_l = []
             all_grads_ov_l = []
             for inp, fn_gov in zip(local_inputs, goverrides_l):
-                if fn_gov == "default":
+                if fn_gov is None:
                     gnext, gnext_ov = OpFromGraph._filter_grad_var(next(gdefaults), inp)
                     all_grads_l.append(gnext)
                     all_grads_ov_l.append(gnext_ov)
@@ -647,13 +649,13 @@ class OpFromGraph(Op, HasInnerGraph):
         fn_rop = partial(Rop, wrt=local_inputs, eval_points=eval_points)
         TYPE_ERR_MSG = (
             "R_op overrides should be (single or list of)"
-            "OpFromGraph | 'default' | None | 0 | callable, got %s"
+            "OpFromGraph, None, a list or a callable, got %s"
         )
         STYPE_ERR_MSG = (
             "Overriding Variable instance can only have type"
             " of DisconnectedType or NullType, got %s"
         )
-        if rop_op == "default":
+        if rop_op is None:
             rdefaults_l = fn_rop(f=local_outputs)
             all_rops_l, all_rops_ov_l = zip(
                 *[
@@ -663,15 +665,6 @@ class OpFromGraph(Op, HasInnerGraph):
             )
             all_rops_l = list(all_rops_l)
             all_rops_ov_l = list(all_rops_ov_l)
-        elif isinstance(rop_op, Variable):
-            if isinstance(rop_op.type, NullType):
-                all_rops_l = [inp.zeros_like() for inp in local_inputs]
-                all_rops_ov_l = [rop_op.type() for _ in range(out_len)]
-            elif isinstance(rop_op.type, DisconnectedType):
-                all_rops_l = [inp.zeros_like() for inp in local_inputs]
-                all_rops_ov_l = [None] * out_len
-            else:
-                raise ValueError(STYPE_ERR_MSG % rop_op.type)
         elif isinstance(rop_op, list):
             roverrides_l = rop_op
             if len(roverrides_l) != out_len:
@@ -681,7 +674,7 @@ class OpFromGraph(Op, HasInnerGraph):
                 )
             # get outputs that does not have Rop override
             odefaults_l = [
-                lo for lo, rov in zip(local_outputs, roverrides_l) if rov == "default"
+                lo for lo, rov in zip(local_outputs, roverrides_l) if rov is None
             ]
             rdefaults_l = fn_rop(f=odefaults_l)
             rdefaults = iter(rdefaults_l if odefaults_l else [])
@@ -689,7 +682,7 @@ class OpFromGraph(Op, HasInnerGraph):
             all_rops_l = []
             all_rops_ov_l = []
             for out, fn_rov in zip(local_outputs, roverrides_l):
-                if fn_rov == "default":
+                if fn_rov is None:
                     rnext, rnext_ov = OpFromGraph._filter_rop_var(next(rdefaults), out)
                     all_rops_l.append(rnext)
                     all_rops_ov_l.append(rnext_ov)
@@ -764,7 +757,6 @@ class OpFromGraph(Op, HasInnerGraph):
         self._lop_op = grad_overrides
         self._lop_op_is_cached = False
         self._lop_type = "grad"
-        self._lop_is_default = grad_overrides == "default"
 
     def set_lop_overrides(self, lop_overrides):
         """
@@ -775,7 +767,6 @@ class OpFromGraph(Op, HasInnerGraph):
         self._lop_op = lop_overrides
         self._lop_op_is_cached = False
         self._lop_type = "lop"
-        self._lop_is_default = lop_overrides == "default"
 
     def set_rop_overrides(self, rop_overrides):
         """
@@ -785,7 +776,6 @@ class OpFromGraph(Op, HasInnerGraph):
         """
         self._rop_op = rop_overrides
         self._rop_op_is_cached = False
-        self._rop_is_default = rop_overrides == "default"
 
     def L_op(self, inputs, outputs, output_grads):
         if not self._lop_op_is_cached:

--- a/pytensor/gradient.py
+++ b/pytensor/gradient.py
@@ -929,12 +929,7 @@ def _populate_var_to_app_to_idx(outputs, wrt, consider_constant):
                     continue
 
                 if ipt not in var_to_app_to_idx:
-                    # This object here *must* be ordered, because
-                    # we iterate over its keys when adding up the terms of the
-                    # gradient on ipt. If it is a regular dict, the grad method
-                    # will return something that is analytically correct, but
-                    # whose order of doing additions depends on the memory
-                    # location of the apply nodes.
+                    # This object *must* be ordered for the grad graph to be deterministic
                     var_to_app_to_idx[ipt] = {}
                 app_to_idx = var_to_app_to_idx[ipt]
                 if app not in app_to_idx:

--- a/tests/compile/test_builders.py
+++ b/tests/compile/test_builders.py
@@ -244,6 +244,8 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
                 [x, w, b],
                 [x * w + b],
                 grad_overrides=[go1, NullType()(), DisconnectedType()()],
+                # This is a fake override, so a fake connection_pattern must be provided as well
+                connection_pattern=[[True], [True], [False]],
             )
         zz2 = pt_sum(op_linear2(xx, ww, bb))
         dx2, dw2, db2 = grad(

--- a/tests/compile/test_builders.py
+++ b/tests/compile/test_builders.py
@@ -181,8 +181,9 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         dedz = vector("dedz")
         op_mul_grad = cls_ofg([x, y, dedz], go([x, y], [dedz]))
 
-        op_mul = cls_ofg([x, y], [x * y], grad_overrides=go)
-        op_mul2 = cls_ofg([x, y], [x * y], grad_overrides=op_mul_grad)
+        with pytest.warns(FutureWarning, match="grad_overrides is deprecated"):
+            op_mul = cls_ofg([x, y], [x * y], grad_overrides=go)
+            op_mul2 = cls_ofg([x, y], [x * y], grad_overrides=op_mul_grad)
 
         # single override case (function or OfG instance)
         xx, yy = vector("xx"), vector("yy")
@@ -209,9 +210,10 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
 
         w, b = vectors("wb")
         # we make the 3rd gradient default (no override)
-        op_linear = cls_ofg(
-            [x, w, b], [x * w + b], grad_overrides=[go1, go2, "default"]
-        )
+        with pytest.warns(FutureWarning, match="grad_overrides is deprecated"):
+            op_linear = cls_ofg(
+                [x, w, b], [x * w + b], grad_overrides=[go1, go2, "default"]
+            )
         xx, ww, bb = vector("xx"), vector("yy"), vector("bb")
         zz = pt_sum(op_linear(xx, ww, bb))
         dx, dw, db = grad(zz, [xx, ww, bb])
@@ -225,11 +227,12 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         np.testing.assert_array_almost_equal(np.ones(16, dtype=config.floatX), dbv, 4)
 
         # NullType and DisconnectedType
-        op_linear2 = cls_ofg(
-            [x, w, b],
-            [x * w + b],
-            grad_overrides=[go1, NullType()(), DisconnectedType()()],
-        )
+        with pytest.warns(FutureWarning, match="grad_overrides is deprecated"):
+            op_linear2 = cls_ofg(
+                [x, w, b],
+                [x * w + b],
+                grad_overrides=[go1, NullType()(), DisconnectedType()()],
+            )
         zz2 = pt_sum(op_linear2(xx, ww, bb))
         dx2, dw2, db2 = grad(
             zz2,
@@ -339,13 +342,14 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         def f1_back(inputs, output_gradients):
             return [output_gradients[0], disconnected_type()]
 
-        op = cls_ofg(
-            inputs=[x, y],
-            outputs=[f1(x, y)],
-            grad_overrides=f1_back,
-            connection_pattern=[[True], [False]],  # This is new
-            on_unused_input="ignore",
-        )  # This is new
+        with pytest.warns(FutureWarning, match="grad_overrides is deprecated"):
+            op = cls_ofg(
+                inputs=[x, y],
+                outputs=[f1(x, y)],
+                grad_overrides=f1_back,
+                connection_pattern=[[True], [False]],
+                on_unused_input="ignore",
+            )
 
         c = op(x, y)
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
PyTensor uses `DisconnectedType` and `NullType` variables to raise informative errors when users request gradients wrt to inputs that can't be computed. This is a problem for OpFromGraph which may include parallel graphs, some of which are disconnected/null and others not. We don't want to fail when the user only needs the gradient that's supported. 

There was already some special logic before, to handle cases where `NullType` and `DisconnectedType` arise from the OFG inner graph. Instead of outputing those types (which OFG cannot produce out of thin air, as they are root variables), we were outputing dummy zeros, and then masking those with the original `NullType` or `DisconnectedType` variables created in the internal call to `grad`/`Rop`. This seems reasonable if only a bit tedious. This PR first refactors this code to avoid the dummy outputs altogether (there's no reason for them!).

Then it extends this logic to also handle cases where `DisconnectedType` (but not `NullType`) arise before the inner graph of OpFromGraph. This was the case behind one of the issues described in #1. When an OFG has multiple outputs, and the requested gradient only uses a subset, PyTensor will feed `DisconnectedType` variables in place of the `output_gradients` used by the `L_op`. The solution to this problem is to filter out these unused input variables. This should be safe, in that if the inner graph of the OFG needs to use these variables and we don't provide them, it will create new DisconnectedTypes on the fly. The pre-existing filtering will then kick in.

This however means we may need distinct OFG from different patterns of disconnected gradients. Accordingly, the cache is now done per pattern. 

I suspect this is the issue behind #652

Question: Do we really need to cache stuff?
 
This PR also deprecates `grad_overrides` and some options of lop_rop overrides, as well as custom logic for invalid `connection_patterns`. Hopefully this helps us making OpFromGrah more maintainable.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1
- [x] Related to #652   

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
