### PR TITLE
Keep stack trace in random_make_inplace

### DIFF
--- a/pytensor/tensor/random/rewriting/basic.py
+++ b/pytensor/tensor/random/rewriting/basic.py
@@ -50,7 +50,10 @@ def random_make_inplace(fgraph, node):
         props = op._props_dict()
         props["inplace"] = True
         new_op = type(op)(**props)
-        return new_op.make_node(*node.inputs).outputs
+        new_outputs = new_op.make_node(*node.inputs).outputs
+        for old_out, new_out in zip(node.outputs, new_outputs):
+            copy_stack_trace(old_out, new_out)
+        return new_outputs
 
     return False
 

--- a/tests/tensor/random/rewriting/test_basic.py
+++ b/tests/tensor/random/rewriting/test_basic.py
@@ -9,7 +9,7 @@ from pytensor.compile.function import function
 from pytensor.compile.mode import Mode
 from pytensor.graph.basic import Constant, Variable, ancestors
 from pytensor.graph.fg import FunctionGraph
-from pytensor.graph.rewriting.basic import EquilibriumGraphRewriter
+from pytensor.graph.rewriting.basic import EquilibriumGraphRewriter, check_stack_trace
 from pytensor.graph.rewriting.db import RewriteDatabaseQuery
 from pytensor.tensor import constant
 from pytensor.tensor.elemwise import DimShuffle
@@ -143,6 +143,7 @@ def test_inplace_rewrites(rv_op):
         for a, b in zip(new_op.dist_params(new_node), op.dist_params(node))
     )
     assert np.array_equal(new_op.size_param(new_node).data, op.size_param(node).data)
+    assert check_stack_trace(f)
 
 
 @config.change_flags(compute_test_value="raise")


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
We should keep the stack trace during our rewrites, so that when the Op fails to perform we can point to the moment where the node was created. We do this very patchily at the moment.

This discourse issue revolves around this very problem: https://discourse.pymc.io/t/debug-mode-in-pytensor/14348

After these changes, the traceback ends like this:

```python
  File "<ipython-input-2-9b04c63d3b82>", line 7, in <module>
    s = pm.HalfNormal('s', sigma=-1)
  File "/home/ricardo/Documents/Projects/pymc/pymc/distributions/distribution.py", line 555, in __new__
    rv_out = cls.dist(*args, **kwargs)
  File "/home/ricardo/Documents/Projects/pymc/pymc/distributions/continuous.py", line 846, in dist
    return super().dist([0.0, sigma], **kwargs)
  File "/home/ricardo/Documents/Projects/pymc/pymc/distributions/distribution.py", line 635, in dist
    rv_out = cls.rv_op(*dist_params, size=create_size, **kwargs)
```

Whereas before there was no idea as to where this RV came from.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Related to https://discourse.pymc.io/t/debug-mode-in-pytensor/14348

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
