### PR TITLE
fix(numba): cholesky did not set off-diag entries to zero

### DIFF
--- a/pytensor/link/numba/dispatch/slinalg.py
+++ b/pytensor/link/numba/dispatch/slinalg.py
@@ -310,8 +310,11 @@ def numba_funcify_SolveTriangular(op, node, **kwargs):
 
 
 def _cholesky(a, lower=False, overwrite_a=False, check_finite=True):
-    return linalg.cholesky(
-        a, lower=lower, overwrite_a=overwrite_a, check_finite=check_finite
+    return (
+        linalg.cholesky(
+            a, lower=lower, overwrite_a=overwrite_a, check_finite=check_finite
+        ),
+        0,
     )
 
 
@@ -345,6 +348,15 @@ def cholesky_impl(A, lower=0, overwrite_a=False, check_finite=True):
             LDA,
             INFO,
         )
+
+        if lower:
+            for j in range(1, _N):
+                for i in range(j):
+                    A_copy[i, j] = 0.0
+        else:
+            for j in range(_N):
+                for i in range(j + 1, _N):
+                    A_copy[i, j] = 0.0
 
         return A_copy, int_ptr_to_val(INFO)
 

--- a/tests/link/numba/test_basic.py
+++ b/tests/link/numba/test_basic.py
@@ -118,8 +118,12 @@ my_multi_out = Elemwise(MyMultiOut())
 my_multi_out.ufunc = MyMultiOut.impl
 my_multi_out.ufunc.nin = 2
 my_multi_out.ufunc.nout = 2
-opts = RewriteDatabaseQuery(include=[None], exclude=["cxx_only", "BlasOpt"])
-numba_mode = Mode(NumbaLinker(), opts.including("numba"))
+opts = RewriteDatabaseQuery(
+    include=[None], exclude=["cxx_only", "BlasOpt", "local_careduce_fusion"]
+)
+numba_mode = Mode(
+    NumbaLinker(), opts.including("numba", "local_useless_unbatched_blockwise")
+)
 py_mode = Mode("py", opts)
 
 rng = np.random.default_rng(42849)


### PR DESCRIPTION
## Description
The cholesky blas function returns an array with values stored in the triagonal part of the array that is zero by definition.

This is the equivalent of the scipy code here: https://github.com/scipy/scipy/blob/d5e1e03ac12fb5ad7fa4949e7ffea2137e780b15/scipy/linalg/flapack_pos_def.pyf.src#L132

fixes #814

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
