### PR TITLE
Implement `@as_jax_op` to wrap a JAX function for use in PyTensor

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -36,6 +36,7 @@ intersphinx_mapping = {
     "jax": ("https://jax.readthedocs.io/en/latest", None),
     "numpy": ("https://numpy.org/doc/stable", None),
     "torch": ("https://pytorch.org/docs/stable", None),
+    "equinox": ("https://docs.kidger.site/equinox/", None),
 }
 
 needs_sphinx = "3"

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -24,4 +24,4 @@ dependencies:
   - pip
   - pip:
     - sphinx_sitemap
-    - -e ..
+    - -e ..[jax]

--- a/doc/library/index.rst
+++ b/doc/library/index.rst
@@ -63,6 +63,13 @@ Convert to Variable
 
 .. autofunction:: pytensor.as_symbolic(...)
 
+Wrap JAX functions
+==================
+
+.. autofunction:: as_jax_op(...)
+
+   Alias for :func:`pytensor.link.jax.ops.as_jax_op`
+
 Debug
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ tests = [
     "pytest-sphinx",
 ]
 rtd = ["sphinx>=5.1.0,<6", "pygments", "pydot", "pydot2", "pydot-ng"]
-jax = ["jax", "jaxlib"]
+jax = ["jax", "jaxlib", "equinox"]
 numba = ["numba>=0.57", "llvmlite"]
 
 [tool.setuptools.packages.find]

--- a/pytensor/__init__.py
+++ b/pytensor/__init__.py
@@ -167,6 +167,18 @@ from pytensor.scan.basic import scan
 from pytensor.scan.views import foldl, foldr, map, reduce
 from pytensor.compile.builders import OpFromGraph
 
+try:
+    import pytensor.link.jax.ops
+    from pytensor.link.jax.ops import as_jax_op
+except ImportError as e:
+    import_error_as_jax_op = e
+
+    def as_jax_op(*args, **kwargs):
+        raise ImportError(
+            "JAX and/or equinox are not installed. Install them"
+            " to use this function: pip install pytensor[jax]"
+        ) from import_error_as_jax_op
+
 # isort: on
 
 

