### PR TITLE
Fix supplying (base_)compiledir as str

### DIFF
--- a/pytensor/configdefaults.py
+++ b/pytensor/configdefaults.py
@@ -1155,14 +1155,14 @@ def _default_compiledirname() -> str:
     return safe
 
 
-def _filter_base_compiledir(path: Path) -> Path:
+def _filter_base_compiledir(path: str | Path) -> Path:
     # Expand '~' in path
-    return path.expanduser()
+    return Path(path).expanduser()
 
 
-def _filter_compiledir(path: Path) -> Path:
+def _filter_compiledir(path: str | Path) -> Path:
     # Expand '~' in path
-    path = path.expanduser()
+    path = Path(path).expanduser()
     # Turn path into the 'real' path. This ensures that:
     #   1. There is no relative path, which would fail e.g. when trying to
     #      import modules from the compile dir.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,6 @@ import configparser as stdlib_configparser
 import io
 import pickle
 from pathlib import Path
-from tempfile import mkdtemp
 
 import pytest
 
@@ -21,13 +20,16 @@ def _create_test_config():
     )
 
 
-def test_config_paths():
-    base_compiledir = mkdtemp()
-    assert configdefaults._filter_base_compiledir(str(base_compiledir)) == Path(
-        base_compiledir
+def test_base_compiledir_str(tmp_path: Path):
+    base_compiledir = tmp_path
+    assert (
+        configdefaults._filter_base_compiledir(str(base_compiledir)) == base_compiledir
     )
-    compiledir = mkdtemp()
-    assert configdefaults._filter_compiledir(str(compiledir)) == Path(compiledir)
+
+
+def test_compiledir_str(tmp_path: Path):
+    compiledir = tmp_path
+    assert configdefaults._filter_compiledir(str(compiledir)) == compiledir
 
 
 def test_invalid_default():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,8 @@
 import configparser as stdlib_configparser
 import io
 import pickle
+from pathlib import Path
+from tempfile import mkdtemp
 
 import pytest
 
@@ -17,6 +19,15 @@ def _create_test_config():
         pytensor_cfg=stdlib_configparser.ConfigParser(),
         pytensor_raw_cfg=stdlib_configparser.RawConfigParser(),
     )
+
+
+def test_config_paths():
+    base_compiledir = mkdtemp()
+    assert configdefaults._filter_base_compiledir(str(base_compiledir)) == Path(
+        base_compiledir
+    )
+    compiledir = mkdtemp()
+    assert configdefaults._filter_compiledir(str(compiledir)) == Path(compiledir)
 
 
 def test_invalid_default():


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
Fixes the bug signaled in https://discourse.pymc.io/t/changing-the-base-compiled-in-pytensor/14764

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #806 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
