### PR TITLE
Remove error check in ConfigParser

### DIFF
--- a/pytensor/configparser.py
+++ b/pytensor/configparser.py
@@ -236,11 +236,7 @@ class PyTensorConfigParser:
             raise ValueError(
                 f"Dot-based sections were removed. Use double underscores! ({name})"
             )
-        # Can't use hasattr here, because it returns False upon AttributeErrors
-        if name in dir(self):
-            raise AttributeError(
-                f"A config parameter with the name '{name}' was already registered on another config instance."
-            )
+
         configparam.doc = doc
         configparam.name = name
         configparam.in_c_key = in_c_key

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -194,15 +194,6 @@ def test_invalid_configvar_access():
     with pytest.raises(configparser.ConfigAccessViolation, match="different instance"):
         print(root.test__on_test_instance)
 
-    # And also that we can't add two configs of the same name to different instances:
-    with pytest.raises(AttributeError, match="already registered"):
-        root.add(
-            "test__on_test_instance",
-            "This config setting was already added to another instance.",
-            configparser.IntParam(5),
-            in_c_key=False,
-        )
-
 
 def test_no_more_dotting():
     root = configdefaults.config


### PR DESCRIPTION
I can't quite tell why this check was added, but it is causing `pymc_experimental` tests to fail here:  https://github.com/pymc-devs/pymc-experimental/actions/runs/11140715111/job/30960085934?pr=300#step:5:1176

which as best as I could track happens when pytest import pymc (multiple times) and this function is executed: https://github.com/pymc-devs/pymc/blob/45069a966d3e123bf98efbc4f28008e31b243df8/pymc/__init__.py#L27-L46

I don't know why PyMC has to add those specific flags, but it seems like the behavior should be supported? I also don't know what pytest is doing to trigger this error.