### PR TITLE
Do not reject PatternNodeRewriter due unrelated multiple clients

### DIFF
--- a/pytensor/graph/rewriting/basic.py
+++ b/pytensor/graph/rewriting/basic.py
@@ -1616,14 +1616,6 @@ class PatternNodeRewriter(NodeRewriter):
         from etuples.core import ExpressionTuple
         from unification import reify, unify
 
-        # TODO: We shouldn't need to iterate like this.
-        if not self.allow_multiple_clients and any(
-            len(fgraph.clients.get(v)) > 1
-            for v in vars_between(fgraph.inputs, node.outputs)
-            if v not in fgraph.inputs
-        ):
-            return False
-
         if get_nodes and self.get_nodes is not None:
             for real_node in self.get_nodes(fgraph, node):
                 if real_node == "output":
@@ -1647,6 +1639,15 @@ class PatternNodeRewriter(NodeRewriter):
 
         if self.values_eq_approx:
             ret.tag.values_eq_approx = self.values_eq_approx
+
+        if not self.allow_multiple_clients:
+            input_vars = list(s.values())
+            if any(
+                len(fgraph.clients[v]) > 1
+                for v in vars_between(input_vars, node.inputs)
+                if v not in input_vars
+            ):
+                return False
 
         if ret.owner:
             if not (


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
The existing check was to restrictive, because it would reject a rewrite due to completely unrelated multiple clients above the replaced subgraph, as well as multiple uses of the output being replaced, neither of which make sense.

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
