### PR TITLE
Set codecov token as an env variable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -263,4 +263,5 @@ jobs:
         with:
           directory: ./coverage/
           fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Hopefully, this will prevent spurious tokenless uploads to codecov