### PR TITLE
Reduce overhead of function call and deprecate rarely used utilities

### DIFF
--- a/pytensor/compile/function/types.py
+++ b/pytensor/compile/function/types.py
@@ -387,6 +387,9 @@ class Function:
         self.nodes_with_inner_function = []
         self.output_keys = output_keys
 
+        if self.output_keys is not None:
+            warnings.warn("output_keys is deprecated.", FutureWarning)
+
         assert len(self.input_storage) == len(self.maker.fgraph.inputs)
         assert len(self.output_storage) == len(self.maker.fgraph.outputs)
 
@@ -836,8 +839,10 @@ class Function:
             t0 = time.perf_counter()
 
         output_subset = kwargs.pop("output_subset", None)
-        if output_subset is not None and self.output_keys is not None:
-            output_subset = [self.output_keys.index(key) for key in output_subset]
+        if output_subset is not None:
+            warnings.warn("output_subset is deprecated.", FutureWarning)
+            if self.output_keys is not None:
+                output_subset = [self.output_keys.index(key) for key in output_subset]
 
         # Reinitialize each container's 'provided' counter
         if self.trust_input:
@@ -1560,6 +1565,8 @@ class FunctionMaker:
             )
             for i in self.inputs
         ]
+        if any(self.refeed):
+            warnings.warn("Inputs with default values are deprecated.", FutureWarning)
 
     def create(self, input_storage=None, storage_map=None):
         """

--- a/pytensor/gradient.py
+++ b/pytensor/gradient.py
@@ -128,9 +128,6 @@ class DisconnectedType(Type):
             " a symbolic placeholder."
         )
 
-    def may_share_memory(a, b):
-        return False
-
     def value_eq(a, b, force_same_dtype=True):
         raise AssertionError(
             "If you're assigning to a DisconnectedType you're"

--- a/pytensor/graph/null_type.py
+++ b/pytensor/graph/null_type.py
@@ -26,9 +26,6 @@ class NullType(Type):
     def filter_variable(self, other, allow_convert=True):
         raise ValueError("No values may be assigned to a NullType")
 
-    def may_share_memory(a, b):
-        return False
-
     def values_eq(self, a, b, force_same_dtype=True):
         raise ValueError("NullType has no values to compare")
 

--- a/pytensor/graph/op.py
+++ b/pytensor/graph/op.py
@@ -513,6 +513,7 @@ class Op(MetaObject):
         """
         node_input_storage = [storage_map[r] for r in node.inputs]
         node_output_storage = [storage_map[r] for r in node.outputs]
+        node_compute_map = [compute_map[r] for r in node.outputs]
 
         if debug and hasattr(self, "debug_perform"):
             p = node.op.debug_perform
@@ -520,10 +521,16 @@ class Op(MetaObject):
             p = node.op.perform
 
         @is_thunk_type
-        def rval(p=p, i=node_input_storage, o=node_output_storage, n=node):
+        def rval(
+            p=p,
+            i=node_input_storage,
+            o=node_output_storage,
+            n=node,
+            cm=node_compute_map,
+        ):
             r = p(n, [x[0] for x in i], o)
-            for o in node.outputs:
-                compute_map[o][0] = True
+            for entry in cm:
+                entry[0] = True
             return r
 
         rval.inputs = node_input_storage

--- a/pytensor/graph/type.py
+++ b/pytensor/graph/type.py
@@ -48,10 +48,7 @@ class Type(MetaObject, Generic[D]):
         unique element (i.e. it uses `self.__eq__`).
 
         """
-        if self == otype:
-            return True
-
-        return False
+        return self == otype
 
     def is_super(self, otype: "Type") -> bool | None:
         """Determine if `self` is a supertype of `otype`.

--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -303,13 +303,6 @@ class ScalarType(CType, HasDataType, HasShape):
             dtype = self.dtype
         return type(self)(dtype)
 
