### PR TITLE
Allow fill_sink rewrite to accomodate changes in broadcastability

### DIFF
--- a/pytensor/tensor/rewriting/basic.py
+++ b/pytensor/tensor/rewriting/basic.py
@@ -351,10 +351,7 @@ def local_fill_sink(fgraph, node):
     # Check if we need to propagate the fill to the new outputs
     # It's enough to check the first output, as Elemwise outputs must all have the same shapes
     # Note: There are orderings that may require fewer fills.
-    old_bcast_pattern = node.outputs[0].type.broadcastable
-    models_iter = iter(models)
-    while old_bcast_pattern != outputs[0].type.broadcastable:
-        model = next(models_iter)
+    for model in models:
         # Only apply this model if it would actually do anything
         if broadcasted_by(outputs[0], model):
             outputs = [fill(model, output) for output in outputs]


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
The strict assumption that one of the existing variables could make the rewritten output broadcastable pattern match the original one, led to a failure in https://github.com/pymc-devs/pymc/pull/7327 (https://github.com/pymc-devs/pymc/actions/runs/9253581078/job/25453566092?pr=7327#step:7:265)

This is related to #408, the sooner we fix that the better, as this kind of problems keep popping all the time, and makes graph subject to changes in behavior depending on whether rewrites are performed or not

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
