### PR TITLE
Support int-like shapes in `pt.full`

### DIFF
--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -1719,6 +1719,9 @@ def full(shape, fill_value, dtype=None):
     fill_value = as_tensor_variable(fill_value)
     if dtype:
         fill_value = fill_value.astype(dtype)
+
+    if isinstance(shape, int | np.integer):
+        shape = (shape,)
     return alloc(fill_value, *shape)
 
 

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -1720,7 +1720,7 @@ def full(shape, fill_value, dtype=None):
     if dtype:
         fill_value = fill_value.astype(dtype)
 
-    if isinstance(shape, int | np.integer):
+    if np.ndim(shape) == 0:
         shape = (shape,)
     return alloc(fill_value, *shape)
 

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -848,17 +848,15 @@ class TestAlloc:
             inp = np.zeros(shp, dtype=config.floatX)
             assert np.allclose(zeros_tensor(inp), np.zeros(shp))
 
-    @pytest.mark.parametrize("shape", [(2, 3), 5, np.int32(5), np.array(5)])
+    @pytest.mark.parametrize(
+        "shape", [(2, 3), 5, np.int32(5), np.array(5), constant(5)]
+    )
     def test_full(self, shape):
         full_pt = ptb.full(shape, 3, dtype="int64")
         res = pytensor.function([], full_pt, mode=self.mode)()
+        if isinstance(shape, ptb.TensorVariable):
+            shape = shape.eval()
         assert np.array_equal(res, np.full(shape, 3, dtype="int64"))
-
-    def test_full_with_scalar(self):
-        shape = scalar("shape", dtype="int64")
-        full_pt = ptb.full(shape, 3, dtype="int64")
-        res = pytensor.function([shape], full_pt, mode=self.mode)(5)
-        assert np.array_equal(res, np.full(5, 3, dtype="int64"))
 
     @pytest.mark.parametrize("func", (ptb.zeros, ptb.empty))
     def test_rebuild(self, func):

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -848,10 +848,11 @@ class TestAlloc:
             inp = np.zeros(shp, dtype=config.floatX)
             assert np.allclose(zeros_tensor(inp), np.zeros(shp))
 
-    def test_full(self):
-        full_pt = ptb.full((2, 3), 3, dtype="int64")
+    @pytest.mark.parametrize("shape", [(2, 3), 5, np.int32(5)])
+    def test_full(self, shape):
+        full_pt = ptb.full(shape, 3, dtype="int64")
         res = pytensor.function([], full_pt, mode=self.mode)()
-        assert np.array_equal(res, np.full((2, 3), 3, dtype="int64"))
+        assert np.array_equal(res, np.full(shape, 3, dtype="int64"))
 
     @pytest.mark.parametrize("func", (ptb.zeros, ptb.empty))
     def test_rebuild(self, func):

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -848,11 +848,29 @@ class TestAlloc:
             inp = np.zeros(shp, dtype=config.floatX)
             assert np.allclose(zeros_tensor(inp), np.zeros(shp))
 
-    @pytest.mark.parametrize("shape", [(2, 3), 5, np.int32(5)])
+    @pytest.mark.parametrize("shape", [(2, 3), 5, np.int32(5), np.array(5)])
     def test_full(self, shape):
         full_pt = ptb.full(shape, 3, dtype="int64")
         res = pytensor.function([], full_pt, mode=self.mode)()
         assert np.array_equal(res, np.full(shape, 3, dtype="int64"))
+
+    def test_full_with_scalar(self):
+        shape = scalar("shape", dtype="int64")
+        full_pt = ptb.full(shape, 3, dtype="int64")
+        res = pytensor.function([shape], full_pt, mode=self.mode)(5)
+        assert np.array_equal(res, np.full(5, 3, dtype="int64"))
+
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            5.5,
+            np.array(5.5),
+            scalar("shape", dtype="float64"),
+        ],
+    )
+    def test_full_with_float(self, shape) -> None:
+        with pytest.raises(TypeError, match="^Shapes must be scalar integers.*"):
+            ptb.full(shape, 3, dtype="int64")
 
     @pytest.mark.parametrize("func", (ptb.zeros, ptb.empty))
     def test_rebuild(self, func):

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -860,18 +860,6 @@ class TestAlloc:
         res = pytensor.function([shape], full_pt, mode=self.mode)(5)
         assert np.array_equal(res, np.full(5, 3, dtype="int64"))
 
-    @pytest.mark.parametrize(
-        "shape",
-        [
-            5.5,
-            np.array(5.5),
-            scalar("shape", dtype="float64"),
-        ],
-    )
-    def test_full_with_float(self, shape) -> None:
-        with pytest.raises(TypeError, match="^Shapes must be scalar integers.*"):
-            ptb.full(shape, 3, dtype="int64")
-
     @pytest.mark.parametrize("func", (ptb.zeros, ptb.empty))
     def test_rebuild(self, func):
         x = vector(shape=(50,))


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->

numpy.full supports int and the pytensor docs suggest full does as well. This brings the numpy expected behavior together

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #758 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
