### PR TITLE
Fix JAX implementation of Argmax

### DIFF
--- a/pytensor/link/jax/dispatch/nlinalg.py
+++ b/pytensor/link/jax/dispatch/nlinalg.py
@@ -1,4 +1,5 @@
 import jax.numpy as jnp
+import numpy as np
 
 from pytensor.link.jax.dispatch import jax_funcify
 from pytensor.tensor.blas import BatchedDot
@@ -137,12 +138,10 @@ def jax_funcify_Argmax(op, **kwargs):
 
         # NumPy does not support multiple axes for argmax; this is a
         # work-around
-        keep_axes = jnp.array(
-            [i for i in range(x.ndim) if i not in axes], dtype="int64"
-        )
+        keep_axes = np.array([i for i in range(x.ndim) if i not in axes], dtype="int64")
         # Not-reduced axes in front
         transposed_x = jnp.transpose(
-            x, jnp.concatenate((keep_axes, jnp.array(axes, dtype="int64")))
+            x, tuple(np.concatenate((keep_axes, np.array(axes, dtype="int64"))))
         )
         kept_shape = transposed_x.shape[: len(keep_axes)]
         reduced_shape = transposed_x.shape[len(keep_axes) :]
@@ -151,9 +150,9 @@ def jax_funcify_Argmax(op, **kwargs):
         # Otherwise reshape would complain citing float arg
         new_shape = (
             *kept_shape,
-            jnp.prod(jnp.array(reduced_shape, dtype="int64"), dtype="int64"),
+            np.prod(np.array(reduced_shape, dtype="int64"), dtype="int64"),
         )
-        reshaped_x = transposed_x.reshape(new_shape)
+        reshaped_x = transposed_x.reshape(tuple(new_shape))
 
         max_idx_res = jnp.argmax(reshaped_x, axis=-1).astype("int64")
 

--- a/tests/link/jax/test_extra_ops.py
+++ b/tests/link/jax/test_extra_ops.py
@@ -67,7 +67,7 @@ def test_extra_ops():
     version_parse(jax.__version__) >= version_parse("0.2.12"),
     reason="JAX Numpy API does not support dynamic shapes",
 )
-def test_extra_ops_omni():
+def test_extra_ops_dynamic_shapes():
     a = matrix("a")
     a.tag.test_value = np.arange(6, dtype=config.floatX).reshape((3, 2))
 

--- a/tests/link/jax/test_extra_ops.py
+++ b/tests/link/jax/test_extra_ops.py
@@ -65,7 +65,7 @@ def test_extra_ops():
 
 @pytest.mark.xfail(
     version_parse(jax.__version__) >= version_parse("0.2.12"),
-    reason="Omnistaging cannot be disabled",
+    reason="JAX Numpy API does not support dynamic shapes",
 )
 def test_extra_ops_omni():
     a = matrix("a")

--- a/tests/link/jax/test_nlinalg.py
+++ b/tests/link/jax/test_nlinalg.py
@@ -95,10 +95,6 @@ def test_jax_basic_multiout_omni():
     compare_jax_and_py(out_fg, [np.r_[1, 2]])
 
 
-@pytest.mark.xfail(
-    version_parse(jax.__version__) >= version_parse("0.2.12"),
-    reason="`dot` -> `Gemv` optimization is incompatible with JAX",
-)
 def test_tensor_basics():
     y = vector("y")
     y.tag.test_value = np.r_[1.0, 2.0].astype(config.floatX)

--- a/tests/link/jax/test_nlinalg.py
+++ b/tests/link/jax/test_nlinalg.py
@@ -13,7 +13,7 @@ from pytensor.tensor import blas as pt_blas
 from pytensor.tensor import nlinalg as pt_nlinalg
 from pytensor.tensor.math import Argmax, Max, maximum
 from pytensor.tensor.math import max as pt_max
-from pytensor.tensor.type import matrix, scalar, tensor3, vector
+from pytensor.tensor.type import dvector, matrix, scalar, tensor3, vector
 from tests.link.jax.test_basic import compare_jax_and_py
 
 

--- a/tests/link/jax/test_nlinalg.py
+++ b/tests/link/jax/test_nlinalg.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-from packaging.version import parse as version_parse
 
 from pytensor.compile.function import function
 from pytensor.compile.mode import Mode
@@ -80,11 +79,7 @@ def test_jax_basic_multiout():
     compare_jax_and_py(out_fg, [X.astype(config.floatX)], assert_fn=assert_fn)
 
 
-@pytest.mark.xfail(
-    version_parse(jax.__version__) >= version_parse("0.2.12"),
-    reason="Operation leads to JAX Tracer object is used in a context where a Python integer is expected (jax.errors.TracerIntegerConversionError).",
-)
-def test_jax_basic_multiout_omni():
+def test_jax_max_and_argmax():
     # Test that a single output of a multi-output `Op` can be used as input to
     # another `Op`
     x = dvector()

--- a/tests/link/jax/test_nlinalg.py
+++ b/tests/link/jax/test_nlinalg.py
@@ -82,7 +82,7 @@ def test_jax_basic_multiout():
 
 @pytest.mark.xfail(
     version_parse(jax.__version__) >= version_parse("0.2.12"),
-    reason="Omnistaging cannot be disabled",
+    reason="JAX Numpy API does not support dynamic shapes",
 )
 def test_jax_basic_multiout_omni():
     # Test that a single output of a multi-output `Op` can be used as input to
@@ -97,7 +97,7 @@ def test_jax_basic_multiout_omni():
 
 @pytest.mark.xfail(
     version_parse(jax.__version__) >= version_parse("0.2.12"),
-    reason="Omnistaging cannot be disabled",
+    reason="`dot` -> `Gemv` optimization is incompatible with JAX",
 )
 def test_tensor_basics():
     y = vector("y")

--- a/tests/link/jax/test_nlinalg.py
+++ b/tests/link/jax/test_nlinalg.py
@@ -13,7 +13,7 @@ from pytensor.tensor import blas as pt_blas
 from pytensor.tensor import nlinalg as pt_nlinalg
 from pytensor.tensor.math import Argmax, Max, maximum
 from pytensor.tensor.math import max as pt_max
-from pytensor.tensor.type import dvector, matrix, scalar, tensor3, vector
+from pytensor.tensor.type import matrix, scalar, tensor3, vector
 from tests.link.jax.test_basic import compare_jax_and_py
 
 
@@ -82,7 +82,7 @@ def test_jax_basic_multiout():
 
 @pytest.mark.xfail(
     version_parse(jax.__version__) >= version_parse("0.2.12"),
-    reason="JAX Numpy API does not support dynamic shapes",
+    reason="Operation leads to JAX Tracer object is used in a context where a Python integer is expected (jax.errors.TracerIntegerConversionError).",
 )
 def test_jax_basic_multiout_omni():
     # Test that a single output of a multi-output `Op` can be used as input to


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
"Omnistaging can't be disabled" was added as reason for some expected failures due to [breaking changes introduced in JAX 0.2.12 onwards](https://jax.readthedocs.io/en/latest/jep/4410-omnistaging.html). As omnistaging already became default in JAX for 4 years, more descriptive reasons are needed for the tests affected (3 in total).

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #780 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
