### PR TITLE
Removes Function Graph, set_test_value/ get_test_value

### DIFF
--- a/pytensor/link/numba/dispatch/slinalg.py
+++ b/pytensor/link/numba/dispatch/slinalg.py
@@ -126,13 +126,17 @@ def solve_triangular_impl(A, B, trans, lower, unit_diagonal, b_ndim, overwrite_b
 
         B_is_1d = B.ndim == 1
 
-        if not overwrite_b:
-            B_copy = _copy_to_fortran_order(B)
-        else:
+        if overwrite_b:
             B_copy = B
+        else:
+            if B_is_1d:
+                # _copy_to_fortran_order does nothing with vectors
+                B_copy = np.copy(B)
+            else:
+                B_copy = _copy_to_fortran_order(B)
 
         if B_is_1d:
-            B_copy = np.expand_dims(B, -1)
+            B_copy = np.expand_dims(B_copy, -1)
 
         NRHS = 1 if B_is_1d else int(B_copy.shape[-1])
 

--- a/tests/link/jax/test_blas.py
+++ b/tests/link/jax/test_blas.py
@@ -4,8 +4,6 @@ import pytest
 from pytensor.compile.function import function
 from pytensor.compile.mode import Mode
 from pytensor.configdefaults import config
-from pytensor.graph.fg import FunctionGraph
-from pytensor.graph.op import get_test_value
 from pytensor.graph.rewriting.db import RewriteDatabaseQuery
 from pytensor.link.jax import JAXLinker
 from pytensor.tensor import blas as pt_blas
@@ -16,21 +14,20 @@ from tests.link.jax.test_basic import compare_jax_and_py
 def test_jax_BatchedDot():
     # tensor3 . tensor3
     a = tensor3("a")
-    a.tag.test_value = (
+    a_test_value = (
         np.linspace(-1, 1, 10 * 5 * 3).astype(config.floatX).reshape((10, 5, 3))
     )
     b = tensor3("b")
-    b.tag.test_value = (
+    b_test_value = (
         np.linspace(1, -1, 10 * 3 * 2).astype(config.floatX).reshape((10, 3, 2))
     )
     out = pt_blas.BatchedDot()(a, b)
-    fgraph = FunctionGraph([a, b], [out])
-    compare_jax_and_py(fgraph, [get_test_value(i) for i in fgraph.inputs])
+    compare_jax_and_py([a, b], [out], [a_test_value, b_test_value])
 
     # A dimension mismatch should raise a TypeError for compatibility
-    inputs = [get_test_value(a)[:-1], get_test_value(b)]
+    inputs = [a_test_value[:-1], b_test_value]
     opts = RewriteDatabaseQuery(include=[None], exclude=["cxx_only", "BlasOpt"])
     jax_mode = Mode(JAXLinker(), opts)
-    pytensor_jax_fn = function(fgraph.inputs, fgraph.outputs, mode=jax_mode)
+    pytensor_jax_fn = function([a, b], [out], mode=jax_mode)
     with pytest.raises(TypeError):
         pytensor_jax_fn(*inputs)

--- a/tests/link/jax/test_blockwise.py
+++ b/tests/link/jax/test_blockwise.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 from pytensor import config
-from pytensor.graph import FunctionGraph
 from pytensor.tensor import tensor
 from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.math import Dot, matmul
@@ -32,8 +31,7 @@ def test_matmul(matmul_op):
 
     out = matmul_op(a, b)
     assert isinstance(out.owner.op, Blockwise)
-    fg = FunctionGraph([a, b], [out])
-    fn, _ = compare_jax_and_py(fg, test_values)
+    fn, _ = compare_jax_and_py([a, b], [out], test_values)
 
     # Check we are not adding any unnecessary stuff
     jaxpr = str(jax.make_jaxpr(fn.vm.jit_fn)(*test_values))

--- a/tests/link/jax/test_einsum.py
+++ b/tests/link/jax/test_einsum.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 import pytensor.tensor as pt
-from pytensor.graph import FunctionGraph
 from tests.link.jax.test_basic import compare_jax_and_py
 
 
@@ -22,8 +21,7 @@ def test_jax_einsum():
     }
     x_pt, y_pt, z_pt = (pt.tensor(name, shape=shape) for name, shape in shapes.items())
     out = pt.einsum(subscripts, x_pt, y_pt, z_pt)
-    fg = FunctionGraph([x_pt, y_pt, z_pt], [out])
-    compare_jax_and_py(fg, [x, y, z])
+    compare_jax_and_py([x_pt, y_pt, z_pt], [out], [x, y, z])
 
 
 def test_ellipsis_einsum():
@@ -34,5 +32,4 @@ def test_ellipsis_einsum():
     x_pt = pt.tensor("x", shape=x.shape)
     y_pt = pt.tensor("y", shape=y.shape)
     out = pt.einsum(subscripts, x_pt, y_pt)
-    fg = FunctionGraph([x_pt, y_pt], [out])
-    compare_jax_and_py(fg, [x, y])
+    compare_jax_and_py([x_pt, y_pt], [out], [x, y])

--- a/tests/link/jax/test_extra_ops.py
+++ b/tests/link/jax/test_extra_ops.py
@@ -3,8 +3,6 @@ import pytest
 
 import pytensor.tensor.basic as ptb
 from pytensor.configdefaults import config
-from pytensor.graph.fg import FunctionGraph
-from pytensor.graph.op import get_test_value
 from pytensor.tensor import extra_ops as pt_extra_ops
 from pytensor.tensor.sort import argsort
 from pytensor.tensor.type import matrix, tensor
@@ -19,57 +17,45 @@ def test_extra_ops():
     a_test = np.arange(6, dtype=config.floatX).reshape((3, 2))
 
     out = pt_extra_ops.cumsum(a, axis=0)
-    fgraph = FunctionGraph([a], [out])
-    compare_jax_and_py(fgraph, [a_test])
+    compare_jax_and_py([a], [out], [a_test])
 
     out = pt_extra_ops.cumprod(a, axis=1)
-    fgraph = FunctionGraph([a], [out])
-    compare_jax_and_py(fgraph, [a_test])
+    compare_jax_and_py([a], [out], [a_test])
 
     out = pt_extra_ops.diff(a, n=2, axis=1)
-    fgraph = FunctionGraph([a], [out])
-    compare_jax_and_py(fgraph, [a_test])
+    compare_jax_and_py([a], [out], [a_test])
 
     out = pt_extra_ops.repeat(a, (3, 3), axis=1)
-    fgraph = FunctionGraph([a], [out])
-    compare_jax_and_py(fgraph, [a_test])
+    compare_jax_and_py([a], [out], [a_test])
 
     c = ptb.as_tensor(5)
     out = pt_extra_ops.fill_diagonal(a, c)
-    fgraph = FunctionGraph([a], [out])
-    compare_jax_and_py(fgraph, [a_test])
+    compare_jax_and_py([a], [out], [a_test])
 
     with pytest.raises(NotImplementedError):
         out = pt_extra_ops.fill_diagonal_offset(a, c, c)
-        fgraph = FunctionGraph([a], [out])
-        compare_jax_and_py(fgraph, [a_test])
+        compare_jax_and_py([a], [out], [a_test])
 
     with pytest.raises(NotImplementedError):
         out = pt_extra_ops.Unique(axis=1)(a)
-        fgraph = FunctionGraph([a], [out])
-        compare_jax_and_py(fgraph, [a_test])
+        compare_jax_and_py([a], [out], [a_test])
 
     indices = np.arange(np.prod((3, 4)))
     out = pt_extra_ops.unravel_index(indices, (3, 4), order="C")
-    fgraph = FunctionGraph([], out)
-    compare_jax_and_py(
-        fgraph, [get_test_value(i) for i in fgraph.inputs], must_be_device_array=False
-    )
+    compare_jax_and_py([], out, [], must_be_device_array=False)
 
     v = ptb.as_tensor_variable(6.0)
     sorted_idx = argsort(a.ravel())
 
     out = pt_extra_ops.searchsorted(a.ravel()[sorted_idx], v)
-    fgraph = FunctionGraph([a], [out])
-    compare_jax_and_py(fgraph, [a_test])
+    compare_jax_and_py([a], [out], [a_test])
 
 
 @pytest.mark.xfail(reason="Jitted JAX does not support dynamic shapes")
 def test_bartlett_dynamic_shape():
     c = tensor(shape=(), dtype=int)
     out = pt_extra_ops.bartlett(c)
-    fgraph = FunctionGraph([], [out])
-    compare_jax_and_py(fgraph, [np.array(5)])
+    compare_jax_and_py([], [out], [np.array(5)])
 
 
 @pytest.mark.xfail(reason="Jitted JAX does not support dynamic shapes")
@@ -79,8 +65,7 @@ def test_ravel_multi_index_dynamic_shape():
     x = tensor(shape=(None,), dtype=int)
     y = tensor(shape=(None,), dtype=int)
     out = pt_extra_ops.ravel_multi_index((x, y), (3, 4))
-    fgraph = FunctionGraph([], [out])
-    compare_jax_and_py(fgraph, [x_test, y_test])
+    compare_jax_and_py([], [out], [x_test, y_test])
 
 
 @pytest.mark.xfail(reason="Jitted JAX does not support dynamic shapes")
@@ -89,5 +74,4 @@ def test_unique_dynamic_shape():
     a_test = np.arange(6, dtype=config.floatX).reshape((3, 2))
 
     out = pt_extra_ops.Unique()(a)
-    fgraph = FunctionGraph([a], [out])
-    compare_jax_and_py(fgraph, [a_test])
+    compare_jax_and_py([a], [out], [a_test])

--- a/tests/link/jax/test_nlinalg.py
+++ b/tests/link/jax/test_nlinalg.py
@@ -3,7 +3,6 @@ import pytest
 
 from pytensor.compile.function import function
 from pytensor.configdefaults import config
-from pytensor.graph.fg import FunctionGraph
 from pytensor.tensor import nlinalg as pt_nlinalg
 from pytensor.tensor.type import matrix
 from tests.link.jax.test_basic import compare_jax_and_py
@@ -21,41 +20,34 @@ def test_jax_basic_multiout():
     x = matrix("x")
 
     outs = pt_nlinalg.eig(x)
-    out_fg = FunctionGraph([x], outs)
 
     def assert_fn(x, y):
         np.testing.assert_allclose(x.astype(config.floatX), y, rtol=1e-3)
 
-    compare_jax_and_py(out_fg, [X.astype(config.floatX)], assert_fn=assert_fn)
+    compare_jax_and_py([x], outs, [X.astype(config.floatX)], assert_fn=assert_fn)
 
     outs = pt_nlinalg.eigh(x)
-    out_fg = FunctionGraph([x], outs)
-    compare_jax_and_py(out_fg, [X.astype(config.floatX)], assert_fn=assert_fn)
+    compare_jax_and_py([x], outs, [X.astype(config.floatX)], assert_fn=assert_fn)
 
     outs = pt_nlinalg.qr(x, mode="full")
-    out_fg = FunctionGraph([x], outs)
-    compare_jax_and_py(out_fg, [X.astype(config.floatX)], assert_fn=assert_fn)
+    compare_jax_and_py([x], outs, [X.astype(config.floatX)], assert_fn=assert_fn)
 
     outs = pt_nlinalg.qr(x, mode="reduced")
-    out_fg = FunctionGraph([x], outs)
-    compare_jax_and_py(out_fg, [X.astype(config.floatX)], assert_fn=assert_fn)
+    compare_jax_and_py([x], outs, [X.astype(config.floatX)], assert_fn=assert_fn)
 
     outs = pt_nlinalg.svd(x)
-    out_fg = FunctionGraph([x], outs)
-    compare_jax_and_py(out_fg, [X.astype(config.floatX)], assert_fn=assert_fn)
+    compare_jax_and_py([x], outs, [X.astype(config.floatX)], assert_fn=assert_fn)
 
     outs = pt_nlinalg.slogdet(x)
-    out_fg = FunctionGraph([x], outs)
-    compare_jax_and_py(out_fg, [X.astype(config.floatX)], assert_fn=assert_fn)
+    compare_jax_and_py([x], outs, [X.astype(config.floatX)], assert_fn=assert_fn)
 
 
 def test_pinv():
     x = matrix("x")
     x_inv = pt_nlinalg.pinv(x)
 
-    fgraph = FunctionGraph([x], [x_inv])
     x_np = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=config.floatX)
-    compare_jax_and_py(fgraph, [x_np])
+    compare_jax_and_py([x], [x_inv], [x_np])
 
 
 def test_pinv_hermitian():
@@ -94,8 +86,7 @@ def test_kron():
     y = matrix("y")
     z = pt_nlinalg.kron(x, y)
 
-    fgraph = FunctionGraph([x, y], [z])
     x_np = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=config.floatX)
     y_np = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=config.floatX)
 
