### PR TITLE
#963 - Correct Article Usage Typo in PyTensor Contributing Guidelines Documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ For issues a minimal working example (MWE) is strongly recommended when relevant
 (fixing a typo in the documentation does not require a MWE). For discussions,
 MWEs are generally required. All MWEs must be implemented using PyTensor. Please
 do not submit MWEs if they are not implemented in PyTensor. In certain cases,
-pseudocode may be acceptable, but an PyTensor implementation is always preferable.
+pseudocode may be acceptable, but a PyTensor implementation is always preferable.
 
 ## Quick links
 


### PR DESCRIPTION
Issue - #963 
# Correct Typo in Contributing Guidelines Documentation

## Overview

This pull request addresses a minor but important typo in the contributing guidelines for the PyTensor project. By correcting this typo, we aim to improve the readability and accuracy of our documentation, making it easier for contributors to follow the guidelines.

## Changes Made

### Typo Correction
- **Original Text:** "an PyTensor"
- **Corrected Text:** "a PyTensor"
  
  The original text contained an incorrect article usage before the project name. The phrase "an PyTensor" has been updated to "a PyTensor" to reflect proper grammar and improve readability.

### Contextual Consistency
- Reviewed and ensured the corrected phrase is consistent with the rest of the documentation.
  
  This change helps maintain the professionalism and clarity of our contributing guidelines, ensuring that contributors are not confused by incorrect grammar.

## Impact

The corrected documentation will provide clearer instructions for both new and existing contributors. By ensuring that our guidelines are free of typos and grammatical errors, we make it easier for the community to engage with the project and contribute effectively.

## Checklist

- [x] Verified that the typo has been corrected.
- [x] Ensured that the documentation reflects the proper usage of the project name.
- [x] Reviewed the guidelines for any additional inconsistencies.

## Conclusion

By merging this pull request, we aim to improve the overall quality and accuracy of our contributing guidelines. This small but significant correction will help maintain the high standard of documentation that our contributors and maintainers expect.