--- a/pytensor/link/jax/ops.py
+++ b/pytensor/link/jax/ops.py
@@ -1,0 +1,424 @@
+"""Convert a jax function to a pytensor compatible function."""
+
+import functools as ft
+import logging
+from collections.abc import Sequence
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.tree_util import tree_flatten, tree_map, tree_unflatten
+
+import pytensor.compile.builders
+import pytensor.tensor as pt
+from pytensor.gradient import DisconnectedType
+from pytensor.graph import Apply, Op
+from pytensor.link.jax.dispatch import jax_funcify
+
+
+log = logging.getLogger(__name__)
+
+
+def _filter_ptvars(x):
+    return isinstance(x, pt.Variable)
+
+
+def as_jax_op(jaxfunc, name=None):
+    """Return a Pytensor from a JAX jittable function.
+
+    This decorator transforms any JAX jittable function into a function that accepts
+    and returns `pytensor.Variables`. The jax jittable function can accept any
+    nested python structure (pytrees) as input, and return any nested Python structure.
+
+    It requires to define the output types of the returned values as pytensor types. A
+    unique name should also be passed in case the name of the jaxfunc is identical to
+    some other node. The design of this function is based on
+    https://www.pymc-labs.io/blog-posts/jax-functions-in-pymc-3-quick-examples/
+
+    Parameters
+    ----------
+    jaxfunc : jax jittable function
+        function for which the node is created, can return multiple tensors as a tuple.
+        It is required that all return values are able to transformed to
+        pytensor.Variable.
+    name: str
+        Name of the created pytensor Op, defaults to the name of the passed function.
+        Only used internally in the pytensor graph.
+
+    Returns
+    -------
+        A function which can be used in a pymc.Model as function, is differentiable
+        and the resulting model can be compiled either with the default C backend, or
+        the JAX backend.
+
+
+    Notes
+    -----
+    The function is based on a blog post by Ricardo Vieira and Adrian Seyboldt,
+    available at
+    `pymc-labls.io <https://www.pymc-labs.io/blog-posts/jax-functions-in-pymc-3-quick
+    -examples/>`__.
+    To accept functions and non pytensor variables as input, the function make use
+    of :func:`equinox.partition` and :func:`equinox.combine` to split and combine the
+    variables. Shapes are inferred using
+    :func:`pytensor.compile.builders.infer_shape` and :func:`jax.eval_shape`.
+    """
+
+    def func(*args, **kwargs):
+        """Return a pytensor from a jax jittable function."""
+        ### Split variables: in the ones that will be transformed to JAX inputs,
+        ### pytensor.Variables; _WrappedFunc, that are functions that have been returned
+        ### from a transformed function; and the rest, static variables that are not
+        ### transformed.
+
+        pt_vars, static_vars_tmp = eqx.partition(
+            (args, kwargs), _filter_ptvars, is_leaf=callable
+        )
+        # is_leaf=callable is used, as libraries like diffrax or equinox might return
+        # functions that are still seen as a nested pytree structure. We consider them
+        # as wrappable functions, that will be wrapped with _WrappedFunc.
+
+        func_vars, static_vars = eqx.partition(
+            static_vars_tmp, lambda x: isinstance(x, _WrappedFunc), is_leaf=callable
+        )
+        vars_from_func = tree_map(lambda x: x.get_vars(), func_vars)
+        pt_vars = dict(vars=pt_vars, vars_from_func=vars_from_func)
+        """
+        def func_unwrapped(vars_all, static_vars):
+            vars, vars_from_func = vars_all["vars"], vars_all["vars_from_func"]
+            func_vars_evaled = tree_map(
+                lambda x, y: x.get_func_with_vars(y), func_vars, vars_from_func
+            )
+            args, kwargs = eqx.combine(vars, static_vars, func_vars_evaled)
+            return self.jaxfunc(*args, **kwargs)
+        """
+
+        pt_vars_flat, vars_treedef = tree_flatten(pt_vars)
+        pt_vars_types_flat = [var.type for var in pt_vars_flat]
+        shapes_vars_flat = pytensor.compile.builders.infer_shape(pt_vars_flat, (), ())
+        shapes_vars = tree_unflatten(vars_treedef, shapes_vars_flat)
+
+        dummy_inputs_jax = jax.tree_util.tree_map(
+            lambda var, shape: jnp.empty(
+                [int(dim.eval()) for dim in shape], dtype=var.type.dtype
+            ),
+            pt_vars,
+            shapes_vars,
+        )
+
+        # Combine the static variables with the inputs, and split them again in the
+        # output. Static variables don't take part in the graph, or might be a
+        # a function that is returned.
+        jaxfunc_partitioned, static_out_dic = _partition_jaxfunc(
+            jaxfunc, static_vars, func_vars
+        )
+
+        func_flattened = _flatten_func(jaxfunc_partitioned, vars_treedef)
+
+        jaxtypes_outvars = jax.eval_shape(
+            ft.partial(jaxfunc_partitioned, vars=dummy_inputs_jax),
+        )
+
+        jaxtypes_outvars_flat, outvars_treedef = tree_flatten(jaxtypes_outvars)
+
+        pttypes_outvars = [
+            pt.TensorType(dtype=var.dtype, shape=var.shape)
+            for var in jaxtypes_outvars_flat
+        ]
+
+        ### Call the function that accepts flat inputs, which in turn calls the one that
+        ### combines the inputs and static variables.
+        jitted_sol_op_jax = jax.jit(func_flattened)
+        len_gz = len(pttypes_outvars)
+
+        vjp_sol_op_jax = _get_vjp_sol_op_jax(func_flattened, len_gz)
+        jitted_vjp_sol_op_jax = jax.jit(vjp_sol_op_jax)
+
+        if name is None:
+            curr_name = jaxfunc.__name__
+        else:
+            curr_name = name
+
+        # Get classes that creates a Pytensor Op out of our function that accept
+        # flattened inputs. They are created each time, to set a custom name for the
+        # class.
+        SolOp, VJPSolOp = _return_pytensor_ops_classes(curr_name)
+
+        local_op = SolOp(
+            vars_treedef,
+            outvars_treedef,
+            input_types=pt_vars_types_flat,
+            output_types=pttypes_outvars,
+            jitted_sol_op_jax=jitted_sol_op_jax,
+            jitted_vjp_sol_op_jax=jitted_vjp_sol_op_jax,
+        )
+
+        @jax_funcify.register(SolOp)
+        def sol_op_jax_funcify(op, **kwargs):
+            return local_op.perform_jax
+
+        @jax_funcify.register(VJPSolOp)
+        def vjp_sol_op_jax_funcify(op, **kwargs):
+            return local_op.vjp_sol_op.perform_jax
+
+        ### Evaluate the Pytensor Op and return unflattened results
+        output_flat = local_op(*pt_vars_flat)
+        if not isinstance(output_flat, Sequence):
+            output_flat = [output_flat]  # tree_unflatten expects a sequence.
+        outvars = tree_unflatten(outvars_treedef, output_flat)
+
+        static_outfuncs, static_outvars = eqx.partition(
+            static_out_dic["out"], callable, is_leaf=callable
+        )
+
+        static_outfuncs_flat, treedef_outfuncs = jax.tree_util.tree_flatten(
+            static_outfuncs, is_leaf=callable
+        )
+        for i_func, _ in enumerate(static_outfuncs_flat):
+            static_outfuncs_flat[i_func] = _WrappedFunc(
+                jaxfunc, i_func, *args, **kwargs
+            )
+
+        static_outfuncs = jax.tree_util.tree_unflatten(
+            treedef_outfuncs, static_outfuncs_flat
+        )
+        static_vars = eqx.combine(static_outfuncs, static_outvars, is_leaf=callable)
+
+        output = eqx.combine(outvars, static_vars, is_leaf=callable)
+
+        return output
+
+    return func
+
+
+class _WrappedFunc:
+    def __init__(self, exterior_func, i_func, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.i_func = i_func
+        vars, static_vars = eqx.partition(
+            (self.args, self.kwargs), _filter_ptvars, is_leaf=callable
+        )
+        self.vars = vars
+        self.static_vars = static_vars
+        self.exterior_func = exterior_func
+
+    def __call__(self, *args, **kwargs):
+        # If called, assume that args and kwargs are pytensors, so return the result
+        # as pytensors.
+        def f(func, *args, **kwargs):
+            res = func(*args, **kwargs)
+            return res
+
+        return as_jax_op(f)(self, *args, **kwargs)
+
+    def get_vars(self):
+        return self.vars
+
+    def get_func_with_vars(self, vars):
+        # Use other variables than the saved ones, to generate the function. This
+        # is used to transform vars externally from pytensor to JAX, and use the
+        # then create the function which is returned.
+
+        args, kwargs = eqx.combine(vars, self.static_vars, is_leaf=callable)
+        output = self.exterior_func(*args, **kwargs)
+        outfuncs, _ = eqx.partition(output, callable, is_leaf=callable)
+        outfuncs_flat, _ = jax.tree_util.tree_flatten(outfuncs, is_leaf=callable)
+        interior_func = outfuncs_flat[self.i_func]
+        return interior_func
+
+
+def _get_vjp_sol_op_jax(jaxfunc, len_gz):
+    def vjp_sol_op_jax(args):
+        y0 = args[:-len_gz]
+        gz = args[-len_gz:]
+        if len(gz) == 1:
+            gz = gz[0]
+
+        def func(*inputs):
+            return jaxfunc(inputs)
+
+        primals, vjp_fn = jax.vjp(func, *y0)
+        gz = tree_map(
+            lambda g, primal: jnp.broadcast_to(g, jnp.shape(primal)),
+            gz,
+            primals,
+        )
+        if len(y0) == 1:
+            return vjp_fn(gz)[0]
+        else:
+            return tuple(vjp_fn(gz))
+
+    return vjp_sol_op_jax
+
+
+def _partition_jaxfunc(jaxfunc, static_vars, func_vars):
+    """Partition the jax function into static and non-static variables.
+
+    Returns a function that accepts only non-static variables and returns the non-static
+    variables. The returned static variables are stored in a dictionary and returned,
+    to allow the referencing after creating the function
+
+    Additionally wrapped functions saved in func_vars are regenerated with
+    vars["vars_from_func"] as input, to allow the transformation of the variables.
+    """
+    static_out_dic = {"out": None}
+
+    def jaxfunc_partitioned(vars):
+        vars, vars_from_func = vars["vars"], vars["vars_from_func"]
+        func_vars_evaled = tree_map(
+            lambda x, y: x.get_func_with_vars(y), func_vars, vars_from_func
+        )
+        args, kwargs = eqx.combine(
+            vars, static_vars, func_vars_evaled, is_leaf=callable
+        )
+
+        out = jaxfunc(*args, **kwargs)
+        outvars, static_out = eqx.partition(out, eqx.is_array, is_leaf=callable)
+        static_out_dic["out"] = static_out
+        return outvars
+
+    return jaxfunc_partitioned, static_out_dic
+
+
+### Construct the function that accepts flat inputs and returns flat outputs.
+def _flatten_func(jaxfunc, vars_treedef):
+    def func_flattened(vars_flat):
+        vars = tree_unflatten(vars_treedef, vars_flat)
+        outvars = jaxfunc(vars)
+        outvars_flat, _ = tree_flatten(outvars)
+        return _normalize_flat_output(outvars_flat)
+
+    return func_flattened
+
+
+def _normalize_flat_output(output):
+    if len(output) > 1:
+        return tuple(
+            output
+        )  # Transform to tuple because jax makes a difference between
+        # tuple and list and not pytensor
+    else:
+        return output[0]
+
+
+def _return_pytensor_ops_classes(name):
+    class SolOp(Op):
+        def __init__(
+            self,
+            input_treedef,
+            output_treeedef,
+            input_types,
+            output_types,
+            jitted_sol_op_jax,
+            jitted_vjp_sol_op_jax,
+        ):
+            self.vjp_sol_op = None
+            self.input_treedef = input_treedef
+            self.output_treedef = output_treeedef
+            self.input_types = input_types
+            self.output_types = output_types
+            self.jitted_sol_op_jax = jitted_sol_op_jax
+            self.jitted_vjp_sol_op_jax = jitted_vjp_sol_op_jax
+
+        def make_node(self, *inputs):
+            self.num_inputs = len(inputs)
+
+            # Define our output variables
+            outputs = [pt.as_tensor_variable(type()) for type in self.output_types]
+            self.num_outputs = len(outputs)
+
+            self.vjp_sol_op = VJPSolOp(
+                self.input_treedef,
+                self.input_types,
+                self.jitted_vjp_sol_op_jax,
+            )
+
+            return Apply(self, inputs, outputs)
+
+        def perform(self, node, inputs, outputs):
+            results = self.jitted_sol_op_jax(inputs)
+            if self.num_outputs > 1:
+                for i in range(self.num_outputs):
+                    outputs[i][0] = np.array(results[i], self.output_types[i].dtype)
+            else:
+                outputs[0][0] = np.array(results, self.output_types[0].dtype)
+
+        def perform_jax(self, *inputs):
+            results = self.jitted_sol_op_jax(inputs)
+            return results
+
+        def grad(self, inputs, output_gradients):
+            # If a output is not used, it is disconnected and doesn't have a gradient.
+            # Set gradient here to zero for those outputs.
+            for i in range(self.num_outputs):
+                if isinstance(output_gradients[i].type, DisconnectedType):
+                    if None not in self.output_types[i].shape:
+                        output_gradients[i] = pt.zeros(
+                            self.output_types[i].shape, self.output_types[i].dtype
+                        )
+                    else:
+                        output_gradients[i] = pt.zeros((), self.output_types[i].dtype)
+            result = self.vjp_sol_op(inputs, output_gradients)
+
+            if self.num_inputs > 1:
+                return result
+            else:
+                return (result,)  # Pytensor requires a tuple here
+
+    # vector-jacobian product Op
+    class VJPSolOp(Op):
+        def __init__(
+            self,
+            input_treedef,
+            input_types,
+            jitted_vjp_sol_op_jax,
+        ):
+            self.input_treedef = input_treedef
+            self.input_types = input_types
+            self.jitted_vjp_sol_op_jax = jitted_vjp_sol_op_jax
+
+        def make_node(self, y0, gz):
+            y0 = [
+                pt.as_tensor_variable(
+                    _y,
+                ).astype(self.input_types[i].dtype)
+                for i, _y in enumerate(y0)
+            ]
+            gz_not_disconntected = [
+                pt.as_tensor_variable(_gz)
+                for _gz in gz
+                if not isinstance(_gz.type, DisconnectedType)
+            ]
+            outputs = [in_type() for in_type in self.input_types]
+            self.num_outputs = len(outputs)
+            return Apply(self, y0 + gz_not_disconntected, outputs)
+
+        def perform(self, node, inputs, outputs):
+            results = self.jitted_vjp_sol_op_jax(tuple(inputs))
+            if len(self.input_types) > 1:
+                for i, result in enumerate(results):
+                    outputs[i][0] = np.array(result, self.input_types[i].dtype)
+            else:
+                outputs[0][0] = np.array(results, self.input_types[0].dtype)
+
+        def perform_jax(self, *inputs):
+            results = self.jitted_vjp_sol_op_jax(tuple(inputs))
+            if self.num_outputs == 1:
+                if isinstance(results, Sequence):
+                    return results[0]
+                else:
+                    return results
+            else:
+                return tuple(results)
+
+    SolOp.__name__ = name
+    SolOp.__qualname__ = ".".join(SolOp.__qualname__.split(".")[:-1] + [name])
+
+    VJPSolOp.__name__ = "VJP_" + name
+    VJPSolOp.__qualname__ = ".".join(
+        VJPSolOp.__qualname__.split(".")[:-1] + ["VJP_" + name]
+    )
+
+    return SolOp, VJPSolOp

--- a/pytensor/link/jax/ops.py
+++ b/pytensor/link/jax/ops.py
@@ -25,32 +25,29 @@ def _filter_ptvars(x):
 
 
 def as_jax_op(jaxfunc, name=None):
-    """Return a Pytensor from a JAX jittable function.
+    """Return a Pytensor function from a JAX jittable function.
 
-    This decorator transforms any JAX jittable function into a function that accepts
-    and returns `pytensor.Variables`. The jax jittable function can accept any
-    nested python structure (pytrees) as input, and return any nested Python structure.
-
-    It requires to define the output types of the returned values as pytensor types. A
-    unique name should also be passed in case the name of the jaxfunc is identical to
-    some other node. The design of this function is based on
-    https://www.pymc-labs.io/blog-posts/jax-functions-in-pymc-3-quick-examples/
+    This decorator transforms any JAX-jittable function into a function that accepts
+    and returns `pytensor.Variable`. The JAX-jittable function can accept any
+    nested python structure (a `Pytree
+    <https://jax.readthedocs.io/en/latest/pytrees.html>`_) as input, and might return
+    any nested Python structure.
 
     Parameters
     ----------
-    jaxfunc : jax jittable function
-        function for which the node is created, can return multiple tensors as a tuple.
-        It is required that all return values are able to transformed to
-        pytensor.Variable.
-    name: str
+    jaxfunc : JAX-jittable function
+        JAX function which will be wrapped in a Pytensor Op.
+    name: str, optional
         Name of the created pytensor Op, defaults to the name of the passed function.
         Only used internally in the pytensor graph.
 
     Returns
     -------
-        A function which can be used in a pymc.Model as function, is differentiable
-        and the resulting model can be compiled either with the default C backend, or
-        the JAX backend.
+    Callable :
+        A function which expects a nested python structure of `pytensor.Variable` and
+        static variables as inputs and returns `pytensor.Variable` with the same
+        API as the original jaxfunc. The resulting model can be compiled either with the
+        default C backend or the JAX backend.
 
 
     Notes

--- a/pytensor/link/jax/ops.py
+++ b/pytensor/link/jax/ops.py
@@ -1,6 +1,5 @@
 """Convert a jax function to a pytensor compatible function."""
 
-import functools as ft
 import logging
 from collections.abc import Sequence
 
@@ -20,62 +19,242 @@ from pytensor.link.jax.dispatch import jax_funcify
 log = logging.getLogger(__name__)
 
 
-def _filter_ptvars(x):
-    return isinstance(x, pt.Variable)
+class JAXOp(Op):
+    """
+    JAXOp is a PyTensor Op that wraps a JAX function, providing both forward computation and reverse-mode differentiation (via the VJPJAXOp class).
+
+    Parameters
+    ----------
+    input_types : list
+        A list of PyTensor types for each input variable.
+    output_types : list
+        A list of PyTensor types for each output variable.
+    flat_func : callable
+        The JAX function that computes outputs from inputs. Inputs and outputs have to be provided as flat arrays.
+    name : str, optional
+        A custom name for the Op instance. If provided, the class name will be
+        updated accordingly.
+
+    Example
+    -------
+    This example defines a simple function that sums the input array with a dynamic shape.
+
+    >>> import numpy as np
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from pytensor.tensor import TensorType
+    >>>
+    >>> # Create the jax function that sums the input array.
+    >>> def sum_function(x, y):
+    ...     return jnp.sum(x + y)
+    >>>
+    >>> # Create the input and output types, input has a dynamic shape.
+    >>> input_type = TensorType("float32", shape=(None,))
+    >>> output_type = TensorType("float32", shape=(1,))
+    >>>
+    >>> # Instantiate a JAXOp; tree definitions are set to None for simplicity.
+    >>> op = JAXOp(
+    ...     [input_type, input_type], [output_type], sum_function, name="DummyJAXOp"
+    ... )
+    >>> # Define symbolic input variables.
+    >>> x = pt.tensor("x", dtype="float32", shape=(2,))
+    >>> y = pt.tensor("y", dtype="float32", shape=(2,))
+    >>> # Compile a PyTensor function.
+    >>> result = op(x, y)
+    >>> f = pytensor.function([x, y], [result])
+    >>> print(
+    ...     f(
+    ...         np.array([2.0, 3.0], dtype=np.float32),
+    ...         np.array([4.0, 5.0], dtype=np.float32),
+    ...     )
+    ... )
+    [array(14., dtype=float32)]
+    >>>
+    >>> # Compute the gradient of op(x, y) with respect to x.
+    >>> g = pt.grad(result[0], x)
+    >>> grad_f = pytensor.function([x, y], [g])
+    >>> print(
+    ...     grad_f(
+    ...         np.array([2.0, 3.0], dtype=np.float32),
+    ...         np.array([4.0, 5.0], dtype=np.float32),
+    ...     )
+    ... )
+    [array([1., 1.], dtype=float32)]
+    """
+
+    def __init__(self, input_types, output_types, flat_func, name=None):
+        self.input_types = input_types
+        self.output_types = output_types
+        self.num_inputs = len(input_types)
+        self.num_outputs = len(output_types)
+        normalized_flat_func = _normalize_flat_func(flat_func)
+        self.jitted_func = jax.jit(normalized_flat_func)
+
+        vjp_func = _get_vjp_jax_op(normalized_flat_func, len(output_types))
+        normalized_vjp_func = _normalize_flat_func(vjp_func)
+        self.jitted_vjp = jax.jit(normalized_vjp_func)
+        self.vjp_jax_op = VJPJAXOp(
+            self.input_types,
+            self.jitted_vjp,
+            name=("VJP" + name) if name is not None else None,
+        )
+
+        if name is not None:
+            self.custom_name = name
+            self.__class__.__name__ = name
+            self.__class__.__qualname__ = ".".join(
+                self.__class__.__qualname__.split(".")[:-1] + [name]
+            )
+
+    def make_node(self, *inputs):
+        outputs = [pt.as_tensor_variable(typ()) for typ in self.output_types]
+        return Apply(self, inputs, outputs)
+
+    def perform(self, node, inputs, outputs):
+        results = self.jitted_func(*inputs)
+        if self.num_outputs > 1:
+            for i in range(self.num_outputs):
+                outputs[i][0] = np.array(results[i], self.output_types[i].dtype)
+        else:
+            outputs[0][0] = np.array(results, self.output_types[0].dtype)
+
+    def perform_jax(self, *inputs):
+        return self.jitted_func(*inputs)
+
+    def grad(self, inputs, output_gradients):
+        # If a output is not used, it gets disconnected by pytensor and won't have a
+        # gradient. Set gradient here to zero for those outputs.
+        for i in range(self.num_outputs):
+            if isinstance(output_gradients[i].type, DisconnectedType):
+                zero_shape = (
+                    self.output_types[i].shape
+                    if None not in self.output_types[i].shape
+                    else ()
+                )
+                output_gradients[i] = pt.zeros(zero_shape, self.output_types[i].dtype)
+
+        # Compute the gradient.
+        grad_result = self.vjp_jax_op(inputs, output_gradients)
+        return grad_result if self.num_inputs > 1 else (grad_result,)
+
+
+class VJPJAXOp(Op):
+    def __init__(self, input_types, jitted_vjp, name=None):
+        self.input_types = input_types
+        self.jitted_vjp = jitted_vjp
+        if name is not None:
+            self.custom_name = name
+            self.__class__.__name__ = name
+            self.__class__.__qualname__ = ".".join(
+                self.__class__.__qualname__.split(".")[:-1] + [name]
+            )
+
+    def make_node(self, y0, gz):
+        y0_converted = [
+            pt.as_tensor_variable(y).astype(self.input_types[i].dtype)
+            for i, y in enumerate(y0)
+        ]
+        gz_not_disconnected = [
+            pt.as_tensor_variable(g)
+            for g in gz
+            if not isinstance(g.type, DisconnectedType)
+        ]
+        outputs = [typ() for typ in self.input_types]
+        self.num_outputs = len(outputs)
+        return Apply(self, y0_converted + gz_not_disconnected, outputs)
+
+    def perform(self, node, inputs, outputs):
+        results = self.jitted_vjp(*inputs)
+        if len(self.input_types) > 1:
+            for i, res in enumerate(results):
+                outputs[i][0] = np.array(res, self.input_types[i].dtype)
+        else:
+            outputs[0][0] = np.array(results, self.input_types[0].dtype)
+
+    def perform_jax(self, *inputs):
+        return self.jitted_vjp(*inputs)
+
+
+def _normalize_flat_func(func):
+    def normalized_func(*flat_vars):
+        out_flat = func(*flat_vars)
+        if isinstance(out_flat, Sequence):
+            return tuple(out_flat) if len(out_flat) > 1 else out_flat[0]
+        else:
+            return out_flat
+
+    return normalized_func
+
+
+def _get_vjp_jax_op(flat_func, num_out):
+    def vjp_op(*args):
+        y0 = args[:-num_out]
+        gz = args[-num_out:]
+        if len(gz) == 1:
+            gz = gz[0]
+
+        def f(*inputs):
+            return flat_func(*inputs)
+
+        primals, vjp_fn = jax.vjp(f, *y0)
+
+        def broadcast_to_shape(g, shape):
+            if g.ndim > 0 and g.shape[0] == 1:
+                g_squeezed = jnp.squeeze(g, axis=0)
+            else:
+                g_squeezed = g
+            return jnp.broadcast_to(g_squeezed, shape)
+
+        gz = tree_map(
+            lambda g, p: broadcast_to_shape(g, jnp.shape(p)).astype(p.dtype),
+            gz,
+            primals,
+        )
+        return vjp_fn(gz)
+
+    return vjp_op
 
 
 def as_jax_op(jaxfunc, use_infer_static_shape=True, name=None):
-    """Return a Pytensor function from a JAX jittable function.
+    """Return a Pytensor-compatible function from a JAX jittable function.
 
-    This decorator transforms any JAX-jittable function into a function that accepts
-    and returns `pytensor.Variable`. The JAX-jittable function can accept any
+    This decorator wraps a JAX function so that it accepts and returns `pytensor.Variable`
+    objects. The JAX-jittable function can accept any
     nested python structure (a `Pytree
     <https://jax.readthedocs.io/en/latest/pytrees.html>`_) as input, and might return
     any nested Python structure.
 
     Parameters
     ----------
-    jaxfunc : JAX-jittable function
-        JAX function which will be wrapped in a Pytensor Op.
-    name: str, optional
-        Name of the created pytensor Op, defaults to the name of the passed function.
-        Only used internally in the pytensor graph.
+    jaxfunc : Callable
+        A JAX function to be wrapped.
+    use_infer_static_shape : bool, optional
+        If True, use static shape inference; otherwise, use runtime shape inference.
+        Default is True.
+    name : str, optional
+        A custom name for the created Pytensor Op instance. If None, the name of jaxfunc
+        is used.
 
     Returns
     -------
-    Callable :
-        A function which expects a nested python structure of `pytensor.Variable` and
-        static variables as inputs and returns `pytensor.Variable` with the same
-        API as the original jaxfunc. The resulting model can be compiled either with the
-        default C backend or the JAX backend.
+    Callable
+        A function that wraps the given JAX function so that it can be called with
+        pytensor.Variable inputs and returns pytensor.Variable outputs.
 
     Examples
     --------
 
-    We define a JAX function `f_jax` that accepts a matrix `x`, a vector `y` and a
-    dictionary as input. This is transformed to a pytensor function  with the decorator
-    `as_jax_op`, and can subsequently be used like normal pytensor operators, i.e.
-    for evaluation and calculating gradients.
-
-    >>> import numpy  # doctest: +ELLIPSIS
-    >>> import jax.numpy as jnp  # doctest: +ELLIPSIS
-    >>> import pytensor  # doctest: +ELLIPSIS
-    >>> import pytensor.tensor as pt  # doctest: +ELLIPSIS
-    >>> x = pt.tensor("x", shape=(2,))
-    >>> y = pt.tensor("y", shape=(2, 2))
-    >>> a = pt.tensor("a", shape=())
-    >>> args_dict = {"a": a}
-    >>> @pytensor.as_jax_op
-    ... def f_jax(x, y, args_dict):
-    ...     z = jnp.dot(x, y) + args_dict["a"]
-    ...     return z
-    >>> z = f_jax(x, y, args_dict)
-    >>> z_sum = pt.sum(z)
-    >>> grad_wrt_a = pt.grad(z_sum, a)
-    >>> f_all = pytensor.function([x, y, a], [z_sum, grad_wrt_a])
-    >>> f_all(numpy.array([1, 2]), numpy.array([[1, 2], [3, 4]]), 1)
-    [array(19.), array(2.)]
-
+    >>> import jax.numpy as jnp
+    >>> import pytensor.tensor as pt
+    >>> @as_jax_op
+    ... def add(x, y):
+    ...     return jnp.add(x, y)
+    >>> x = pt.scalar("x")
+    >>> y = pt.scalar("y")
+    >>> result = add(x, y)
+    >>> f = pytensor.function([x, y], [result])
+    >>> print(f(1, 2))
+    [array(3.)]
 
     Notes
     -----
@@ -87,214 +266,131 @@ def as_jax_op(jaxfunc, use_infer_static_shape=True, name=None):
     of :func:`equinox.partition` and :func:`equinox.combine` to split and combine the
     variables. Shapes are inferred using
     :func:`pytensor.compile.builders.infer_shape` and :func:`jax.eval_shape`.
+
     """
 
     def func(*args, **kwargs):
-        """Return a pytensor from a jax jittable function."""
-        ### Split variables: in the ones that will be transformed to JAX inputs,
-        ### pytensor.Variables; _WrappedFunc, that are functions that have been returned
-        ### from a transformed function; and the rest, static variables that are not
-        ### transformed.
+        # 1. Partition inputs into dynamic pytensor variables, wrapped functions and
+        # static variables.
+        # Static variables don't take part in the graph.
+        pt_vars, func_vars, static_vars = _split_inputs(args, kwargs)
 
-        pt_vars, static_vars_tmp = eqx.partition(
-            (args, kwargs), _filter_ptvars, is_leaf=callable
+        # 2. Get the original variables from the wrapped functions.
+        vars_from_func = tree_map(lambda f: f.get_vars(), func_vars)
+        input_dict = {"vars": pt_vars, "vars_from_func": vars_from_func}
+
+        # 3. Flatten the input dictionary.
+        # e.g. {"a": tensor_a, "b": [tensor_b]} becomes [tensor_a, tensor_b], because
+        # pytensor ops only accepts lists of pytensor.Variables as input.
+        pt_vars_flat, pt_vars_treedef = tree_flatten(
+            input_dict,
         )
-        # is_leaf=callable is used, as libraries like diffrax or equinox might return
-        # functions that are still seen as a nested pytree structure. We consider them
-        # as wrappable functions, that will be wrapped with _WrappedFunc.
+        pt_types = [var.type for var in pt_vars_flat]
 
-        func_vars, static_vars = eqx.partition(
-            static_vars_tmp, lambda x: isinstance(x, _WrappedFunc), is_leaf=callable
+        # 4. Create dummy inputs for shape inference.
+        shapes = _infer_shapes(pt_vars_flat, use_infer_static_shape)
+        dummy_in_flat = _create_dummy_inputs_from_shapes(
+            pt_vars_flat, shapes, use_infer_static_shape
         )
-        vars_from_func = tree_map(lambda x: x.get_vars(), func_vars)
-        pt_vars = dict(vars=pt_vars, vars_from_func=vars_from_func)
+        dummy_inputs = tree_unflatten(pt_vars_treedef, dummy_in_flat)
 
-        # Flatten nested python structures, e.g. {"a": tensor_a, "b": [tensor_b]}
-        # becomes [tensor_a, tensor_b], because pytensor ops only accepts lists of
-        # pytensor.Variables as input.
-        pt_vars_flat, vars_treedef = tree_flatten(pt_vars)
-
-        # Infer shapes and types of the variables
-        pt_vars_types_flat = [var.type for var in pt_vars_flat]
-
-        if use_infer_static_shape:
-            shapes_vars_flat = [
-                pt.basic.infer_static_shape(var.shape)[1] for var in pt_vars_flat
-            ]
-
-            dummy_inputs_jax_flat = [
-                jnp.empty(shape, dtype=var.type.dtype)
-                for var, shape in zip(pt_vars_flat, shapes_vars_flat, strict=True)
-            ]
-
-        else:
-            shapes_vars_flat = pytensor.compile.builders.infer_shape(
-                pt_vars_flat, (), ()
-            )
-            dummy_inputs_jax_flat = [
-                jnp.empty([int(dim.eval()) for dim in shape], dtype=var.type.dtype)
-                for var, shape in zip(pt_vars_flat, shapes_vars_flat, strict=True)
-            ]
-
-        dummy_inputs_jax = tree_unflatten(vars_treedef, dummy_inputs_jax_flat)
-
-        # Combine the static variables with the inputs, and split them again in the
-        # output. Static variables don't take part in the graph, or might be a
-        # a function that is returned.
-        jaxfunc_partitioned, static_out_dic = _partition_jaxfunc(
+        # 5. Partition the JAX function into dynamic and static parts.
+        jaxfunc_dynamic, static_out_dic = _partition_jaxfunc(
             jaxfunc, static_vars, func_vars
         )
+        flat_func = _flatten_func(jaxfunc_dynamic, pt_vars_treedef)
 
-        func_flattened = _flatten_func(jaxfunc_partitioned, vars_treedef)
+        # 6. Infer output types using JAX's eval_shape.
+        out_treedef, pt_types_flat = _infer_output_types(jaxfunc_dynamic, dummy_inputs)
 
-        jaxtypes_outvars = jax.eval_shape(
-            ft.partial(jaxfunc_partitioned, vars=dummy_inputs_jax),
+        # 7. Create the Pytensor Op instance.
+        curr_name = "JAXOp_" + (jaxfunc.__name__ if name is None else name)
+        op_instance = JAXOp(
+            pt_types,
+            pt_types_flat,
+            flat_func,
+            name=curr_name,
         )
 
-        jaxtypes_outvars_flat, outvars_treedef = tree_flatten(jaxtypes_outvars)
-
-        pttypes_outvars = [
-            pt.TensorType(dtype=var.dtype, shape=var.shape)
-            for var in jaxtypes_outvars_flat
-        ]
-
-        ### Call the function that accepts flat inputs, which in turn calls the one that
-        ### combines the inputs and static variables.
-        jitted_jax_op = jax.jit(func_flattened)
-        len_gz = len(pttypes_outvars)
-
-        vjp_jax_op = _get_vjp_jax_op(func_flattened, len_gz)
-        jitted_vjp_jax_op = jax.jit(vjp_jax_op)
-
-        # Get classes that creates a Pytensor Op out of our function that accept
-        # flattened inputs. They are created each time, to set a custom name for the
-        # class.
-        class JAXOp_local(JAXOp):
-            pass
-
-        class VJPJAXOp_local(VJPJAXOp):
-            pass
-
-        if name is None:
-            curr_name = jaxfunc.__name__
-        else:
-            curr_name = name
-        JAXOp_local.__name__ = curr_name
-        JAXOp_local.__qualname__ = ".".join(
-            JAXOp_local.__qualname__.split(".")[:-1] + [curr_name]
-        )
-
-        VJPJAXOp_local.__name__ = "VJP_" + curr_name
-        VJPJAXOp_local.__qualname__ = ".".join(
-            VJPJAXOp_local.__qualname__.split(".")[:-1] + ["VJP_" + curr_name]
-        )
-
-        local_op = JAXOp_local(
-            vars_treedef,
-            outvars_treedef,
-            input_types=pt_vars_types_flat,
-            output_types=pttypes_outvars,
-            jitted_jax_op=jitted_jax_op,
-            jitted_vjp_jax_op=jitted_vjp_jax_op,
-        )
-
-        ### Evaluate the Pytensor Op and return unflattened results
-        output_flat = local_op(*pt_vars_flat)
+        # 8. Execute the op and unflatten the outputs.
+        output_flat = op_instance(*pt_vars_flat)
         if not isinstance(output_flat, Sequence):
-            output_flat = [output_flat]  # tree_unflatten expects a sequence.
-        outvars = tree_unflatten(outvars_treedef, output_flat)
+            output_flat = [output_flat]
+        outvars = tree_unflatten(out_treedef, output_flat)
 
-        static_outfuncs, static_outvars = eqx.partition(
-            static_out_dic["out"], callable, is_leaf=callable
-        )
-
-        static_outfuncs_flat, treedef_outfuncs = jax.tree_util.tree_flatten(
-            static_outfuncs, is_leaf=callable
-        )
-        for i_func, _ in enumerate(static_outfuncs_flat):
-            static_outfuncs_flat[i_func] = _WrappedFunc(
-                jaxfunc, i_func, *args, **kwargs
-            )
-
-        static_outfuncs = jax.tree_util.tree_unflatten(
-            treedef_outfuncs, static_outfuncs_flat
-        )
-        static_vars = eqx.combine(static_outfuncs, static_outvars, is_leaf=callable)
-
-        output = eqx.combine(outvars, static_vars, is_leaf=callable)
-
-        return output
+        # 9. Combine with static outputs and wrap eventual output functions with
+        # _WrappedFunc
+        return _process_outputs(static_out_dic, jaxfunc, args, kwargs, outvars)
 
     return func
 
 
-class _WrappedFunc:
-    def __init__(self, exterior_func, i_func, *args, **kwargs):
-        self.args = args
-        self.kwargs = kwargs
-        self.i_func = i_func
-        vars, static_vars = eqx.partition(
-            (self.args, self.kwargs), _filter_ptvars, is_leaf=callable
-        )
-        self.vars = vars
-        self.static_vars = static_vars
-        self.exterior_func = exterior_func
-
-    def __call__(self, *args, **kwargs):
-        # If called, assume that args and kwargs are pytensors, so return the result
-        # as pytensors.
-        def f(func, *args, **kwargs):
-            res = func(*args, **kwargs)
-            return res
-
-        return as_jax_op(f)(self, *args, **kwargs)
-
-    def get_vars(self):
-        return self.vars
-
-    def get_func_with_vars(self, vars):
-        # Use other variables than the saved ones, to generate the function. This
-        # is used to transform vars externally from pytensor to JAX, and use the
-        # then create the function which is returned.
-
-        args, kwargs = eqx.combine(vars, self.static_vars, is_leaf=callable)
-        output = self.exterior_func(*args, **kwargs)
-        outfuncs, _ = eqx.partition(output, callable, is_leaf=callable)
-        outfuncs_flat, _ = jax.tree_util.tree_flatten(outfuncs, is_leaf=callable)
-        interior_func = outfuncs_flat[self.i_func]
-        return interior_func
+def _filter_ptvars(x):
+    return isinstance(x, pt.Variable)
 
 
-def _get_vjp_jax_op(jaxfunc, len_gz):
-    def vjp_jax_op(args):
-        y0 = args[:-len_gz]
-        gz = args[-len_gz:]
-        if len(gz) == 1:
-            gz = gz[0]
+def _split_inputs(args, kwargs):
+    """Split inputs into pytensor variables, static values and wrapped functions."""
 
-        def func(*inputs):
-            return jaxfunc(inputs)
+    pt_vars, static_tmp = eqx.partition(
+        (args, kwargs), _filter_ptvars, is_leaf=callable
+    )
+    # is_leaf=callable is used, as libraries like diffrax or equinox might return
+    # functions that are still seen as a nested pytree structure. We consider them
+    # as wrappable functions, that will be wrapped with _WrappedFunc.
+    func_vars, static_vars = eqx.partition(
+        static_tmp, lambda x: isinstance(x, _WrappedFunc), is_leaf=callable
+    )
+    return pt_vars, func_vars, static_vars
 
-        primals, vjp_fn = jax.vjp(func, *y0)
-        gz = tree_map(
-            lambda g, primal: jnp.broadcast_to(g, jnp.shape(primal)).astype(
-                primal.dtype
-            ),  # Also cast to the dtype of the primal, this shouldn't be
-            # necessary, but it happens that the returned dtype of the gradient isn't
-            # the same anymore.
-            gz,
-            primals,
-        )
-        if len(y0) == 1:
-            return vjp_fn(gz)[0]
-        else:
-            return tuple(vjp_fn(gz))
 
-    return vjp_jax_op
+def _infer_shapes(pt_vars_flat, use_infer_static_shape):
+    """Infer shapes of pytensor variables."""
+    if use_infer_static_shape:
+        return [pt.basic.infer_static_shape(var.shape)[1] for var in pt_vars_flat]
+    else:
+        return pytensor.compile.builders.infer_shape(pt_vars_flat, (), ())
+
+
+def _create_dummy_inputs_from_shapes(pt_vars_flat, shapes, use_infer_static_shape):
+    """Create dummy inputs for the jax function from inferred shapes."""
+    if use_infer_static_shape:
+        return [
+            jnp.empty(shape, dtype=var.type.dtype)
+            for var, shape in zip(pt_vars_flat, shapes, strict=True)
+        ]
+    else:
+        return [
+            jnp.empty([int(dim.eval()) for dim in shape], dtype=var.type.dtype)
+            for var, shape in zip(pt_vars_flat, shapes, strict=True)
+        ]
+
+
+def _infer_output_types(jaxfunc_part, dummy_inputs):
+    """Infer output types using JAX's eval_shape."""
+    jax_out = jax.eval_shape(jaxfunc_part, dummy_inputs)
+    jax_out_flat, out_treedef = tree_flatten(jax_out)
+    pt_out_types = [
+        pt.TensorType(dtype=var.dtype, shape=var.shape) for var in jax_out_flat
+    ]
+    return out_treedef, pt_out_types
+
+
+def _process_outputs(static_out_dic, jaxfunc, args, kwargs, outvars):
+    """Process and combine static outputs with the dynamic ones."""
+    static_funcs, static_vars_out = eqx.partition(
+        static_out_dic["out"], callable, is_leaf=callable
+    )
+    flat_static, func_treedef = tree_flatten(static_funcs, is_leaf=callable)
+    for i in range(len(flat_static)):
+        flat_static[i] = _WrappedFunc(jaxfunc, i, *args, **kwargs)
+    static_funcs = tree_unflatten(func_treedef, flat_static)
+    static_combined = eqx.combine(static_funcs, static_vars_out, is_leaf=callable)
+    return eqx.combine(outvars, static_combined, is_leaf=callable)
 
 
 def _partition_jaxfunc(jaxfunc, static_vars, func_vars):
-    """Partition the jax function into static and non-static variables.
+    """Split the jax function into dynamic and static components.
 
     Returns a function that accepts only non-static variables and returns the non-static
     variables. The returned static variables are stored in a dictionary and returned,
@@ -306,152 +402,64 @@ def _partition_jaxfunc(jaxfunc, static_vars, func_vars):
     static_out_dic = {"out": None}
 
     def jaxfunc_partitioned(vars):
-        vars, vars_from_func = vars["vars"], vars["vars_from_func"]
-        func_vars_evaled = tree_map(
-            lambda x, y: x.get_func_with_vars(y), func_vars, vars_from_func
+        dyn_vars, func_vars_input = vars["vars"], vars["vars_from_func"]
+        evaluated_funcs = tree_map(
+            lambda f, v: f.get_func_with_vars(v), func_vars, func_vars_input
         )
         args, kwargs = eqx.combine(
-            vars, static_vars, func_vars_evaled, is_leaf=callable
+            dyn_vars, static_vars, evaluated_funcs, is_leaf=callable
         )
-
-        out = jaxfunc(*args, **kwargs)
-        outvars, static_out = eqx.partition(out, eqx.is_array, is_leaf=callable)
+        output = jaxfunc(*args, **kwargs)
+        out_dyn, static_out = eqx.partition(output, eqx.is_array, is_leaf=callable)
         static_out_dic["out"] = static_out
-        return outvars
+        return out_dyn
 
     return jaxfunc_partitioned, static_out_dic
 
 
-### Construct the function that accepts flat inputs and returns flat outputs.
-def _flatten_func(jaxfunc, vars_treedef):
-    def func_flattened(vars_flat):
-        vars = tree_unflatten(vars_treedef, vars_flat)
-        outvars = jaxfunc(vars)
-        outvars_flat, _ = tree_flatten(outvars)
-        return _normalize_flat_output(outvars_flat)
+def _flatten_func(jaxfunc, treedef):
+    def flat_func(*flat_vars):
+        vars = tree_unflatten(treedef, flat_vars)
+        out = jaxfunc(vars)
+        out_flat, _ = tree_flatten(out)
+        return out_flat
 
-    return func_flattened
-
-
-def _normalize_flat_output(output):
-    if len(output) > 1:
-        return tuple(
-            output
-        )  # Transform to tuple because jax makes a difference between
-        # tuple and list and not pytensor
-    else:
-        return output[0]
+    return flat_func
 
 
-class JAXOp(Op):
-    def __init__(
-        self,
-        input_treedef,
-        output_treeedef,
-        input_types,
-        output_types,
-        jitted_jax_op,
-        jitted_vjp_jax_op,
-    ):
-        self.vjp_jax_op = None
-        self.input_treedef = input_treedef
-        self.output_treedef = output_treeedef
-        self.input_types = input_types
-        self.output_types = output_types
-        self.jitted_jax_op = jitted_jax_op
-        self.jitted_vjp_jax_op = jitted_vjp_jax_op
-
-    def make_node(self, *inputs):
-        self.num_inputs = len(inputs)
-
-        # Define our output variables
-        outputs = [pt.as_tensor_variable(type()) for type in self.output_types]
-        self.num_outputs = len(outputs)
-
-        self.vjp_jax_op = VJPJAXOp(
-            self.input_treedef,
-            self.input_types,
-            self.jitted_vjp_jax_op,
+class _WrappedFunc:
+    def __init__(self, exterior_func, i_func, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.i_func = i_func
+        # Partition the inputs to separate dynamic variables from static ones.
+        vars, static_vars = eqx.partition(
+            (self.args, self.kwargs), _filter_ptvars, is_leaf=callable
         )
+        self.vars = vars
+        self.static_vars = static_vars
+        self.exterior_func = exterior_func
 
-        return Apply(self, inputs, outputs)
+    def __call__(self, *args, **kwargs):
+        # If called, assume that args and kwargs are pytensors, so return the result
+        # as pytensors.
+        def f(func, *args, **kwargs):
+            return func(*args, **kwargs)
 
-    def perform(self, node, inputs, outputs):
-        results = self.jitted_jax_op(inputs)
-        if self.num_outputs > 1:
-            for i in range(self.num_outputs):
-                outputs[i][0] = np.array(results[i], self.output_types[i].dtype)
-        else:
-            outputs[0][0] = np.array(results, self.output_types[0].dtype)
+        return as_jax_op(f)(self, *args, **kwargs)
 
-    def perform_jax(self, *inputs):
-        results = self.jitted_jax_op(inputs)
-        return results
+    def get_vars(self):
+        return self.vars
 
-    def grad(self, inputs, output_gradients):
-        # If a output is not used, it is disconnected and doesn't have a gradient.
-        # Set gradient here to zero for those outputs.
-        for i in range(self.num_outputs):
-            if isinstance(output_gradients[i].type, DisconnectedType):
-                if None not in self.output_types[i].shape:
-                    output_gradients[i] = pt.zeros(
-                        self.output_types[i].shape, self.output_types[i].dtype
-                    )
-                else:
-                    output_gradients[i] = pt.zeros((), self.output_types[i].dtype)
-        result = self.vjp_jax_op(inputs, output_gradients)
-
-        if self.num_inputs > 1:
-            return result
-        else:
-            return (result,)  # Pytensor requires a tuple here
-
-
-# vector-jacobian product Op
-class VJPJAXOp(Op):
-    def __init__(
-        self,
-        input_treedef,
-        input_types,
-        jitted_vjp_jax_op,
-    ):
-        self.input_treedef = input_treedef
-        self.input_types = input_types
-        self.jitted_vjp_jax_op = jitted_vjp_jax_op
-
-    def make_node(self, y0, gz):
-        y0 = [
-            pt.as_tensor_variable(
-                _y,
-            ).astype(self.input_types[i].dtype)
-            for i, _y in enumerate(y0)
-        ]
-        gz_not_disconntected = [
-            pt.as_tensor_variable(_gz)
-            for _gz in gz
-            if not isinstance(_gz.type, DisconnectedType)
-        ]
-        outputs = [in_type() for in_type in self.input_types]
-        self.num_outputs = len(outputs)
-        return Apply(self, y0 + gz_not_disconntected, outputs)
-
-    def perform(self, node, inputs, outputs):
-        results = self.jitted_vjp_jax_op(tuple(inputs))
-        if len(self.input_types) > 1:
-            for i, result in enumerate(results):
-                outputs[i][0] = np.array(result, self.input_types[i].dtype)
-        else:
-            outputs[0][0] = np.array(results, self.input_types[0].dtype)
-
-    def perform_jax(self, *inputs):
-        results = self.jitted_vjp_jax_op(tuple(inputs))
-        if self.num_outputs == 1:
-            if isinstance(results, Sequence):
-                return results[0]
-            else:
-                return results
-        else:
-            return tuple(results)
+    def get_func_with_vars(self, vars):
+        # Use other variables than the saved ones, to generate the function. This
+        # is used to transform vars externally from pytensor to JAX, and use the
+        # then create the function which is returned.
+        args, kwargs = eqx.combine(vars, self.static_vars, is_leaf=callable)
+        output = self.exterior_func(*args, **kwargs)
+        out_funcs, _ = eqx.partition(output, callable, is_leaf=callable)
+        out_funcs_flat, _ = tree_flatten(out_funcs, is_leaf=callable)
+        return out_funcs_flat[self.i_func]
 
 
 @jax_funcify.register(JAXOp)

--- a/pytensor/link/jax/ops.py
+++ b/pytensor/link/jax/ops.py
@@ -241,7 +241,11 @@ def _get_vjp_sol_op_jax(jaxfunc, len_gz):
 
         primals, vjp_fn = jax.vjp(func, *y0)
         gz = tree_map(
-            lambda g, primal: jnp.broadcast_to(g, jnp.shape(primal)),
+            lambda g, primal: jnp.broadcast_to(g, jnp.shape(primal)).astype(
+                primal.dtype
+            ),  # Also cast to the dtype of the primal, this shouldn't be
+            # necessary, but it happens that the returned dtype of the gradient isn't
+            # the same anymore.
             gz,
             primals,
         )
@@ -326,6 +330,7 @@ def _return_pytensor_ops_classes(name):
             self.num_inputs = len(inputs)
 
             # Define our output variables
+            print(self.output_types)
             outputs = [pt.as_tensor_variable(type()) for type in self.output_types]
             self.num_outputs = len(outputs)
 

--- a/pytensor/link/jax/ops.py
+++ b/pytensor/link/jax/ops.py
@@ -85,8 +85,12 @@ def as_jax_op(jaxfunc, name=None):
         vars_from_func = tree_map(lambda x: x.get_vars(), func_vars)
         pt_vars = dict(vars=pt_vars, vars_from_func=vars_from_func)
 
-        # Infer shapes and types of the variables
+        # Flatten nested python structures, e.g. {"a": tensor_a, "b": [tensor_b]}
+        # becomes [tensor_a, tensor_b], because pytensor ops only accepts lists of
+        # pytensor.Variables as input.
         pt_vars_flat, vars_treedef = tree_flatten(pt_vars)
+
+        # Infer shapes and types of the variables
         pt_vars_types_flat = [var.type for var in pt_vars_flat]
         shapes_vars_flat = pytensor.compile.builders.infer_shape(pt_vars_flat, (), ())
         shapes_vars = tree_unflatten(vars_treedef, shapes_vars_flat)

--- a/pytensor/link/jax/ops.py
+++ b/pytensor/link/jax/ops.py
@@ -49,6 +49,33 @@ def as_jax_op(jaxfunc, name=None):
         API as the original jaxfunc. The resulting model can be compiled either with the
         default C backend or the JAX backend.
 
+    Examples
+    --------
+
+    We define a JAX function `f_jax` that accepts a matrix `x`, a vector `y` and a
+    dictionary as input. This is transformed to a pytensor function  with the decorator
+    `as_jax_op`, and can subsequently be used like normal pytensor operators, i.e.
+    for evaluation and calculating gradients.
+
+    >>> import numpy
+    >>> import jax.numpy as jnp
+    >>> import pytensor
+    >>> import pytensor.tensor as pt
+    >>> x = pt.tensor("x", shape=(2,))
+    >>> y = pt.tensor("y", shape=(2, 2))
+    >>> a = pt.tensor("a", shape=())
+    >>> args_dict = {"a": a}
+    >>> @pytensor.as_jax_op
+    ... def f_jax(x, y, args_dict):
+    ...     z = jnp.dot(x, y) + args_dict["a"]
+    ...     return z
+    >>> z = f_jax(x, y, args_dict)
+    >>> z_sum = pt.sum(z)
+    >>> grad_wrt_a = pt.grad(z_sum, a)
+    >>> f_all = pytensor.function([x, y, a], [z_sum, grad_wrt_a])
+    >>> f_all(numpy.array([1, 2]), numpy.array([[1, 2], [3, 4]]), 1)
+    [array(19.), array(2.)]
+
 
     Notes
     -----
@@ -327,7 +354,6 @@ class JAXOp(Op):
         self.num_inputs = len(inputs)
 
         # Define our output variables
-        print(self.output_types)
         outputs = [pt.as_tensor_variable(type()) for type in self.output_types]
         self.num_outputs = len(outputs)
 

--- a/tests/link/jax/test_as_jax_op.py
+++ b/tests/link/jax/test_as_jax_op.py
@@ -11,7 +11,7 @@ from pytensor.tensor import tensor
 from tests.link.jax.test_basic import compare_jax_and_py
 
 
-def test_2in_1out():
+def test_two_inputs_single_output():
     rng = np.random.default_rng(1)
     x = tensor("a", shape=(2,))
     y = tensor("b", shape=(2,))
@@ -32,7 +32,7 @@ def test_2in_1out():
         fn, _ = compare_jax_and_py(fg, test_values)
 
 
-def test_2in_tupleout():
+def test_two_inputs_tuple_output():
     rng = np.random.default_rng(2)
     x = tensor("a", shape=(2,))
     y = tensor("b", shape=(2,))
@@ -53,7 +53,7 @@ def test_2in_tupleout():
         fn, _ = compare_jax_and_py(fg, test_values)
 
 
-def test_2in_listout():
+def test_two_inputs_list_output():
     rng = np.random.default_rng(3)
     x = tensor("a", shape=(2,))
     y = tensor("b", shape=(2,))
@@ -74,7 +74,7 @@ def test_2in_listout():
         fn, _ = compare_jax_and_py(fg, test_values)
 
 
-def test_1din_tupleout():
+def test_single_input_tuple_output():
     rng = np.random.default_rng(4)
     x = tensor("a", shape=(2,))
     test_values = [rng.normal(size=(x.type.shape)).astype(config.floatX)]
@@ -92,7 +92,7 @@ def test_1din_tupleout():
         fn, _ = compare_jax_and_py(fg, test_values)
 
 
-def test_0din_tupleout():
+def test_scalar_input_tuple_output():
     rng = np.random.default_rng(5)
     x = tensor("a", shape=())
     test_values = [rng.normal(size=(x.type.shape)).astype(config.floatX)]
@@ -110,7 +110,7 @@ def test_0din_tupleout():
         fn, _ = compare_jax_and_py(fg, test_values)
 
 
-def test_1in_listout():
+def test_single_input_list_output():
     rng = np.random.default_rng(6)
     x = tensor("a", shape=(2,))
     test_values = [rng.normal(size=(x.type.shape)).astype(config.floatX)]
@@ -129,7 +129,7 @@ def test_1in_listout():
         fn, _ = compare_jax_and_py(fg, test_values)
 
 
-def test_pytreein_tupleout():
+def test_pytree_input_tuple_output():
     rng = np.random.default_rng(7)
     x = tensor("a", shape=(2,))
     y = tensor("b", shape=(2,))
@@ -152,7 +152,7 @@ def test_pytreein_tupleout():
         fn, _ = compare_jax_and_py(fg, test_values)
 
 
-def test_pytreein_pytreeout():
+def test_pytree_input_pytree_output():
     rng = np.random.default_rng(8)
     x = tensor("a", shape=(3,))
     y = tensor("b", shape=(1,))
@@ -172,7 +172,7 @@ def test_pytreein_pytreeout():
     fn, _ = compare_jax_and_py(fg, test_values)
 
 
-def test_pytreein_pytreeout_w_nongraphargs():
+def test_pytree_input_with_non_graph_args():
     rng = np.random.default_rng(9)
     x = tensor("a", shape=(3,))
     y = tensor("b", shape=(1,))
@@ -212,8 +212,7 @@ def test_pytreein_pytreeout_w_nongraphargs():
     assert out == "Unsupported argument"
 
 
-def test_as_jax_op10():
-    # Use "None" in shape specification and have a non-used output of higher rank
+def test_unused_matrix_product_and_exp_gradient():
     rng = np.random.default_rng(10)
     x = tensor("a", shape=(3,))
     y = tensor("b", shape=(3,))
@@ -235,8 +234,7 @@ def test_as_jax_op10():
         fn, _ = compare_jax_and_py(fg, test_values)
 
 
-def test_as_jax_op11():
-    # Test unknown static shape
+def test_unknown_static_shape():
     rng = np.random.default_rng(11)
     x = tensor("a", shape=(3,))
     y = tensor("b", shape=(3,))
@@ -260,8 +258,7 @@ def test_as_jax_op11():
         fn, _ = compare_jax_and_py(fg, test_values)
 
 
-def test_as_jax_op12():
-    # Test non-array return values
+def test_non_array_return_values():
     rng = np.random.default_rng(12)
     x = tensor("a", shape=(3,))
     y = tensor("b", shape=(3,))
@@ -283,8 +280,7 @@ def test_as_jax_op12():
         fn, _ = compare_jax_and_py(fg, test_values)
 
 
-def test_as_jax_op13():
-    # Test nested functions
+def test_nested_functions():
     rng = np.random.default_rng(13)
     x = tensor("a", shape=(3,))
     y = tensor("b", shape=(3,))

--- a/tests/link/jax/test_as_jax_op.py
+++ b/tests/link/jax/test_as_jax_op.py
@@ -1,15 +1,20 @@
 import jax
+import jax.numpy as jnp
 import numpy as np
+import pytest
 
-from pytensor import config
+import pytensor.tensor as pt
+from pytensor import config, grad
 from pytensor.graph.fg import FunctionGraph
 from pytensor.link.jax.ops import as_jax_op
+from pytensor.scalar import all_types
 from pytensor.tensor import tensor
 from tests.link.jax.test_basic import compare_jax_and_py
 
+
 def test_as_jax_op1():
     # 2 parameters input, single output
-    rng = np.random.default_rng(14)
+    rng = np.random.default_rng(1)
     x = tensor("a", shape=(2,))
     y = tensor("b", shape=(2,))
     test_values = [
@@ -21,6 +26,363 @@ def test_as_jax_op1():
         return jax.nn.sigmoid(x + y)
 
     out = f(x, y)
+    grad_out = grad(pt.sum(out), [x, y])
 
-    fg = FunctionGraph([x, y], [out])
+    fg = FunctionGraph([x, y], [out, *grad_out])
     fn, _ = compare_jax_and_py(fg, test_values)
+    with jax.disable_jit():
+        fn, _ = compare_jax_and_py(fg, test_values)
+
+
+def test_as_jax_op2():
+    # 2 parameters input, tuple output
+    rng = np.random.default_rng(2)
+    x = tensor("a", shape=(2,))
+    y = tensor("b", shape=(2,))
+    test_values = [
+        rng.normal(size=(inp.type.shape)).astype(config.floatX) for inp in (x, y)
+    ]
+
+    @as_jax_op
+    def f(x, y):
+        return jax.nn.sigmoid(x + y), y * 2
+
+    out, _ = f(x, y)
+    grad_out = grad(pt.sum(out), [x, y])
+
+    fg = FunctionGraph([x, y], [out, *grad_out])
+    fn, _ = compare_jax_and_py(fg, test_values)
+    with jax.disable_jit():
+        fn, _ = compare_jax_and_py(fg, test_values)
+
+
+def test_as_jax_op3():
+    # 2 parameters input, list output
+    rng = np.random.default_rng(3)
+    x = tensor("a", shape=(2,))
+    y = tensor("b", shape=(2,))
+    test_values = [
+        rng.normal(size=(inp.type.shape)).astype(config.floatX) for inp in (x, y)
+    ]
+
+    @as_jax_op
+    def f(x, y):
+        return [jax.nn.sigmoid(x + y), y * 2]
+
+    out, _ = f(x, y)
+    grad_out = grad(pt.sum(out), [x, y])
+
+    fg = FunctionGraph([x, y], [out, *grad_out])
+    fn, _ = compare_jax_and_py(fg, test_values)
+    with jax.disable_jit():
+        fn, _ = compare_jax_and_py(fg, test_values)
+
+
+def test_as_jax_op4():
+    # single 1d input, tuple output
+    rng = np.random.default_rng(4)
+    x = tensor("a", shape=(2,))
+    test_values = [rng.normal(size=(x.type.shape)).astype(config.floatX)]
+
+    @as_jax_op
+    def f(x):
+        return jax.nn.sigmoid(x), x * 2
+
+    out, _ = f(x)
+    grad_out = grad(pt.sum(out), [x])
+
+    fg = FunctionGraph([x], [out, *grad_out])
+    fn, _ = compare_jax_and_py(fg, test_values)
+    with jax.disable_jit():
+        fn, _ = compare_jax_and_py(fg, test_values)
+
+
+def test_as_jax_op5():
+    # single 0d input, tuple output
+    rng = np.random.default_rng(5)
+    x = tensor("a", shape=())
+    test_values = [rng.normal(size=(x.type.shape)).astype(config.floatX)]
+
+    @as_jax_op
+    def f(x):
+        return jax.nn.sigmoid(x), x
+
+    out, _ = f(x)
+    grad_out = grad(pt.sum(out), [x])
+
+    fg = FunctionGraph([x], [out, *grad_out])
+    fn, _ = compare_jax_and_py(fg, test_values)
+    with jax.disable_jit():
+        fn, _ = compare_jax_and_py(fg, test_values)
+
+
+def test_as_jax_op6():
+    # single input, list output
+    rng = np.random.default_rng(6)
+    x = tensor("a", shape=(2,))
+    test_values = [rng.normal(size=(x.type.shape)).astype(config.floatX)]
+
+    @as_jax_op
+    def f(x):
+        return [jax.nn.sigmoid(x), 2 * x]
+
+    out, _ = f(x)
+    grad_out = grad(pt.sum(out), [x])
+
+    fg = FunctionGraph([x], [out, *grad_out])
+    fn, _ = compare_jax_and_py(fg, test_values)
+
+    with jax.disable_jit():
+        fn, _ = compare_jax_and_py(fg, test_values)
+
+
+def test_as_jax_op7():
+    # 2 parameters input with pytree, tuple output
+    rng = np.random.default_rng(7)
+    x = tensor("a", shape=(2,))
+    y = tensor("b", shape=(2,))
+    y_tmp = {"y": y, "y2": [y**2]}
+    test_values = [
+        rng.normal(size=(inp.type.shape)).astype(config.floatX) for inp in (x, y)
+    ]
+
+    @as_jax_op
+    def f(x, y):
+        return jax.nn.sigmoid(x), 2 * x + y["y"] + y["y2"][0]
+
+    out = f(x, y_tmp)
+    grad_out = grad(pt.sum(out[1]), [x, y])
+
+    fg = FunctionGraph([x, y], [out[0], out[1], *grad_out])
+    fn, _ = compare_jax_and_py(fg, test_values)
+
+    with jax.disable_jit():
+        fn, _ = compare_jax_and_py(fg, test_values)
+
+
+def test_as_jax_op8():
+    # 2 parameters input with pytree, pytree output
+    rng = np.random.default_rng(8)
+    x = tensor("a", shape=(3,))
+    y = tensor("b", shape=(1,))
+    y_tmp = {"a": y, "b": [y**2]}
+    test_values = [
+        rng.normal(size=(inp.type.shape)).astype(config.floatX) for inp in (x, y)
+    ]
+
+    @as_jax_op
+    def f(x, y):
+        return x, jax.tree_util.tree_map(lambda x: jnp.exp(x), y)
+
+    out = f(x, y_tmp)
+    grad_out = grad(pt.sum(out[1]["b"][0]), [x, y])
+
+    fg = FunctionGraph([x, y], [out[0], out[1]["a"], *grad_out])
+    fn, _ = compare_jax_and_py(fg, test_values)
+
+
+def test_as_jax_op9():
+    # 2 parameters input with pytree, pytree output and non-graph argument
+    rng = np.random.default_rng(9)
+    x = tensor("a", shape=(3,))
+    y = tensor("b", shape=(1,))
+    y_tmp = {"a": y, "b": [y**2]}
+    test_values = [
+        rng.normal(size=(inp.type.shape)).astype(config.floatX) for inp in (x, y)
+    ]
+
+    @as_jax_op
+    def f(x, y, non_model_arg):
+        return jnp.exp(x), jax.tree_util.tree_map(jax.nn.sigmoid, y)
+
+    out = f(x, y_tmp, "Hello World!")
+    grad_out = grad(pt.sum(out[0]), [x])
+
+    fg = FunctionGraph([x, y], [out[0], *grad_out])
+    fn, _ = compare_jax_and_py(fg, test_values)
+
+    with jax.disable_jit():
+        fn, _ = compare_jax_and_py(fg, test_values)
+
+
+def test_as_jax_op10():
+    # Use "None" in shape specification and have a non-used output of higher rank
+    rng = np.random.default_rng(10)
+    x = tensor("a", shape=(3,))
+    y = tensor("b", shape=(3,))
+    test_values = [
+        rng.normal(size=(inp.type.shape)).astype(config.floatX) for inp in (x, y)
+    ]
+
+    @as_jax_op
+    def f(x, y):
+        return x[:, None] @ y[None], jnp.exp(x)
+
+    out = f(x, y)
+    grad_out = grad(pt.sum(out[1]), [x])
+
+    fg = FunctionGraph([x, y], [out[1], *grad_out])
+    fn, _ = compare_jax_and_py(fg, test_values)
+
+    with jax.disable_jit():
+        fn, _ = compare_jax_and_py(fg, test_values)
+
+
+def test_as_jax_op11():
+    # Test unknown static shape
+    rng = np.random.default_rng(11)
+    x = tensor("a", shape=(3,))
+    y = tensor("b", shape=(3,))
+    test_values = [
+        rng.normal(size=(inp.type.shape)).astype(config.floatX) for inp in (x, y)
+    ]
+
+    x = pt.cumsum(x)  # Now x has an unknown shape
+
+    @as_jax_op
+    def f(x, y):
+        return x * jnp.ones(3)
+
+    out = f(x, y)
+    grad_out = grad(pt.sum(out), [x])
+
+    fg = FunctionGraph([x, y], [out, *grad_out])
+    fn, _ = compare_jax_and_py(fg, test_values)
+
+    with jax.disable_jit():
+        fn, _ = compare_jax_and_py(fg, test_values)
+
+
+def test_as_jax_op12():
+    # Test non-array return values
+    rng = np.random.default_rng(12)
+    x = tensor("a", shape=(3,))
+    y = tensor("b", shape=(3,))
+    test_values = [
+        rng.normal(size=(inp.type.shape)).astype(config.floatX) for inp in (x, y)
+    ]
+
+    @as_jax_op
+    def f(x, y, message):
+        return x * jnp.ones(3), "Success: " + message
+
+    out = f(x, y, "Hi")
+    grad_out = grad(pt.sum(out[0]), [x])
+
+    fg = FunctionGraph([x, y], [out[0], *grad_out])
+    fn, _ = compare_jax_and_py(fg, test_values)
+
+    with jax.disable_jit():
+        fn, _ = compare_jax_and_py(fg, test_values)
+
+
+def test_as_jax_op13():
+    # Test nested functions
+    rng = np.random.default_rng(13)
+    x = tensor("a", shape=(3,))
+    y = tensor("b", shape=(3,))
+    test_values = [
+        rng.normal(size=(inp.type.shape)).astype(config.floatX) for inp in (x, y)
+    ]
+
+    @as_jax_op
+    def f_internal(y):
+        def f_ret(t):
+            return y + t
+
+        def f_ret2(t):
+            return f_ret(t) + t**2
+
+        return f_ret, y**2 * jnp.ones(1), f_ret2
+
+    f, y_pow, f2 = f_internal(y)
+
+    @as_jax_op
+    def f_outer(x, dict_other):
+        f, y_pow = dict_other["func"], dict_other["y"]
+        return x * jnp.ones(3), f(x) * y_pow
+
+    out = f_outer(x, {"func": f, "y": y_pow})
+    grad_out = grad(pt.sum(out[1]), [x])
+
+    fg = FunctionGraph([x, y], [out[1], *grad_out])
+    fn, _ = compare_jax_and_py(fg, test_values)
+
+    with jax.disable_jit():
+        fn, _ = compare_jax_and_py(fg, test_values)
+
+
+class TestDtypes:
+    @pytest.mark.parametrize("in_dtype", list(map(str, all_types)))
+    @pytest.mark.parametrize("out_dtype", list(map(str, all_types)))
+    def test_different_in_output(self, in_dtype, out_dtype):
+        x = tensor("a", shape=(3,), dtype=in_dtype)
+        y = tensor("b", shape=(3,), dtype=in_dtype)
+
+        if "int" in in_dtype:
+            test_values = [
+                np.random.randint(0, 10, size=(inp.type.shape)).astype(inp.type.dtype)
+                for inp in (x, y)
+            ]
+        else:
+            test_values = [
+                np.random.normal(size=(inp.type.shape)).astype(inp.type.dtype)
+                for inp in (x, y)
+            ]
+
+        @as_jax_op
+        def f(x, y):
+            out = jnp.add(x, y)
+            return jnp.real(out).astype(out_dtype)
+
+        out = f(x, y)
+        assert out.dtype == out_dtype
+
+        if "float" in in_dtype and "float" in out_dtype:
+            grad_out = grad(out[0], [x, y])
+            assert grad_out[0].dtype == in_dtype
+            fg = FunctionGraph([x, y], [out, *grad_out])
+        else:
+            fg = FunctionGraph([x, y], [out])
+
+        fn, _ = compare_jax_and_py(fg, test_values)
+
+        with jax.disable_jit():
+            fn, _ = compare_jax_and_py(fg, test_values)
+
+    @pytest.mark.parametrize("in1_dtype", list(map(str, all_types)))
+    @pytest.mark.parametrize("in2_dtype", list(map(str, all_types)))
+    def test_test_different_inputs(self, in1_dtype, in2_dtype):
+        x = tensor("a", shape=(3,), dtype=in1_dtype)
+        y = tensor("b", shape=(3,), dtype=in2_dtype)
+
+        if "int" in in1_dtype:
+            test_values = [np.random.randint(0, 10, size=(3,)).astype(x.type.dtype)]
+        else:
+            test_values = [np.random.normal(size=(3,)).astype(x.type.dtype)]
+        if "int" in in2_dtype:
+            test_values.append(np.random.randint(0, 10, size=(3,)).astype(y.type.dtype))
+        else:
+            test_values.append(np.random.normal(size=(3,)).astype(y.type.dtype))
+
+        @as_jax_op
+        def f(x, y):
+            out = jnp.add(x, y)
+            return jnp.real(out).astype(in1_dtype)
+
+        out = f(x, y)
+        assert out.dtype == in1_dtype
+
+        if "float" in in1_dtype and "float" in in2_dtype:
+            # In principle, the gradient should also be defined if the second input is
+            # an integer, but it doesn't work for some reason.
+            grad_out = grad(out[0], [x])
+            assert grad_out[0].dtype == in1_dtype
+            fg = FunctionGraph([x, y], [out, *grad_out])
+        else:
+            fg = FunctionGraph([x, y], [out])
+
+        fn, _ = compare_jax_and_py(fg, test_values)
+
+        with jax.disable_jit():
+            fn, _ = compare_jax_and_py(fg, test_values)

--- a/tests/link/jax/test_as_jax_op.py
+++ b/tests/link/jax/test_as_jax_op.py
@@ -4,9 +4,8 @@ import numpy as np
 import pytest
 
 import pytensor.tensor as pt
-from pytensor import config, grad
+from pytensor import as_jax_op, config, grad
 from pytensor.graph.fg import FunctionGraph
-from pytensor.link.jax.ops import as_jax_op
 from pytensor.scalar import all_types
 from pytensor.tensor import tensor
 from tests.link.jax.test_basic import compare_jax_and_py

--- a/tests/link/jax/test_as_jax_op.py
+++ b/tests/link/jax/test_as_jax_op.py
@@ -1,0 +1,26 @@
+import jax
+import numpy as np
+
+from pytensor import config
+from pytensor.graph.fg import FunctionGraph
+from pytensor.link.jax.ops import as_jax_op
+from pytensor.tensor import tensor
+from tests.link.jax.test_basic import compare_jax_and_py
+
+def test_as_jax_op1():
+    # 2 parameters input, single output
+    rng = np.random.default_rng(14)
+    x = tensor("a", shape=(2,))
+    y = tensor("b", shape=(2,))
+    test_values = [
+        rng.normal(size=(inp.type.shape)).astype(config.floatX) for inp in (x, y)
+    ]
+
+    @as_jax_op
+    def f(x, y):
+        return jax.nn.sigmoid(x + y)
+
+    out = f(x, y)
+
+    fg = FunctionGraph([x, y], [out])
+    fn, _ = compare_jax_and_py(fg, test_values)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description

Add a decorator that transforms a JAX function such that it can be used in PyTensor. Shape and dtype inference works automatically and input and output can be any nested python structure (e.g. [Pytrees](https://jax.readthedocs.io/en/latest/pytrees.html)). Furthermore, using a transformed function as an argument for another transformed function should also work. 

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #537

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


## ToDos

- [ ] Implement `Op.__props__`
- [x] Let `make_node` be specified by the user, to support non-inferrable shapes
        - JAXOp is now directly usable by the user
- [x] Add tests for JAXOp
- [ ] Add some meaningful error messages to common runtime errors

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1120.org.readthedocs.build/en/1120/

<!-- readthedocs-preview pytensor end -->