### PR TITLE
Implemented Eye Op in PyTorch

### DIFF
--- a/pytensor/link/pytorch/dispatch/basic.py
+++ b/pytensor/link/pytorch/dispatch/basic.py
@@ -104,15 +104,15 @@ def pytorch_funcify_Join(op, **kwargs):
 
 @pytorch_funcify.register(Eye)
 def pytorch_funcify_eye(op, **kwargs):
-    dtype = getattr(torch, op.dtype)
+    torch_dtype = getattr(torch, op.dtype)
 
     def eye(N, M, k):
-        mjr, mnr = (M, N) if k > 0 else (N, M)
+        major, minor = (M, N) if k > 0 else (N, M)
         k_abs = torch.abs(k)
-        zeros = torch.zeros(N, M, dtype=dtype)
-        if k_abs < mjr:
-            l_ones = torch.min(mjr - k_abs, mnr)
-            return zeros.diagonal_scatter(torch.ones(l_ones, dtype=dtype), k)
+        zeros = torch.zeros(N, M, dtype=torch_dtype)
+        if k_abs < major:
+            l_ones = torch.min(major - k_abs, minor)
+            return zeros.diagonal_scatter(torch.ones(l_ones, dtype=torch_dtype), k)
         return zeros
 
     return eye

--- a/pytensor/link/pytorch/dispatch/basic.py
+++ b/pytensor/link/pytorch/dispatch/basic.py
@@ -108,10 +108,10 @@ def pytorch_funcify_eye(op, **kwargs):
 
     def eye(N, M, k):
         mjr, mnr = (M, N) if k > 0 else (N, M)
-        k_abs = abs(k)
+        k_abs = torch.abs(k)
         zeros = torch.zeros(N, M, dtype=dtype)
         if k_abs < mjr:
-            l_ones = min(mjr - k_abs, mnr)
+            l_ones = torch.min(mjr - k_abs, mnr)
             return zeros.diagonal_scatter(torch.ones(l_ones, dtype=dtype), k)
         return zeros
 

--- a/tests/link/pytorch/test_basic.py
+++ b/tests/link/pytorch/test_basic.py
@@ -13,7 +13,7 @@ from pytensor.graph.basic import Apply
 from pytensor.graph.fg import FunctionGraph
 from pytensor.graph.op import Op
 from pytensor.raise_op import CheckAndRaise
-from pytensor.tensor import alloc, arange, as_tensor, empty
+from pytensor.tensor import alloc, arange, as_tensor, empty, eye
 from pytensor.tensor.type import matrix, scalar, vector
 
 
@@ -275,3 +275,20 @@ def test_pytorch_Join():
             np.c_[[5.0, 6.0]].astype(config.floatX),
         ],
     )
+
+
+def test_eye():
+    N = scalar("N", dtype="int64")
+    M = scalar("M", dtype="int64")
+    k = scalar("k", dtype="int64")
+
+    out = eye(N, M, k, dtype="int16")
+
+    trange = range(1, 6)
+    for _N in trange:
+        for _M in trange:
+            for _k in list(range(_M + 2)) + [-x for x in range(1, _N + 2)]:
+                compare_pytorch_and_py(
+                    FunctionGraph([N, M, k], [out]),
+                    [np.array(_N + 1), np.array(_M + 1), np.array(_k)],
+                )

--- a/tests/link/pytorch/test_basic.py
+++ b/tests/link/pytorch/test_basic.py
@@ -277,12 +277,16 @@ def test_pytorch_Join():
     )
 
 
-def test_eye():
+@pytest.mark.parametrize(
+    "dtype",
+    ["int64", config.floatX],
+)
+def test_eye(dtype):
     N = scalar("N", dtype="int64")
     M = scalar("M", dtype="int64")
     k = scalar("k", dtype="int64")
 
-    out = eye(N, M, k, dtype="float32")
+    out = eye(N, M, k, dtype=dtype)
 
     fn = function([N, M, k], out, mode=pytorch_mode)
 

--- a/tests/link/pytorch/test_basic.py
+++ b/tests/link/pytorch/test_basic.py
@@ -282,13 +282,13 @@ def test_eye():
     M = scalar("M", dtype="int64")
     k = scalar("k", dtype="int64")
 
-    out = eye(N, M, k, dtype="int16")
+    out = eye(N, M, k, dtype="float32")
 
     trange = range(1, 6)
+
+    fn = function([N, M, k], out, mode=pytorch_mode)
+
     for _N in trange:
         for _M in trange:
             for _k in list(range(_M + 2)) + [-x for x in range(1, _N + 2)]:
-                compare_pytorch_and_py(
-                    FunctionGraph([N, M, k], [out]),
-                    [np.array(_N), np.array(_M), np.array(_k)],
-                )
+                np.testing.assert_array_equal(fn(_N, _M, _k), np.eye(_N, _M, _k))

--- a/tests/link/pytorch/test_basic.py
+++ b/tests/link/pytorch/test_basic.py
@@ -290,5 +290,5 @@ def test_eye():
             for _k in list(range(_M + 2)) + [-x for x in range(1, _N + 2)]:
                 compare_pytorch_and_py(
                     FunctionGraph([N, M, k], [out]),
-                    [np.array(_N + 1), np.array(_M + 1), np.array(_k)],
+                    [np.array(_N), np.array(_M), np.array(_k)],
                 )

--- a/tests/link/pytorch/test_basic.py
+++ b/tests/link/pytorch/test_basic.py
@@ -284,11 +284,9 @@ def test_eye():
 
     out = eye(N, M, k, dtype="float32")
 
-    trange = range(1, 6)
-
     fn = function([N, M, k], out, mode=pytorch_mode)
 
-    for _N in trange:
-        for _M in trange:
+    for _N in range(1, 6):
+        for _M in range(1, 6):
             for _k in list(range(_M + 2)) + [-x for x in range(1, _N + 2)]:
                 np.testing.assert_array_equal(fn(_N, _M, _k), np.eye(_N, _M, _k))


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
- Implemented Eye Op with diagonal offset in `PyTorch`
      - `torch.eye` doesn't support a diagonal offset param `k` directly.  The implementation of this offset required composing two `torch` functions.
-  Added tests for different dimensions and diagonal offset, including corner cases. 
## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Related to #821 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
