### PR TITLE
[WIP] Allow function dispatch for constants

### DIFF
--- a/pytensor/link/pytorch/dispatch/basic.py
+++ b/pytensor/link/pytorch/dispatch/basic.py
@@ -61,20 +61,13 @@ def pytorch_funcify_FunctionGraph(
     conversion_func=pytorch_funcify,
     **kwargs,
 ):
-    def constants_wrapper(x, **kwargs):
-        x = pytorch_typify(x)
-
-        @torch.compiler.assume_constant_result
-        def torch_assume_constant(arg=x):
-            return arg
-
-        return torch_assume_constant
+    if "type_conversion_fn" not in kwargs:
+        kwargs["type_conversion_fn"] = pytorch_typify
 
     built_kwargs = {"conversion_func": conversion_func, **kwargs}
     return fgraph_to_python(
         fgraph,
         conversion_func,
-        type_conversion_fn=constants_wrapper,
         fgraph_name=fgraph_name,
         **built_kwargs,
     )

--- a/pytensor/link/pytorch/dispatch/basic.py
+++ b/pytensor/link/pytorch/dispatch/basic.py
@@ -39,9 +39,11 @@ def pytorch_typify_tensor(data, dtype=None, **kwargs):
 def pytorch_typify_no_conversion_needed(data, **kwargs):
     return data
 
+
 @pytorch_typify.register(np.number)
 def pytorch_typify_extract(data, **kwargs):
     return data.item()
+
 
 @singledispatch
 def pytorch_funcify(op, node=None, storage_map=None, **kwargs):

--- a/pytensor/link/pytorch/linker.py
+++ b/pytensor/link/pytorch/linker.py
@@ -51,6 +51,7 @@ class PytorchLinker(JITLinker):
             """
 
             def __init__(self, fn, gen_functors):
+                self._fn = fn
                 self.fn = torch.compile(fn)
                 self.gen_functors = gen_functors.copy()
 

--- a/pytensor/link/pytorch/linker.py
+++ b/pytensor/link/pytorch/linker.py
@@ -51,7 +51,6 @@ class PytorchLinker(JITLinker):
             """
 
             def __init__(self, fn, gen_functors):
-                self._fn = fn
                 self.fn = torch.compile(fn)
                 self.gen_functors = gen_functors.copy()
 

--- a/pytensor/link/utils.py
+++ b/pytensor/link/utils.py
@@ -758,9 +758,7 @@ def fgraph_to_python(
                     new_output_name = unique_name(i)
                     getter_unique_name = unique_name(getter_or_value)
                     global_env[getter_unique_name] = getter_or_value
-                    assign_str = (
-                        f"{new_output_name} = {getter_unique_name}()"
-                    )
+                    assign_str = f"{new_output_name} = {getter_unique_name}()"
                     body_assigns.append(assign_str)
                     node_input_names.append(new_output_name)
                     continue

--- a/pytensor/link/utils.py
+++ b/pytensor/link/utils.py
@@ -766,8 +766,8 @@ def fgraph_to_python(
                     global_env[local_input_name] = type_conversion_fn(
                         input_storage[0], variable=i, storage=input_storage, **kwargs
                     )
-                # TODO: We could attempt to use the storage arrays directly
-                # E.g. `local_input_name = f"{local_input_name}[0]"`
+            # TODO: We could attempt to use the storage arrays directly
+            # E.g. `local_input_name = f"{local_input_name}[0]"`
             node_input_names.append(local_input_name)
 
         node_output_names = [unique_name(v) for v in node.outputs]


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
Pytorch doesn't seem to handle the constants we put in the globals of the generated code well. It can cause graph breaks for things that shouldn't be graph break (example: The index in IncSubtensor when the index is static). This change allows the typify method to instead return a function, and then defer fetching the constants in the generated code as a function call. 

A small example:
```py
import pytensor
import pytensor.tensor as ptt

x = ptt.vector('x')
o = x[-1].inc(1)
f = pytensor.function(inputs=[x], outputs=o, mode="PYTORCH")
```

will generate

```py
def pytorch_funcified_fgraph(x):
    tensor_constant = torch_assume_constant()
    scalar_constant = torch_assume_constant_1()
    # IncSubtensor{i}(x, 1, -1)
    tensor_variable = inc_subtensor(x, tensor_constant, scalar_constant)
    return (tensor_variable,)
```

`torch_assume_constant` can now do whatever it needs to do to allow the backend (torch in this case) to know that the variable is infact a constant. 

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #1154 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [X] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [X] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [X] New feature / enhancement
- [X] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1159.org.readthedocs.build/en/1159/

<!-- readthedocs-preview pytensor end -->