### PR TITLE
Enable no-cpython-wrapper in numba where possible

### DIFF
--- a/pytensor/link/numba/dispatch/basic.py
+++ b/pytensor/link/numba/dispatch/basic.py
@@ -421,7 +421,12 @@ def generate_fallback_impl(op, node=None, storage_map=None, **kwargs):
 
 @singledispatch
 def numba_funcify(op, node=None, storage_map=None, **kwargs):
-    """Generate a numba function for a given op and apply node."""
+    """Generate a numba function for a given op and apply node.
+
+    The resulting function will usually use the `no_cpython_wrapper`
+    argument in numba, so it can not be called directly from python,
+    but only from other jit functions.
+    """
     return generate_fallback_impl(op, node, storage_map, **kwargs)
 
 

--- a/pytensor/link/numba/dispatch/basic.py
+++ b/pytensor/link/numba/dispatch/basic.py
@@ -59,6 +59,8 @@ def global_numba_func(func):
 
 def numba_njit(*args, **kwargs):
     kwargs.setdefault("cache", config.numba__cache)
+    kwargs.setdefault("no_cpython_wrapper", True)
+    kwargs.setdefault("no_cfunc_wrapper", True)
 
     # Supress caching warnings
     warnings.filterwarnings(

--- a/pytensor/link/numba/dispatch/elemwise.py
+++ b/pytensor/link/numba/dispatch/elemwise.py
@@ -470,7 +470,9 @@ _jit_options = {
         "afn",  # Approximate functions
         "reassoc",
         "nsz",  # TODO Do we want this one?
-    }
+    },
+    "no_cpython_wrapper": True,
+    "no_cfunc_wrapper": True,
 }
 
 
@@ -698,7 +700,14 @@ def numba_funcify_Elemwise(op, node, **kwargs):
             return tuple(outputs_summed)
         return outputs_summed[0]
 
-    @overload(elemwise)
+    @overload(
+        elemwise,
+        jit_options={
+            "fastmath": flags,
+            "no_cpython_wrapper": True,
+            "no_cfunc_wrapper": True,
+        },
+    )
     def ov_elemwise(*inputs):
         return elemwise_wrapper
 

--- a/pytensor/link/numba/linker.py
+++ b/pytensor/link/numba/linker.py
@@ -29,7 +29,7 @@ class NumbaLinker(JITLinker):
     def jit_compile(self, fn):
         from pytensor.link.numba.dispatch.basic import numba_njit
 
-        jitted_fn = numba_njit(fn)
+        jitted_fn = numba_njit(fn, no_cpython_wrapper=False, no_cfunc_wrapper=False)
         return jitted_fn
 
     def create_thunk_inputs(self, storage_map):


### PR DESCRIPTION
Disabling the generation of cpython wrappers should speed up compilation quite a bit.
Most of our intermediate functions are never called from python, so we don't need numba to generate wrapper code.

Note, that calling a `njit` function with `no_cpython_wrapper` directly from python (so not within a different njit function) will not work, and usually segfault.

The compilation time should further improve, if something like https://github.com/numba/numba/pull/9566 lands in numba.