### PR TITLE
Add building of pyodide universal wheels

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -70,7 +70,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install dependencies
-        run: pip install numpy versioneer
+        run: pip install numpy versioneer wheel
 
       - name: Build universal wheel
         run: |

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Build universal wheel
         run: |
-          PYODIDE=1 venv-sdist/bin/python setup.py bdist_wheel --universal
+          PYODIDE=1 python setup.py bdist_wheel --universal
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           PYODIDE=1 python setup.py bdist_wheel --universal
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: universal_wheel
           path: dist/*.whl

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -11,6 +11,8 @@ on:
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
+  # The concurrency group contains the workflow name and the branch name for pull requests
+  # or the commit hash for any other events.
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
@@ -72,7 +74,7 @@ jobs:
 
       - name: Build universal wheel
         run: |
-          PYODIDE=1 python setup.py bdist_wheel --universal
+          PYODIDE=1 venv-sdist/bin/python setup.py bdist_wheel --universal
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -17,6 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # The job to build precompiled pypi wheels.
   make_sdist:
     name: Make SDist
     runs-on: ubuntu-latest

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -11,13 +11,10 @@ on:
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
-  # The concurrency group contains the workflow name and the branch name for pull requests
-  # or the commit hash for any other events.
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
 jobs:
-  # The job to build precompiled pypi wheels.
   make_sdist:
     name: Make SDist
     runs-on: ubuntu-latest
@@ -56,6 +53,31 @@ jobs:
         with:
           name: wheels-${{ matrix.platform }}
           path: ./wheelhouse/*.whl
+
+  build_universal_wheel:
+    name: Build universal wheel for Pyodide
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: pip install numpy versioneer
+
+      - name: Build universal wheel
+        run: |
+          PYODIDE=1 python setup.py bdist_wheel --universal
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: universal_wheel
+          path: dist/*.whl
 
   check_dist:
     name: Check dist
@@ -102,6 +124,11 @@ jobs:
           pattern: wheels-*
           path: dist
           merge-multiple: true
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: universal_wheel
+          path: dist
 
       - uses: pypa/gh-action-pypi-publish@v1.9.0
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: pip install numpy versioneer

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
+import os
+
 import numpy
 from setuptools import Extension, setup
 from setuptools.dist import Distribution
-import os
+
 import versioneer
+
 
 dist = Distribution()
 dist.parse_config_files()
@@ -11,7 +14,7 @@ dist.parse_config_files()
 NAME = dist.get_name()  # type: ignore
 
 # Check if building for Pyodide
-is_pyodide = os.getenv('PYODIDE', '0') == '1'
+is_pyodide = os.getenv("PYODIDE", "0") == "1"
 
 # Define the ext_modules conditionally
 ext_modules = []

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,11 @@ NAME = dist.get_name()  # type: ignore
 # Check if building for Pyodide
 is_pyodide = os.getenv("PYODIDE", "0") == "1"
 
-# Define the ext_modules conditionally
-ext_modules = []
-if not is_pyodide:
+if is_pyodide:
+    # For pyodide we build a universal wheel that must be pure-python
+    # so we must omit the cython-version of scan.
+    ext_modules = []
+else:
     ext_modules = [
         Extension(
             name="pytensor.scan.scan_perform",

--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,33 @@
 #!/usr/bin/env python
 import numpy
-import versioneer
 from setuptools import Extension, setup
 from setuptools.dist import Distribution
-
+import os
+import versioneer
 
 dist = Distribution()
 dist.parse_config_files()
 
+NAME = dist.get_name()  # type: ignore
 
-NAME: str = dist.get_name()  # type: ignore
+# Check if building for Pyodide
+is_pyodide = os.getenv('PYODIDE', '0') == '1'
 
+# Define the ext_modules conditionally
+ext_modules = []
+if not is_pyodide:
+    ext_modules = [
+        Extension(
+            name="pytensor.scan.scan_perform",
+            sources=["pytensor/scan/scan_perform.pyx"],
+            include_dirs=[numpy.get_include()],
+        ),
+    ]
 
 if __name__ == "__main__":
     setup(
         name=NAME,
         version=versioneer.get_version(),
         cmdclass=versioneer.get_cmdclass(),
-        ext_modules=[
-            Extension(
-                name="pytensor.scan.scan_perform",
-                sources=["pytensor/scan/scan_perform.pyx"],
-                include_dirs=[numpy.get_include()],
-            ),
-        ],
+        ext_modules=ext_modules,
     )

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,9 @@
 import os
 
 import numpy
+import versioneer
 from setuptools import Extension, setup
 from setuptools.dist import Distribution
-
-import versioneer
 
 
 dist = Distribution()

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ import versioneer
 dist = Distribution()
 dist.parse_config_files()
 
-NAME = dist.get_name()  # type: ignore
+
+NAME: str = dist.get_name()  # type: ignore
 
 # Check if building for Pyodide
 is_pyodide = os.getenv("PYODIDE", "0") == "1"


### PR DESCRIPTION
Closes https://github.com/pymc-devs/pytensor/issues/285 and https://github.com/pymc-devs/pytensor/issues/360.

These require pure-python wheels which does not work if we ship a cython-version of scan, so this build does not include this extension module.