### PR TITLE
Simplify elemwise perform method and don't fallback to C-impl

### DIFF
--- a/pytensor/tensor/utils.py
+++ b/pytensor/tensor/utils.py
@@ -120,7 +120,7 @@ def import_func_from_string(func_string: str):  # -> Optional[Callable]:
     if func is not None:
         return func
 
-    # Not inside NumPy or Scipy. So probably another package like scipy.
+    # Not inside NumPy. So probably another package like Scipy.
     module = None
     items = func_string.split(".")
     for idx in range(1, len(items)):


### PR DESCRIPTION
There was some convoluted logic in Elemwise perform method to create the python perform callable. 

In old times, Theano tried to fallback to the C-impl when the number of operands exceeds those supported by Numpy (32), but this doesn't make sense when the C-backend is not available. I don't think this was even working recently with the C backend around. 

Either way, it led to strange errors for users with an invalid C-setup (recently reported by many MacOS users), that read something like `Scratchpad object has no attribute 'ufunc'`. This situation usually arises when PyTensor thinks the C backend is properly setup and fuses many Elemwise operations into large `Composite` that can easily surpass 32 operands. Then it figures out C is not compiling, and ends up having to use the python perform method. This finally, checked the number of operands was less than 32 and if not tried to fallback to the C implementation that had already failed!

https://discourse.pymc.io/search?q=object%20has%20no%20attribute%20%27ufunc%27

There is now an informative warning explaining users how it might have arrived at this situation and offering working solutions.

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1050.org.readthedocs.build/en/1050/

<!-- readthedocs-preview pytensor end -->