### PR TITLE
Fix downcasting bug in `local_[mul|div]_switch_sink` rewrite

### DIFF
--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -4349,7 +4349,7 @@ class Composite(ScalarInnerGraphOp):
                 if var not in self.fgraph.inputs:
                     # This is an orphan
                     if isinstance(var, Constant) and isinstance(var.type, CLinkerType):
-                        subd[var] = var.type.c_literal(var.data)
+                        subd[var] = f"({var.type.c_literal(var.data)})"
                     else:
                         raise ValueError(
                             "All orphans in the fgraph to Composite must"
@@ -4408,7 +4408,7 @@ class Composite(ScalarInnerGraphOp):
         return self.c_code_template % d
 
     def c_code_cache_version_outer(self) -> tuple[int, ...]:
-        return (4,)
+        return (5,)
 
 
 class Compositef32:

--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -4246,7 +4246,11 @@ class Composite(ScalarInnerGraphOp):
             r.name = f"o{int(i)}"
         io = set(self.fgraph.inputs + self.fgraph.outputs)
         for i, r in enumerate(self.fgraph.variables):
-            if r not in io and len(self.fgraph.clients[r]) > 1:
+            if (
+                not isinstance(r, Constant)
+                and r not in io
+                and len(self.fgraph.clients[r]) > 1
+            ):
                 r.name = f"t{int(i)}"
 
         if len(self.fgraph.outputs) > 1 or len(self.fgraph.apply_nodes) > 10:

--- a/pytensor/scalar/loop.py
+++ b/pytensor/scalar/loop.py
@@ -239,7 +239,7 @@ class ScalarLoop(ScalarInnerGraphOp):
                 if var not in self.fgraph.inputs:
                     # This is an orphan
                     if isinstance(var, Constant) and isinstance(var.type, CLinkerType):
-                        subd[var] = var.type.c_literal(var.data)
+                        subd[var] = f"({var.type.c_literal(var.data)})"
                     else:
                         raise ValueError(
                             "All orphans in the fgraph to ScalarLoop must"
@@ -342,4 +342,4 @@ class ScalarLoop(ScalarInnerGraphOp):
         return res
 
     def c_code_cache_version_outer(self):
-        return (2,)
+        return (3,)

--- a/pytensor/tensor/variable.py
+++ b/pytensor/tensor/variable.py
@@ -1045,11 +1045,13 @@ def get_unique_constant_value(x: TensorVariable) -> Number | None:
     if isinstance(x, Constant):
         data = x.data
 
-        if isinstance(data, np.ndarray) and data.ndim > 0:
+        if isinstance(data, np.ndarray) and data.size > 0:
+            if data.size == 1:
+                return data.squeeze()
+
             flat_data = data.ravel()
-            if flat_data.shape[0]:
-                if (flat_data == flat_data[0]).all():
-                    return flat_data[0]
+            if (flat_data == flat_data[0]).all():
+                return flat_data[0]
 
     return None
 

--- a/tests/scan/test_printing.py
+++ b/tests/scan/test_printing.py
@@ -654,24 +654,22 @@ def test_debugprint_compiled_fn():
     Inner graphs:
 
     Scan{scan_fn, while_loop=False, inplace=all} [id A]
-     ← Composite{switch(lt(i0, i1), i2, i0)} [id I] (inner_out_sit_sot-0)
-        ├─ 0 [id J]
-        ├─ Subtensor{i, j, k} [id K]
-        │  ├─ *2-<Tensor3(float64, shape=(20000, 2, 2))> [id L] -> [id H] (inner_in_non_seqs-0)
-        │  ├─ ScalarFromTensor [id M]
-        │  │  └─ *0-<Scalar(int64, shape=())> [id N] -> [id C] (inner_in_seqs-0)
-        │  ├─ ScalarFromTensor [id O]
-        │  │  └─ *1-<Scalar(int64, shape=())> [id P] -> [id D] (inner_in_sit_sot-0)
-        │  └─ 0 [id Q]
-        └─ 1 [id R]
+     ← Composite{switch(lt(0, i0), 1, 0)} [id I] (inner_out_sit_sot-0)
+        └─ Subtensor{i, j, k} [id J]
+           ├─ *2-<Tensor3(float64, shape=(20000, 2, 2))> [id K] -> [id H] (inner_in_non_seqs-0)
+           ├─ ScalarFromTensor [id L]
+           │  └─ *0-<Scalar(int64, shape=())> [id M] -> [id C] (inner_in_seqs-0)
+           ├─ ScalarFromTensor [id N]
+           │  └─ *1-<Scalar(int64, shape=())> [id O] -> [id D] (inner_in_sit_sot-0)
+           └─ 0 [id P]
 
-    Composite{switch(lt(i0, i1), i2, i0)} [id I]
-     ← Switch [id S] 'o0'
-        ├─ LT [id T]
-        │  ├─ i0 [id U]
-        │  └─ i1 [id V]
-        ├─ i2 [id W]
-        └─ i0 [id U]
+    Composite{switch(lt(0, i0), 1, 0)} [id I]
+     ← Switch [id Q] 'o0'
+        ├─ LT [id R]
+        │  ├─ 0 [id S]
+        │  └─ i0 [id T]
+        ├─ 1 [id U]
+        └─ 0 [id S]
     """
 
     output_str = debugprint(out, file="str", print_op_info=True)


### PR DESCRIPTION
Closes #1037 

It also refactors the two rewrites to avoid so much duplicated code

The fix revealed some subtle bugs in the C implementation of Scalar Ops with negative literal constants, that were also fixed.

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1059.org.readthedocs.build/en/1059/

<!-- readthedocs-preview pytensor end -->