### PR TITLE
Raise NotImplementedError for boolean scalar indexing

### DIFF
--- a/pytensor/tensor/subtensor.py
+++ b/pytensor/tensor/subtensor.py
@@ -2627,6 +2627,11 @@ def as_index_variable(idx):
     idx = as_tensor_variable(idx)
     if idx.type.dtype not in discrete_dtypes:
         raise TypeError("index must be integers or a boolean mask")
+    if idx.type.dtype == "bool" and idx.type.ndim == 0:
+        raise NotImplementedError(
+            "Boolean scalar indexing not implemented. "
+            "Open an issue in https://github.com/pymc-devs/pytensor/issues if you need this behavior."
+        )
     return idx
 
 

--- a/pytensor/tensor/variable.py
+++ b/pytensor/tensor/variable.py
@@ -598,7 +598,7 @@ class _tensor_py_operators:
 
     def __setitem__(self, key, value):
         raise TypeError(
-            "TensorVariable does not support item assignment. Use the output of `set` or `add` instead."
+            "TensorVariable does not support item assignment. Use the output of `x[idx].set` or `x[idx].inc` instead."
         )
 
     def take(self, indices, axis=None, mode="raise"):

--- a/tests/tensor/test_subtensor.py
+++ b/tests/tensor/test_subtensor.py
@@ -2228,6 +2228,11 @@ class TestAdvancedSubtensor:
             mode=self.mode,
         )
 
+    def test_boolean_scalar_raises(self):
+        x = vector("x")
+        with pytest.raises(NotImplementedError):
+            x[np.array(True)]
+
 
 class TestInferShape(utt.InferShapeTester):
     @staticmethod

--- a/tests/tensor/test_variable.py
+++ b/tests/tensor/test_variable.py
@@ -1,3 +1,4 @@
+import re
 from copy import copy
 
 import numpy as np
@@ -444,7 +445,7 @@ class TestTensorInstanceMethods:
     def test_set_item_error(self):
         x = matrix("x")
 
-        msg = "Use the output of `set` or `add` instead."
+        msg = re.escape("Use the output of `x[idx].set` or `x[idx].inc` instead.")
         with pytest.raises(TypeError, match=msg):
             x[0] = 5
         with pytest.raises(TypeError, match=msg):


### PR DESCRIPTION
This is a special-edge case that behaves differently than other boolean indexing. It adds a new dimension (either empty or with one entry). The logic in `make_node` and `infer_shape` don't handle this.

Small cleanup around #442. I suspect the extra logic needed in the Op (and rewrites) to accommodate this special rule aren't justified or needed (since nobody requested it until now). If someone wants to work on it, they can of course!

The PR simply raises an informative error instead of failing cryptically like before.

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1063.org.readthedocs.build/en/1063/

<!-- readthedocs-preview pytensor end -->