### PR TITLE
Add `nan_to_num` helper

### DIFF
--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -1533,6 +1533,56 @@ class IsInf(FixedLogicalComparison):
 isinf = IsInf()
 
 
+class IsPosInf(FixedLogicalComparison):
+    nfunc_spec = ("isposinf", 1, 1)
+
+    def impl(self, x):
+        return np.isposinf(x)
+
+    def c_code(self, node, name, inputs, outputs, sub):
+        (x,) = inputs
+        (z,) = outputs
+        if node.inputs[0].type in complex_types:
+            raise NotImplementedError()
+        # Discrete type can never be posinf
+        if node.inputs[0].type in discrete_types:
+            return f"{z} = false;"
+
+        return f"{z} = isinf({x}) && !signbit({x});"
+
+    def c_code_cache_version(self):
+        scalarop_version = super().c_code_cache_version()
+        return (*scalarop_version, 4)
+
+
+isposinf = IsPosInf()
+
+
+class IsNegInf(FixedLogicalComparison):
+    nfunc_spec = ("isneginf", 1, 1)
+
+    def impl(self, x):
+        return np.isneginf(x)
+
+    def c_code(self, node, name, inputs, outputs, sub):
+        (x,) = inputs
+        (z,) = outputs
+        if node.inputs[0].type in complex_types:
+            raise NotImplementedError()
+        # Discrete type can never be neginf
+        if node.inputs[0].type in discrete_types:
+            return f"{z} = false;"
+
+        return f"{z} = isinf({x}) && signbit({x});"
+
+    def c_code_cache_version(self):
+        scalarop_version = super().c_code_cache_version()
+        return (*scalarop_version, 4)
+
+
+isneginf = IsNegInf()
+
+
 class InRange(LogicalComparison):
     nin = 3
 

--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -1533,56 +1533,6 @@ class IsInf(FixedLogicalComparison):
 isinf = IsInf()
 
 
-class IsPosInf(FixedLogicalComparison):
-    nfunc_spec = ("isposinf", 1, 1)
-
-    def impl(self, x):
-        return np.isposinf(x)
-
-    def c_code(self, node, name, inputs, outputs, sub):
-        (x,) = inputs
-        (z,) = outputs
-        if node.inputs[0].type in complex_types:
-            raise NotImplementedError()
-        # Discrete type can never be posinf
-        if node.inputs[0].type in discrete_types:
-            return f"{z} = false;"
-
-        return f"{z} = isinf({x}) && !signbit({x});"
-
-    def c_code_cache_version(self):
-        scalarop_version = super().c_code_cache_version()
-        return (*scalarop_version, 4)
-
-
-isposinf = IsPosInf()
-
-
-class IsNegInf(FixedLogicalComparison):
-    nfunc_spec = ("isneginf", 1, 1)
-
-    def impl(self, x):
-        return np.isneginf(x)
-
-    def c_code(self, node, name, inputs, outputs, sub):
-        (x,) = inputs
-        (z,) = outputs
-        if node.inputs[0].type in complex_types:
-            raise NotImplementedError()
-        # Discrete type can never be neginf
-        if node.inputs[0].type in discrete_types:
-            return f"{z} = false;"
-
-        return f"{z} = isinf({x}) && signbit({x});"
-
-    def c_code_cache_version(self):
-        scalarop_version = super().c_code_cache_version()
-        return (*scalarop_version, 4)
-
-
-isneginf = IsNegInf()
-
-
 class InRange(LogicalComparison):
     nin = 3
 

--- a/pytensor/tensor/math.py
+++ b/pytensor/tensor/math.py
@@ -811,6 +811,22 @@ def largest(*args):
         return max(stack(args), axis=0)
 
 
+def isposinf(x):
+    """
+    Return if the input variable has positive infinity element
+
+    """
+    return eq(x, np.inf)
+
+
+def isneginf(x):
+    """
+    Return if the input variable has negative infinity element
+
+    """
+    return eq(x, -np.inf)
+
+
 @scalar_elemwise
 def lt(a, b):
     """a < b"""
@@ -3077,11 +3093,8 @@ def nan_to_num(x, nan=0.0, posinf=None, neginf=None):
     """
     # Replace NaN's with nan keyword
     is_nan = isnan(x)
-    is_pos_inf = eq(x, np.inf)
-    is_neg_inf = eq(x, -np.inf)
-
-    if not any(is_nan) and not any(is_pos_inf) and not any(is_neg_inf):
-        return
+    is_pos_inf = isposinf(x)
+    is_neg_inf = isneginf(x)
 
     x = switch(is_nan, nan, x)
 
@@ -3140,6 +3153,8 @@ __all__ = [
     "not_equal",
     "isnan",
     "isinf",
+    "isposinf",
+    "isneginf",
     "allclose",
     "isclose",
     "and_",

--- a/pytensor/tensor/math.py
+++ b/pytensor/tensor/math.py
@@ -881,46 +881,6 @@ def isinf(a):
     return isinf_(a)
 
 
-@scalar_elemwise
-def isposinf(a):
-    """isposinf(a)"""
-
-
-# Rename isposnan to isposnan_ to allow to bypass it when not needed.
-# glibc 2.23 don't allow isposnan on int, so we remove it from the graph.
-isposinf_ = isposinf
-
-
-def isposinf(a):
-    """isposinf(a)"""
-    a = as_tensor_variable(a)
-    if a.dtype in discrete_dtypes:
-        return alloc(
-            np.asarray(False, dtype="bool"), *[a.shape[i] for i in range(a.ndim)]
-        )
-    return isposinf_(a)
-
-
-@scalar_elemwise
-def isneginf(a):
-    """isneginf(a)"""
-
-
-# Rename isnegnan to isnegnan_ to allow to bypass it when not needed.
-# glibc 2.23 don't allow isnegnan on int, so we remove it from the graph.
-isneginf_ = isneginf
-
-
-def isneginf(a):
-    """isneginf(a)"""
-    a = as_tensor_variable(a)
-    if a.dtype in discrete_dtypes:
-        return alloc(
-            np.asarray(False, dtype="bool"), *[a.shape[i] for i in range(a.ndim)]
-        )
-    return isneginf_(a)
-
-
 def allclose(a, b, rtol=1.0e-5, atol=1.0e-8, equal_nan=False):
     """
     Implement Numpy's ``allclose`` on tensors.
