### PR TITLE
Track generated functions for torch compile

### DIFF
--- a/pytensor/link/pytorch/dispatch/basic.py
+++ b/pytensor/link/pytorch/dispatch/basic.py
@@ -54,14 +54,16 @@ def pytorch_funcify_FunctionGraph(
     fgraph,
     node=None,
     fgraph_name="pytorch_funcified_fgraph",
+    conversion_func=pytorch_funcify,
     **kwargs,
 ):
+    built_kwargs = {"conversion_func": conversion_func, **kwargs}
     return fgraph_to_python(
         fgraph,
-        pytorch_funcify,
+        conversion_func,
         type_conversion_fn=pytorch_typify,
         fgraph_name=fgraph_name,
-        **kwargs,
+        **built_kwargs,
     )
 
 
@@ -173,11 +175,8 @@ def pytorch_funcify_OpFromGraph(op, node, **kwargs):
 
     # Apply inner rewrites
     PYTORCH.optimizer(op.fgraph)
-
     fgraph_fn = pytorch_funcify(op.fgraph, **kwargs, squeeze_output=True)
-    # Disable one step inlining to prevent torch from trying to import local functions
-    # defined in `pytorch_funcify`
-    return torch.compiler.disable(fgraph_fn, recursive=False)
+    return fgraph_fn
 
 
 @pytorch_funcify.register(TensorFromScalar)

--- a/pytensor/link/pytorch/linker.py
+++ b/pytensor/link/pytorch/linker.py
@@ -1,11 +1,17 @@
+import copy
 from typing import Any
 
 from pytensor.graph.basic import Variable
 from pytensor.link.basic import JITLinker
+from pytensor.link.utils import unique_name_generator
 
 
 class PytorchLinker(JITLinker):
     """A `Linker` that compiles NumPy-based operations using torch.compile."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.gen_functors = []
 
     def input_filter(self, inp: Any) -> Any:
         from pytensor.link.pytorch.dispatch import pytorch_typify
@@ -18,14 +24,68 @@ class PytorchLinker(JITLinker):
     def fgraph_convert(self, fgraph, input_storage, storage_map, **kwargs):
         from pytensor.link.pytorch.dispatch import pytorch_funcify
 
+        # We want to have globally unique names
+        # across the entire pytensor graph, not
+        # just the subgraph
+        generator = unique_name_generator(["torch_linker"])
+
+        # Ensure that torch is aware of the generated
+        # code so we can compile without graph breaks
+        def conversion_func_register(*args, **kwargs):
+            functor = pytorch_funcify(*args, **kwargs)
+            name = kwargs["unique_name"](functor)
+            self.gen_functors.append((f"_{name}", functor))
+            return functor
+
+        built_kwargs = {
+            "unique_name": generator,
+            "conversion_func": conversion_func_register,
+            **kwargs,
+        }
         return pytorch_funcify(
-            fgraph, input_storage=input_storage, storage_map=storage_map, **kwargs
+            fgraph, input_storage=input_storage, storage_map=storage_map, **built_kwargs
         )
 
     def jit_compile(self, fn):
         import torch
 
-        return torch.compile(fn)
+        class wrapper:
+            """
+            Pytorch would fail compiling our method when trying
+            to resolve some of the methods returned from dispatch
+            calls. We want to be careful to not leak the methods,
+            so this class just holds them and provisions the expected
+            location accordingly
+
+            https://discuss.pytorch.org/t/closures-are-being-gcd-and-causing-failures-to-compile/213319
+            """
+
+            def __init__(self, fn, gen_functors):
+                self.fn = torch.compile(fn)
+                self.gen_functors = copy.copy(gen_functors)
+
+            def __call__(self, *args, **kwargs):
+                import pytensor.link.utils
+
+                # set attrs
+                for n, fn in self.gen_functors:
+                    setattr(pytensor.link.utils, n[1:], fn)
+
+                res = self.fn(*args, **kwargs)
+
+                # unset attrs
+                for n, _ in self.gen_functors:
+                    if getattr(pytensor.link.utils, n[1:], False):
+                        delattr(pytensor.link.utils, n[1:])
+
+                return res
+
+            def __del__(self):
+                del self.gen_functors
+
+        res = wrapper(fn, self.gen_functors)
+        self.gen_functors = []
+        return res
 
     def create_thunk_inputs(self, storage_map):
         thunk_inputs = []

--- a/pytensor/link/utils.py
+++ b/pytensor/link/utils.py
@@ -675,6 +675,7 @@ def fgraph_to_python(
     local_env: dict[Any, Any] | None = None,
     get_name_for_object: Callable[[Any], str] = get_name_for_object,
     squeeze_output: bool = False,
+    unique_name: Callable | None = None,
     **kwargs,
 ) -> Callable:
     """Convert a `FunctionGraph` into a regular Python function.
