### PR TITLE
Add jax dispatch for `KroneckerProduct` `Op`

### DIFF
--- a/pytensor/link/jax/dispatch/nlinalg.py
+++ b/pytensor/link/jax/dispatch/nlinalg.py
@@ -8,6 +8,7 @@ from pytensor.tensor.nlinalg import (
     Det,
     Eig,
     Eigh,
+    KroneckerProduct,
     MatrixInverse,
     MatrixPinv,
     QRFull,
@@ -102,6 +103,14 @@ def jax_funcify_BatchedDot(op, **kwargs):
         return jnp.matmul(a, b)
 
     return batched_dot
+
+
+@jax_funcify.register(KroneckerProduct)
+def jax_funcify_KroneckerProduct(op, **kwargs):
+    def _kron(x, y):
+        return jnp.kron(x, y)
+
+    return _kron
 
 
 @jax_funcify.register(Max)

--- a/tests/link/jax/test_nlinalg.py
+++ b/tests/link/jax/test_nlinalg.py
@@ -165,3 +165,15 @@ def test_pinv_hermitian():
     assert not np.allclose(
         jax_fn(A_not_h_test), np.linalg.pinv(A_not_h_test, hermitian=True)
     )
+
+
+def test_kron():
+    x = matrix("x")
+    y = matrix("y")
+    z = pt_nlinalg.kron(x, y)
+
+    fgraph = FunctionGraph([x, y], [z])
+    x_np = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=config.floatX)
+    y_np = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=config.floatX)
+
+    compare_jax_and_py(fgraph, [x_np, y_np])


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->

#622 broke the JAX dispatch for `pt.nlinalg.kron`, because we're wrapping it in a dummy `OpFromGraph(inline=False)`. I tried just changing it to `inline=True`, but got some dynamic shape errors when the graph was converted to JAX. I think it's easier to just directly register the new OpFromGraph to `jnp.kron`, which this PR does. It also adds a test.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #622

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->