### PR TITLE
Do not emmit confusing warning from FusionOptimizer by default

### DIFF
--- a/pytensor/tensor/rewriting/elemwise.py
+++ b/pytensor/tensor/rewriting/elemwise.py
@@ -699,12 +699,10 @@ class FusionOptimizer(GraphRewriter):
                     if node.op.scalar_op.supports_c_code(node.inputs, node.outputs):
                         return True
                     else:
-                        warn(
-                            "Optimization Warning: "
-                            f"The Op {node.op.scalar_op} does not provide a C implementation."
-                            " As well as being potentially slow, this also disables "
-                            "loop fusion."
-                        )
+                        if config.optimizer_verbose:
+                            warn(
+                                f"Loop fusion interrupted because {node.op.scalar_op} does not provide a C implementation."
+                            )
                         return False
 
                 # Fuseable nodes have to be accessed in a deterministic manner


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
This warning is confusing and has detracted dev work in case it is likely to not matter at all. Since we are not actively pushing the C-backend anymore seems like a good time as any to stop emitting it by default. Now it's only triggered when `optimizer_verbose` is True (by default it's not)

We still need to address the fact that the absense of a C-implementation may be leading to less fusion in unrelated backends (only Numba atm, since we don't fuse stuff for JAX, they do it themselves).

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Related to #140
- [x] Related to #673

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
