### PR TITLE
Updates a rewrite for det(kronecker) instead of slogdet

### DIFF
--- a/tests/tensor/rewriting/test_linalg.py
+++ b/tests/tensor/rewriting/test_linalg.py
@@ -776,11 +776,40 @@ def test_diag_kronecker_rewrite():
     )
 
 
-def test_slogdet_kronecker_rewrite():
+# def test_slogdet_kronecker_rewrite():
+#     a, b = pt.dmatrices("a", "b")
+#     kron_prod = pt.linalg.kron(a, b)
+#     sign_output, logdet_output = pt.linalg.slogdet(kron_prod)
+#     f_rewritten = function([kron_prod], [sign_output, logdet_output], mode="FAST_RUN")
+
+#     # Rewrite Test
+#     nodes = f_rewritten.maker.fgraph.apply_nodes
+#     assert not any(isinstance(node.op, KroneckerProduct) for node in nodes)
+
+#     # Value Test
+#     a_test, b_test = np.random.rand(2, 20, 20)
+#     kron_prod_test = np.kron(a_test, b_test)
+#     sign_output_test, logdet_output_test = np.linalg.slogdet(kron_prod_test)
+#     rewritten_sign_val, rewritten_logdet_val = f_rewritten(kron_prod_test)
+#     assert_allclose(
+#         sign_output_test,
+#         rewritten_sign_val,
+#         atol=1e-3 if config.floatX == "float32" else 1e-8,
+#         rtol=1e-3 if config.floatX == "float32" else 1e-8,
+#     )
+#     assert_allclose(
+#         logdet_output_test,
+#         rewritten_logdet_val,
+#         atol=1e-3 if config.floatX == "float32" else 1e-8,
+#         rtol=1e-3 if config.floatX == "float32" else 1e-8,
+#     )
+
+
+def test_det_kronecker_rewrite():
     a, b = pt.dmatrices("a", "b")
     kron_prod = pt.linalg.kron(a, b)
-    sign_output, logdet_output = pt.linalg.slogdet(kron_prod)
-    f_rewritten = function([kron_prod], [sign_output, logdet_output], mode="FAST_RUN")
+    det_output = pt.linalg.det(kron_prod)
+    f_rewritten = function([kron_prod], [det_output], mode="FAST_RUN")
 
     # Rewrite Test
     nodes = f_rewritten.maker.fgraph.apply_nodes
@@ -789,17 +818,11 @@ def test_slogdet_kronecker_rewrite():
     # Value Test
     a_test, b_test = np.random.rand(2, 20, 20)
     kron_prod_test = np.kron(a_test, b_test)
-    sign_output_test, logdet_output_test = np.linalg.slogdet(kron_prod_test)
-    rewritten_sign_val, rewritten_logdet_val = f_rewritten(kron_prod_test)
+    det_output_test = np.linalg.det(kron_prod_test)
+    rewritten_det_val = f_rewritten(kron_prod_test)
     assert_allclose(
-        sign_output_test,
-        rewritten_sign_val,
-        atol=1e-3 if config.floatX == "float32" else 1e-8,
-        rtol=1e-3 if config.floatX == "float32" else 1e-8,
-    )
-    assert_allclose(
-        logdet_output_test,
-        rewritten_logdet_val,
+        det_output_test,
+        rewritten_det_val,
         atol=1e-3 if config.floatX == "float32" else 1e-8,
         rtol=1e-3 if config.floatX == "float32" else 1e-8,
     )


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
Instead of rewriting slogdet(kron), the rewrite is applied to det op directly.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Related to #1041 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1042.org.readthedocs.build/en/1042/

<!-- readthedocs-preview pytensor end -->