@@ -3117,8 +3077,8 @@ def nan_to_num(x, nan=0.0, posinf=None, neginf=None):
     """
     # Replace NaN's with nan keyword
     is_nan = isnan(x)
-    is_pos_inf = isposinf(x)
-    is_neg_inf = isneginf(x)
+    is_pos_inf = eq(x, np.inf)
+    is_neg_inf = eq(x, -np.inf)
 
     if not any(is_nan) and not any(is_pos_inf) and not any(is_neg_inf):
         return

--- a/pytensor/tensor/math.py
+++ b/pytensor/tensor/math.py
@@ -881,6 +881,46 @@ def isinf(a):
     return isinf_(a)
 
 
+@scalar_elemwise
+def isposinf(a):
+    """isposinf(a)"""
+
+
+# Rename isposnan to isposnan_ to allow to bypass it when not needed.
+# glibc 2.23 don't allow isposnan on int, so we remove it from the graph.
+isposinf_ = isposinf
+
+
+def isposinf(a):
+    """isposinf(a)"""
+    a = as_tensor_variable(a)
+    if a.dtype in discrete_dtypes:
+        return alloc(
+            np.asarray(False, dtype="bool"), *[a.shape[i] for i in range(a.ndim)]
+        )
+    return isposinf_(a)
+
+
+@scalar_elemwise
+def isneginf(a):
+    """isneginf(a)"""
+
+
+# Rename isnegnan to isnegnan_ to allow to bypass it when not needed.
+# glibc 2.23 don't allow isnegnan on int, so we remove it from the graph.
+isneginf_ = isneginf
+
+
+def isneginf(a):
+    """isneginf(a)"""
+    a = as_tensor_variable(a)
+    if a.dtype in discrete_dtypes:
+        return alloc(
+            np.asarray(False, dtype="bool"), *[a.shape[i] for i in range(a.ndim)]
+        )
+    return isneginf_(a)
+
+
 def allclose(a, b, rtol=1.0e-5, atol=1.0e-8, equal_nan=False):
     """
     Implement Numpy's ``allclose`` on tensors.
@@ -3043,6 +3083,65 @@ def vectorize_node_dot_to_matmul(op, node, batched_x, batched_y):
         return vectorize_node_fallback(op, node, batched_x, batched_y)
 
 
+def nan_to_num(x, nan=0.0, posinf=None, neginf=None):
+    """
+    Replace NaN with zero and infinity with large finite numbers (default
+    behaviour) or with the numbers defined by the user using the `nan`,
+    `posinf` and/or `neginf` keywords.
+
+    NaN is replaced by zero or by the user defined value in
+    `nan` keyword, infinity is replaced by the largest finite floating point
+    values representable by ``x.dtype`` or by the user defined value in
+    `posinf` keyword and -infinity is replaced by the most negative finite
+    floating point values representable by ``x.dtype`` or by the user defined
+    value in `neginf` keyword.
+
+    Parameters
+    ----------
+    x : symbolic tensor
+        Input array.
+    nan
+        The value to replace NaN's with in the tensor (default = 0).
+    posinf
+        The value to replace +INF with in the tensor (default max
+        in range representable by ``x.dtype``).
+    neginf
+        The value to replace -INF with in the tensor (default min
+        in range representable by ``x.dtype``).
+
+    Returns
+    -------
+    out
+        The tensor with NaN's, +INF, and -INF replaced with the
+        specified and/or default substitutions.
+    """
+    # Replace NaN's with nan keyword
+    is_nan = isnan(x)
+    is_pos_inf = isposinf(x)
+    is_neg_inf = isneginf(x)
+
+    if not any(is_nan) and not any(is_pos_inf) and not any(is_neg_inf):
+        return
+
+    x = switch(is_nan, nan, x)
+
+    # Get max and min values representable by x.dtype
+    maxf = posinf
+    minf = neginf
+
+    # Specify the value to replace +INF and -INF with
+    if maxf is None:
+        maxf = np.finfo(x.real.dtype).max
+    if minf is None:
+        minf = np.finfo(x.real.dtype).min
+
+    # Replace +INF and -INF values
+    x = switch(is_pos_inf, maxf, x)
+    x = switch(is_neg_inf, minf, x)
+
+    return x
+
+
 # NumPy logical aliases
 square = sqr
 
@@ -3199,4 +3298,5 @@ __all__ = [
     "logaddexp",
     "logsumexp",
     "hyp2f1",
+    "nan_to_num",
 ]


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
Added pytensor equivalent of numpy's [nan_to_num](https://numpy.org/doc/stable/reference/generated/numpy.nan_to_num.html). Also added ```isposinf``` and ```isneginf``` similar to ```isinf```.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #479
- [x] Closes #540 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