-    compare_jax_and_py(fgraph, [x_np, y_np])
+    compare_jax_and_py([x, y], [z], [x_np, y_np])

--- a/tests/link/jax/test_pad.py
+++ b/tests/link/jax/test_pad.py
@@ -3,7 +3,6 @@ import pytest
 
 import pytensor.tensor as pt
 from pytensor import config
-from pytensor.graph import FunctionGraph
 from pytensor.tensor.pad import PadMode
 from tests.link.jax.test_basic import compare_jax_and_py
 
@@ -53,10 +52,10 @@ def test_jax_pad(mode: PadMode, kwargs):
     x = np.random.normal(size=(3, 3))
 
     res = pt.pad(x_pt, mode=mode, pad_width=3, **kwargs)
-    res_fg = FunctionGraph([x_pt], [res])
 
     compare_jax_and_py(
-        res_fg,
+        [x_pt],
+        [res],
         [x],
         assert_fn=lambda x, y: np.testing.assert_allclose(x, y, rtol=RTOL, atol=ATOL),
         py_mode="FAST_RUN",

--- a/tests/link/jax/test_random.py
+++ b/tests/link/jax/test_random.py
@@ -7,13 +7,11 @@ import pytensor.tensor as pt
 import pytensor.tensor.random.basic as ptr
 from pytensor import clone_replace
 from pytensor.compile.function import function
-from pytensor.compile.sharedvalue import SharedVariable, shared
-from pytensor.graph.basic import Constant
-from pytensor.graph.fg import FunctionGraph
+from pytensor.compile.sharedvalue import shared
 from pytensor.tensor.random.basic import RandomVariable
 from pytensor.tensor.random.type import RandomType
 from pytensor.tensor.random.utils import RandomStream
-from tests.link.jax.test_basic import compare_jax_and_py, jax_mode, set_test_value
+from tests.link.jax.test_basic import compare_jax_and_py, jax_mode
 from tests.tensor.random.test_basic import (
     batched_permutation_tester,
     batched_unweighted_choice_without_replacement_tester,
@@ -147,11 +145,11 @@ def test_replaced_shared_rng_storage_ordering_equality():
         (
             ptr.beta,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(1.0, dtype=np.float64),
                 ),
@@ -163,11 +161,11 @@ def test_replaced_shared_rng_storage_ordering_equality():
         (
             ptr.cauchy,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(1.0, dtype=np.float64),
                 ),
@@ -179,7 +177,7 @@ def test_replaced_shared_rng_storage_ordering_equality():
         (
             ptr.exponential,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
@@ -191,11 +189,11 @@ def test_replaced_shared_rng_storage_ordering_equality():
         (
             ptr._gamma,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([0.5, 3.0], dtype=np.float64),
                 ),
@@ -207,11 +205,11 @@ def test_replaced_shared_rng_storage_ordering_equality():
         (
             ptr.gumbel,
             [
-                set_test_value(
+                (
                     pt.lvector(),
                     np.array([1, 2], dtype=np.int64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(1.0, dtype=np.float64),
                 ),
@@ -223,8 +221,8 @@ def test_replaced_shared_rng_storage_ordering_equality():
         (
             ptr.laplace,
             [
-                set_test_value(pt.dvector(), np.array([1.0, 2.0], dtype=np.float64)),
-                set_test_value(pt.dscalar(), np.array(1.0, dtype=np.float64)),
+                (pt.dvector(), np.array([1.0, 2.0], dtype=np.float64)),
+                (pt.dscalar(), np.array(1.0, dtype=np.float64)),
             ],
             (2,),
             "laplace",
@@ -233,11 +231,11 @@ def test_replaced_shared_rng_storage_ordering_equality():
         (
             ptr.logistic,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(1.0, dtype=np.float64),
                 ),
@@ -249,11 +247,11 @@ def test_replaced_shared_rng_storage_ordering_equality():
         (
             ptr.lognormal,
             [
-                set_test_value(
+                (
                     pt.lvector(),
                     np.array([0, 0], dtype=np.int64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(1.0, dtype=np.float64),
                 ),
@@ -265,11 +263,11 @@ def test_replaced_shared_rng_storage_ordering_equality():
         (
             ptr.normal,
             [
-                set_test_value(
+                (
                     pt.lvector(),
                     np.array([1, 2], dtype=np.int64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(1.0, dtype=np.float64),
                 ),
@@ -281,11 +279,11 @@ def test_replaced_shared_rng_storage_ordering_equality():
         (
             ptr.pareto,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([2.0, 10.0], dtype=np.float64),
                 ),
@@ -297,7 +295,7 @@ def test_replaced_shared_rng_storage_ordering_equality():
         (
             ptr.poisson,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([100000.0, 200000.0], dtype=np.float64),
                 ),
@@ -309,11 +307,11 @@ def test_replaced_shared_rng_storage_ordering_equality():
         (
             ptr.integers,
             [
-                set_test_value(
+                (
                     pt.lscalar(),
                     np.array(0, dtype=np.int64),
                 ),
-                set_test_value(  # high-value necessary since test on cdf
+                (  # high-value necessary since test on cdf
                     pt.lscalar(),
                     np.array(1000, dtype=np.int64),
                 ),
@@ -332,15 +330,15 @@ def test_replaced_shared_rng_storage_ordering_equality():
         (
             ptr.t,
             [
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(2.0, dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(1.0, dtype=np.float64),
                 ),
@@ -352,11 +350,11 @@ def test_replaced_shared_rng_storage_ordering_equality():
         (
             ptr.uniform,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(1000.0, dtype=np.float64),
                 ),
@@ -368,11 +366,11 @@ def test_replaced_shared_rng_storage_ordering_equality():
         (
             ptr.halfnormal,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([-1.0, 200.0], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(1000.0, dtype=np.float64),
                 ),
@@ -384,11 +382,11 @@ def test_replaced_shared_rng_storage_ordering_equality():
         (
             ptr.invgamma,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([10.4, 2.8], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([3.4, 7.3], dtype=np.float64),
                 ),
@@ -400,7 +398,7 @@ def test_replaced_shared_rng_storage_ordering_equality():
         (
             ptr.chisquare,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([2.4, 4.9], dtype=np.float64),
                 ),
@@ -412,15 +410,15 @@ def test_replaced_shared_rng_storage_ordering_equality():
         (
             ptr.gengamma,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([10.4, 2.8], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([3.4, 7.3], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([0.9, 2.0], dtype=np.float64),
                 ),
@@ -432,11 +430,11 @@ def test_replaced_shared_rng_storage_ordering_equality():
         (
             ptr.wald,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([10.4, 2.8], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([4.5, 2.0], dtype=np.float64),
                 ),
@@ -449,11 +447,11 @@ def test_replaced_shared_rng_storage_ordering_equality():
         pytest.param(
             ptr.vonmises,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([-0.5, 1.3], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([5.5, 13.0], dtype=np.float64),
                 ),
@@ -478,20 +476,16 @@ def test_random_RandomVariable(rv_op, dist_params, base_size, cdf_name, params_c
         The transpiled `RandomVariable` `Op`.
     dist_params
         The parameters passed to the op.
-
     """
+    dist_params, test_values = (
+        zip(*dist_params, strict=True) if dist_params else ([], [])
+    )
     rng = shared(np.random.default_rng(29403))
     g = rv_op(*dist_params, size=(10000, *base_size), rng=rng)
     g_fn = compile_random_function(dist_params, g, mode=jax_mode)
-    samples = g_fn(
-        *[
-            i.tag.test_value
-            for i in g_fn.maker.fgraph.inputs
-            if not isinstance(i, SharedVariable | Constant)
-        ]
-    )
+    samples = g_fn(*test_values)
 
-    bcast_dist_args = np.broadcast_arrays(*[i.tag.test_value for i in dist_params])
+    bcast_dist_args = np.broadcast_arrays(*test_values)
 
     for idx in np.ndindex(*base_size):
         cdf_params = params_conv(*(arg[idx] for arg in bcast_dist_args))
@@ -775,13 +769,12 @@ def test_random_unimplemented():
     nonexistentrv = NonExistentRV()
     rng = shared(np.random.default_rng(123))
     out = nonexistentrv(rng=rng)
-    fgraph = FunctionGraph([out.owner.inputs[0]], [out], clone=False)
 
     with pytest.raises(NotImplementedError):
         with pytest.warns(
             UserWarning, match=r"The RandomType SharedVariables \[.+\] will not be used"
         ):
-            compare_jax_and_py(fgraph, [])
+            compare_jax_and_py([], [out], [])
 
 
 def test_random_custom_implementation():
@@ -810,11 +803,10 @@ def test_random_custom_implementation():
     nonexistentrv = CustomRV()
     rng = shared(np.random.default_rng(123))
     out = nonexistentrv(rng=rng)
-    fgraph = FunctionGraph([out.owner.inputs[0]], [out], clone=False)
     with pytest.warns(
         UserWarning, match=r"The RandomType SharedVariables \[.+\] will not be used"
     ):
-        compare_jax_and_py(fgraph, [])
+        compare_jax_and_py([], [out], [])
 
 
 def test_random_concrete_shape():

--- a/tests/link/jax/test_scalar.py
+++ b/tests/link/jax/test_scalar.py
@@ -5,7 +5,6 @@ import pytensor.scalar.basic as ps
 import pytensor.tensor as pt
 from pytensor.configdefaults import config
 from pytensor.graph.fg import FunctionGraph
-from pytensor.graph.op import get_test_value
 from pytensor.scalar.basic import Composite
 from pytensor.tensor import as_tensor
 from pytensor.tensor.elemwise import Elemwise
@@ -51,20 +50,19 @@ def test_second():
     b = scalar("b")
 
     out = ps.second(a0, b)
-    fgraph = FunctionGraph([a0, b], [out])
-    compare_jax_and_py(fgraph, [10.0, 5.0])
+    compare_jax_and_py([a0, b], [out], [10.0, 5.0])
 
     a1 = vector("a1")
     out = pt.second(a1, b)
-    fgraph = FunctionGraph([a1, b], [out])
-    compare_jax_and_py(fgraph, [np.zeros([5], dtype=config.floatX), 5.0])
+    compare_jax_and_py([a1, b], [out], [np.zeros([5], dtype=config.floatX), 5.0])
 
     a2 = matrix("a2", shape=(1, None), dtype="float64")
     b2 = matrix("b2", shape=(None, 1), dtype="int32")
     out = pt.second(a2, b2)
-    fgraph = FunctionGraph([a2, b2], [out])
     compare_jax_and_py(
-        fgraph, [np.zeros((1, 3), dtype="float64"), np.ones((5, 1), dtype="int32")]
+        [a2, b2],
+        [out],
+        [np.zeros((1, 3), dtype="float64"), np.ones((5, 1), dtype="int32")],
     )
 
 
@@ -81,11 +79,10 @@ def test_second_constant_scalar():
 
 def test_identity():
     a = scalar("a")
-    a.tag.test_value = 10
+    a_test_value = 10
 
     out = ps.identity(a)
-    fgraph = FunctionGraph([a], [out])
-    compare_jax_and_py(fgraph, [get_test_value(i) for i in fgraph.inputs])
+    compare_jax_and_py([a], [out], [a_test_value])
 
 
 @pytest.mark.parametrize(
@@ -109,13 +106,11 @@ def test_jax_Composite_singe_output(x, y, x_val, y_val):
 
     out = comp_op(x, y)
 
-    out_fg = FunctionGraph([x, y], [out])
-
     test_input_vals = [
         x_val.astype(config.floatX),
         y_val.astype(config.floatX),
     ]
-    _ = compare_jax_and_py(out_fg, test_input_vals)
+    _ = compare_jax_and_py([x, y], [out], test_input_vals)
 
 
 def test_jax_Composite_multi_output():
@@ -124,32 +119,28 @@ def test_jax_Composite_multi_output():
     x_s = ps.float64("xs")
     outs = Elemwise(Composite(inputs=[x_s], outputs=[x_s + 1, x_s - 1]))(x)
 
-    fgraph = FunctionGraph([x], outs)
-    compare_jax_and_py(fgraph, [np.arange(10, dtype=config.floatX)])
+    compare_jax_and_py([x], outs, [np.arange(10, dtype=config.floatX)])
 
 
 def test_erf():
     x = scalar("x")
     out = erf(x)
-    fg = FunctionGraph([x], [out])
 
-    compare_jax_and_py(fg, [1.0])
+    compare_jax_and_py([x], [out], [1.0])
 
 
 def test_erfc():
     x = scalar("x")
     out = erfc(x)
-    fg = FunctionGraph([x], [out])
 
-    compare_jax_and_py(fg, [1.0])
+    compare_jax_and_py([x], [out], [1.0])
 
 
 def test_erfinv():
     x = scalar("x")
     out = erfinv(x)
-    fg = FunctionGraph([x], [out])
 
-    compare_jax_and_py(fg, [0.95])
+    compare_jax_and_py([x], [out], [0.95])
 
 
 @pytest.mark.parametrize(
@@ -166,8 +157,7 @@ def test_tfp_ops(op, test_values):
     inputs = [as_tensor(test_value).type() for test_value in test_values]
     output = op(*inputs)
 
-    fg = FunctionGraph(inputs, [output])
-    compare_jax_and_py(fg, test_values)
+    compare_jax_and_py(inputs, [output], test_values)
 
 
 def test_betaincinv():
@@ -175,9 +165,10 @@ def test_betaincinv():
     b = vector("b", dtype="float64")
     x = vector("x", dtype="float64")
     out = betaincinv(a, b, x)
-    fg = FunctionGraph([a, b, x], [out])
+
     compare_jax_and_py(
-        fg,
+        [a, b, x],
+        [out],
         [
             np.array([5.5, 7.0]),
             np.array([5.5, 7.0]),
@@ -190,39 +181,40 @@ def test_gammaincinv():
     k = vector("k", dtype="float64")
     x = vector("x", dtype="float64")
     out = gammaincinv(k, x)
-    fg = FunctionGraph([k, x], [out])
-    compare_jax_and_py(fg, [np.array([5.5, 7.0]), np.array([0.25, 0.7])])
+
+    compare_jax_and_py([k, x], [out], [np.array([5.5, 7.0]), np.array([0.25, 0.7])])
 
 
 def test_gammainccinv():
     k = vector("k", dtype="float64")
     x = vector("x", dtype="float64")
     out = gammainccinv(k, x)
-    fg = FunctionGraph([k, x], [out])
-    compare_jax_and_py(fg, [np.array([5.5, 7.0]), np.array([0.25, 0.7])])
+
+    compare_jax_and_py([k, x], [out], [np.array([5.5, 7.0]), np.array([0.25, 0.7])])
 
 
 def test_psi():
     x = scalar("x")
     out = psi(x)
-    fg = FunctionGraph([x], [out])
-    compare_jax_and_py(fg, [3.0])
+
+    compare_jax_and_py([x], [out], [3.0])
 
 
 def test_tri_gamma():
     x = vector("x", dtype="float64")
     out = tri_gamma(x)
-    fg = FunctionGraph([x], [out])
-    compare_jax_and_py(fg, [np.array([3.0, 5.0])])
+
+    compare_jax_and_py([x], [out], [np.array([3.0, 5.0])])
 
 
 def test_polygamma():
     n = vector("n", dtype="int32")
     x = vector("x", dtype="float32")
     out = polygamma(n, x)
-    fg = FunctionGraph([n, x], [out])
+
     compare_jax_and_py(
-        fg,
+        [n, x],
+        [out],
         [
             np.array([0, 1, 2]).astype("int32"),
             np.array([0.5, 0.9, 2.5]).astype("float32"),
@@ -233,41 +225,34 @@ def test_polygamma():
 def test_log1mexp():
     x = vector("x")
     out = log1mexp(x)
-    fg = FunctionGraph([x], [out])
 
-    compare_jax_and_py(fg, [[-1.0, -0.75, -0.5, -0.25]])
+    compare_jax_and_py([x], [out], [[-1.0, -0.75, -0.5, -0.25]])
 
 
 def test_nnet():
     x = vector("x")
-    x.tag.test_value = np.r_[1.0, 2.0].astype(config.floatX)
+    x_test_value = np.r_[1.0, 2.0].astype(config.floatX)
 
     out = sigmoid(x)
-    fgraph = FunctionGraph([x], [out])
-    compare_jax_and_py(fgraph, [get_test_value(i) for i in fgraph.inputs])
+    compare_jax_and_py([x], [out], [x_test_value])
 
     out = softplus(x)
-    fgraph = FunctionGraph([x], [out])
-    compare_jax_and_py(fgraph, [get_test_value(i) for i in fgraph.inputs])
+    compare_jax_and_py([x], [out], [x_test_value])
 
 
 def test_jax_variadic_Scalar():
     mu = vector("mu", dtype=config.floatX)
-    mu.tag.test_value = np.r_[0.1, 1.1].astype(config.floatX)
+    mu_test_value = np.r_[0.1, 1.1].astype(config.floatX)
     tau = vector("tau", dtype=config.floatX)
-    tau.tag.test_value = np.r_[1.0, 2.0].astype(config.floatX)
+    tau_test_value = np.r_[1.0, 2.0].astype(config.floatX)
 
     res = -tau * mu
 
-    fgraph = FunctionGraph([mu, tau], [res])
-
-    compare_jax_and_py(fgraph, [get_test_value(i) for i in fgraph.inputs])
+    compare_jax_and_py([mu, tau], [res], [mu_test_value, tau_test_value])
 
     res = -tau * (tau - mu) ** 2
 
-    fgraph = FunctionGraph([mu, tau], [res])
-
-    compare_jax_and_py(fgraph, [get_test_value(i) for i in fgraph.inputs])
+    compare_jax_and_py([mu, tau], [res], [mu_test_value, tau_test_value])
 
 
 def test_add_scalars():
@@ -275,8 +260,7 @@ def test_add_scalars():
     size = x.shape[0] + x.shape[0] + x.shape[1]
     out = pt.ones(size).astype(config.floatX)
 
-    out_fg = FunctionGraph([x], [out])
-    compare_jax_and_py(out_fg, [np.ones((2, 3)).astype(config.floatX)])
+    compare_jax_and_py([x], [out], [np.ones((2, 3)).astype(config.floatX)])
 
 
 def test_mul_scalars():
@@ -284,8 +268,7 @@ def test_mul_scalars():
     size = x.shape[0] * x.shape[0] * x.shape[1]
     out = pt.ones(size).astype(config.floatX)
 
-    out_fg = FunctionGraph([x], [out])
-    compare_jax_and_py(out_fg, [np.ones((2, 3)).astype(config.floatX)])
+    compare_jax_and_py([x], [out], [np.ones((2, 3)).astype(config.floatX)])
 
 
 def test_div_scalars():
@@ -293,8 +276,7 @@ def test_div_scalars():
     size = x.shape[0] // x.shape[1]
     out = pt.ones(size).astype(config.floatX)
 
-    out_fg = FunctionGraph([x], [out])
-    compare_jax_and_py(out_fg, [np.ones((12, 3)).astype(config.floatX)])
+    compare_jax_and_py([x], [out], [np.ones((12, 3)).astype(config.floatX)])
 
 
 def test_mod_scalars():
@@ -302,39 +284,43 @@ def test_mod_scalars():
     size = x.shape[0] % x.shape[1]
     out = pt.ones(size).astype(config.floatX)
 
-    out_fg = FunctionGraph([x], [out])
-    compare_jax_and_py(out_fg, [np.ones((12, 3)).astype(config.floatX)])
+    compare_jax_and_py([x], [out], [np.ones((12, 3)).astype(config.floatX)])
 
 
 def test_jax_multioutput():
     x = vector("x")
-    x.tag.test_value = np.r_[1.0, 2.0].astype(config.floatX)
+    x_test_value = np.r_[1.0, 2.0].astype(config.floatX)
     y = vector("y")
-    y.tag.test_value = np.r_[3.0, 4.0].astype(config.floatX)
+    y_test_value = np.r_[3.0, 4.0].astype(config.floatX)
 
     w = cosh(x**2 + y / 3.0)
     v = cosh(x / 3.0 + y**2)
 
-    fgraph = FunctionGraph([x, y], [w, v])
-
-    compare_jax_and_py(fgraph, [get_test_value(i) for i in fgraph.inputs])
+    compare_jax_and_py([x, y], [w, v], [x_test_value, y_test_value])
 
 
 def test_jax_logp():
     mu = vector("mu")
-    mu.tag.test_value = np.r_[0.0, 0.0].astype(config.floatX)
+    mu_test_value = np.r_[0.0, 0.0].astype(config.floatX)
     tau = vector("tau")
-    tau.tag.test_value = np.r_[1.0, 1.0].astype(config.floatX)
+    tau_test_value = np.r_[1.0, 1.0].astype(config.floatX)
     sigma = vector("sigma")
-    sigma.tag.test_value = (1.0 / get_test_value(tau)).astype(config.floatX)
+    sigma_test_value = (1.0 / tau_test_value).astype(config.floatX)
     value = vector("value")
-    value.tag.test_value = np.r_[0.1, -10].astype(config.floatX)
+    value_test_value = np.r_[0.1, -10].astype(config.floatX)
 
     logp = (-tau * (value - mu) ** 2 + log(tau / np.pi / 2.0)) / 2.0
     conditions = [sigma > 0]
     alltrue = pt_all([pt_all(1 * val) for val in conditions])
     normal_logp = pt.switch(alltrue, logp, -np.inf)
 
-    fgraph = FunctionGraph([mu, tau, sigma, value], [normal_logp])
-
-    compare_jax_and_py(fgraph, [get_test_value(i) for i in fgraph.inputs])
+    compare_jax_and_py(
+        [mu, tau, sigma, value],
+        [normal_logp],
+        [
+            mu_test_value,
+            tau_test_value,
+            sigma_test_value,
+            value_test_value,
+        ],
+    )

--- a/tests/link/jax/test_shape.py
+++ b/tests/link/jax/test_shape.py
@@ -4,7 +4,6 @@ import pytest
 import pytensor.tensor as pt
 from pytensor.compile.ops import DeepCopyOp, ViewOp
 from pytensor.configdefaults import config
-from pytensor.graph.fg import FunctionGraph
 from pytensor.tensor.shape import Shape, Shape_i, Unbroadcast, reshape
 from pytensor.tensor.type import iscalar, vector
 from tests.link.jax.test_basic import compare_jax_and_py
@@ -13,29 +12,27 @@ from tests.link.jax.test_basic import compare_jax_and_py
 def test_jax_shape_ops():
     x_np = np.zeros((20, 3))
     x = Shape()(pt.as_tensor_variable(x_np))
-    x_fg = FunctionGraph([], [x])
 
-    compare_jax_and_py(x_fg, [], must_be_device_array=False)
+    compare_jax_and_py([], [x], [], must_be_device_array=False)
 
     x = Shape_i(1)(pt.as_tensor_variable(x_np))
-    x_fg = FunctionGraph([], [x])
 
-    compare_jax_and_py(x_fg, [], must_be_device_array=False)
+    compare_jax_and_py([], [x], [], must_be_device_array=False)
 
 
 def test_jax_specify_shape():
     in_pt = pt.matrix("in")
     x = pt.specify_shape(in_pt, (4, None))
-    x_fg = FunctionGraph([in_pt], [x])
-    compare_jax_and_py(x_fg, [np.ones((4, 5)).astype(config.floatX)])
+    compare_jax_and_py([in_pt], [x], [np.ones((4, 5)).astype(config.floatX)])
 
     # When used to assert two arrays have similar shapes
     in_pt = pt.matrix("in")
     shape_pt = pt.matrix("shape")
     x = pt.specify_shape(in_pt, shape_pt.shape)
-    x_fg = FunctionGraph([in_pt, shape_pt], [x])
+
     compare_jax_and_py(
-        x_fg,
+        [in_pt, shape_pt],
+        [x],
         [np.ones((4, 5)).astype(config.floatX), np.ones((4, 5)).astype(config.floatX)],
     )
 
@@ -43,20 +40,17 @@ def test_jax_specify_shape():
 def test_jax_Reshape_constant():
     a = vector("a")
     x = reshape(a, (2, 2))
-    x_fg = FunctionGraph([a], [x])
-    compare_jax_and_py(x_fg, [np.r_[1.0, 2.0, 3.0, 4.0].astype(config.floatX)])
+    compare_jax_and_py([a], [x], [np.r_[1.0, 2.0, 3.0, 4.0].astype(config.floatX)])
 
 
 def test_jax_Reshape_concrete_shape():
     """JAX should compile when a concrete value is passed for the `shape` parameter."""
     a = vector("a")
     x = reshape(a, a.shape)
-    x_fg = FunctionGraph([a], [x])
-    compare_jax_and_py(x_fg, [np.r_[1.0, 2.0, 3.0, 4.0].astype(config.floatX)])
+    compare_jax_and_py([a], [x], [np.r_[1.0, 2.0, 3.0, 4.0].astype(config.floatX)])
 
     x = reshape(a, (a.shape[0] // 2, a.shape[0] // 2))
-    x_fg = FunctionGraph([a], [x])
-    compare_jax_and_py(x_fg, [np.r_[1.0, 2.0, 3.0, 4.0].astype(config.floatX)])
+    compare_jax_and_py([a], [x], [np.r_[1.0, 2.0, 3.0, 4.0].astype(config.floatX)])
 
 
 @pytest.mark.xfail(
@@ -66,23 +60,20 @@ def test_jax_Reshape_shape_graph_input():
     a = vector("a")
     shape_pt = iscalar("b")
     x = reshape(a, (shape_pt, shape_pt))
-    x_fg = FunctionGraph([a, shape_pt], [x])
-    compare_jax_and_py(x_fg, [np.r_[1.0, 2.0, 3.0, 4.0].astype(config.floatX), 2])
+    compare_jax_and_py(
+        [a, shape_pt], [x], [np.r_[1.0, 2.0, 3.0, 4.0].astype(config.floatX), 2]
+    )
 
 
 def test_jax_compile_ops():
     x = DeepCopyOp()(pt.as_tensor_variable(1.1))
-    x_fg = FunctionGraph([], [x])
-
-    compare_jax_and_py(x_fg, [])
+    compare_jax_and_py([], [x], [])
 
     x_np = np.zeros((20, 1, 1))
     x = Unbroadcast(0, 2)(pt.as_tensor_variable(x_np))
-    x_fg = FunctionGraph([], [x])
 
-    compare_jax_and_py(x_fg, [])
+    compare_jax_and_py([], [x], [])
 
     x = ViewOp()(pt.as_tensor_variable(x_np))
-    x_fg = FunctionGraph([], [x])
 
-    compare_jax_and_py(x_fg, [])
+    compare_jax_and_py([], [x], [])

--- a/tests/link/jax/test_sort.py
+++ b/tests/link/jax/test_sort.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-from pytensor.graph import FunctionGraph
 from pytensor.tensor import matrix
 from pytensor.tensor.sort import argsort, sort
 from tests.link.jax.test_basic import compare_jax_and_py
@@ -12,6 +11,5 @@ from tests.link.jax.test_basic import compare_jax_and_py
 def test_sort(func, axis):
     x = matrix("x", shape=(2, 2), dtype="float64")
     out = func(x, axis=axis)
-    fgraph = FunctionGraph([x], [out])
     arr = np.array([[1.0, 4.0], [5.0, 2.0]])
-    compare_jax_and_py(fgraph, [arr])
+    compare_jax_and_py([x], [out], [arr])

--- a/tests/link/jax/test_sparse.py
+++ b/tests/link/jax/test_sparse.py
@@ -5,7 +5,6 @@ import scipy.sparse
 import pytensor.sparse as ps
 import pytensor.tensor as pt
 from pytensor import function
-from pytensor.graph import FunctionGraph
 from tests.link.jax.test_basic import compare_jax_and_py
 
 
@@ -50,8 +49,7 @@ def test_sparse_dot_constant_sparse(x_type, y_type, op):
         test_values.append(y_test)
 
     dot_pt = op(x_pt, y_pt)
-    fgraph = FunctionGraph(inputs, [dot_pt])
-    compare_jax_and_py(fgraph, test_values, jax_mode="JAX")
+    compare_jax_and_py(inputs, [dot_pt], test_values, jax_mode="JAX")
 
 
 def test_sparse_dot_non_const_raises():

--- a/tests/link/numba/test_blockwise.py
+++ b/tests/link/numba/test_blockwise.py
@@ -27,7 +27,8 @@ def test_blockwise(core_op, shape_opt):
     )
     x_test = np.eye(3) * np.arange(1, 6)[:, None, None]
     compare_numba_and_py(
-        ([x], outs),
+        [x],
+        outs,
         [x_test],
         numba_mode=mode,
         eval_obj_mode=False,

--- a/tests/link/numba/test_nlinalg.py
+++ b/tests/link/numba/test_nlinalg.py
@@ -4,11 +4,8 @@ import numpy as np
 import pytest
 
 import pytensor.tensor as pt
-from pytensor.compile.sharedvalue import SharedVariable
-from pytensor.graph.basic import Constant
-from pytensor.graph.fg import FunctionGraph
 from pytensor.tensor import nlinalg
-from tests.link.numba.test_basic import compare_numba_and_py, set_test_value
+from tests.link.numba.test_basic import compare_numba_and_py
 
 
 rng = np.random.default_rng(42849)
@@ -18,14 +15,14 @@ rng = np.random.default_rng(42849)
     "x, exc",
     [
         (
-            set_test_value(
+            (
                 pt.dmatrix(),
                 (lambda x: x.T.dot(x))(rng.random(size=(3, 3)).astype("float64")),
             ),
             None,
         ),
         (
-            set_test_value(
+            (
                 pt.lmatrix(),
                 (lambda x: x.T.dot(x))(rng.poisson(size=(3, 3)).astype("int64")),
             ),
@@ -34,18 +31,15 @@ rng = np.random.default_rng(42849)
     ],
 )
 def test_Det(x, exc):
+    x, test_x = x
     g = nlinalg.Det()(x)
-    g_fg = FunctionGraph(outputs=[g])
 
     cm = contextlib.suppress() if exc is None else pytest.warns(exc)
     with cm:
         compare_numba_and_py(
-            g_fg,
-            [
-                i.tag.test_value
-                for i in g_fg.inputs
-                if not isinstance(i, SharedVariable | Constant)
-            ],
+            [x],
+            g,
+            [test_x],
         )
 
 
@@ -53,14 +47,14 @@ def test_Det(x, exc):
     "x, exc",
     [
         (
-            set_test_value(
+            (
                 pt.dmatrix(),
                 (lambda x: x.T.dot(x))(rng.random(size=(3, 3)).astype("float64")),
             ),
             None,
         ),
         (
-            set_test_value(
+            (
                 pt.lmatrix(),
                 (lambda x: x.T.dot(x))(rng.poisson(size=(3, 3)).astype("int64")),
             ),
@@ -69,18 +63,15 @@ def test_Det(x, exc):
     ],
 )
 def test_SLogDet(x, exc):
+    x, test_x = x
     g = nlinalg.SLogDet()(x)
-    g_fg = FunctionGraph(outputs=g)
 
     cm = contextlib.suppress() if exc is None else pytest.warns(exc)
     with cm:
         compare_numba_and_py(
-            g_fg,
-            [
-                i.tag.test_value
-                for i in g_fg.inputs
-                if not isinstance(i, SharedVariable | Constant)
-            ],
+            [x],
+            g,
+            [test_x],
         )
 
 
@@ -112,21 +103,21 @@ y = np.array(
     "x, exc",
     [
         (
-            set_test_value(
+            (
                 pt.dmatrix(),
                 (lambda x: x.T.dot(x))(x),
             ),
             None,
         ),
         (
-            set_test_value(
+            (
                 pt.dmatrix(),
                 (lambda x: x.T.dot(x))(y),
             ),
             None,
         ),
         (
-            set_test_value(
+            (
                 pt.lmatrix(),
                 (lambda x: x.T.dot(x))(
                     rng.integers(1, 10, size=(3, 3)).astype("int64")
@@ -137,22 +128,15 @@ y = np.array(
     ],
 )
 def test_Eig(x, exc):
+    x, test_x = x
     g = nlinalg.Eig()(x)
-
-    if isinstance(g, list):
-        g_fg = FunctionGraph(outputs=g)
-    else:
-        g_fg = FunctionGraph(outputs=[g])
 
     cm = contextlib.suppress() if exc is None else pytest.warns(exc)
     with cm:
         compare_numba_and_py(
-            g_fg,
-            [
-                i.tag.test_value
-                for i in g_fg.inputs
-                if not isinstance(i, SharedVariable | Constant)
-            ],
+            [x],
+            g,
+            [test_x],
         )
 
 
@@ -160,7 +144,7 @@ def test_Eig(x, exc):
     "x, uplo, exc",
     [
         (
-            set_test_value(
+            (
                 pt.dmatrix(),
                 (lambda x: x.T.dot(x))(rng.random(size=(3, 3)).astype("float64")),
             ),
@@ -168,7 +152,7 @@ def test_Eig(x, exc):
             None,
         ),
         (
-            set_test_value(
+            (
                 pt.lmatrix(),
                 (lambda x: x.T.dot(x))(
                     rng.integers(1, 10, size=(3, 3)).astype("int64")
@@ -180,22 +164,15 @@ def test_Eig(x, exc):
     ],
 )
 def test_Eigh(x, uplo, exc):
+    x, test_x = x
     g = nlinalg.Eigh(uplo)(x)
-
-    if isinstance(g, list):
-        g_fg = FunctionGraph(outputs=g)
-    else:
-        g_fg = FunctionGraph(outputs=[g])
 
     cm = contextlib.suppress() if exc is None else pytest.warns(exc)
     with cm:
         compare_numba_and_py(
-            g_fg,
-            [
-                i.tag.test_value
-                for i in g_fg.inputs
-                if not isinstance(i, SharedVariable | Constant)
-            ],
+            [x],
+            g,
+            [test_x],
         )
 
 
@@ -204,7 +181,7 @@ def test_Eigh(x, uplo, exc):
     [
         (
             nlinalg.MatrixInverse,
-            set_test_value(
+            (
                 pt.dmatrix(),
                 (lambda x: x.T.dot(x))(rng.random(size=(3, 3)).astype("float64")),
             ),
@@ -213,7 +190,7 @@ def test_Eigh(x, uplo, exc):
         ),
         (
             nlinalg.MatrixInverse,
-            set_test_value(
+            (
                 pt.lmatrix(),
                 (lambda x: x.T.dot(x))(
                     rng.integers(1, 10, size=(3, 3)).astype("int64")
@@ -224,7 +201,7 @@ def test_Eigh(x, uplo, exc):
         ),
         (
             nlinalg.MatrixPinv,
-            set_test_value(
+            (
                 pt.dmatrix(),
                 (lambda x: x.T.dot(x))(rng.random(size=(3, 3)).astype("float64")),
             ),
@@ -233,7 +210,7 @@ def test_Eigh(x, uplo, exc):
         ),
         (
             nlinalg.MatrixPinv,
-            set_test_value(
+            (
                 pt.lmatrix(),
                 (lambda x: x.T.dot(x))(
                     rng.integers(1, 10, size=(3, 3)).astype("int64")
@@ -245,18 +222,15 @@ def test_Eigh(x, uplo, exc):
     ],
 )
 def test_matrix_inverses(op, x, exc, op_args):
+    x, test_x = x
     g = op(*op_args)(x)
-    g_fg = FunctionGraph(outputs=[g])
 
     cm = contextlib.suppress() if exc is None else pytest.warns(exc)
     with cm:
         compare_numba_and_py(
-            g_fg,
-            [
-                i.tag.test_value
-                for i in g_fg.inputs
-                if not isinstance(i, SharedVariable | Constant)
-            ],
+            [x],
+            g,
+            [test_x],
         )
 
 
@@ -264,7 +238,7 @@ def test_matrix_inverses(op, x, exc, op_args):
     "x, mode, exc",
     [
         (
-            set_test_value(
+            (
                 pt.dmatrix(),
                 (lambda x: x.T.dot(x))(rng.random(size=(3, 3)).astype("float64")),
             ),
@@ -272,7 +246,7 @@ def test_matrix_inverses(op, x, exc, op_args):
             None,
         ),
         (
-            set_test_value(
+            (
                 pt.dmatrix(),
                 (lambda x: x.T.dot(x))(rng.random(size=(3, 3)).astype("float64")),
             ),
@@ -280,7 +254,7 @@ def test_matrix_inverses(op, x, exc, op_args):
             None,
         ),
         (
-            set_test_value(
+            (
                 pt.lmatrix(),
                 (lambda x: x.T.dot(x))(
                     rng.integers(1, 10, size=(3, 3)).astype("int64")
@@ -290,7 +264,7 @@ def test_matrix_inverses(op, x, exc, op_args):
             None,
         ),
         (
-            set_test_value(
+            (
                 pt.lmatrix(),
                 (lambda x: x.T.dot(x))(
                     rng.integers(1, 10, size=(3, 3)).astype("int64")
@@ -302,22 +276,15 @@ def test_matrix_inverses(op, x, exc, op_args):
     ],
 )
 def test_QRFull(x, mode, exc):
+    x, test_x = x
     g = nlinalg.QRFull(mode)(x)
-
-    if isinstance(g, list):
-        g_fg = FunctionGraph(outputs=g)
-    else:
-        g_fg = FunctionGraph(outputs=[g])
 
     cm = contextlib.suppress() if exc is None else pytest.warns(exc)
     with cm:
         compare_numba_and_py(
-            g_fg,
-            [
-                i.tag.test_value
-                for i in g_fg.inputs
-                if not isinstance(i, SharedVariable | Constant)
-            ],
+            [x],
+            g,
+            [test_x],
         )
 
 
@@ -325,7 +292,7 @@ def test_QRFull(x, mode, exc):
     "x, full_matrices, compute_uv, exc",
     [
         (
-            set_test_value(
+            (
                 pt.dmatrix(),
                 (lambda x: x.T.dot(x))(rng.random(size=(3, 3)).astype("float64")),
             ),
@@ -334,7 +301,7 @@ def test_QRFull(x, mode, exc):
             None,
         ),
         (
-            set_test_value(
+            (
                 pt.dmatrix(),
                 (lambda x: x.T.dot(x))(rng.random(size=(3, 3)).astype("float64")),
             ),
@@ -343,7 +310,7 @@ def test_QRFull(x, mode, exc):
             None,
         ),
         (
-            set_test_value(
+            (
                 pt.lmatrix(),
                 (lambda x: x.T.dot(x))(
                     rng.integers(1, 10, size=(3, 3)).astype("int64")
@@ -354,7 +321,7 @@ def test_QRFull(x, mode, exc):
             None,
         ),
         (
-            set_test_value(
+            (
                 pt.lmatrix(),
                 (lambda x: x.T.dot(x))(
                     rng.integers(1, 10, size=(3, 3)).astype("int64")
@@ -367,20 +334,13 @@ def test_QRFull(x, mode, exc):
     ],
 )
 def test_SVD(x, full_matrices, compute_uv, exc):
+    x, test_x = x
     g = nlinalg.SVD(full_matrices, compute_uv)(x)
-
-    if isinstance(g, list):
-        g_fg = FunctionGraph(outputs=g)
-    else:
-        g_fg = FunctionGraph(outputs=[g])
 
     cm = contextlib.suppress() if exc is None else pytest.warns(exc)
     with cm:
         compare_numba_and_py(
-            g_fg,
-            [
-                i.tag.test_value
-                for i in g_fg.inputs
-                if not isinstance(i, SharedVariable | Constant)
-            ],
+            [x],
+            g,
+            [test_x],
         )

--- a/tests/link/numba/test_pad.py
+++ b/tests/link/numba/test_pad.py
@@ -3,7 +3,6 @@ import pytest
 
 import pytensor.tensor as pt
 from pytensor import config
-from pytensor.graph import FunctionGraph
 from pytensor.tensor.pad import PadMode
 from tests.link.numba.test_basic import compare_numba_and_py
 
@@ -58,10 +57,10 @@ def test_numba_pad(mode: PadMode, kwargs):
     x = np.random.normal(size=(3, 3))
 
     res = pt.pad(x_pt, mode=mode, pad_width=3, **kwargs)
-    res_fg = FunctionGraph([x_pt], [res])
 
     compare_numba_and_py(
-        res_fg,
+        [x_pt],
+        [res],
         [x],
         assert_fn=lambda x, y: np.testing.assert_allclose(x, y, rtol=RTOL, atol=ATOL),
         py_mode="FAST_RUN",

--- a/tests/link/numba/test_random.py
+++ b/tests/link/numba/test_random.py
@@ -10,13 +10,9 @@ import pytensor.tensor.random.basic as ptr
 from pytensor import shared
 from pytensor.compile.builders import OpFromGraph
 from pytensor.compile.function import function
-from pytensor.compile.sharedvalue import SharedVariable
-from pytensor.graph.basic import Constant
-from pytensor.graph.fg import FunctionGraph
 from tests.link.numba.test_basic import (
     compare_numba_and_py,
     numba_mode,
-    set_test_value,
 )
 from tests.tensor.random.test_basic import (
     batched_permutation_tester,
@@ -159,11 +155,11 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
         (
             ptr.uniform,
             [
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(1.0, dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
@@ -173,15 +169,15 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
         (
             ptr.triangular,
             [
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(-5.0, dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(1.0, dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(5.0, dtype=np.float64),
                 ),
@@ -191,11 +187,11 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
         (
             ptr.lognormal,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(1.0, dtype=np.float64),
                 ),
@@ -205,11 +201,11 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
         (
             ptr.pareto,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([2.0, 10.0], dtype=np.float64),
                 ),
@@ -219,7 +215,7 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
         (
             ptr.exponential,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
@@ -229,7 +225,7 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
         (
             ptr.weibull,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
@@ -239,11 +235,11 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
         (
             ptr.logistic,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(1.0, dtype=np.float64),
                 ),
@@ -253,7 +249,7 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
         (
             ptr.geometric,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([0.3, 0.4], dtype=np.float64),
                 ),
@@ -263,15 +259,15 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
         pytest.param(
             ptr.hypergeometric,
             [
-                set_test_value(
+                (
                     pt.lscalar(),
                     np.array(7, dtype=np.int64),
                 ),
-                set_test_value(
+                (
                     pt.lscalar(),
                     np.array(8, dtype=np.int64),
                 ),
-                set_test_value(
+                (
                     pt.lscalar(),
                     np.array(15, dtype=np.int64),
                 ),
@@ -282,11 +278,11 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
         (
             ptr.wald,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(1.0, dtype=np.float64),
                 ),
@@ -296,11 +292,11 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
         (
             ptr.laplace,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(1.0, dtype=np.float64),
                 ),
@@ -310,11 +306,11 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
         (
             ptr.binomial,
             [
-                set_test_value(
+                (
                     pt.lvector(),
                     np.array([1, 2], dtype=np.int64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(0.9, dtype=np.float64),
                 ),
@@ -324,21 +320,21 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
         (
             ptr.normal,
             [
-                set_test_value(
+                (
                     pt.lvector(),
                     np.array([1, 2], dtype=np.int64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(1.0, dtype=np.float64),
                 ),
             ],
-            pt.as_tensor(tuple(set_test_value(pt.lscalar(), v) for v in [3, 2])),
+            pt.as_tensor([3, 2]),
         ),
         (
             ptr.poisson,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
@@ -348,11 +344,11 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
         (
             ptr.halfnormal,
             [
-                set_test_value(
+                (
                     pt.lvector(),
                     np.array([1, 2], dtype=np.int64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(1.0, dtype=np.float64),
                 ),
@@ -362,7 +358,7 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
         (
             ptr.bernoulli,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([0.1, 0.9], dtype=np.float64),
                 ),
@@ -372,11 +368,11 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
         (
             ptr.beta,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(1.0, dtype=np.float64),
                 ),
@@ -386,11 +382,11 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
         (
             ptr._gamma,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([0.5, 3.0], dtype=np.float64),
                 ),
@@ -400,7 +396,7 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
         (
             ptr.chisquare,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 )
@@ -410,11 +406,11 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
         (
             ptr.negative_binomial,
             [
-                set_test_value(
+                (
                     pt.lvector(),
                     np.array([100, 200], dtype=np.int64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(0.09, dtype=np.float64),
                 ),
@@ -424,11 +420,11 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
         (
             ptr.vonmises,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([-0.5, 0.5], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(1.0, dtype=np.float64),
                 ),
@@ -438,14 +434,14 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
         (
             ptr.permutation,
             [
-                set_test_value(pt.dmatrix(), np.eye(5, dtype=np.float64)),
+                (pt.dmatrix(), np.eye(5, dtype=np.float64)),
             ],
             (),
         ),
         (
             partial(ptr.choice, replace=True),
             [
-                set_test_value(pt.dmatrix(), np.eye(5, dtype=np.float64)),
+                (pt.dmatrix(), np.eye(5, dtype=np.float64)),
             ],
             pt.as_tensor([2]),
         ),
@@ -455,17 +451,15 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
                 a, p=p, size=size, replace=True, rng=rng
             ),
             [
-                set_test_value(pt.dmatrix(), np.eye(3, dtype=np.float64)),
-                set_test_value(
-                    pt.dvector(), np.array([0.25, 0.5, 0.25], dtype=np.float64)
-                ),
+                (pt.dmatrix(), np.eye(3, dtype=np.float64)),
+                (pt.dvector(), np.array([0.25, 0.5, 0.25], dtype=np.float64)),
             ],
             (pt.as_tensor([2, 3])),
         ),
         pytest.param(
             partial(ptr.choice, replace=False),
             [
-                set_test_value(pt.dvector(), np.arange(5, dtype=np.float64)),
+                (pt.dvector(), np.arange(5, dtype=np.float64)),
             ],
             pt.as_tensor([2]),
             marks=pytest.mark.xfail(
@@ -476,7 +470,7 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
         pytest.param(
             partial(ptr.choice, replace=False),
             [
-                set_test_value(pt.dmatrix(), np.eye(5, dtype=np.float64)),
+                (pt.dmatrix(), np.eye(5, dtype=np.float64)),
             ],
             pt.as_tensor([2]),
             marks=pytest.mark.xfail(
@@ -490,8 +484,8 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
                 a, p=p, size=size, replace=False, rng=rng
             ),
             [
-                set_test_value(pt.vector(), np.arange(5, dtype=np.float64)),
-                set_test_value(
+                (pt.vector(), np.arange(5, dtype=np.float64)),
+                (
                     pt.dvector(),
                     np.array([0.5, 0.0, 0.25, 0.0, 0.25], dtype=np.float64),
                 ),
@@ -504,10 +498,8 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
                 a, p=p, size=size, replace=False, rng=rng
             ),
             [
-                set_test_value(pt.dmatrix(), np.eye(3, dtype=np.float64)),
-                set_test_value(
-                    pt.dvector(), np.array([0.25, 0.5, 0.25], dtype=np.float64)
-                ),
+                (pt.dmatrix(), np.eye(3, dtype=np.float64)),
+                (pt.dvector(), np.array([0.25, 0.5, 0.25], dtype=np.float64)),
             ],
             (),
         ),
@@ -517,10 +509,8 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
                 a, p=p, size=size, replace=False, rng=rng
             ),
             [
-                set_test_value(pt.dmatrix(), np.eye(3, dtype=np.float64)),
-                set_test_value(
-                    pt.dvector(), np.array([0.25, 0.5, 0.25], dtype=np.float64)
-                ),
+                (pt.dmatrix(), np.eye(3, dtype=np.float64)),
+                (pt.dvector(), np.array([0.25, 0.5, 0.25], dtype=np.float64)),
             ],
             (pt.as_tensor([2, 1])),
         ),
@@ -529,17 +519,14 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
 )
 def test_aligned_RandomVariable(rv_op, dist_args, size):
     """Tests for Numba samplers that are one-to-one with PyTensor's/NumPy's samplers."""
+    dist_args, test_dist_args = zip(*dist_args, strict=True)
     rng = shared(np.random.default_rng(29402))
     g = rv_op(*dist_args, size=size, rng=rng)
-    g_fg = FunctionGraph(outputs=[g])
 
     compare_numba_and_py(
-        g_fg,
-        [
-            i.tag.test_value
-            for i in g_fg.inputs
-            if not isinstance(i, SharedVariable | Constant)
-        ],
+        dist_args,
+        [g],
+        test_dist_args,
         eval_obj_mode=False,  # No python impl
     )
 
@@ -550,11 +537,11 @@ def test_aligned_RandomVariable(rv_op, dist_args, size):
         (
             ptr.cauchy,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(1.0, dtype=np.float64),
                 ),
@@ -566,11 +553,11 @@ def test_aligned_RandomVariable(rv_op, dist_args, size):
         (
             ptr.gumbel,
             [
-                set_test_value(
+                (
                     pt.dvector(),
                     np.array([1.0, 2.0], dtype=np.float64),
                 ),
-                set_test_value(
+                (
                     pt.dscalar(),
                     np.array(1.0, dtype=np.float64),
                 ),
@@ -583,18 +570,13 @@ def test_aligned_RandomVariable(rv_op, dist_args, size):
 )
 def test_unaligned_RandomVariable(rv_op, dist_args, base_size, cdf_name, params_conv):
     """Tests for Numba samplers that are not one-to-one with PyTensor's/NumPy's samplers."""
+    dist_args, test_dist_args = zip(*dist_args, strict=True)
     rng = shared(np.random.default_rng(29402))
     g = rv_op(*dist_args, size=(2000, *base_size), rng=rng)
     g_fn = function(dist_args, g, mode=numba_mode)
-    samples = g_fn(
-        *[
-            i.tag.test_value
-            for i in g_fn.maker.fgraph.inputs
-            if not isinstance(i, SharedVariable | Constant)
-        ]
-    )
+    samples = g_fn(*test_dist_args)
 
-    bcast_dist_args = np.broadcast_arrays(*[i.tag.test_value for i in dist_args])
+    bcast_dist_args = np.broadcast_arrays(*test_dist_args)
 
     for idx in np.ndindex(*base_size):
         cdf_params = params_conv(*(arg[idx] for arg in bcast_dist_args))
@@ -608,7 +590,7 @@ def test_unaligned_RandomVariable(rv_op, dist_args, base_size, cdf_name, params_
     "a, size, cm",
     [
         pytest.param(
-            set_test_value(
+            (
                 pt.dvector(),
                 np.array([100000, 1, 1], dtype=np.float64),
             ),
@@ -616,7 +598,7 @@ def test_unaligned_RandomVariable(rv_op, dist_args, base_size, cdf_name, params_
             contextlib.suppress(),
         ),
         pytest.param(
-            set_test_value(
+            (
                 pt.dmatrix(),
                 np.array(
                     [[100000, 1, 1], [1, 100000, 1], [1, 1, 100000]],
@@ -627,7 +609,7 @@ def test_unaligned_RandomVariable(rv_op, dist_args, base_size, cdf_name, params_
             contextlib.suppress(),
         ),
         pytest.param(
-            set_test_value(
+            (
                 pt.dmatrix(),
                 np.array(
                     [[100000, 1, 1], [1, 100000, 1], [1, 1, 100000]],
@@ -643,13 +625,12 @@ def test_unaligned_RandomVariable(rv_op, dist_args, base_size, cdf_name, params_
     ],
 )
 def test_DirichletRV(a, size, cm):
+    a, a_val = a
     rng = shared(np.random.default_rng(29402))
     g = ptr.dirichlet(a, size=size, rng=rng)
     g_fn = function([a], g, mode=numba_mode)
 
     with cm:
-        a_val = a.tag.test_value
-
         all_samples = []
         for i in range(1000):
             samples = g_fn(a_val)

--- a/tests/link/numba/test_scalar.py
+++ b/tests/link/numba/test_scalar.py
@@ -5,13 +5,10 @@ import pytensor.scalar as ps
 import pytensor.scalar.basic as psb
 import pytensor.tensor as pt
 from pytensor import config
-from pytensor.compile.sharedvalue import SharedVariable
-from pytensor.graph.basic import Constant
-from pytensor.graph.fg import FunctionGraph
 from pytensor.scalar.basic import Composite
 from pytensor.tensor import tensor
 from pytensor.tensor.elemwise import Elemwise
-from tests.link.numba.test_basic import compare_numba_and_py, set_test_value
+from tests.link.numba.test_basic import compare_numba_and_py
 
 
 rng = np.random.default_rng(42849)
@@ -21,48 +18,43 @@ rng = np.random.default_rng(42849)
     "x, y",
     [
         (
-            set_test_value(pt.lvector(), np.arange(4, dtype="int64")),
-            set_test_value(pt.dvector(), np.arange(4, dtype="float64")),
+            (pt.lvector(), np.arange(4, dtype="int64")),
+            (pt.dvector(), np.arange(4, dtype="float64")),
         ),
         (
-            set_test_value(pt.dmatrix(), np.arange(4, dtype="float64").reshape((2, 2))),
-            set_test_value(pt.lscalar(), np.array(4, dtype="int64")),
+            (pt.dmatrix(), np.arange(4, dtype="float64").reshape((2, 2))),
+            (pt.lscalar(), np.array(4, dtype="int64")),
         ),
     ],
 )
 def test_Second(x, y):
+    x, x_test = x
+    y, y_test = y
     # We use the `Elemwise`-wrapped version of `Second`
     g = pt.second(x, y)
-    g_fg = FunctionGraph(outputs=[g])
     compare_numba_and_py(
-        g_fg,
-        [
-            i.tag.test_value
-            for i in g_fg.inputs
-            if not isinstance(i, SharedVariable | Constant)
-        ],
+        [x, y],
+        g,
+        [x_test, y_test],
     )
 
 
 @pytest.mark.parametrize(
     "v, min, max",
     [
-        (set_test_value(pt.scalar(), np.array(10, dtype=config.floatX)), 3.0, 7.0),
-        (set_test_value(pt.scalar(), np.array(1, dtype=config.floatX)), 3.0, 7.0),
-        (set_test_value(pt.scalar(), np.array(10, dtype=config.floatX)), 7.0, 3.0),
+        ((pt.scalar(), np.array(10, dtype=config.floatX)), 3.0, 7.0),
+        ((pt.scalar(), np.array(1, dtype=config.floatX)), 3.0, 7.0),
+        ((pt.scalar(), np.array(10, dtype=config.floatX)), 7.0, 3.0),
     ],
 )
 def test_Clip(v, min, max):
+    v, v_test = v
     g = ps.clip(v, min, max)
-    g_fg = FunctionGraph(outputs=[g])
 
     compare_numba_and_py(
-        g_fg,
-        [
-            i.tag.test_value
-            for i in g_fg.inputs
-            if not isinstance(i, SharedVariable | Constant)
-        ],
+        [v],
+        [g],
+        [v_test],
     )
 
 
@@ -100,46 +92,39 @@ def test_Clip(v, min, max):
 def test_Composite(inputs, input_values, scalar_fn):
     composite_inputs = [ps.ScalarType(config.floatX)(name=i.name) for i in inputs]
     comp_op = Elemwise(Composite(composite_inputs, [scalar_fn(*composite_inputs)]))
-    out_fg = FunctionGraph(inputs, [comp_op(*inputs)])
-    compare_numba_and_py(out_fg, input_values)
+    compare_numba_and_py(inputs, [comp_op(*inputs)], input_values)
 
 
 @pytest.mark.parametrize(
     "v, dtype",
     [
-        (set_test_value(pt.fscalar(), np.array(1.0, dtype="float32")), psb.float64),
-        (set_test_value(pt.dscalar(), np.array(1.0, dtype="float64")), psb.float32),
+        ((pt.fscalar(), np.array(1.0, dtype="float32")), psb.float64),
+        ((pt.dscalar(), np.array(1.0, dtype="float64")), psb.float32),
     ],
 )
 def test_Cast(v, dtype):
+    v, v_test = v
     g = psb.Cast(dtype)(v)
-    g_fg = FunctionGraph(outputs=[g])
     compare_numba_and_py(
-        g_fg,
-        [
-            i.tag.test_value
-            for i in g_fg.inputs
-            if not isinstance(i, SharedVariable | Constant)
-        ],
+        [v],
+        [g],
+        [v_test],
     )
 
 
 @pytest.mark.parametrize(
     "v, dtype",
     [
-        (set_test_value(pt.iscalar(), np.array(10, dtype="int32")), psb.float64),
+        ((pt.iscalar(), np.array(10, dtype="int32")), psb.float64),
     ],
 )
 def test_reciprocal(v, dtype):
+    v, v_test = v
     g = psb.reciprocal(v)
-    g_fg = FunctionGraph(outputs=[g])
     compare_numba_and_py(
-        g_fg,
-        [
-            i.tag.test_value
-            for i in g_fg.inputs
-            if not isinstance(i, SharedVariable | Constant)
-        ],
+        [v],
+        [g],
+        [v_test],
     )
 
 
@@ -156,6 +141,7 @@ def test_isnan(composite):
         out = pt.isnan(x)
 
     compare_numba_and_py(
-        ([x], [out]),
+        [x],
+        [out],
         [np.array([1, 0], dtype="float64")],
     )

--- a/tests/link/numba/test_slinalg.py
+++ b/tests/link/numba/test_slinalg.py
@@ -79,9 +79,9 @@ def test_solve_triangular(b_shape: tuple[int], lower, trans, unit_diag, is_compl
         A_val = A_val + np.random.normal(size=(5, 5)) * 1j
         b_val = b_val + np.random.normal(size=b_shape) * 1j
 
-    X_np = f(A_func(A_val.copy()), b_val.copy())
+    X_np = f(A_func(A_val), b_val)
 
-    test_input = transpose_func(A_func(A_val.copy()), trans)
+    test_input = transpose_func(A_func(A_val), trans)
 
     ATOL = 1e-8 if floatX.endswith("64") else 1e-4
     RTOL = 1e-8 if floatX.endswith("64") else 1e-4
@@ -92,7 +92,7 @@ def test_solve_triangular(b_shape: tuple[int], lower, trans, unit_diag, is_compl
     compare_numba_and_py(
         compiled_fgraph.inputs,
         compiled_fgraph.outputs,
-        [A_func(A_val.copy()), b_val.copy()],
+        [A_func(A_val), b_val],
     )
 
 

--- a/tests/link/numba/test_sparse.py
+++ b/tests/link/numba/test_sparse.py
@@ -100,4 +100,4 @@ def test_sparse_objmode():
         UserWarning,
         match="Numba will use object mode to run SparseDot's perform method",
     ):
-        compare_numba_and_py(((x, y), (out,)), [x_val, y_val])
+        compare_numba_and_py([x, y], out, [x_val, y_val])

--- a/tests/link/pytorch/test_blas.py
+++ b/tests/link/pytorch/test_blas.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 from pytensor.configdefaults import config
-from pytensor.graph.fg import FunctionGraph
 from pytensor.tensor import blas as pt_blas
 from pytensor.tensor.type import tensor3
 from tests.link.pytorch.test_basic import compare_pytorch_and_py
@@ -15,8 +14,8 @@ def test_pytorch_BatchedDot():
     b = tensor3("b")
     b_test = np.linspace(1, -1, 10 * 3 * 2).astype(config.floatX).reshape((10, 3, 2))
     out = pt_blas.BatchedDot()(a, b)
-    fgraph = FunctionGraph([a, b], [out])
-    pytensor_pytorch_fn, _ = compare_pytorch_and_py(fgraph, [a_test, b_test])
+
+    pytensor_pytorch_fn, _ = compare_pytorch_and_py([a, b], [out], [a_test, b_test])
 
     # A dimension mismatch should raise a TypeError for compatibility
     inputs = [a_test[:-1], b_test]

--- a/tests/link/pytorch/test_elemwise.py
+++ b/tests/link/pytorch/test_elemwise.py
@@ -5,7 +5,6 @@ import pytensor
 import pytensor.tensor as pt
 import pytensor.tensor.math as ptm
 from pytensor.configdefaults import config
-from pytensor.graph.fg import FunctionGraph
 from pytensor.scalar.basic import ScalarOp, get_scalar_type
 from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.special import SoftmaxGrad, log_softmax, softmax
@@ -20,17 +19,23 @@ def test_pytorch_Dimshuffle():
     a_pt = matrix("a")
 
     x = a_pt.T
-    x_fg = FunctionGraph([a_pt], [x])
-    compare_pytorch_and_py(x_fg, [np.c_[[1.0, 2.0], [3.0, 4.0]].astype(config.floatX)])
+
+    compare_pytorch_and_py(
+        [a_pt], [x], [np.c_[[1.0, 2.0], [3.0, 4.0]].astype(config.floatX)]
+    )
 
     x = a_pt.dimshuffle([0, 1, "x"])
-    x_fg = FunctionGraph([a_pt], [x])
-    compare_pytorch_and_py(x_fg, [np.c_[[1.0, 2.0], [3.0, 4.0]].astype(config.floatX)])
+
+    compare_pytorch_and_py(
+        [a_pt], [x], [np.c_[[1.0, 2.0], [3.0, 4.0]].astype(config.floatX)]
+    )
 
     a_pt = tensor(dtype=config.floatX, shape=(None, 1))
     x = a_pt.dimshuffle((0,))
-    x_fg = FunctionGraph([a_pt], [x])
-    compare_pytorch_and_py(x_fg, [np.c_[[1.0, 2.0, 3.0, 4.0]].astype(config.floatX)])
+
+    compare_pytorch_and_py(
+        [a_pt], [x], [np.c_[[1.0, 2.0, 3.0, 4.0]].astype(config.floatX)]
+    )
 
 
 def test_multiple_input_output():
@@ -38,24 +43,21 @@ def test_multiple_input_output():
     y = vector("y")
     out = pt.mul(x, y)
 
-    fg = FunctionGraph(outputs=[out], clone=False)
-    compare_pytorch_and_py(fg, [[1.5], [2.5]])
+    compare_pytorch_and_py([x, y], [out], [[1.5], [2.5]])
 
     x = vector("x")
     y = vector("y")
     div = pt.int_div(x, y)
     pt_sum = pt.add(y, x)
 
-    fg = FunctionGraph(outputs=[div, pt_sum], clone=False)
-    compare_pytorch_and_py(fg, [[1.5], [2.5]])
+    compare_pytorch_and_py([x, y], [div, pt_sum], [[1.5], [2.5]])
 
 
 def test_pytorch_elemwise():
     x = pt.vector("x")
     out = pt.log(1 - x)
 
-    fg = FunctionGraph([x], [out])
-    compare_pytorch_and_py(fg, [[0.9, 0.9]])
+    compare_pytorch_and_py([x], [out], [[0.9, 0.9]])
 
 
 @pytest.mark.parametrize("fn", [ptm.sum, ptm.prod, ptm.max, ptm.min])
@@ -81,9 +83,8 @@ def test_pytorch_careduce(fn, axis):
     ).astype(config.floatX)
 
     x = fn(a_pt, axis=axis)
-    x_fg = FunctionGraph([a_pt], [x])
 
-    compare_pytorch_and_py(x_fg, [test_value])
+    compare_pytorch_and_py([a_pt], [x], [test_value])
 
 
 @pytest.mark.parametrize("fn", [ptm.any, ptm.all])
@@ -93,9 +94,8 @@ def test_pytorch_any_all(fn, axis):
     test_value = np.array([[True, False, True], [False, True, True]])
 
     x = fn(a_pt, axis=axis)
-    x_fg = FunctionGraph([a_pt], [x])
 
-    compare_pytorch_and_py(x_fg, [test_value])
+    compare_pytorch_and_py([a_pt], [x], [test_value])
 
 
 @pytest.mark.parametrize("dtype", ["float64", "int64"])
@@ -103,7 +103,6 @@ def test_pytorch_any_all(fn, axis):
 def test_softmax(axis, dtype):
     x = matrix("x", dtype=dtype)
     out = softmax(x, axis=axis)
-    fgraph = FunctionGraph([x], [out])
     test_input = np.arange(6, dtype=config.floatX).reshape(2, 3)
 
     if dtype == "int64":
@@ -111,9 +110,9 @@ def test_softmax(axis, dtype):
             NotImplementedError,
             match="Pytorch Softmax is not currently implemented for non-float types.",
         ):
-            compare_pytorch_and_py(fgraph, [test_input])
+            compare_pytorch_and_py([x], [out], [test_input])
     else:
-        compare_pytorch_and_py(fgraph, [test_input])
+        compare_pytorch_and_py([x], [out], [test_input])
 
 
 @pytest.mark.parametrize("dtype", ["float64", "int64"])
@@ -121,7 +120,6 @@ def test_softmax(axis, dtype):
 def test_logsoftmax(axis, dtype):
     x = matrix("x", dtype=dtype)
     out = log_softmax(x, axis=axis)
-    fgraph = FunctionGraph([x], [out])
     test_input = np.arange(6, dtype=config.floatX).reshape(2, 3)
 
     if dtype == "int64":
@@ -129,9 +127,9 @@ def test_logsoftmax(axis, dtype):
             NotImplementedError,
             match="Pytorch LogSoftmax is not currently implemented for non-float types.",
         ):
-            compare_pytorch_and_py(fgraph, [test_input])
+            compare_pytorch_and_py([x], [out], [test_input])
     else:
-        compare_pytorch_and_py(fgraph, [test_input])
+        compare_pytorch_and_py([x], [out], [test_input])
 
 
 @pytest.mark.parametrize("axis", [None, 0, 1])
@@ -141,16 +139,14 @@ def test_softmax_grad(axis):
     sm = matrix("sm")
     sm_value = np.arange(6, dtype=config.floatX).reshape(2, 3)
     out = SoftmaxGrad(axis=axis)(dy, sm)
-    fgraph = FunctionGraph([dy, sm], [out])
-    compare_pytorch_and_py(fgraph, [dy_value, sm_value])
+    compare_pytorch_and_py([dy, sm], [out], [dy_value, sm_value])
 
 
 def test_cast():
     x = matrix("x", dtype="float32")
     out = pt.cast(x, "int32")
-    fgraph = FunctionGraph([x], [out])
     _, [res] = compare_pytorch_and_py(
-        fgraph, [np.arange(6, dtype="float32").reshape(2, 3)]
+        [x], [out], [np.arange(6, dtype="float32").reshape(2, 3)]
     )
     assert res.dtype == np.int32
 

--- a/tests/link/pytorch/test_extra_ops.py
+++ b/tests/link/pytorch/test_extra_ops.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 import pytensor.tensor as pt
-from pytensor.graph import FunctionGraph
 from tests.link.pytorch.test_basic import compare_pytorch_and_py
 
 
@@ -31,16 +30,14 @@ def test_pytorch_CumOp(axis, dtype):
             out = pt.cumprod(a, axis=axis)
     else:
         out = pt.cumsum(a, axis=axis)
-        # Create a PyTensor `FunctionGraph`
-        fgraph = FunctionGraph([a], [out])
 
-        # Pass the graph and inputs to the testing function
-        compare_pytorch_and_py(fgraph, [test_value])
+        # Pass the inputs and outputs to the testing function
+        compare_pytorch_and_py([a], [out], [test_value])
 
         # For the second mode of CumOp
         out = pt.cumprod(a, axis=axis)
-        fgraph = FunctionGraph([a], [out])
-        compare_pytorch_and_py(fgraph, [test_value])
+
+        compare_pytorch_and_py([a], [out], [test_value])
 
 
 @pytest.mark.parametrize("axis, repeats", [(0, (1, 2, 3)), (1, (3, 3)), (None, 3)])
@@ -50,8 +47,8 @@ def test_pytorch_Repeat(axis, repeats):
     test_value = np.arange(6, dtype="float64").reshape((3, 2))
 
     out = pt.repeat(a, repeats, axis=axis)
-    fgraph = FunctionGraph([a], [out])
-    compare_pytorch_and_py(fgraph, [test_value])
+
+    compare_pytorch_and_py([a], [out], [test_value])
 
 
 @pytest.mark.parametrize("axis", [None, 0, 1])
@@ -63,8 +60,8 @@ def test_pytorch_Unique_axis(axis):
     )
 
     out = pt.unique(a, axis=axis)
-    fgraph = FunctionGraph([a], [out])
-    compare_pytorch_and_py(fgraph, [test_value])
+
+    compare_pytorch_and_py([a], [out], [test_value])
 
 
 @pytest.mark.parametrize("return_inverse", [False, True])
@@ -86,5 +83,7 @@ def test_pytorch_Unique_params(return_index, return_inverse, return_counts):
         return_counts=return_counts,
         axis=0,
     )
-    fgraph = FunctionGraph([a], [out[0] if isinstance(out, list) else out])
-    compare_pytorch_and_py(fgraph, [test_value])
+
+    compare_pytorch_and_py(
+        [a], [out[0] if isinstance(out, list) else out], [test_value]
+    )

--- a/tests/link/pytorch/test_math.py
+++ b/tests/link/pytorch/test_math.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from pytensor.configdefaults import config
-from pytensor.graph.fg import FunctionGraph
 from pytensor.tensor.type import matrix, scalar, vector
 from tests.link.pytorch.test_basic import compare_pytorch_and_py
 
@@ -20,10 +19,12 @@ def test_pytorch_dot():
 
     # 2D * 2D
     out = A.dot(A * alpha) + beta * A
-    fgraph = FunctionGraph([A, alpha, beta], [out])
-    compare_pytorch_and_py(fgraph, [A_test, alpha_test, beta_test])
+
+    compare_pytorch_and_py([A, alpha, beta], [out], [A_test, alpha_test, beta_test])
 
     # 1D * 2D and 1D * 1D
     out = y.dot(alpha * A).dot(x) + beta * y
-    fgraph = FunctionGraph([y, x, A, alpha, beta], [out])
-    compare_pytorch_and_py(fgraph, [y_test, x_test, A_test, alpha_test, beta_test])
+
+    compare_pytorch_and_py(
+        [y, x, A, alpha, beta], [out], [y_test, x_test, A_test, alpha_test, beta_test]
+    )

--- a/tests/link/pytorch/test_shape.py
+++ b/tests/link/pytorch/test_shape.py
@@ -2,7 +2,6 @@ import numpy as np
 
 import pytensor.tensor as pt
 from pytensor.configdefaults import config
-from pytensor.graph.fg import FunctionGraph
 from pytensor.tensor.shape import Shape, Shape_i, Unbroadcast, reshape
 from pytensor.tensor.type import iscalar, vector
 from tests.link.pytorch.test_basic import compare_pytorch_and_py
@@ -11,29 +10,27 @@ from tests.link.pytorch.test_basic import compare_pytorch_and_py
 def test_pytorch_shape_ops():
     x_np = np.zeros((20, 3))
     x = Shape()(pt.as_tensor_variable(x_np))
-    x_fg = FunctionGraph([], [x])
 
-    compare_pytorch_and_py(x_fg, [], must_be_device_array=False)
+    compare_pytorch_and_py([], [x], [])
 
     x = Shape_i(1)(pt.as_tensor_variable(x_np))
-    x_fg = FunctionGraph([], [x])
 
-    compare_pytorch_and_py(x_fg, [], must_be_device_array=False)
+    compare_pytorch_and_py([], [x], [])
 
 
 def test_pytorch_specify_shape():
     in_pt = pt.matrix("in")
     x = pt.specify_shape(in_pt, (4, None))
-    x_fg = FunctionGraph([in_pt], [x])
-    compare_pytorch_and_py(x_fg, [np.ones((4, 5)).astype(config.floatX)])
+    compare_pytorch_and_py([in_pt], [x], [np.ones((4, 5)).astype(config.floatX)])
 
     # When used to assert two arrays have similar shapes
     in_pt = pt.matrix("in")
     shape_pt = pt.matrix("shape")
     x = pt.specify_shape(in_pt, shape_pt.shape)
-    x_fg = FunctionGraph([in_pt, shape_pt], [x])
+
     compare_pytorch_and_py(
-        x_fg,
+        [in_pt, shape_pt],
+        [x],
         [np.ones((4, 5)).astype(config.floatX), np.ones((4, 5)).astype(config.floatX)],
     )
 
@@ -41,21 +38,22 @@ def test_pytorch_specify_shape():
 def test_pytorch_Reshape_constant():
     a = vector("a")
     x = reshape(a, (2, 2))
-    x_fg = FunctionGraph([a], [x])
-    compare_pytorch_and_py(x_fg, [np.r_[1.0, 2.0, 3.0, 4.0].astype(config.floatX)])
+
+    compare_pytorch_and_py([a], [x], [np.r_[1.0, 2.0, 3.0, 4.0].astype(config.floatX)])
 
 
 def test_pytorch_Reshape_dynamic():
     a = vector("a")
     shape_pt = iscalar("b")
     x = reshape(a, (shape_pt, shape_pt))
-    x_fg = FunctionGraph([a, shape_pt], [x])
-    compare_pytorch_and_py(x_fg, [np.r_[1.0, 2.0, 3.0, 4.0].astype(config.floatX), 2])
+
+    compare_pytorch_and_py(
+        [a, shape_pt], [x], [np.r_[1.0, 2.0, 3.0, 4.0].astype(config.floatX), 2]
+    )
 
 
 def test_pytorch_unbroadcast():
     x_np = np.zeros((20, 1, 1))
     x = Unbroadcast(0, 2)(pt.as_tensor_variable(x_np))
-    x_fg = FunctionGraph([], [x])
 
-    compare_pytorch_and_py(x_fg, [])
+    compare_pytorch_and_py([], [x], [])

--- a/tests/link/pytorch/test_sort.py
+++ b/tests/link/pytorch/test_sort.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-from pytensor.graph import FunctionGraph
 from pytensor.tensor import matrix
 from pytensor.tensor.sort import argsort, sort
 from tests.link.pytorch.test_basic import compare_pytorch_and_py
@@ -12,6 +11,5 @@ from tests.link.pytorch.test_basic import compare_pytorch_and_py
 def test_sort(func, axis):
     x = matrix("x", shape=(2, 2), dtype="float64")
     out = func(x, axis=axis)
-    fgraph = FunctionGraph([x], [out])
     arr = np.array([[1.0, 4.0], [5.0, 2.0]])
-    compare_pytorch_and_py(fgraph, [arr])
+    compare_pytorch_and_py([x], [out], [arr])

--- a/tests/link/pytorch/test_subtensor.py
+++ b/tests/link/pytorch/test_subtensor.py
@@ -6,7 +6,6 @@ import pytest
 import pytensor.scalar as ps
 import pytensor.tensor as pt
 from pytensor.configdefaults import config
-from pytensor.graph.fg import FunctionGraph
 from pytensor.tensor import inc_subtensor, set_subtensor
 from pytensor.tensor import subtensor as pt_subtensor
 from tests.link.pytorch.test_basic import compare_pytorch_and_py
@@ -19,38 +18,33 @@ def test_pytorch_Subtensor():
 
     out_pt = x_pt[1, 2, 0]
     assert isinstance(out_pt.owner.op, pt_subtensor.Subtensor)
-    out_fg = FunctionGraph([x_pt], [out_pt])
-    compare_pytorch_and_py(out_fg, [x_np])
+
+    compare_pytorch_and_py([x_pt], [out_pt], [x_np])
 
     out_pt = x_pt[1:, 1, :]
     assert isinstance(out_pt.owner.op, pt_subtensor.Subtensor)
-    out_fg = FunctionGraph([x_pt], [out_pt])
-    compare_pytorch_and_py(out_fg, [x_np])
+    compare_pytorch_and_py([x_pt], [out_pt], [x_np])
 
     out_pt = x_pt[:2, 1, :]
     assert isinstance(out_pt.owner.op, pt_subtensor.Subtensor)
-    out_fg = FunctionGraph([x_pt], [out_pt])
-    compare_pytorch_and_py(out_fg, [x_np])
+    compare_pytorch_and_py([x_pt], [out_pt], [x_np])
 
     out_pt = x_pt[1:2, 1, :]
     assert isinstance(out_pt.owner.op, pt_subtensor.Subtensor)
-    out_fg = FunctionGraph([x_pt], [out_pt])
-    compare_pytorch_and_py(out_fg, [x_np])
+    compare_pytorch_and_py([x_pt], [out_pt], [x_np])
 
     # symbolic index
     a_pt = ps.int64("a")
     a_np = 1
     out_pt = x_pt[a_pt, 2, a_pt:2]
     assert isinstance(out_pt.owner.op, pt_subtensor.Subtensor)
-    out_fg = FunctionGraph([x_pt, a_pt], [out_pt])
-    compare_pytorch_and_py(out_fg, [x_np, a_np])
+    compare_pytorch_and_py([x_pt, a_pt], [out_pt], [x_np, a_np])
 
     with pytest.raises(
         NotImplementedError, match="Negative step sizes are not supported in Pytorch"
     ):
         out_pt = x_pt[::-1]
-        out_fg = FunctionGraph([x_pt], [out_pt])
-        compare_pytorch_and_py(out_fg, [x_np])
+        compare_pytorch_and_py([x_pt], [out_pt], [x_np])
 
 
 def test_pytorch_AdvSubtensor():
@@ -60,52 +54,43 @@ def test_pytorch_AdvSubtensor():
 
     out_pt = pt_subtensor.advanced_subtensor1(x_pt, [1, 2])
     assert isinstance(out_pt.owner.op, pt_subtensor.AdvancedSubtensor1)
-    out_fg = FunctionGraph([x_pt], [out_pt])
-    compare_pytorch_and_py(out_fg, [x_np])
+    compare_pytorch_and_py([x_pt], [out_pt], [x_np])
 
     out_pt = x_pt[[1, 2], [2, 3]]
     assert isinstance(out_pt.owner.op, pt_subtensor.AdvancedSubtensor)
-    out_fg = FunctionGraph([x_pt], [out_pt])
-    compare_pytorch_and_py(out_fg, [x_np])
+    compare_pytorch_and_py([x_pt], [out_pt], [x_np])
 
     out_pt = x_pt[[1, 2], 1:]
     assert isinstance(out_pt.owner.op, pt_subtensor.AdvancedSubtensor)
-    out_fg = FunctionGraph([x_pt], [out_pt])
-    compare_pytorch_and_py(out_fg, [x_np])
+    compare_pytorch_and_py([x_pt], [out_pt], [x_np])
 
     out_pt = x_pt[[1, 2], :, [3, 4]]
     assert isinstance(out_pt.owner.op, pt_subtensor.AdvancedSubtensor)
-    out_fg = FunctionGraph([x_pt], [out_pt])
-    compare_pytorch_and_py(out_fg, [x_np])
+    compare_pytorch_and_py([x_pt], [out_pt], [x_np])
 
     out_pt = x_pt[[1, 2], None]
-    out_fg = FunctionGraph([x_pt], [out_pt])
-    compare_pytorch_and_py(out_fg, [x_np])
+    compare_pytorch_and_py([x_pt], [out_pt], [x_np])
 
     a_pt = ps.int64("a")
     a_np = 2
     out_pt = x_pt[[1, a_pt], a_pt]
-    out_fg = FunctionGraph([x_pt, a_pt], [out_pt])
-    compare_pytorch_and_py(out_fg, [x_np, a_np])
+    compare_pytorch_and_py([x_pt, a_pt], [out_pt], [x_np, a_np])
 
     # boolean indices
     out_pt = x_pt[np.random.binomial(1, 0.5, size=(3, 4, 5)).astype(bool)]
-    out_fg = FunctionGraph([x_pt], [out_pt])
-    compare_pytorch_and_py(out_fg, [x_np])
+    compare_pytorch_and_py([x_pt], [out_pt], [x_np])
 
     a_pt = pt.tensor3("a", dtype="bool")
     a_np = np.random.binomial(1, 0.5, size=(3, 4, 5)).astype(bool)
     out_pt = x_pt[a_pt]
-    out_fg = FunctionGraph([x_pt, a_pt], [out_pt])
-    compare_pytorch_and_py(out_fg, [x_np, a_np])
+    compare_pytorch_and_py([x_pt, a_pt], [out_pt], [x_np, a_np])
 
     with pytest.raises(
         NotImplementedError, match="Negative step sizes are not supported in Pytorch"
     ):
         out_pt = x_pt[[1, 2], ::-1]
-        out_fg = FunctionGraph([x_pt], [out_pt])
         assert isinstance(out_pt.owner.op, pt_subtensor.AdvancedSubtensor)
-        compare_pytorch_and_py(out_fg, [x_np])
+        compare_pytorch_and_py([x_pt], [out_pt], [x_np])
 
 
 @pytest.mark.parametrize("subtensor_op", [set_subtensor, inc_subtensor])
@@ -116,20 +101,17 @@ def test_pytorch_IncSubtensor(subtensor_op):
     st_pt = pt.as_tensor_variable(np.array(-10.0, dtype=config.floatX))
     out_pt = subtensor_op(x_pt[1, 2, 3], st_pt)
     assert isinstance(out_pt.owner.op, pt_subtensor.IncSubtensor)
-    out_fg = FunctionGraph([x_pt], [out_pt])
-    compare_pytorch_and_py(out_fg, [x_test])
+    compare_pytorch_and_py([x_pt], [out_pt], [x_test])
 
     # Test different type update
     st_pt = pt.as_tensor_variable(np.r_[-1.0, 0.0].astype("float32"))
     out_pt = subtensor_op(x_pt[:2, 0, 0], st_pt)
     assert isinstance(out_pt.owner.op, pt_subtensor.IncSubtensor)
-    out_fg = FunctionGraph([x_pt], [out_pt])
-    compare_pytorch_and_py(out_fg, [x_test])
+    compare_pytorch_and_py([x_pt], [out_pt], [x_test])
 
     out_pt = subtensor_op(x_pt[0, 1:3, 0], st_pt)
     assert isinstance(out_pt.owner.op, pt_subtensor.IncSubtensor)
-    out_fg = FunctionGraph([x_pt], [out_pt])
-    compare_pytorch_and_py(out_fg, [x_test])
+    compare_pytorch_and_py([x_pt], [out_pt], [x_test])
 
 
 def inc_subtensor_ignore_duplicates(x, y):
@@ -150,14 +132,12 @@ def test_pytorch_AvdancedIncSubtensor(advsubtensor_op):
     )
     out_pt = advsubtensor_op(x_pt[np.r_[0, 2]], st_pt)
     assert isinstance(out_pt.owner.op, pt_subtensor.AdvancedIncSubtensor)
-    out_fg = FunctionGraph([x_pt], [out_pt])
-    compare_pytorch_and_py(out_fg, [x_test])
+    compare_pytorch_and_py([x_pt], [out_pt], [x_test])
 
     # Repeated indices
     out_pt = advsubtensor_op(x_pt[np.r_[0, 0]], st_pt)
     assert isinstance(out_pt.owner.op, pt_subtensor.AdvancedIncSubtensor)
-    out_fg = FunctionGraph([x_pt], [out_pt])
-    compare_pytorch_and_py(out_fg, [x_test])
+    compare_pytorch_and_py([x_pt], [out_pt], [x_test])
 
     # Mixing advanced and basic indexing
     if advsubtensor_op is inc_subtensor:
@@ -168,19 +148,16 @@ def test_pytorch_AvdancedIncSubtensor(advsubtensor_op):
     st_pt = pt.as_tensor_variable(x_test[[0, 2], 0, :3])
     out_pt = advsubtensor_op(x_pt[[0, 0], 0, :3], st_pt)
     assert isinstance(out_pt.owner.op, pt_subtensor.AdvancedIncSubtensor)
-    out_fg = FunctionGraph([x_pt], [out_pt])
     with expectation:
-        compare_pytorch_and_py(out_fg, [x_test])
+        compare_pytorch_and_py([x_pt], [out_pt], [x_test])
 
     # Test different dtype update
     st_pt = pt.as_tensor_variable(np.r_[-1.0, 0.0].astype("float32"))
     out_pt = advsubtensor_op(x_pt[[0, 2], 0, 0], st_pt)
     assert isinstance(out_pt.owner.op, pt_subtensor.AdvancedIncSubtensor)
-    out_fg = FunctionGraph([x_pt], [out_pt])
-    compare_pytorch_and_py(out_fg, [x_test])
+    compare_pytorch_and_py([x_pt], [out_pt], [x_test])
 
     # Boolean indices
     out_pt = advsubtensor_op(x_pt[x_pt > 5], 1.0)
     assert isinstance(out_pt.owner.op, pt_subtensor.AdvancedIncSubtensor)
-    out_fg = FunctionGraph([x_pt], [out_pt])
-    compare_pytorch_and_py(out_fg, [x_test])
+    compare_pytorch_and_py([x_pt], [out_pt], [x_test])

--- a/tests/tensor/test_extra_ops.py
+++ b/tests/tensor/test_extra_ops.py
@@ -63,11 +63,6 @@ from pytensor.utils import LOCAL_BITWIDTH, PYTHON_INT_BITWIDTH
 from tests import unittest_tools as utt
 
 
-def set_test_value(x, v):
-    x.tag.test_value = v
-    return x
-
-
 def test_cpu_contiguous():
     a = fmatrix("a")
     i = iscalar("i")


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
Removes the FunctionGraph mechanism of taking inputs and outputs and instead takes them directly in compare_py_and_x  . Remove the setting getting of test_values into variables  in compare_py_and_x and instead passes them directly to the function.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1022 
- [x] Related to #1022

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1107.org.readthedocs.build/en/1107/

<!-- readthedocs-preview pytensor end -->