### PR TITLE
Support multidimensional boolean set/inc_subtensor in Numba via rewrite

### DIFF
--- a/pytensor/tensor/subtensor.py
+++ b/pytensor/tensor/subtensor.py
@@ -1456,11 +1456,8 @@ def inc_subtensor(
         views; if they overlap, the result of this `Op` will generally be
         incorrect. This value has no effect if ``inplace=False``.
     ignore_duplicates
-        This determines whether or not ``x[indices] += y`` is used or
-        ``np.add.at(x, indices, y)``.  When the special duplicates handling of
-        ``np.add.at`` isn't required, setting this option to ``True``
-        (i.e. using ``x[indices] += y``) can resulting in faster compiled
-        graphs.
+        This determines whether ``x[indices] += y`` is used or
+        ``np.add.at(x, indices, y)``.
 
     Examples
     --------


### PR DESCRIPTION
Follow up to #818

It's simple to support multidimensional boolean set_subtensor. The corresponding integer indexing would be slightly trickier because it requires reshaping y as well.

Although there are still cases that are not covered outside of object mode (np.newaxis, non-contiguous adv index, broadcasted integer indexing, mixed boolean/integer indexing) I think it's fine to close #772. Efforts can be directed on a per-need basis. Numpy indexing is just too wild :)

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1108.org.readthedocs.build/en/1108/

<!-- readthedocs-preview pytensor end -->