### PR TITLE
Replace dot of 1 and x -> x

### DIFF
--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -191,6 +191,43 @@ def local_0_dot_x(fgraph, node):
 
 
 @register_canonicalize
+@register_stabilize
+@node_rewriter([Dot])
+def local_1_dot_x(fgraph, node):
+    if not isinstance(node.op, Dot):
+        return False
+
+    x = node.inputs[0]
+    y = node.inputs[1]
+    replace = False
+    try:
+        if get_underlying_scalar_constant_value(x, only_process_constants=True) == 1:
+            replace = True
+            var = y
+    except NotScalarConstantError:
+        pass
+
+    try:
+        if get_underlying_scalar_constant_value(y, only_process_constants=True) == 1:
+            replace = True
+            var = x
+    except NotScalarConstantError:
+        pass
+
+    if replace:
+        new_out = var
+        old_out = node.outputs[0]
+
+        if new_out.dtype != old_out.dtype:
+            new_out = cast(new_out, old_out.dtype)
+        if not old_out.type.is_super(new_out.type):
+            new_out = new_out.reshape(old_out.shape)
+            # new_out = alloc_like(new_out, old_out, fgraph)
+
+        return [new_out]
+
+
+@register_canonicalize
 @node_rewriter([DimShuffle])
 def local_lift_transpose_through_dot(fgraph, node):
     r"""Perform the rewrite ``dot(x,y).T -> dot(y.T, x.T)``.

--- a/tests/tensor/rewriting/test_math.py
+++ b/tests/tensor/rewriting/test_math.py
@@ -4475,3 +4475,22 @@ def test_local_batched_matmul_to_core_matmul():
     x_test = rng.normal(size=(5, 3, 2))
     y_test = rng.normal(size=(5, 2, 2))
     np.testing.assert_allclose(fn(x_test, y_test), x_test @ y_test)
+
+
+@pytest.mark.parametrize(
+    "x",
+    (
+        pt.col("x"),
+        fmatrix("x"),
+        vector("x"),
+        pt.tensor("x", shape=(1, 3, 2), dtype="float64"),
+    ),
+)
+def test_mul_with_1(x):
+    f = x @ [[1.0]]
+    with pytensor.config.change_flags(optimizer_verbose=True):
+        fn = pytensor.function([x], f, mode=get_default_mode().excluding("BlasOpt"))
+
+    pytensor.dprint(fn)
+
+    assert 0


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
So here, I aim to replace the output of a graph of ```x.[1]``` or ```x@[1]``` with x.
I am not quite sure if this is the correct way to do so.  When ```x = pt.col('x')``` this works fine.
However for ```x = fmatrix("x")``` or ```x = vector("x")``` or ```x = pt.tensor("x", shape=(1, 3, 2), dtype="float64")``` I kept running into the error:
```
TypeError: The type of the replacement (Matrix(float64, shape=(3, 2))) must be compatible with the type of the original Variable (Matrix(float64, shape=(3, 1))).
```

To solve this, I introduced:
```
if not old_out.type.is_super(new_out.type):
    new_out = alloc_like(new_out, old_out, fgraph)
```
However, ```x = pt.tensor("x", shape=(1, 3, 2), dtype="float64")``` still complained with:
```
raise ValueError(
ValueError: Alloc static input type and target shape are incompatible: Matrix(float64, shape=(3, 2)) vs (3, 1)
```
Finally, 
```
if not old_out.type.is_super(new_out.type):
    new_out = new_out.reshape(old_out.shape)
```
works fine but introduces a ```Reshape op``` in the graph.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #638
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
