### PR TITLE
Make `local_pow_to_nested_squaring` more permissive

### DIFF
--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -2120,10 +2120,6 @@ def local_pow_to_nested_squaring(fgraph, node):
                 rval = [rval1]
         if rval:
             rval[0] = cast(rval[0], odtype)
-            # TODO: We can add a specify_broadcastable and/or unbroadcast to make the
-            #  output types compatible. Or work on #408 and let TensorType.filter_variable do it.
-            if rval[0].type.broadcastable != node.outputs[0].type.broadcastable:
-                return None
             return rval
 
 

--- a/tests/tensor/rewriting/test_math.py
+++ b/tests/tensor/rewriting/test_math.py
@@ -29,7 +29,7 @@ from pytensor.graph.rewriting.db import RewriteDatabaseQuery
 from pytensor.graph.rewriting.utils import is_same_graph, rewrite_graph
 from pytensor.misc.safe_asarray import _asarray
 from pytensor.printing import debugprint
-from pytensor.scalar import PolyGamma, Pow, Psi, TriGamma
+from pytensor.scalar import PolyGamma, Psi, TriGamma
 from pytensor.tensor import inplace
 from pytensor.tensor.basic import Alloc, constant, join, second, switch
 from pytensor.tensor.blas import Dot22, Gemv
@@ -1757,7 +1757,7 @@ def test_local_pow_to_nested_squaring():
     utt.assert_allclose(f(val_no0), val_no0 ** (-16))
 
 
-def test_local_pow_to_nested_squaring_fails_gracefully():
+def test_local_pow_to_nested_squaring_works_with_static_type():
     # Reported in #456
 
     x = vector("x", shape=(1,))
@@ -1770,12 +1770,6 @@ def test_local_pow_to_nested_squaring_fails_gracefully():
     y = node.default_output()
 
     fn = function([x], y)
-
-    # Check rewrite is not applied (this could change in the future)
-    assert any(
-        (isinstance(node.op, Elemwise) and isinstance(node.op.scalar_op, Pow))
-        for node in fn.maker.fgraph.apply_nodes
-    )
 
     np.testing.assert_allclose(fn([2.0]), np.array([4.0]))
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
Showed up in #740 and it was a result of a conservative fixed to #456 in #461
## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
