### PR TITLE
Fix bug due to `__props__` in OpFromGraph subclasses

### DIFF
--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -3780,14 +3780,15 @@ class AllocDiag(OpFromGraph):
     Wrapper Op for alloc_diag graphs
     """
 
-    __props__ = ("axis1", "axis2")
-
     def __init__(self, *args, axis1, axis2, offset, **kwargs):
         self.axis1 = axis1
         self.axis2 = axis2
         self.offset = offset
 
         super().__init__(*args, **kwargs, strict=True)
+
+    def __str__(self):
+        return f"AllocDiag{{{self.axis1=}, {self.axis2=}, {self.offset=}}}"
 
     @staticmethod
     def is_offset_zero(node) -> bool:

--- a/pytensor/tensor/einsum.py
+++ b/pytensor/tensor/einsum.py
@@ -52,13 +52,14 @@ class Einsum(OpFromGraph):
     desired. We haven't decided whether we want to provide this functionality.
     """
 
-    __props__ = ("subscripts", "path", "optimized")
-
     def __init__(self, *args, subscripts: str, path: PATH, optimized: bool, **kwargs):
         self.subscripts = subscripts
         self.path = path
         self.optimized = optimized
         super().__init__(*args, **kwargs, strict=True)
+
+    def __str__(self):
+        return f"Einsum{{{self.subscripts=}, {self.path=}, {self.optimized=}}}"
 
 
 def _iota(shape: TensorVariable, axis: int) -> TensorVariable:

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -37,6 +37,7 @@ from pytensor.tensor.basic import (
     TensorFromScalar,
     Tri,
     alloc,
+    alloc_diag,
     arange,
     as_tensor_variable,
     atleast_Nd,
@@ -3792,6 +3793,18 @@ class TestAllocDiag:
                     grad_diag_input, offset=offset, axis1=axis1, axis2=axis2
                 )
                 assert np.all(true_grad_input == grad_input)
+
+    def test_multiple_ops_same_graph(self):
+        """Regression test when AllocDiag OFG was given insufficient props, causing incompatible Ops to be merged."""
+        v1 = vector("v1", shape=(2,), dtype="float64")
+        v2 = vector("v2", shape=(3,), dtype="float64")
+        a1 = alloc_diag(v1)
+        a2 = alloc_diag(v2)
+
+        fn = function([v1, v2], [a1, a2])
+        res1, res2 = fn(v1=[np.e, np.e], v2=[np.pi, np.pi, np.pi])
+        np.testing.assert_allclose(res1, np.eye(2) * np.e)
+        np.testing.assert_allclose(res2, np.eye(3) * np.pi)
 
 
 def test_diagonal_negative_axis():


### PR DESCRIPTION
When specified, Ops with identical __props__ are considered identical, in that they can be swapped and given the original inputs to obtain the same output.

<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
This was causing distinct OFG to be reused incorrectly for different nodes during function inner graph cloning. When provided Ops with the same `__props__` are considered identical and can be swapped / recycled. It would be fine for `OFG` to have `__props__` but would need to include the `fgraph` as well. However, then, the `fgraph` should be frozen because `__props__` are also used for hashing and can't be mutable. For now I removed the `__props__` from the two use cases. 