-    @staticmethod
-    def may_share_memory(a, b):
-        # This class represent basic c type, represented in python
-        # with numpy.scalar. They are read only. So from python, they
-        # can never share memory.
-        return False
-
     def filter(self, data, strict=False, allow_downcast=None):
         py_type = self.dtype_specs()[0]
         if strict and not isinstance(data, py_type):

--- a/pytensor/tensor/random/op.py
+++ b/pytensor/tensor/random/op.py
@@ -387,24 +387,17 @@ class RandomVariable(Op):
         return node.inputs[2:]
 
     def perform(self, node, inputs, outputs):
-        rng_var_out, smpl_out = outputs
-
         rng, size, *args = inputs
 
         # Draw from `rng` if `self.inplace` is `True`, and from a copy of `rng` otherwise.
         if not self.inplace:
             rng = copy(rng)
 
-        rng_var_out[0] = rng
-
-        if size is not None:
-            size = tuple(size)
-        smpl_val = self.rng_fn(rng, *([*args, size]))
-
-        if not isinstance(smpl_val, np.ndarray) or str(smpl_val.dtype) != self.dtype:
-            smpl_val = np.asarray(smpl_val, dtype=self.dtype)
-
-        smpl_out[0] = smpl_val
+        outputs[0][0] = rng
+        outputs[1][0] = np.asarray(
+            self.rng_fn(rng, *args, None if size is None else tuple(size)),
+            dtype=self.dtype,
+        )
 
     def grad(self, inputs, outputs):
         return [

--- a/pytensor/tensor/type_other.py
+++ b/pytensor/tensor/type_other.py
@@ -126,12 +126,6 @@ class NoneTypeT(Generic):
         else:
             raise TypeError("Expected None!")
 
-    @staticmethod
-    def may_share_memory(a, b):
-        # None never share memory between object, in the sense of DebugMode.
-        # Python None are singleton
-        return False
-
 
 none_type_t = NoneTypeT()
 

--- a/tests/compile/function/test_types.py
+++ b/tests/compile/function/test_types.py
@@ -35,6 +35,9 @@ from pytensor.tensor.type import (
 )
 
 
+pytestmark = pytest.mark.filterwarnings("error")
+
+
 def PatternOptimizer(p1, p2, ign=True):
     return OpKeyGraphRewriter(PatternNodeRewriter(p1, p2), ignore_newtrees=ign)
 
@@ -195,7 +198,10 @@ class TestFunction:
         x, s = scalars("xs")
 
         # x's name is not ignored (as in test_naming_rule2) because a has a default value.
-        f = function([x, In(a, value=1.0), s], a / s + x)
+        with pytest.warns(
+            FutureWarning, match="Inputs with default values are deprecated."
+        ):
+            f = function([x, In(a, value=1.0), s], a / s + x)
         assert f(9, 2, 4) == 9.5  # can specify all args in order
         assert f(9, 2, s=4) == 9.5  # can give s as kwarg
         assert f(9, s=4) == 9.25  # can give s as kwarg, get default a
@@ -214,7 +220,10 @@ class TestFunction:
         a = scalar()  # the a is for 'anonymous' (un-named).
         x, s = scalars("xs")
 
-        f = function([x, In(a, value=1.0, name="a"), s], a / s + x)
+        with pytest.warns(
+            FutureWarning, match="Inputs with default values are deprecated."
+        ):
+            f = function([x, In(a, value=1.0, name="a"), s], a / s + x)
 
         assert f(9, 2, 4) == 9.5  # can specify all args in order
         assert f(9, 2, s=4) == 9.5  # can give s as kwarg
@@ -248,11 +257,14 @@ class TestFunction:
         a = scalar()
         x, s = scalars("xs")
 
-        f = function(
-            [x, In(a, value=1.0, name="a"), In(s, value=0.0, update=s + a * x)],
-            s + a * x,
-            mode=mode,
-        )
+        with pytest.warns(
+            FutureWarning, match="Inputs with default values are deprecated."
+        ):
+            f = function(
+                [x, In(a, value=1.0, name="a"), In(s, value=0.0, update=s + a * x)],
+                s + a * x,
+                mode=mode,
+            )
 
         assert f[a] == 1.0
         assert f[s] == 0.0
@@ -303,16 +315,19 @@ class TestFunction:
         a = scalar()
         x, s = scalars("xs")
 
-        f = function(
-            [
-                x,
-                In(a, value=1.0, name="a"),
-                In(s, value=0.0, update=s + a * x, mutable=True),
-            ],
-            s + a * x,
-        )
+        with pytest.warns(
+            FutureWarning, match="Inputs with default values are deprecated."
+        ):
+            f = function(
+                [
+                    x,
+                    In(a, value=1.0, name="a"),
+                    In(s, value=0.0, update=s + a * x, mutable=True),
+                ],
+                s + a * x,
+            )
 
-        g = copy.copy(f)
+            g = copy.copy(f)
 
         assert f.unpack_single == g.unpack_single
         assert f.trust_input == g.trust_input
@@ -504,22 +519,25 @@ class TestFunction:
         a = scalar()  # the a is for 'anonymous' (un-named).
         x, s = scalars("xs")
 
-        f = function(
-            [
-                x,
-                In(a, value=1.0, name="a"),
-                In(s, value=0.0, update=s + a * x, mutable=True),
-            ],
-            s + a * x,
-        )
-        g = function(
-            [
-                x,
-                In(a, value=1.0, name="a"),
-                In(s, value=f.container[s], update=s - a * x, mutable=True),
-            ],
-            s + a * x,
-        )
+        with pytest.warns(
+            FutureWarning, match="Inputs with default values are deprecated."
+        ):
+            f = function(
+                [
+                    x,
+                    In(a, value=1.0, name="a"),
+                    In(s, value=0.0, update=s + a * x, mutable=True),
+                ],
+                s + a * x,
+            )
+            g = function(
+                [
+                    x,
+                    In(a, value=1.0, name="a"),
+                    In(s, value=f.container[s], update=s - a * x, mutable=True),
+                ],
+                s + a * x,
+            )
 
         f(1, 2)
         assert f[s] == 2
@@ -532,17 +550,20 @@ class TestFunction:
         a = scalar()  # the a is for 'anonymous' (un-named).
         x, s = scalars("xs")
 
-        f = function(
-            [
-                x,
-                In(a, value=1.0, name="a"),
-                In(s, value=0.0, update=s + a * x, mutable=True),
-            ],
-            s + a * x,
-        )
-        g = function(
-            [x, In(a, value=1.0, name="a"), In(s, value=f.container[s])], s + a * x
-        )
+        with pytest.warns(
+            FutureWarning, match="Inputs with default values are deprecated."
+        ):
+            f = function(
+                [
+                    x,
+                    In(a, value=1.0, name="a"),
+                    In(s, value=0.0, update=s + a * x, mutable=True),
+                ],
+                s + a * x,
+            )
+            g = function(
+                [x, In(a, value=1.0, name="a"), In(s, value=f.container[s])], s + a * x
+            )
 
         f(1, 2)
         assert f[s] == 2
@@ -556,17 +577,20 @@ class TestFunction:
         a = scalar()  # the a is for 'anonymous' (un-named).
         x, s = scalars("xs")
 
-        f = function(
-            [
-                x,
-                In(a, value=1.0, name="a"),
-                In(s, value=0.0, update=s + a * x, mutable=False),
-            ],
-            s + a * x,
-        )
-        g = function(
-            [x, In(a, value=1.0, name="a"), In(s, value=f.container[s])], s + a * x
-        )
+        with pytest.warns(
+            FutureWarning, match="Inputs with default values are deprecated."
+        ):
+            f = function(
+                [
+                    x,
+                    In(a, value=1.0, name="a"),
+                    In(s, value=0.0, update=s + a * x, mutable=False),
+                ],
+                s + a * x,
+            )
+            g = function(
+                [x, In(a, value=1.0, name="a"), In(s, value=f.container[s])], s + a * x
+            )
 
         f(1, 2)
         assert f[s] == 2
@@ -718,7 +742,10 @@ class TestFunction:
 
         a, b = dscalars("a", "b")
         c = a + b
-        funct = function([In(a, name="first"), In(b, value=1, name="second")], c)
+        with pytest.warns(
+            FutureWarning, match="Inputs with default values are deprecated."
+        ):
+            funct = function([In(a, name="first"), In(b, value=1, name="second")], c)
         x = funct(first=1)
         try:
             funct(second=2)
@@ -775,7 +802,8 @@ class TestFunction:
         # Tests that function works when outputs is a dictionary
 
         x = scalar()
-        f = function([x], outputs={"a": x, "c": x * 2, "b": x * 3, "1": x * 4})
+        with pytest.warns(FutureWarning, match="output_keys is deprecated."):
+            f = function([x], outputs={"a": x, "c": x * 2, "b": x * 3, "1": x * 4})
 
         outputs = f(10.0)
 
@@ -790,7 +818,8 @@ class TestFunction:
         x = scalar("x")
         y = scalar("y")
 
-        f = function([x, y], outputs={"a": x + y, "b": x * y})
+        with pytest.warns(FutureWarning, match="output_keys is deprecated."):
+            f = function([x, y], outputs={"a": x + y, "b": x * y})
 
         assert f(2, 4) == {"a": 6, "b": 8}
         assert f(2, y=4) == f(2, 4)
@@ -805,9 +834,10 @@ class TestFunction:
         e1 = scalar("1")
         e2 = scalar("2")
 
-        f = function(
-            [x, y, z, e1, e2], outputs={"x": x, "y": y, "z": z, "1": e1, "2": e2}
-        )
+        with pytest.warns(FutureWarning, match="output_keys is deprecated."):
+            f = function(
+                [x, y, z, e1, e2], outputs={"x": x, "y": y, "z": z, "1": e1, "2": e2}
+            )
 
         assert "1" in str(f.outputs[0])
         assert "2" in str(f.outputs[1])
@@ -825,7 +855,8 @@ class TestFunction:
         a = x + y
         b = x * y
 
-        f = function([x, y], outputs={"a": a, "b": b})
+        with pytest.warns(FutureWarning, match="output_keys is deprecated."):
+            f = function([x, y], outputs={"a": a, "b": b})
 
         a = scalar("a")
         b = scalar("b")
@@ -880,14 +911,17 @@ class TestPicklefunction:
         a = scalar()  # the a is for 'anonymous' (un-named).
         x, s = scalars("xs")
 
-        f = function(
-            [
-                x,
-                In(a, value=1.0, name="a", mutable=True),
-                In(s, value=0.0, update=s + a * x, mutable=True),
-            ],
-            s + a * x,
-        )
+        with pytest.warns(
+            FutureWarning, match="Inputs with default values are deprecated."
+        ):
+            f = function(
+                [
+                    x,
+                    In(a, value=1.0, name="a", mutable=True),
+                    In(s, value=0.0, update=s + a * x, mutable=True),
+                ],
+                s + a * x,
+            )
         try:
             g = copy.deepcopy(f)
         except NotImplementedError as e:
@@ -941,14 +975,17 @@ class TestPicklefunction:
         a = dscalar()  # the a is for 'anonymous' (un-named).
         x, s = dscalars("xs")
 
-        f = function(
-            [
-                x,
-                In(a, value=1.0, name="a"),
-                In(s, value=0.0, update=s + a * x, mutable=True),
-            ],
-            s + a * x,
-        )
+        with pytest.warns(
+            FutureWarning, match="Inputs with default values are deprecated."
+        ):
+            f = function(
+                [
+                    x,
+                    In(a, value=1.0, name="a"),
+                    In(s, value=0.0, update=s + a * x, mutable=True),
+                ],
+                s + a * x,
+            )
         f.trust_input = True
         try:
             g = copy.deepcopy(f)
@@ -967,11 +1004,13 @@ class TestPicklefunction:
 
     def test_output_keys(self):
         x = vector()
-        f = function([x], {"vec": x**2})
+        with pytest.warns(FutureWarning, match="output_keys is deprecated."):
+            f = function([x], {"vec": x**2})
         o = f([2, 3, 4])
         assert isinstance(o, dict)
         assert np.allclose(o["vec"], [4, 9, 16])
-        g = copy.deepcopy(f)
+        with pytest.warns(FutureWarning, match="output_keys is deprecated."):
+            g = copy.deepcopy(f)
         o = g([2, 3, 4])
         assert isinstance(o, dict)
         assert np.allclose(o["vec"], [4, 9, 16])
@@ -980,7 +1019,10 @@ class TestPicklefunction:
         # Ensure that shared containers remain shared after a deep copy.
         a, x = scalars("ax")
 
-        h = function([In(a, value=0.0)], a)
+        with pytest.warns(
+            FutureWarning, match="Inputs with default values are deprecated."
+        ):
+            h = function([In(a, value=0.0)], a)
         f = function([x, In(a, value=h.container[a], implicit=True)], x + a)
 
         try:
@@ -1004,14 +1046,17 @@ class TestPicklefunction:
         a = scalar()  # the a is for 'anonymous' (un-named).
         x, s = scalars("xs")
 
-        f = function(
-            [
-                x,
-                In(a, value=1.0, name="a"),
-                In(s, value=0.0, update=s + a * x, mutable=True),
-            ],
-            s + a * x,
-        )
+        with pytest.warns(
+            FutureWarning, match="Inputs with default values are deprecated."
+        ):
+            f = function(
+                [
+                    x,
+                    In(a, value=1.0, name="a"),
+                    In(s, value=0.0, update=s + a * x, mutable=True),
+                ],
+                s + a * x,
+            )
 
         try:
             # Note that here we also test protocol 0 on purpose, since it
@@ -1105,25 +1150,31 @@ class TestPicklefunction:
         # some derived thing, whose inputs aren't all in the list
         list_of_things.append(a * x + s)
 
-        f1 = function(
-            [
-                x,
-                In(a, value=1.0, name="a"),
-                In(s, value=0.0, update=s + a * x, mutable=True),
-            ],
-            s + a * x,
-        )
+        with pytest.warns(
+            FutureWarning, match="Inputs with default values are deprecated."
+        ):
+            f1 = function(
+                [
+                    x,
+                    In(a, value=1.0, name="a"),
+                    In(s, value=0.0, update=s + a * x, mutable=True),
+                ],
+                s + a * x,
+            )
         list_of_things.append(f1)
 
         # now put in a function sharing container with the previous one
-        f2 = function(
-            [
-                x,
-                In(a, value=1.0, name="a"),
-                In(s, value=f1.container[s], update=s + a * x, mutable=True),
-            ],
-            s + a * x,
-        )
+        with pytest.warns(
+            FutureWarning, match="Inputs with default values are deprecated."
+        ):
+            f2 = function(
+                [
+                    x,
+                    In(a, value=1.0, name="a"),
+                    In(s, value=f1.container[s], update=s + a * x, mutable=True),
+                ],
+                s + a * x,
+            )
         list_of_things.append(f2)
 
         assert isinstance(f2.container[s].storage, list)
@@ -1131,7 +1182,10 @@ class TestPicklefunction:
 
         # now put in a function with non-scalar
         v_value = np.asarray([2, 3, 4.0], dtype=config.floatX)
-        f3 = function([x, In(v, value=v_value)], x + v)
+        with pytest.warns(
+            FutureWarning, match="Inputs with default values are deprecated."
+        ):
+            f3 = function([x, In(v, value=v_value)], x + v)
         list_of_things.append(f3)
 
         # try to pickle the entire things
@@ -1263,23 +1317,29 @@ class SomethingToPickle:
 
         self.e = a * x + s
 
-        self.f1 = function(
-            [
-                x,
-                In(a, value=1.0, name="a"),
-                In(s, value=0.0, update=s + a * x, mutable=True),
-            ],
-            s + a * x,
-        )
+        with pytest.warns(
+            FutureWarning, match="Inputs with default values are deprecated."
+        ):
+            self.f1 = function(
+                [
+                    x,
+                    In(a, value=1.0, name="a"),
+                    In(s, value=0.0, update=s + a * x, mutable=True),
+                ],
+                s + a * x,
+            )
 
-        self.f2 = function(
-            [
-                x,
-                In(a, value=1.0, name="a"),
-                In(s, value=self.f1.container[s], update=s + a * x, mutable=True),
-            ],
-            s + a * x,
-        )
+        with pytest.warns(
+            FutureWarning, match="Inputs with default values are deprecated."
+        ):
+            self.f2 = function(
+                [
+                    x,
+                    In(a, value=1.0, name="a"),
+                    In(s, value=self.f1.container[s], update=s + a * x, mutable=True),
+                ],
+                s + a * x,
+            )
 
 
 def test_empty_givens_updates():

--- a/tests/compile/function/test_types.py
+++ b/tests/compile/function/test_types.py
@@ -19,6 +19,8 @@ from pytensor.link.vm import VMLinker
 from pytensor.printing import debugprint
 from pytensor.tensor.math import dot, tanh
 from pytensor.tensor.math import sum as pt_sum
+from pytensor.tensor.random import normal
+from pytensor.tensor.random.type import random_generator_type
 from pytensor.tensor.type import (
     dmatrix,
     dscalar,
@@ -1280,3 +1282,15 @@ def test_empty_givens_updates():
     y = x * 2
     function([In(x)], y, givens={})
     function([In(x)], y, updates={})
+
+
+@pytest.mark.parametrize("trust_input", [True, False])
+def test_minimal_random_function_call_benchmark(trust_input, benchmark):
+    rng = random_generator_type()
+    x = normal(rng=rng, size=(100,))
+
+    f = function([In(rng, mutable=True)], x)
+    f.trust_input = trust_input
+
+    rng_val = np.random.default_rng()
+    benchmark(f, rng_val)


### PR DESCRIPTION
We have way too much function overhead call. This PR tries to remove some of it.

I used this simple one Op function as a test:

```python
import numpy as np
import pytensor
import pytensor.tensor as pt
from pytensor.tensor.random.type import random_generator_type

rng = np.random.default_rng(123)
def numpy_normal(rng):
    # We have an explicit expand dims in PyTensor
    return rng.normal(np.array([0]), np.array([1]), size=(100,)) 

print("Direct numpy call:")
%timeit numpy_normal(rng)

rng_pt = random_generator_type()
x = pt.random.normal(rng=rng_pt, size=(100,))
fn = pytensor.function([pytensor.In(rng_pt, mutable=True)], x)

print("Fn call without trust input:")
%timeit fn(rng)

fn.trust_input = True
print("Fn call with trust input: ")
%timeit fn(rng)

fn.input_storage[0].storage[0] = rng
print("VM call bypassing Fn:")
%timeit fn.vm()
```

Note the largest speedup comes from removing the extra checks in RandomVariable.perform. But you can see some minor speedup in the fn eval beyond what's observed by calling the vm directly.

Before the PR:
```
Direct numpy call:
14.1 μs ± 43.9 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

Fn call without trust input:
41 μs ± 377 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

Fn call with trust input: 
39.1 μs ± 889 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

VM call bypassing Fn:
30.3 μs ± 885 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

After the PR:
```
Direct numpy call:
14.5 μs ± 435 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

Fn call without trust input:
27.3 μs ± 788 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

Fn call with trust input: 
26.4 μs ± 458 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

VM call bypassing Fn:
20.4 μs ± 334 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

Some of the changes would be more visible in a function with more inputs (but still relatively fast).

It also deprecates a bunch of obscure options that should allow us to remove a few more conditionals in the future.

Related to #552 




<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1024.org.readthedocs.build/en/1024/

<!-- readthedocs-preview pytensor end -->