### PR TITLE
Implement `ufunc_outer` like `add.outer` for binary `Elemwise` operations

### DIFF
--- a/pytensor/tensor/elemwise.py
+++ b/pytensor/tensor/elemwise.py
@@ -1170,6 +1170,16 @@ class Elemwise(OpenMPOp):
         else:
             return ()
 
+    def outer(self, x, y):
+        from pytensor.tensor.basic import expand_dims
+
+        if self.scalar_op.nin not in (-1, 2):
+            raise NotImplementedError("outer is only available for binary operators")
+
+        x_ = expand_dims(x, tuple(range(-y.ndim, 0)))
+        y_ = expand_dims(y, tuple(range(x.ndim)))
+        return self(x_, y_)
+
 
 class CAReduce(COp):
     """Reduces a scalar operation along specified axes.


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
Compute the outer product of two vectors.

Given two vectors `a` and `b` of length ``M`` and ``N``, respectively, the outer product [1]_ is:
```
  [[a_0*b_0  a_0*b_1 ... a_0*b_{N-1} ]
   [a_1*b_0    .
   [ ...          .
   [a_{M-1}*b_0            a_{M-1}*b_{N-1} ]]
```

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #55
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
