### PR TITLE
Fix bug in vectorize of random variables with empty size

### DIFF
--- a/pytensor/tensor/random/op.py
+++ b/pytensor/tensor/random/op.py
@@ -238,7 +238,7 @@ class RandomVariable(Op):
                     raise ValueError(
                         f"Size length is incompatible with batched dimensions of parameter {i} {param}:\n"
                         f"len(size) = {size_len}, len(batched dims {param}) = {param_batched_dims}. "
-                        f"Size length must be 0 or >= {param_batched_dims}"
+                        f"Size must be None or have length >= {param_batched_dims}"
                     )
 
             return tuple(size) + supp_shape
@@ -454,11 +454,10 @@ def vectorize_random_variable(
 
     original_dist_params = op.dist_params(node)
     old_size = op.size_param(node)
-    len_old_size = (
-        None if isinstance(old_size.type, NoneTypeT) else get_vector_length(old_size)
-    )
 
-    if len_old_size and equal_computations([old_size], [size]):
+    if not isinstance(old_size.type, NoneTypeT) and equal_computations(
+        [old_size], [size]
+    ):
         # If the original RV had a size variable and a new one has not been provided,
         # we need to define a new size as the concatenation of the original size dimensions
         # and the novel ones implied by new broadcasted batched parameters dimensions.

--- a/tests/tensor/random/test_op.py
+++ b/tests/tensor/random/test_op.py
@@ -296,6 +296,16 @@ def test_vectorize():
     assert vect_node.default_output().type.shape == (10, 2, 5)
 
 
+def test_vectorize_empty_size():
+    scalar_mu = pt.scalar("scalar_mu")
+    scalar_x = pt.random.normal(loc=scalar_mu, size=())
+    assert scalar_x.type.shape == ()
+
+    vector_mu = pt.vector("vector_mu", shape=(5,))
+    vector_x = vectorize_graph(scalar_x, {scalar_mu: vector_mu})
+    assert vector_x.type.shape == (5,)
+
+
 def test_size_none_vs_empty():
     rv = RandomVariable(
         "normal",


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
Bug left out from when we fixed shape=None != shape=()

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
