### PR TITLE
Harmonize Scan rewrite and tag names

### DIFF
--- a/pytensor/link/numba/dispatch/scan.py
+++ b/pytensor/link/numba/dispatch/scan.py
@@ -184,7 +184,7 @@ def numba_funcify_Scan(op, node, **kwargs):
     # rotation for initially truncated storage.
     output_storage_post_proc_stmts: list[str] = []
 
-    # In truncated storage situations (e.g. created by `save_mem_new_scan`),
+    # In truncated storage situations (e.g. created by `scan_save_mem`),
     # the taps and output storage overlap, instead of the standard situation in
     # which the output storage is large enough to contain both the initial taps
     # values and the output storage.  In this truncated case, we use the

--- a/tests/scan/test_rewriting.py
+++ b/tests/scan/test_rewriting.py
@@ -304,7 +304,7 @@ class TestPushOutDot:
 
 class TestPushOutNonSeqScan:
     """
-    Tests for the `push_out_non_seq_scan` optimization in the case where the inner
+    Tests for the `scan_push_out_non_seq` optimization in the case where the inner
     function of a `Scan` `Op` has an output which is the result of a `Dot` product
     on a non-sequence matrix input to `Scan` and a vector that is the result of
     computation in the inner function.
@@ -595,7 +595,7 @@ class TestPushOutNonSeqScan:
 
 class TestPushOutAddScan:
     """
-    Test case for the `push_out_add_scan` optimization in the case where the `Scan`
+    Test case for the `scan_push_out_add` optimization in the case where the `Scan`
     is used to compute the sum over the dot products between the corresponding
     elements of two list of matrices.
 
@@ -1208,7 +1208,7 @@ class TestScanInplaceOptimizer:
 
 
 class TestSaveMem:
-    mode = get_default_mode().including("scan_save_mem", "save_mem_new_scan")
+    mode = get_default_mode().including("scan_save_mem", "scan_save_mem")
 
     def test_save_mem(self):
         rng = np.random.default_rng(utt.fetch_seed())


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
We were trying to test scan rewrites and hit again the fact that the name reported by the `optimizer_verbose=True` is not the name we can use to filter out rewrites due to the arbitrary custom names given. If we make them match the function it will work, because in2out gives the name of the function to the rewrite by default.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #247 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
