### PR TITLE
Improve variable debugging methods

### DIFF
--- a/pytensor/graph/basic.py
+++ b/pytensor/graph/basic.py
@@ -75,6 +75,18 @@ class Node(MetaObject):
         """
         raise NotImplementedError()
 
+    def dprint(self, **kwargs):
+        """Debug print itself
+
+        Parameters
+        ----------
+        kwargs:
+            Optional keyword arguments to pass to debugprint function.
+        """
+        from pytensor.printing import debugprint
+
+        return debugprint(self, **kwargs)
+
 
 class Apply(Node, Generic[OpType]):
     """A `Node` representing the application of an operation to inputs.

--- a/pytensor/graph/basic.py
+++ b/pytensor/graph/basic.py
@@ -555,13 +555,20 @@ class Variable(Node, Generic[_TypeType, OptionalApplyType]):
             return [self.owner]
         return []
 
-    def eval(self, inputs_to_values=None):
-        r"""Evaluate the `Variable`.
+    def eval(
+        self,
+        inputs_to_values: dict[Union["Variable", str], Any] | None = None,
+        **kwargs,
+    ):
+        r"""Evaluate the `Variable` given a set of values for its inputs.
 
         Parameters
         ----------
         inputs_to_values :
-            A dictionary mapping PyTensor `Variable`\s to values.
+            A dictionary mapping PyTensor `Variable`\s or names to values.
+            Not needed if variable has no required inputs.
+        kwargs :
+            Optional keyword arguments to pass to the underlying `pytensor.function`
 
         Examples
         --------
@@ -591,10 +598,7 @@ class Variable(Node, Generic[_TypeType, OptionalApplyType]):
         """
         from pytensor.compile.function import function
 
-        if inputs_to_values is None:
-            inputs_to_values = {}
-
-        def convert_string_keys_to_variables(input_to_values):
+        def convert_string_keys_to_variables(inputs_to_values) -> dict["Variable", Any]:
             new_input_to_values = {}
             for key, value in inputs_to_values.items():
                 if isinstance(key, str):
@@ -608,19 +612,32 @@ class Variable(Node, Generic[_TypeType, OptionalApplyType]):
                     new_input_to_values[key] = value
             return new_input_to_values
 
-        inputs_to_values = convert_string_keys_to_variables(inputs_to_values)
+        parsed_inputs_to_values: dict[Variable, Any] = {}
+        if inputs_to_values is not None:
+            parsed_inputs_to_values = convert_string_keys_to_variables(inputs_to_values)
 
         if not hasattr(self, "_fn_cache"):
-            self._fn_cache = dict()
+            self._fn_cache: dict = dict()
 
-        inputs = tuple(sorted(inputs_to_values.keys(), key=id))
-        if inputs not in self._fn_cache:
-            self._fn_cache[inputs] = function(inputs, self)
-        args = [inputs_to_values[param] for param in inputs]
+        inputs = tuple(sorted(parsed_inputs_to_values.keys(), key=id))
+        cache_key = (inputs, tuple(kwargs.items()))
+        try:
+            fn = self._fn_cache[cache_key]
+        except (KeyError, TypeError):
+            fn = None
 
-        rval = self._fn_cache[inputs](*args)
+        if fn is None:
+            fn = function(inputs, self, **kwargs)
+            try:
+                self._fn_cache[cache_key] = fn
+            except TypeError as exc:
+                warnings.warn(
+                    "Keyword arguments could not be used to create a cache key for the underlying variable. "
+                    f"A function will be recompiled on every call with such keyword arguments.\n{exc}"
+                )
 
-        return rval
+        args = [parsed_inputs_to_values[param] for param in inputs]
+        return fn(*args)
 
     def __getstate__(self):
         d = self.__dict__.copy()

--- a/tests/graph/test_basic.py
+++ b/tests/graph/test_basic.py
@@ -6,6 +6,7 @@ import pytest
 
 from pytensor import shared
 from pytensor import tensor as pt
+from pytensor.compile import UnusedInputError
 from pytensor.graph.basic import (
     Apply,
     NominalVariable,
@@ -30,6 +31,7 @@ from pytensor.graph.basic import (
 )
 from pytensor.graph.op import Op
 from pytensor.graph.type import Type
+from pytensor.tensor import constant
 from pytensor.tensor.math import max_and_argmax
 from pytensor.tensor.type import TensorType, iscalars, matrix, scalars, vector
 from pytensor.tensor.type_other import NoneConst
@@ -358,6 +360,24 @@ class TestEval:
         t.name = "p"
         with pytest.raises(Exception, match="o not found in graph"):
             t.eval({"o": 1})
+
+    def test_eval_kwargs(self):
+        with pytest.raises(UnusedInputError):
+            self.w.eval({self.z: 3, self.x: 2.5})
+        assert self.w.eval({self.z: 3, self.x: 2.5}, on_unused_input="ignore") == 6.0
+
+    @pytest.mark.filterwarnings("error")
+    def test_eval_unashable_kwargs(self):
+        y_repl = constant(2.0, dtype="floatX")
+
+        assert self.w.eval({self.x: 1.0}, givens=((self.y, y_repl),)) == 6.0
+
+        with pytest.warns(
+            UserWarning,
+            match="Keyword arguments could not be used to create a cache key",
+        ):
+            # givens dict is not hashable
+            assert self.w.eval({self.x: 1.0}, givens={self.y: y_repl}) == 6.0
 
 
 class TestAutoName:

--- a/tests/graph/test_basic.py
+++ b/tests/graph/test_basic.py
@@ -31,6 +31,7 @@ from pytensor.graph.basic import (
 )
 from pytensor.graph.op import Op
 from pytensor.graph.type import Type
+from pytensor.printing import debugprint
 from pytensor.tensor import constant
 from pytensor.tensor.math import max_and_argmax
 from pytensor.tensor.type import TensorType, iscalars, matrix, scalars, vector
@@ -869,3 +870,10 @@ class TestTruncatedGraphInputs:
         assert len(inspect.call_args_list) == len(
             {a for ((a, b), kw) in inspect.call_args_list}
         )
+
+
+def test_dprint():
+    r1, r2 = MyVariable(1), MyVariable(2)
+    o1 = MyOp(r1, r2)
+    assert o1.dprint(file="str") == debugprint(o1, file="str")
+    assert o1.owner.dprint(file="str") == debugprint(o1.owner, file="str")


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
This PR adds a `dprint` method to PyTensor nodes (i.e., Variables and Apply). 
It also allow passing keyword arguments to the debug `eval` method of Variables. This allows setting the `mode` or other useful configurations.

Both of these are quite useful during interactive debugging, where it saves having to import PyTensor. 

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
