### PR TITLE
added check for square matrix in make_node to Det

### DIFF
--- a/pytensor/tensor/nlinalg.py
+++ b/pytensor/tensor/nlinalg.py
@@ -198,7 +198,15 @@ class Det(Op):
 
     def make_node(self, x):
         x = as_tensor_variable(x)
-        assert x.ndim == 2
+        if x.ndim != 2:
+            raise ValueError()
+        # Check for known shapes and square matrix
+        if all(shape is not None for shape in x.type.shape) and (
+            x.type.shape[0] != x.type.shape[1]
+        ):
+            raise ValueError(
+                f"Det not defined for non-square matrix inputs. Shape received is {x.type.shape}"
+            )
         o = scalar(dtype=x.dtype)
         return Apply(self, [x], [o])
 

--- a/pytensor/tensor/nlinalg.py
+++ b/pytensor/tensor/nlinalg.py
@@ -199,11 +199,11 @@ class Det(Op):
     def make_node(self, x):
         x = as_tensor_variable(x)
         if x.ndim != 2:
-            raise ValueError()
+            raise ValueError(
+                f"Input passed is not a valid 2D matrix. Current ndim {x.ndim} != 2"
+            )
         # Check for known shapes and square matrix
-        if all(shape is not None for shape in x.type.shape) and (
-            x.type.shape[0] != x.type.shape[1]
-        ):
+        if None not in x.type.shape and (x.type.shape[0] != x.type.shape[1]):
             raise ValueError(
                 f"Det not defined for non-square matrix inputs. Shape received is {x.type.shape}"
             )

--- a/pytensor/tensor/nlinalg.py
+++ b/pytensor/tensor/nlinalg.py
@@ -205,7 +205,7 @@ class Det(Op):
         # Check for known shapes and square matrix
         if None not in x.type.shape and (x.type.shape[0] != x.type.shape[1]):
             raise ValueError(
-                f"Det not defined for non-square matrix inputs. Shape received is {x.type.shape}"
+                f"Determinant not defined for non-square matrix inputs. Shape received is {x.type.shape}"
             )
         o = scalar(dtype=x.dtype)
         return Apply(self, [x], [o])

--- a/tests/tensor/test_nlinalg.py
+++ b/tests/tensor/test_nlinalg.py
@@ -365,6 +365,11 @@ def test_det():
     assert np.allclose(np.linalg.det(r), f(r))
 
 
+def test_det_non_square():
+    with pytest.raises(ValueError, match="Det not defined"):
+        det(tensor("x", shape=(5, 7)))
+
+
 def test_det_grad():
     rng = np.random.default_rng(utt.fetch_seed())
 

--- a/tests/tensor/test_nlinalg.py
+++ b/tests/tensor/test_nlinalg.py
@@ -366,7 +366,7 @@ def test_det():
 
 
 def test_det_non_square_raises():
-    with pytest.raises(ValueError, match="Det not defined"):
+    with pytest.raises(ValueError, match="Determinant not defined"):
         det(tensor("x", shape=(5, 7)))
 
 

--- a/tests/tensor/test_nlinalg.py
+++ b/tests/tensor/test_nlinalg.py
@@ -365,7 +365,7 @@ def test_det():
     assert np.allclose(np.linalg.det(r), f(r))
 
 
-def test_det_non_square():
+def test_det_non_square_raises():
     with pytest.raises(ValueError, match="Det not defined"):
         det(tensor("x", shape=(5, 7)))
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
Raise a ValueError if non square matrix (with non shapes) is passed to the Det Op

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #856 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
