### PR TITLE
Deprecate redundant utilities for extracting constants

### DIFF
--- a/pytensor/__init__.py
+++ b/pytensor/__init__.py
@@ -24,6 +24,7 @@ __docformat__ = "restructuredtext en"
 # pytensor code, since this code may want to log some messages.
 import logging
 import sys
+import warnings
 from functools import singledispatch
 from pathlib import Path
 from typing import Any, NoReturn, Optional
@@ -148,13 +149,13 @@ def get_underlying_scalar_constant(v):
     If `v` is not some view of constant data, then raise a
     `NotScalarConstantError`.
     """
-    # Is it necessary to test for presence of pytensor.sparse at runtime?
-    sparse = globals().get("sparse")
-    if sparse and isinstance(v.type, sparse.SparseTensorType):
-        if v.owner is not None and isinstance(v.owner.op, sparse.CSM):
-            data = v.owner.inputs[0]
-            return tensor.get_underlying_scalar_constant_value(data)
-    return tensor.get_underlying_scalar_constant_value(v)
+    warnings.warn(
+        "get_underlying_scalar_constant is deprecated. Use tensor.get_underlying_scalar_constant_value instead.",
+        FutureWarning,
+    )
+    from pytensor.tensor.basic import get_underlying_scalar_constant_value
+
+    return get_underlying_scalar_constant_value(v)
 
 
 # isort: off

--- a/pytensor/gradient.py
+++ b/pytensor/gradient.py
@@ -1329,7 +1329,7 @@ def _populate_grad_dict(var_to_app_to_idx, grad_dict, wrt, cost_name=None):
                                 f" {i}. Since this input is only connected "
                                 "to integer-valued outputs, it should "
                                 "evaluate to zeros, but it evaluates to"
-                                f"{pytensor.get_underlying_scalar_constant(term)}."
+                                f"{pytensor.get_underlying_scalar_constant_value(term)}."
                             )
                             raise ValueError(msg)
 
@@ -2157,6 +2157,9 @@ def _is_zero(x):
     'maybe' means that x is an expression that is complicated enough
     that we can't tell that it simplifies to 0.
     """
+    from pytensor.tensor import get_underlying_scalar_constant_value
+    from pytensor.tensor.exceptions import NotScalarConstantError
+
     if not hasattr(x, "type"):
         return np.all(x == 0.0)
     if isinstance(x.type, NullType):
@@ -2166,9 +2169,9 @@ def _is_zero(x):
 
     no_constant_value = True
     try:
-        constant_value = pytensor.get_underlying_scalar_constant(x)
+        constant_value = get_underlying_scalar_constant_value(x)
         no_constant_value = False
-    except pytensor.tensor.exceptions.NotScalarConstantError:
+    except NotScalarConstantError:
         pass
 
     if no_constant_value:

--- a/pytensor/link/jax/dispatch/tensor_basic.py
+++ b/pytensor/link/jax/dispatch/tensor_basic.py
@@ -18,7 +18,7 @@ from pytensor.tensor.basic import (
     Split,
     TensorFromScalar,
     Tri,
-    get_underlying_scalar_constant_value,
+    get_scalar_constant_value,
 )
 from pytensor.tensor.exceptions import NotScalarConstantError
 from pytensor.tensor.shape import Shape_i
@@ -103,7 +103,7 @@ def jax_funcify_Join(op, **kwargs):
 def jax_funcify_Split(op: Split, node, **kwargs):
     _, axis, splits = node.inputs
     try:
