### PR TITLE
Cleanup for Optimal Control Ops

### DIFF
--- a/pytensor/tensor/rewriting/blockwise.py
+++ b/pytensor/tensor/rewriting/blockwise.py
@@ -127,8 +127,8 @@ def local_blockwise_alloc(fgraph, node):
                 value, *shape = inp.owner.inputs
 
                 # Check what to do with the value of the Alloc
-                squeezed_value = _squeeze_left(value, batch_ndim)
-                missing_ndim = len(shape) - value.type.ndim
+                missing_ndim = inp.type.ndim - value.type.ndim
+                squeezed_value = _squeeze_left(value, (batch_ndim - missing_ndim))
                 if (
                     (((1,) * missing_ndim + value.type.broadcastable)[batch_ndim:])
                     != inp.type.broadcastable[batch_ndim:]

--- a/pytensor/tensor/rewriting/linalg.py
+++ b/pytensor/tensor/rewriting/linalg.py
@@ -972,7 +972,7 @@ def rewrite_cholesky_diag_to_sqrt_diag(fgraph, node):
     return [eye_input * (non_eye_input**0.5)]
 
 
-@node_rewriter([_solve_bilinear_discrete_lyapunov])
+@node_rewriter([_solve_bilinear_discrete_lyapunov])  #  type: ignore
 def jax_bilinaer_lyapunov_to_direct(fgraph: FunctionGraph, node: Apply):
     """
     Replace BilinearSolveDiscreteLyapunov with a direct computation that is supported by JAX

--- a/pytensor/tensor/rewriting/linalg.py
+++ b/pytensor/tensor/rewriting/linalg.py
@@ -43,11 +43,11 @@ from pytensor.tensor.rewriting.basic import (
     register_stabilize,
 )
 from pytensor.tensor.slinalg import (
-    BilinearSolveDiscreteLyapunov,
     BlockDiagonal,
     Cholesky,
     Solve,
     SolveBase,
+    _bilinear_solve_discrete_lyapunov,
     block_diag,
     cholesky,
     solve,
@@ -972,14 +972,11 @@ def rewrite_cholesky_diag_to_sqrt_diag(fgraph, node):
     return [eye_input * (non_eye_input**0.5)]
 
 
-@node_rewriter([Blockwise])
+@node_rewriter([_bilinear_solve_discrete_lyapunov])
 def jax_bilinaer_lyapunov_to_direct(fgraph: FunctionGraph, node: Apply):
     """
     Replace BilinearSolveDiscreteLyapunov with a direct computation that is supported by JAX
     """
-    if not isinstance(node.op.core_op, BilinearSolveDiscreteLyapunov):
-        return None
-
     A, B = (cast(TensorVariable, x) for x in node.inputs)
     result = solve_discrete_lyapunov(A, B, method="direct")
 

--- a/pytensor/tensor/rewriting/linalg.py
+++ b/pytensor/tensor/rewriting/linalg.py
@@ -972,7 +972,7 @@ def rewrite_cholesky_diag_to_sqrt_diag(fgraph, node):
     return [eye_input * (non_eye_input**0.5)]
 
 
-@node_rewriter([Blockwise])  #  type: ignore
+@node_rewriter([Blockwise])
 def jax_bilinaer_lyapunov_to_direct(fgraph: FunctionGraph, node: Apply):
     """
     Replace BilinearSolveDiscreteLyapunov with a direct computation that is supported by JAX

--- a/pytensor/tensor/rewriting/linalg.py
+++ b/pytensor/tensor/rewriting/linalg.py
@@ -983,7 +983,7 @@ def jax_bilinaer_lyapunov_to_direct(fgraph: FunctionGraph, node: Apply):
         return None
 
     # Extract the inputs
-    (A, B) = node.inputs
+    A, B = (cast(TensorVariable, x) for x in node.inputs)
 
     # Compute the result
     result = _direct_solve_discrete_lyapunov(A, B)

--- a/pytensor/tensor/rewriting/linalg.py
+++ b/pytensor/tensor/rewriting/linalg.py
@@ -43,11 +43,11 @@ from pytensor.tensor.rewriting.basic import (
     register_stabilize,
 )
 from pytensor.tensor.slinalg import (
+    BilinearSolveDiscreteLyapunov,
     BlockDiagonal,
     Cholesky,
     Solve,
     SolveBase,
-    _solve_bilinear_discrete_lyapunov,
     block_diag,
     cholesky,
     solve,
@@ -972,11 +972,14 @@ def rewrite_cholesky_diag_to_sqrt_diag(fgraph, node):
     return [eye_input * (non_eye_input**0.5)]
 
 
-@node_rewriter([_solve_bilinear_discrete_lyapunov])  #  type: ignore
+@node_rewriter([Blockwise])  #  type: ignore
 def jax_bilinaer_lyapunov_to_direct(fgraph: FunctionGraph, node: Apply):
     """
     Replace BilinearSolveDiscreteLyapunov with a direct computation that is supported by JAX
     """
+    if not isinstance(node.op.core_op, BilinearSolveDiscreteLyapunov):
+        return None
+
     A, B = (cast(TensorVariable, x) for x in node.inputs)
     result = solve_discrete_lyapunov(A, B, method="direct")
 

--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -792,8 +792,8 @@ class SolveContinuousLyapunov(Op):
     def perform(self, node, inputs, output_storage):
         (A, B) = inputs
         X = output_storage[0]
-
-        X[0] = scipy.linalg.solve_continuous_lyapunov(A, B)
+        out_dtype = pytensor.scalar.upcast(A.dtype, B.dtype)
+        X[0] = scipy.linalg.solve_continuous_lyapunov(A, B).astype(out_dtype)
 
     def infer_shape(self, fgraph, node, shapes):
         return [shapes[0]]
@@ -830,7 +830,10 @@ class BilinearSolveDiscreteLyapunov(Op):
         (A, B) = inputs
         X = output_storage[0]
 
-        X[0] = scipy.linalg.solve_discrete_lyapunov(A, B, method="bilinear")
+        dtype = pytensor.scalar.upcast(A.dtype, B.dtype)
+        X[0] = scipy.linalg.solve_discrete_lyapunov(A, B, method="bilinear").astype(
+            dtype
+        )
 
     def infer_shape(self, fgraph, node, shapes):
         return [shapes[0]]

--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -911,7 +911,14 @@ def solve_discrete_lyapunov(
     A = as_tensor_variable(A)
     Q = as_tensor_variable(Q)
 
-    return cast(TensorVariable, _solve_bilinear_direct_lyapunov(A, Q))
+    if method == "direct":
+        return _direct_solve_discrete_lyapunov(A, Q)
+
+    elif method == "bilinear":
+        return cast(TensorVariable, _solve_bilinear_direct_lyapunov(A, Q))
+
+    else:
+        raise ValueError(f"Unknown method {method}")
 
 
 def solve_continuous_lyapunov(A: TensorVariable, Q: TensorVariable) -> TensorVariable:

--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -2,7 +2,7 @@ import logging
 import typing
 import warnings
 from functools import reduce
-from typing import TYPE_CHECKING, Literal, cast
+from typing import Literal, cast
 
 import numpy as np
 import scipy.linalg
@@ -11,7 +11,7 @@ import pytensor
 import pytensor.tensor as pt
 from pytensor.graph.basic import Apply
 from pytensor.graph.op import Op
-from pytensor.tensor import as_tensor_variable
+from pytensor.tensor import TensorLike, as_tensor_variable
 from pytensor.tensor import basic as ptb
 from pytensor.tensor import math as ptm
 from pytensor.tensor.blockwise import Blockwise
@@ -20,9 +20,6 @@ from pytensor.tensor.shape import reshape
 from pytensor.tensor.type import matrix, tensor, vector
 from pytensor.tensor.variable import TensorVariable
 
-
-if TYPE_CHECKING:
-    from pytensor.tensor import TensorLike
 
 logger = logging.getLogger(__name__)
 

--- a/tests/link/jax/test_slinalg.py
+++ b/tests/link/jax/test_slinalg.py
@@ -199,16 +199,20 @@ def test_jax_eigvalsh(lower):
 
 
 @pytest.mark.parametrize("method", ["direct", "bilinear"])
-def test_jax_solve_discrete_lyapunov(method: Literal["direct", "bilinear"]):
-    A = matrix("A")
-    B = matrix("B")
+@pytest.mark.parametrize("shape", [(5, 5), (5, 5, 5)], ids=["matrix", "batch"])
+def test_jax_solve_discrete_lyapunov(
+    method: Literal["direct", "bilinear"], shape: tuple[int]
+):
+    A = pt.tensor(name="A", shape=shape)
+    B = pt.tensor(name="B", shape=shape)
     out = pt_slinalg.solve_discrete_lyapunov(A, B, method=method)
     out_fg = FunctionGraph([A, B], [out])
 
     compare_jax_and_py(
         out_fg,
         [
-            np.random.normal(size=(5, 5)).astype(config.floatX),
-            np.random.normal(size=(5, 5)).astype(config.floatX),
+            np.random.normal(size=shape).astype(config.floatX),
+            np.random.normal(size=shape).astype(config.floatX),
         ],
+        jax_mode="JAX",
     )

--- a/tests/link/jax/test_slinalg.py
+++ b/tests/link/jax/test_slinalg.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Literal
 
 import numpy as np
@@ -208,6 +209,7 @@ def test_jax_solve_discrete_lyapunov(
     out = pt_slinalg.solve_discrete_lyapunov(A, B, method=method)
     out_fg = FunctionGraph([A, B], [out])
 
+    atol = rtol = 1e-8 if config.floatX == "float64" else 1e-3
     compare_jax_and_py(
         out_fg,
         [
@@ -215,4 +217,5 @@ def test_jax_solve_discrete_lyapunov(
             np.random.normal(size=shape).astype(config.floatX),
         ],
         jax_mode="JAX",
+        assert_fn=partial(np.testing.assert_allclose, atol=atol, rtol=rtol),
     )

--- a/tests/link/jax/test_slinalg.py
+++ b/tests/link/jax/test_slinalg.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 import numpy as np
 import pytest
 
@@ -192,5 +194,21 @@ def test_jax_eigvalsh(lower):
                 config.floatX
             ),
             None,
+        ],
+    )
+
+
+@pytest.mark.parametrize("method", ["direct", "bilinear"])
+def test_jax_solve_discrete_lyapunov(method: Literal["direct", "bilinear"]):
+    A = matrix("A")
+    B = matrix("B")
+    out = pt_slinalg.solve_discrete_lyapunov(A, B, method=method)
+    out_fg = FunctionGraph([A, B], [out])
+
+    compare_jax_and_py(
+        out_fg,
+        [
+            np.random.normal(size=(5, 5)).astype(config.floatX),
+            np.random.normal(size=(5, 5)).astype(config.floatX),
         ],
     )

--- a/tests/tensor/test_slinalg.py
+++ b/tests/tensor/test_slinalg.py
@@ -528,7 +528,6 @@ vec_recover_Q = np.vectorize(recover_Q, signature="(m,m),(m,m),()->(m,m)")
 @pytest.mark.parametrize("use_complex", [False, True], ids=["float", "complex"])
 @pytest.mark.parametrize("shape", [(5, 5), (5, 5, 5)], ids=["matrix", "batch"])
 @pytest.mark.parametrize("method", ["direct", "bilinear"])
-@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_solve_discrete_lyapunov(
     use_complex, shape: tuple[int], method: Literal["direct", "bilinear"]
 ):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->

- Add blockwise support for optimal control ops (`SolveDiscreteLyapunov`, `SolveContinuousLyapunov`, `SolveDiscreteARE`)
- Add rewrite to remove `BilinearSolveDiscreteLyapunov` in JAX mode. JAX can't call out to the necessary LAPACK functions, but we can still fall back to the direct method
- Simplify tests, adding batched cases
- Add/update typehints 

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1045.org.readthedocs.build/en/1045/

<!-- readthedocs-preview pytensor end -->