### PR TITLE
Ld64

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,7 +133,7 @@ jobs:
             fast-compile: 0
             float32: 0
             part: "tests/link/pytorch"
-          - os: macos-latest
+          - os: macos-15
             python-version: "3.12"
             fast-compile: 0
             float32: 0
@@ -169,7 +169,7 @@ jobs:
         shell: micromamba-shell {0}
         run: |
 
-          if [[ $OS == "macos-latest" ]]; then
+          if [[ $OS == "macos-15" ]]; then
             micromamba install --yes -q "python~=${PYTHON_VERSION}=*_cpython" numpy scipy pip graphviz cython pytest coverage pytest-cov pytest-benchmark pytest-mock libblas=*=*accelerate;
           else
             micromamba install --yes -q "python~=${PYTHON_VERSION}=*_cpython" mkl numpy scipy pip mkl-service graphviz cython pytest coverage pytest-cov pytest-benchmark pytest-mock;
@@ -182,7 +182,7 @@ jobs:
           pip install -e ./
           micromamba list && pip freeze
           python -c 'import pytensor; print(pytensor.config.__str__(print_doc=False))'
-          if [[ $OS == "macos-latest" ]]; then
+          if [[ $OS == "macos-15" ]]; then
             python -c 'import pytensor; assert pytensor.config.blas__ldflags.startswith("-framework Accelerate"), "Blas flags are not set to MacOS Accelerate"';
           else
             python -c 'import pytensor; assert pytensor.config.blas__ldflags != "", "Blas flags are empty"';

--- a/pytensor/link/c/cmodule.py
+++ b/pytensor/link/c/cmodule.py
@@ -2379,6 +2379,14 @@ class GCC_compiler(Compiler):
         if sys.platform == "darwin":
             # Use the already-loaded python symbols.
             cxxflags.extend(["-undefined", "dynamic_lookup"])
+            # XCode15 introduced ld_prime linker. At the time of writing, this linker
+            # leads to multiple issues, so we supply a flag to use the older dynamic
+            # linker: ld64
+            if int(platform.mac_ver()[0].split(".")[0]) >= 15:
+                # This might be incorrect. We know that ld_prime was introduced in
+                # XCode15, but we don't know if the platform version is aligned with
+                # xcode's version.
+                cxxflags.append("-ld64")
 
         if sys.platform == "win32":
             # Workaround for https://github.com/Theano/Theano/issues/4926.


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
Add a flag to use Mac's older `ld64` linker instead of the new `ld_prime` linker. This might be the underlying cause of the problems that are still coming out of #1005. These issues show that `pytensor` fails in its compilation phase. The exception is a bit masked, but it seems to indicate that the linker had problems and exited with a signal. In my case it was a segfault with signal 11. I've seen other cases that seem similar and complain about symbols that should be defined in libtapi.dylib. The problem is that I can't reproduce in this isolated environment. My attempt to check whether this problem exists on Mac was to bump the version of the macos runner to 15 (the bump was supposed to happen during december anyway).

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [X] Related to #1005 (specifically [this comment](https://github.com/pymc-devs/pytensor/issues/1005#issuecomment-2466475884))

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [X] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [X] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [X] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1083.org.readthedocs.build/en/1083/

<!-- readthedocs-preview pytensor end -->