-        constant_axis = get_underlying_scalar_constant_value(axis)
+        constant_axis = get_scalar_constant_value(axis)
     except NotScalarConstantError:
         constant_axis = None
         warnings.warn(
@@ -113,7 +113,7 @@ def jax_funcify_Split(op: Split, node, **kwargs):
     try:
         constant_splits = np.array(
             [
-                get_underlying_scalar_constant_value(splits[i])
+                get_scalar_constant_value(splits[i])
                 for i in range(get_vector_length(splits))
             ]
         )

--- a/pytensor/scan/basic.py
+++ b/pytensor/scan/basic.py
@@ -484,7 +484,7 @@ def scan(
         n_fixed_steps = int(n_steps)
     else:
         try:
-            n_fixed_steps = pt.get_underlying_scalar_constant_value(n_steps)
+            n_fixed_steps = pt.get_scalar_constant_value(n_steps)
         except NotScalarConstantError:
             n_fixed_steps = None
 

--- a/pytensor/scan/rewriting.py
+++ b/pytensor/scan/rewriting.py
@@ -71,7 +71,7 @@ from pytensor.tensor.subtensor import (
     get_slice_elements,
     set_subtensor,
 )
-from pytensor.tensor.variable import TensorConstant, get_unique_constant_value
+from pytensor.tensor.variable import TensorConstant
 
 
 list_opt_slice = [
@@ -136,10 +136,7 @@ def remove_constants_and_unused_inputs_scan(fgraph, node):
     all_ins = list(graph_inputs(op_outs))
     for idx in range(op_info.n_seqs):
         node_inp = node.inputs[idx + 1]
-        if (
-            isinstance(node_inp, TensorConstant)
-            and get_unique_constant_value(node_inp) is not None
-        ):
+        if isinstance(node_inp, TensorConstant) and node_inp.unique_value is not None:
             try:
                 # This works if input is a constant that has all entries
                 # equal

--- a/pytensor/scan/rewriting.py
+++ b/pytensor/scan/rewriting.py
@@ -55,7 +55,6 @@ from pytensor.tensor.basic import (
     Alloc,
     AllocEmpty,
     get_scalar_constant_value,
-    get_underlying_scalar_constant_value,
 )
 from pytensor.tensor.elemwise import DimShuffle, Elemwise
 from pytensor.tensor.exceptions import NotScalarConstantError
@@ -1976,13 +1975,13 @@ class ScanMerge(GraphRewriter):
 
         nsteps = node.inputs[0]
         try:
-            nsteps = int(get_underlying_scalar_constant_value(nsteps))
+            nsteps = int(get_scalar_constant_value(nsteps))
         except NotScalarConstantError:
             pass
 
         rep_nsteps = rep_node.inputs[0]
         try:
-            rep_nsteps = int(get_underlying_scalar_constant_value(rep_nsteps))
+            rep_nsteps = int(get_scalar_constant_value(rep_nsteps))
         except NotScalarConstantError:
             pass
 

--- a/pytensor/sparse/basic.py
+++ b/pytensor/sparse/basic.py
@@ -491,6 +491,10 @@ class SparseConstant(SparseVariable, TensorConstant):
     def __repr__(self):
         return str(self)
 
+    @property
+    def unique_value(self):
+        return None
+
 
 SparseTensorType.variable_type = SparseVariable
 SparseTensorType.constant_type = SparseConstant

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -1808,7 +1808,7 @@ pprint.assign(alloc, printing.FunctionPrinter(["alloc"]))
 @_get_vector_length.register(Alloc)
 def _get_vector_length_Alloc(var_inst, var):
     try:
-        return get_underlying_scalar_constant_value(var.owner.inputs[1])
+        return get_scalar_constant_value(var.owner.inputs[1])
     except NotScalarConstantError:
         raise ValueError(f"Length of {var} cannot be determined")
 
@@ -2509,7 +2509,7 @@ class Join(COp):
 
             if not isinstance(axis, int):
                 try:
-                    axis = int(get_underlying_scalar_constant_value(axis))
+                    axis = int(get_scalar_constant_value(axis))
                 except NotScalarConstantError:
                     pass
 
@@ -2753,7 +2753,7 @@ pprint.assign(Join, printing.FunctionPrinter(["join"]))
 def _get_vector_length_Join(op, var):
     axis, *arrays = var.owner.inputs
     try:
-        axis = get_underlying_scalar_constant_value(axis)
+        axis = get_scalar_constant_value(axis)
         assert axis == 0 and builtins.all(a.ndim == 1 for a in arrays)
         return builtins.sum(get_vector_length(a) for a in arrays)
     except NotScalarConstantError:
@@ -4146,7 +4146,7 @@ class Choose(Op):
         static_out_shape = ()
         for s in out_shape:
             try:
-                s_val = get_underlying_scalar_constant_value(s)
+                s_val = get_scalar_constant_value(s)
             except (NotScalarConstantError, AttributeError):
                 s_val = None
 

--- a/pytensor/tensor/conv/abstract_conv.py
+++ b/pytensor/tensor/conv/abstract_conv.py
@@ -25,7 +25,7 @@ from pytensor.graph.op import Op
 from pytensor.raise_op import Assert
 from pytensor.tensor.basic import (
     as_tensor_variable,
-    get_underlying_scalar_constant_value,
+    get_scalar_constant_value,
 )
 from pytensor.tensor.exceptions import NotScalarConstantError
 from pytensor.tensor.variable import TensorConstant, TensorVariable
@@ -497,8 +497,8 @@ def check_conv_gradinputs_shape(
         if given is None or computed is None:
             return True
         try:
-            given = get_underlying_scalar_constant_value(given)
-            computed = get_underlying_scalar_constant_value(computed)
+            given = get_scalar_constant_value(given)
+            computed = get_scalar_constant_value(computed)
             return int(given) == int(computed)
         except NotScalarConstantError:
             # no answer possible, accept for now
@@ -534,7 +534,7 @@ def assert_conv_shape(shape):
     out_shape = []
     for i, n in enumerate(shape):
         try:
-            const_n = get_underlying_scalar_constant_value(n)
+            const_n = get_scalar_constant_value(n)
             if i < 2:
                 if const_n < 0:
                     raise ValueError(
@@ -2203,9 +2203,7 @@ class BaseAbstractConv(Op):
             if imshp_i is not None:
                 # Components of imshp should be constant or ints
                 try:
-                    get_underlying_scalar_constant_value(
-                        imshp_i, only_process_constants=True
-                    )
+                    get_scalar_constant_value(imshp_i, only_process_constants=True)
                 except NotScalarConstantError:
                     raise ValueError(
                         "imshp should be None or a tuple of constant int values"
@@ -2218,9 +2216,7 @@ class BaseAbstractConv(Op):
             if kshp_i is not None:
                 # Components of kshp should be constant or ints
                 try:
-                    get_underlying_scalar_constant_value(
-                        kshp_i, only_process_constants=True
-                    )
+                    get_scalar_constant_value(kshp_i, only_process_constants=True)
                 except NotScalarConstantError:
                     raise ValueError(
                         "kshp should be None or a tuple of constant int values"

--- a/pytensor/tensor/extra_ops.py
+++ b/pytensor/tensor/extra_ops.py
@@ -678,7 +678,7 @@ class Repeat(Op):
             out_shape = [None]
         else:
             try:
-                const_reps = ptb.get_underlying_scalar_constant_value(repeats)
+                const_reps = ptb.get_scalar_constant_value(repeats)
             except NotScalarConstantError:
                 const_reps = None
             if const_reps == 1:

--- a/pytensor/tensor/rewriting/basic.py
+++ b/pytensor/tensor/rewriting/basic.py
@@ -57,7 +57,6 @@ from pytensor.tensor.basic import (
     cast,
     fill,
     get_scalar_constant_value,
-    get_underlying_scalar_constant_value,
     join,
     ones_like,
     register_infer_shape,
@@ -739,7 +738,7 @@ def local_remove_useless_assert(fgraph, node):
     n_conds = len(node.inputs[1:])
     for c in node.inputs[1:]:
         try:
-            const = get_underlying_scalar_constant_value(c)
+            const = get_scalar_constant_value(c)
 
             if 0 != const.ndim or const == 0:
                 # Should we raise an error here? How to be sure it
@@ -834,7 +833,7 @@ def local_join_empty(fgraph, node):
         return
     new_inputs = []
     try:
-        join_idx = get_underlying_scalar_constant_value(
+        join_idx = get_scalar_constant_value(
             node.inputs[0], only_process_constants=True
         )
     except NotScalarConstantError:

--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -153,18 +153,16 @@ def local_0_dot_x(fgraph, node):
 
     x = node.inputs[0]
     y = node.inputs[1]
-    replace = False
-    try:
-        if get_underlying_scalar_constant_value(x, only_process_constants=True) == 0:
-            replace = True
-    except NotScalarConstantError:
-        pass
-
-    try:
-        if get_underlying_scalar_constant_value(y, only_process_constants=True) == 0:
-            replace = True
-    except NotScalarConstantError:
-        pass
+    replace = (
+        get_underlying_scalar_constant_value(
+            x, only_process_constants=True, raise_not_constant=False
+        )
+        == 0
+        or get_underlying_scalar_constant_value(
+            y, only_process_constants=True, raise_not_constant=False
+        )
+        == 0
+    )
 
     if replace:
         constant_zero = constant(0, dtype=node.outputs[0].type.dtype)
@@ -2111,7 +2109,7 @@ def local_add_remove_zeros(fgraph, node):
             y = get_underlying_scalar_constant_value(inp)
         except NotScalarConstantError:
             y = inp
-        if np.all(y == 0.0):
+        if y == 0.0:
             continue
         new_inputs.append(inp)
 
@@ -2209,7 +2207,7 @@ def local_abs_merge(fgraph, node):
                     )
                 except NotScalarConstantError:
                     return False
-                if not (const >= 0).all():
+                if not const >= 0:
                     return False
                 inputs.append(i)
             else:
@@ -2861,7 +2859,7 @@ def _is_1(expr):
     """
     try:
         v = get_underlying_scalar_constant_value(expr)
-        return np.allclose(v, 1)
+        return np.isclose(v, 1)
     except NotScalarConstantError:
         return False
 
@@ -3029,7 +3027,7 @@ def is_neg(var):
         for idx, mul_input in enumerate(var_node.inputs):
             try:
                 constant = get_underlying_scalar_constant_value(mul_input)
-                is_minus_1 = np.allclose(constant, -1)
+                is_minus_1 = np.isclose(constant, -1)
             except NotScalarConstantError:
                 is_minus_1 = False
             if is_minus_1:

--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -106,7 +106,6 @@ from pytensor.tensor.type import (
 from pytensor.tensor.variable import (
     TensorConstant,
     TensorVariable,
-    get_unique_constant_value,
 )
 
 
@@ -138,16 +137,8 @@ def get_constant(v):
         numeric constant. If v is a plain Variable, returns None.
 
     """
-    if isinstance(v, Constant):
-        unique_value = get_unique_constant_value(v)
-        if unique_value is not None:
-            data = unique_value
-        else:
-            data = v.data
-        if data.ndim == 0:
-            return data
-        else:
-            return None
+    if isinstance(v, TensorConstant):
+        return v.unique_value
     elif isinstance(v, Variable):
         return None
     else:
@@ -628,7 +619,14 @@ def local_mul_switch_sink(fgraph, node):
             # Look for a zero as the first or second branch of the switch
             for branch in range(2):
                 zero_switch_input = switch_node.inputs[1 + branch]
-                if not get_unique_constant_value(zero_switch_input) == 0.0:
+                if (
+                    not get_underlying_scalar_constant_value(
+                        zero_switch_input,
+                        only_process_constants=True,
+                        raise_not_constant=False,
+                    )
+                    == 0.0
+                ):
                     continue
 
                 switch_cond = switch_node.inputs[0]
@@ -685,7 +683,14 @@ def local_div_switch_sink(fgraph, node):
         # Look for a zero as the first or second branch of the switch
         for branch in range(2):
             zero_switch_input = switch_node.inputs[1 + branch]
-            if not get_unique_constant_value(zero_switch_input) == 0.0:
+            if (
+                not get_underlying_scalar_constant_value(
+                    zero_switch_input,
+                    only_process_constants=True,
+                    raise_not_constant=False,
+                )
+                == 0.0
+            ):
                 continue
 
             switch_cond = switch_node.inputs[0]

--- a/pytensor/tensor/rewriting/shape.py
+++ b/pytensor/tensor/rewriting/shape.py
@@ -23,7 +23,6 @@ from pytensor.tensor.basic import (
     cast,
     constant,
     get_scalar_constant_value,
-    get_underlying_scalar_constant_value,
     register_infer_shape,
     stack,
 )
@@ -213,7 +212,7 @@ class ShapeFeature(Feature):
             # Do not call make_node for test_value
             s = Shape_i(i)(r)
             try:
-                s = get_underlying_scalar_constant_value(s)
+                s = get_scalar_constant_value(s)
             except NotScalarConstantError:
                 pass
             return s
@@ -297,7 +296,7 @@ class ShapeFeature(Feature):
             assert len(idx) == 1
             idx = idx[0]
             try:
-                i = get_underlying_scalar_constant_value(idx)
+                i = get_scalar_constant_value(idx)
             except NotScalarConstantError:
                 pass
             else:
@@ -452,7 +451,7 @@ class ShapeFeature(Feature):
             )
             or self.lscalar_one.equals(merged_shape[i])
             or self.lscalar_one.equals(
-                get_underlying_scalar_constant_value(
+                get_scalar_constant_value(
                     merged_shape[i],
                     only_process_constants=True,
                     raise_not_constant=False,
@@ -481,9 +480,7 @@ class ShapeFeature(Feature):
             or r.type.shape[idx] != 1
             or self.lscalar_one.equals(new_shape[idx])
             or self.lscalar_one.equals(
-                get_underlying_scalar_constant_value(
-                    new_shape[idx], raise_not_constant=False
-                )
+                get_scalar_constant_value(new_shape[idx], raise_not_constant=False)
             )
             for idx in range(r.type.ndim)
         )

--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -999,7 +999,7 @@ def local_useless_subtensor(fgraph, node):
         if isinstance(idx.stop, int | np.integer):
             length_pos_data = sys.maxsize
             try:
-                length_pos_data = get_underlying_scalar_constant_value(
+                length_pos_data = get_scalar_constant_value(
                     length_pos, only_process_constants=True
                 )
             except NotScalarConstantError:
@@ -1064,7 +1064,7 @@ def local_useless_AdvancedSubtensor1(fgraph, node):
 
     # get length of the indexed tensor along the first axis
     try:
-        length = get_underlying_scalar_constant_value(
+        length = get_scalar_constant_value(
             shape_of[node.inputs[0]][0], only_process_constants=True
         )
     except NotScalarConstantError:
@@ -1736,7 +1736,7 @@ def local_join_subtensors(fgraph, node):
     axis, tensors = node.inputs[0], node.inputs[1:]
 
     try:
-        axis = get_underlying_scalar_constant_value(axis)
+        axis = get_scalar_constant_value(axis)
     except NotScalarConstantError:
         return
 
@@ -1797,12 +1797,7 @@ def local_join_subtensors(fgraph, node):
             if step is None:
                 continue
             try:
-                if (
-                    get_underlying_scalar_constant_value(
-                        step, only_process_constants=True
-                    )
-                    != 1
-                ):
+                if get_scalar_constant_value(step, only_process_constants=True) != 1:
                     return None
             except NotScalarConstantError:
                 return None

--- a/pytensor/tensor/shape.py
+++ b/pytensor/tensor/shape.py
@@ -428,7 +428,7 @@ class SpecifyShape(COp):
                 type_shape[i] = xts
             elif not isinstance(s.type, NoneTypeT):
                 try:
-                    type_shape[i] = int(ptb.get_underlying_scalar_constant_value(s))
+                    type_shape[i] = int(ptb.get_scalar_constant_value(s))
                 except NotScalarConstantError:
                     pass
 
@@ -580,7 +580,7 @@ def specify_shape(
 @_get_vector_length.register(SpecifyShape)  # type: ignore
 def _get_vector_length_SpecifyShape(op: Op, var: TensorVariable) -> int:
     try:
-        return int(ptb.get_underlying_scalar_constant_value(var.owner.inputs[1]).item())
+        return int(ptb.get_scalar_constant_value(var.owner.inputs[1]).item())
     except NotScalarConstantError:
         raise ValueError(f"Length of {var} cannot be determined")
 
@@ -661,7 +661,7 @@ class Reshape(COp):
                 y = shp_list[index]
                 y = ptb.as_tensor_variable(y)
                 try:
-                    s_val = ptb.get_underlying_scalar_constant_value(y).item()
+                    s_val = ptb.get_scalar_constant_value(y).item()
                     if s_val >= 0:
                         out_shape[index] = s_val
                 except NotScalarConstantError:

--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -259,9 +259,10 @@ class SolveBase(Op):
             raise ValueError(f"`b` must have {self.b_ndim} dims; got {b.type} instead.")
 
         # Infer dtype by solving the most simple case with 1x1 matrices
-        o_dtype = scipy.linalg.solve(
-            np.eye(1).astype(A.dtype), np.eye(1).astype(b.dtype)
-        ).dtype
+        inp_arr = [np.eye(1).astype(A.dtype), np.eye(1).astype(b.dtype)]
+        out_arr = [[None]]
+        self.perform(None, inp_arr, out_arr)
+        o_dtype = out_arr[0][0].dtype
         x = tensor(dtype=o_dtype, shape=b.type.shape)
         return Apply(self, [A, b], [x])
 

--- a/pytensor/tensor/subtensor.py
+++ b/pytensor/tensor/subtensor.py
@@ -29,7 +29,7 @@ from pytensor.tensor import (
 from pytensor.tensor.basic import (
     ScalarFromTensor,
     alloc,
-    get_underlying_scalar_constant_value,
+    get_scalar_constant_value,
     nonzero,
     scalar_from_tensor,
 )
@@ -778,7 +778,7 @@ def get_constant_idx(
             return slice(conv(val.start), conv(val.stop), conv(val.step))
         else:
             try:
-                return get_underlying_scalar_constant_value(
+                return get_scalar_constant_value(
                     val,
                     only_process_constants=only_process_constants,
                     elemwise=elemwise,
@@ -855,7 +855,7 @@ class Subtensor(COp):
             if value is None:
                 return value, True
             try:
-                value = get_underlying_scalar_constant_value(value)
+                value = get_scalar_constant_value(value)
                 return value, True
             except NotScalarConstantError:
                 return value, False
@@ -3022,17 +3022,17 @@ def _get_vector_length_Subtensor(op, var):
         start = (
             None
             if indices[0].start is None
-            else get_underlying_scalar_constant_value(indices[0].start)
+            else get_scalar_constant_value(indices[0].start)
         )
         stop = (
             None
             if indices[0].stop is None
-            else get_underlying_scalar_constant_value(indices[0].stop)
+            else get_scalar_constant_value(indices[0].stop)
         )
         step = (
             None
             if indices[0].step is None
-            else get_underlying_scalar_constant_value(indices[0].step)
+            else get_scalar_constant_value(indices[0].step)
         )
 
         if start == stop:

--- a/tests/tensor/rewriting/test_math.py
+++ b/tests/tensor/rewriting/test_math.py
@@ -4440,16 +4440,18 @@ def test_local_add_neg_to_sub(first_negative):
     assert np.allclose(f(x_test, y_test), exp)
 
 
-def test_local_add_neg_to_sub_const():
+@pytest.mark.parametrize("const_left", (True, False))
+def test_local_add_neg_to_sub_const(const_left):
     x = vector("x")
-    const = 5.0
+    const = np.full((3, 2), 5.0)
+    out = -const + x if const_left else x + (-const)
 
-    f = function([x], x + (-const), mode=Mode("py"))
+    f = function([x], out, mode=Mode("py"))
 
     nodes = [
         node.op
         for node in f.maker.fgraph.toposort()
-        if not isinstance(node.op, DimShuffle)
+        if not isinstance(node.op, DimShuffle | Alloc)
     ]
     assert nodes == [pt.sub]
 

--- a/tests/tensor/rewriting/test_math.py
+++ b/tests/tensor/rewriting/test_math.py
@@ -1383,11 +1383,11 @@ class TestLocalUselessElemwiseComparison:
         if op == deep_copy_op:
             assert len(elem.inputs) == 1, elem.inputs
             assert isinstance(elem.inputs[0], TensorConstant), elem
-            assert pt.extract_constant(elem.inputs[0]) == val, val
+            assert pt.get_underlying_scalar_constant_value(elem.inputs[0]) == val, val
         else:
             assert len(elem.inputs) == 2, elem.inputs
             assert isinstance(elem.inputs[0], TensorConstant), elem
-            assert pt.extract_constant(elem.inputs[0]) == val, val
+            assert pt.get_underlying_scalar_constant_value(elem.inputs[0]) == val, val
 
     def assert_identity(self, f):
         topo = f.maker.fgraph.toposort()

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -3571,11 +3571,12 @@ class TestGetUnderlyingScalarConstantValue:
         assert get_underlying_scalar_constant_value(s) == c.data
 
     def test_copy(self):
-        # Make sure we do not return the internal storage of a constant,
+        # Make sure we do not return a writeable internal storage of a constant,
         # so we cannot change the value of a constant by mistake.
         c = constant(3)
         d = extract_constant(c)
-        d += 1
+        with pytest.raises(ValueError, match="output array is read-only"):
+            d += 1
         e = extract_constant(c)
         assert e == 3, (c, d, e)
 

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -46,7 +46,6 @@ from pytensor.tensor.basic import (
     default,
     diag,
     expand_dims,
-    extract_constant,
     eye,
     fill,
     flatnonzero,
@@ -3574,10 +3573,10 @@ class TestGetUnderlyingScalarConstantValue:
         # Make sure we do not return a writeable internal storage of a constant,
         # so we cannot change the value of a constant by mistake.
         c = constant(3)
-        d = extract_constant(c)
+        d = get_scalar_constant_value(c)
         with pytest.raises(ValueError, match="output array is read-only"):
             d += 1
-        e = extract_constant(c)
+        e = get_scalar_constant_value(c)
         assert e == 3, (c, d, e)
 
     @pytest.mark.parametrize("only_process_constants", (True, False))

--- a/tests/tensor/test_blockwise.py
+++ b/tests/tensor/test_blockwise.py
@@ -590,7 +590,7 @@ class TestInplace:
             A_val_copy, b_val_copy
         )
         np.testing.assert_allclose(
-            out, expected_out, atol=1e-5 if config.floatX == "float32" else 0
+            out, expected_out, atol=1e-4 if config.floatX == "float32" else 0
         )
 
         # Confirm input was destroyed

--- a/tests/tensor/test_elemwise.py
+++ b/tests/tensor/test_elemwise.py
@@ -19,7 +19,7 @@ from pytensor.graph.replace import vectorize_node
 from pytensor.link.basic import PerformLinker
 from pytensor.link.c.basic import CLinker, OpWiseCLinker
 from pytensor.tensor import as_tensor_variable
-from pytensor.tensor.basic import second
+from pytensor.tensor.basic import get_scalar_constant_value, second
 from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
 from pytensor.tensor.math import Any, Sum, exp
 from pytensor.tensor.math import all as pt_all
@@ -807,8 +807,8 @@ class TestElemwise(unittest_tools.InferShapeTester):
 
         assert len(res_shape) == 1
         assert len(res_shape[0]) == 2
-        assert pytensor.get_underlying_scalar_constant(res_shape[0][0]) == 1
-        assert pytensor.get_underlying_scalar_constant(res_shape[0][1]) == 1
+        assert get_scalar_constant_value(res_shape[0][0]) == 1
+        assert get_scalar_constant_value(res_shape[0][1]) == 1
 
     def test_infer_shape_multi_output(self):
         class CustomElemwise(Elemwise):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
In PyTensor we have tho following similar utilities
1. `pytensor.get_underlying_scalar_constant`
1. `pytensor.tensor.basic.get_underlying_scalar_constant_value`
1. `pytensor.tensor.basic.get_scalar_constant_value`
1. `pytensor.tensor.basic.extract_constant`
1. `pytensor.tensor.rewriting.math.get_constant`

This PR removes and deprecates all except:
1. `pytensor.tensor.basic.get_underlying_scalar_constant_value`
1. `pytensor.tensor.basic.get_scalar_constant_value`

The reason for this distinction, is that the core utility, `get_underlying_scalar_constant_value` actually works for non-scalar inputs, if it can find a single scalar value underlies a potential n-dimensional tensor (say as in pt.zeros(5, 3, 2)). This is powerful, but can lead to subtle bugs when the caller forgets about it. This was the source of the bug behind #584 and was also likely present in other graphs such as `gt(x, [0, 0, 0, 0])` and alike where the repeated condition broadcasts the output of the operation.

The utility `get_scalar_constant_value` raises if the input is not a scalar (ndim=0) type.

I don't love the `underlying` distinguishing the two. Perhaps `unique` would be better.

Both utilities now accept a `raise_not_constant` which when False (not-default) return the variable as is. I think I would prefer for it to return `None` but this requires less code changes.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #584 
- [ ] Related to #