@@ -706,6 +707,8 @@ def fgraph_to_python(
     get_name_for_object
         A function used to provide names for the objects referenced within the
         generated function.
+    unique_name
+        A function to make random function names for generated code
     squeeze_output
         If the `FunctionGraph` has only one output and this option is
         ``True``, return the single output instead of a tuple with the output.
@@ -719,7 +722,11 @@ def fgraph_to_python(
     if storage_map is None:
         storage_map = {}
 
-    unique_name = unique_name_generator([fgraph_name])
+    if not unique_name:
+        unique_name = unique_name_generator([fgraph_name])
+
+    # make sure we plumb this through
+    kwargs["unique_name"] = unique_name
 
     if global_env is None:
         global_env = {}

--- a/tests/link/pytorch/test_blockwise.py
+++ b/tests/link/pytorch/test_blockwise.py
@@ -12,7 +12,7 @@ torch = pytest.importorskip("torch")
 basic = pytest.importorskip("pytensor.link.pytorch.dispatch.basic")
 
 
-class TestOp(Op):
+class BatchedTestOp(Op):
     gufunc_signature = "(m,n),(n,p)->(m,p)"
 
     def __init__(self, final_shape):
@@ -27,7 +27,7 @@ class TestOp(Op):
         raise RuntimeError("In perform")
 
 
-@basic.pytorch_funcify.register(TestOp)
+@basic.pytorch_funcify.register(BatchedTestOp)
 def evaluate_test_op(op, **_):
     def func(a, b):
         op.call_shapes.extend(map(torch.Tensor.size, [a, b]))
@@ -42,7 +42,7 @@ def test_blockwise_broadcast():
 
     x = pt.tensor4("x", shape=(5, 1, 2, 3))
     y = pt.tensor3("y", shape=(3, 3, 2))
-    op = TestOp((2, 2))
+    op = BatchedTestOp((2, 2))
     z = Blockwise(op)(x, y)
 
     f = pytensor.function([x, y], z, mode="PYTORCH")

--- a/tests/link/pytorch/test_blockwise.py
+++ b/tests/link/pytorch/test_blockwise.py
@@ -29,7 +29,6 @@ class TestOp(Op):
 
 @basic.pytorch_funcify.register(TestOp)
 def evaluate_test_op(op, **_):
-    @torch.compiler.disable(recursive=False)
     def func(a, b):
         op.call_shapes.extend(map(torch.Tensor.size, [a, b]))
         return a @ b


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
The torch compiler was having an issue running pytensor graphs with subgraphs. The way pytorch / module resolution worked was causing pytorch guards to fail during creation. Torch requires the guards to be created, and for them to be correct at runtime, so not being able to make one meant things couldn't get compiled. This tries to bandaid that by putting the modules we generate onto a module, essentially giving an explicit lifecycle to that module. This means we don't need to have graph breaks. That means faster compiler times, and better compiler results.

for this code
```py
import numpy as np
import torch._dynamo as dynamo

from pytensor.configdefaults import config
from pytensor.compile.builders import OpFromGraph
from pytensor.compile.function import function
from pytensor.tensor.type import matrices

x, y, z = matrices("xyz")
ofg_1 = OpFromGraph([x, y], [x + y])
ofg_2 = OpFromGraph([x, y], [x * y, x - y])

o1, o2 = ofg_2(y, z)
out = ofg_1(x, o1) / o2

xv = np.ones((2, 2), dtype=config.floatX)
yv = np.ones((2, 2), dtype=config.floatX) * 3
zv = np.ones((2, 2), dtype=config.floatX) * 5

f = function([x, y, z], out, mode="PYTORCH")
print(f(xv, yv, zv))

```


with change
```txt
Graph Count: 1
Graph Break Count: 0
Op Count: 4
Break Reasons:
Ops per Graph:
  Ops 1:
    <built-in method multiply of type object at 0x128d5a9a0>
    <built-in method subtract of type object at 0x128d5a9a0>
    <built-in method add of type object at 0x128d5a9a0>
    <built-in method true_divide of type object at 0x128d5a9a0>
Compile Times: TorchDynamo compilation metrics:
Function, Runtimes (s)
Number of Out Guards: 58
_compile.<locals>.compile_inner, 0.0773
OutputGraph.call_user_compiler, 0.0006
```

without change
```txt
(pytensor-dev) ➜  pytensor git:(33a4d4882) ✗ python test.py
Graph Count: 4
Graph Break Count: 3
Op Count: 4
Break Reasons:
Ops per Graph:
  Ops 1:
    <built-in method multiply of type object at 0x11ed5a9a0>
  Ops 2:
    <built-in method subtract of type object at 0x11ed5a9a0>
  Ops 3:
    <built-in method add of type object at 0x11ed5a9a0>
  Ops 4:
    <built-in method true_divide of type object at 0x11ed5a9a0>
Number of Out Guards: 140
Compile Times: TorchDynamo compilation metrics:
Function, Runtimes (s)
_compile.<locals>.compile_inner, 0.0397, 0.0174, 0.0145, 0.0056, 0.0147, 0.0151
OutputGraph.call_user_compiler, 0.0007, 0.0000, 0.0000, 0.0000
```

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #1076 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1094.org.readthedocs.build/en/1094/

<!-- readthedocs-preview pytensor end -->