### PR TITLE
Speedup pytensor import

### DIFF
--- a/pytensor/compile/compilelock.py
+++ b/pytensor/compile/compilelock.py
@@ -8,8 +8,6 @@ import threading
 from contextlib import contextmanager
 from pathlib import Path
 
-import filelock
-
 from pytensor.configdefaults import config
 
 
@@ -35,8 +33,9 @@ def force_unlock(lock_dir: os.PathLike):
     lock_dir : os.PathLike
         Path to a directory that was locked with `lock_ctx`.
     """
+    from filelock import FileLock
 
-    fl = filelock.FileLock(Path(lock_dir) / ".lock")
+    fl = FileLock(Path(lock_dir) / ".lock")
     fl.release(force=True)
 
     dir_key = f"{lock_dir}-{os.getpid()}"
@@ -62,6 +61,8 @@ def lock_ctx(
         Timeout in seconds for waiting in lock acquisition.
         Defaults to `pytensor.config.compile__timeout`.
     """
+    from filelock import FileLock
+
     if lock_dir is None:
         lock_dir = config.compiledir
 
@@ -73,7 +74,7 @@ def lock_ctx(
 
     if dir_key not in local_mem._locks:
         local_mem._locks[dir_key] = True
-        fl = filelock.FileLock(Path(lock_dir) / ".lock")
+        fl = FileLock(Path(lock_dir) / ".lock")
         fl.acquire(timeout=timeout)
         try:
             yield

--- a/pytensor/configdefaults.py
+++ b/pytensor/configdefaults.py
@@ -3,10 +3,10 @@ import logging
 import os
 import platform
 import re
-import shutil
 import sys
 import textwrap
 from pathlib import Path
+from shutil import which
 
 import numpy as np
 
@@ -348,7 +348,7 @@ def add_compile_configvars():
 
     # Try to find the full compiler path from the name
     if param != "":
-        newp = shutil.which(param)
+        newp = which(param)
         if newp is not None:
             param = newp
         del newp

--- a/pytensor/configdefaults.py
+++ b/pytensor/configdefaults.py
@@ -4,7 +4,6 @@ import os
 import platform
 import re
 import shutil
-import socket
 import sys
 import textwrap
 from pathlib import Path
@@ -1190,7 +1189,7 @@ _compiledir_format_dict = {
     "pytensor_version": pytensor.__version__,
     "numpy_version": np.__version__,
     "gxx_version": "xxx",
-    "hostname": socket.gethostname(),
+    "hostname": platform.node(),
 }
 
 

--- a/pytensor/configparser.py
+++ b/pytensor/configparser.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import shlex
 import sys
 import warnings
 from collections.abc import Callable, Sequence
@@ -14,6 +13,7 @@ from configparser import (
 from functools import wraps
 from io import StringIO
 from pathlib import Path
+from shlex import shlex
 
 from pytensor.utils import hash_from_code
 
@@ -541,7 +541,7 @@ def parse_config_string(
     Parses a config string (comma-separated key=value components) into a dict.
     """
     config_dict = {}
-    my_splitter = shlex.shlex(config_string, posix=True)
+    my_splitter = shlex(config_string, posix=True)
     my_splitter.whitespace = ","
     my_splitter.whitespace_split = True
     for kv_pair in my_splitter:

--- a/pytensor/d3viz/formatting.py
+++ b/pytensor/d3viz/formatting.py
@@ -12,13 +12,7 @@ import pytensor
 from pytensor.compile import Function, builders
 from pytensor.graph.basic import Apply, Constant, Variable, graph_inputs
 from pytensor.graph.fg import FunctionGraph
-from pytensor.printing import pydot_imported, pydot_imported_msg
-
-
-try:
-    from pytensor.printing import pd
-except ImportError:
-    pass
+from pytensor.printing import _try_pydot_import
 
 
 class PyDotFormatter:
@@ -41,8 +35,7 @@ class PyDotFormatter:
 
     def __init__(self, compact=True):
         """Construct PyDotFormatter object."""
-        if not pydot_imported:
-            raise ImportError("Failed to import pydot. " + pydot_imported_msg)
+        _try_pydot_import()
 
         self.compact = compact
         self.node_colors = {
@@ -115,6 +108,8 @@ class PyDotFormatter:
         pydot.Dot
             Pydot graph of `fct`
         """
+        pd = _try_pydot_import()
+
         if graph is None:
             graph = pd.Dot()
 
@@ -356,6 +351,8 @@ def type_to_str(t):
 
 def dict_to_pdnode(d):
     """Create pydot node from dict."""
+    pd = _try_pydot_import()
+
     e = dict()
     for k, v in d.items():
         if v is not None:

--- a/pytensor/graph/rewriting/basic.py
+++ b/pytensor/graph/rewriting/basic.py
@@ -5,7 +5,6 @@ import copy
 import functools
 import inspect
 import logging
-import pdb
 import sys
 import time
 import traceback
@@ -237,6 +236,8 @@ class SequentialGraphRewriter(GraphRewriter, UserList):
         if config.on_opt_error == "raise":
             raise exc
         elif config.on_opt_error == "pdb":
+            import pdb
+
             pdb.post_mortem(sys.exc_info()[2])
 
     def __init__(self, *rewrites, failure_callback=None):
@@ -1752,6 +1753,8 @@ class NodeProcessingGraphRewriter(GraphRewriter):
             _logger.error("TRACEBACK:")
             _logger.error(traceback.format_exc())
         if config.on_opt_error == "pdb":
+            import pdb
+
             pdb.post_mortem(sys.exc_info()[2])
         elif isinstance(exc, AssertionError) or config.on_opt_error == "raise":
             # We always crash on AssertionError because something may be

--- a/pytensor/link/vm.py
+++ b/pytensor/link/vm.py
@@ -19,7 +19,6 @@ from typing import TYPE_CHECKING, Any
 from pytensor.configdefaults import config
 from pytensor.graph.basic import Apply, Constant, Variable
 from pytensor.link.basic import Container, LocalLinker
-from pytensor.link.c.exceptions import MissingGXX
 from pytensor.link.utils import (
     gc_helper,
     get_destroy_dependencies,
@@ -1006,6 +1005,8 @@ class VMLinker(LocalLinker):
         compute_map,
         updated_vars,
     ):
+        from pytensor.link.c.exceptions import MissingGXX
+
         pre_call_clear = [storage_map[v] for v in self.no_recycling]
 
         try:

--- a/pytensor/printing.py
+++ b/pytensor/printing.py
@@ -26,39 +26,6 @@ from pytensor.graph.utils import Scratchpad
 
 IDTypesType = Literal["id", "int", "CHAR", "auto", ""]
 
-pydot_imported = False
-pydot_imported_msg = ""
-try:
-    # pydot-ng is a fork of pydot that is better maintained
-    import pydot_ng as pd
-
-    if pd.find_graphviz():
-        pydot_imported = True
-    else:
-        pydot_imported_msg = "pydot-ng can't find graphviz. Install graphviz."
-except ImportError:
-    try:
-        # fall back on pydot if necessary
-        import pydot as pd
-
-        if hasattr(pd, "find_graphviz"):
-            if pd.find_graphviz():
-                pydot_imported = True
-            else:
-                pydot_imported_msg = "pydot can't find graphviz"
-        else:
-            pd.Dot.create(pd.Dot())
-            pydot_imported = True
-    except ImportError:
-        # tests should not fail on optional dependency
-        pydot_imported_msg = (
-            "Install the python package pydot or pydot-ng. Install graphviz."
-        )
-    except Exception as e:
-        pydot_imported_msg = "An error happened while importing/trying pydot: "
-        pydot_imported_msg += str(e.args)
-
-
 _logger = logging.getLogger("pytensor.printing")
 VALID_ASSOC = {"left", "right", "either"}
 
@@ -1196,6 +1163,48 @@ default_colorCodes = {
 }
 
 
+def _try_pydot_import():
+    pydot_imported = False
+    pydot_imported_msg = ""
+    try:
+        # pydot-ng is a fork of pydot that is better maintained
+        import pydot_ng as pd
+
+        if pd.find_graphviz():
+            pydot_imported = True
+        else:
+            pydot_imported_msg = "pydot-ng can't find graphviz. Install graphviz."
+    except ImportError:
+        try:
+            # fall back on pydot if necessary
+            import pydot as pd
+
+            if hasattr(pd, "find_graphviz"):
+                if pd.find_graphviz():
+                    pydot_imported = True
+                else:
+                    pydot_imported_msg = "pydot can't find graphviz"
+            else:
+                pd.Dot.create(pd.Dot())
+                pydot_imported = True
+        except ImportError:
+            # tests should not fail on optional dependency
+            pydot_imported_msg = (
+                "Install the python package pydot or pydot-ng. Install graphviz."
+            )
+        except Exception as e:
+            pydot_imported_msg = "An error happened while importing/trying pydot: "
+            pydot_imported_msg += str(e.args)
+
+    if not pydot_imported:
+        raise ImportError(
+            "Failed to import pydot. You must install graphviz "
+            "and either pydot or pydot-ng for "
+            f"`pydotprint` to work:\n {pydot_imported_msg}",
+        )
+    return pd
+
+
 def pydotprint(
     fct,
     outfile: Path | str | None = None,
@@ -1288,6 +1297,8 @@ def pydotprint(
         scan separately after the top level debugprint output.
 
     """
+    pd = _try_pydot_import()
+
     from pytensor.scan.op import Scan
 
     if colorCodes is None:
@@ -1320,12 +1331,6 @@ def pydotprint(
         outputs = fct.outputs
         topo = fct.toposort()
         fgraph = fct
-    if not pydot_imported:
-        raise RuntimeError(
-            "Failed to import pydot. You must install graphviz "
-            "and either pydot or pydot-ng for "
-            f"`pydotprint` to work:\n {pydot_imported_msg}",
-        )
 
     g = pd.Dot()
 

--- a/pytensor/scalar/math.py
+++ b/pytensor/scalar/math.py
@@ -9,8 +9,6 @@ from pathlib import Path
 from textwrap import dedent
 
 import numpy as np
-import scipy.special
-import scipy.stats
 
 from pytensor.configdefaults import config
 from pytensor.gradient import grad_not_implemented, grad_undefined
@@ -54,7 +52,9 @@ class Erf(UnaryScalarOp):
     nfunc_spec = ("scipy.special.erf", 1, 1)
 
     def impl(self, x):
-        return scipy.special.erf(x)
+        from scipy.special import erf
+
+        return erf(x)
 
     def L_op(self, inputs, outputs, grads):
         (x,) = inputs
@@ -88,7 +88,9 @@ class Erfc(UnaryScalarOp):
     nfunc_spec = ("scipy.special.erfc", 1, 1)
 
     def impl(self, x):
-        return scipy.special.erfc(x)
+        from scipy.special import erfc
+
+        return erfc(x)
 
     def L_op(self, inputs, outputs, grads):
         (x,) = inputs
@@ -137,7 +139,9 @@ class Erfcx(UnaryScalarOp):
     nfunc_spec = ("scipy.special.erfcx", 1, 1)
 
     def impl(self, x):
-        return scipy.special.erfcx(x)
+        from scipy.special import erfcx
+
+        return erfcx(x)
 
     def L_op(self, inputs, outputs, grads):
         (x,) = inputs
@@ -193,7 +197,9 @@ class Erfinv(UnaryScalarOp):
     nfunc_spec = ("scipy.special.erfinv", 1, 1)
 
     def impl(self, x):
-        return scipy.special.erfinv(x)
+        from scipy.special import erfinv
+
+        return erfinv(x)
 
     def L_op(self, inputs, outputs, grads):
         (x,) = inputs
@@ -228,7 +234,9 @@ class Erfcinv(UnaryScalarOp):
     nfunc_spec = ("scipy.special.erfcinv", 1, 1)
 
     def impl(self, x):
-        return scipy.special.erfcinv(x)
+        from scipy.special import erfcinv
+
+        return erfcinv(x)
 
     def L_op(self, inputs, outputs, grads):
         (x,) = inputs
@@ -264,7 +272,9 @@ class Owens_t(BinaryScalarOp):
 
     @staticmethod
     def st_impl(h, a):
-        return scipy.special.owens_t(h, a)
+        from scipy.special import owens_t
+
+        return owens_t(h, a)
 
     def impl(self, h, a):
         return Owens_t.st_impl(h, a)
@@ -293,7 +303,9 @@ class Gamma(UnaryScalarOp):
 
     @staticmethod
     def st_impl(x):
-        return scipy.special.gamma(x)
+        from scipy.special import gamma
+
+        return gamma(x)
 
     def impl(self, x):
         return Gamma.st_impl(x)
@@ -332,7 +344,9 @@ class GammaLn(UnaryScalarOp):
 
     @staticmethod
     def st_impl(x):
-        return scipy.special.gammaln(x)
+        from scipy.special import gammaln
+
+        return gammaln(x)
 
     def impl(self, x):
         return GammaLn.st_impl(x)
@@ -376,7 +390,9 @@ class Psi(UnaryScalarOp):
 
     @staticmethod
     def st_impl(x):
-        return scipy.special.psi(x)
+        from scipy.special import psi
+
+        return psi(x)
 
     def impl(self, x):
         return Psi.st_impl(x)
@@ -467,7 +483,9 @@ class TriGamma(UnaryScalarOp):
 
     @staticmethod
     def st_impl(x):
-        return scipy.special.polygamma(1, x)
+        from scipy.special import polygamma
+
+        return polygamma(1, x)
 
     def impl(self, x):
         return TriGamma.st_impl(x)
@@ -570,7 +588,9 @@ class PolyGamma(BinaryScalarOp):
 
     @staticmethod
     def st_impl(n, x):
-        return scipy.special.polygamma(n, x)
+        from scipy.special import polygamma
+
+        return polygamma(n, x)
 
     def impl(self, n, x):
         return PolyGamma.st_impl(n, x)
@@ -602,7 +622,9 @@ class Chi2SF(BinaryScalarOp):
 
     @staticmethod
     def st_impl(x, k):
-        return scipy.stats.chi2.sf(x, k)
+        from scipy.stats import chi2
+
+        return chi2.sf(x, k)
 
     def impl(self, x, k):
         return Chi2SF.st_impl(x, k)
@@ -645,7 +667,9 @@ class GammaInc(BinaryScalarOp):
 
     @staticmethod
     def st_impl(k, x):
-        return scipy.special.gammainc(k, x)
+        from scipy.special import gammainc
+
+        return gammainc(k, x)
 
     def impl(self, k, x):
         return GammaInc.st_impl(k, x)
@@ -696,7 +720,9 @@ class GammaIncC(BinaryScalarOp):
 
     @staticmethod
     def st_impl(k, x):
-        return scipy.special.gammaincc(k, x)
+        from scipy.special import gammaincc
+
+        return gammaincc(k, x)
 
     def impl(self, k, x):
         return GammaIncC.st_impl(k, x)
@@ -747,7 +773,9 @@ class GammaIncInv(BinaryScalarOp):
 
     @staticmethod
     def st_impl(k, x):
-        return scipy.special.gammaincinv(k, x)
+        from scipy.special import gammaincinv
+
+        return gammaincinv(k, x)
 
     def impl(self, k, x):
         return GammaIncInv.st_impl(k, x)
@@ -776,7 +804,9 @@ class GammaIncCInv(BinaryScalarOp):
 
     @staticmethod
     def st_impl(k, x):
-        return scipy.special.gammainccinv(k, x)
+        from scipy.special import gammainccinv
+
+        return gammainccinv(k, x)
 
     def impl(self, k, x):
         return GammaIncCInv.st_impl(k, x)
@@ -1015,7 +1045,9 @@ class GammaU(BinaryScalarOp):
 
     @staticmethod
     def st_impl(k, x):
-        return scipy.special.gammaincc(k, x) * scipy.special.gamma(k)
+        from scipy.special import gamma, gammaincc
+
+        return gammaincc(k, x) * gamma(k)
 
     def impl(self, k, x):
         return GammaU.st_impl(k, x)
@@ -1051,7 +1083,9 @@ class GammaL(BinaryScalarOp):
 
     @staticmethod
     def st_impl(k, x):
-        return scipy.special.gammainc(k, x) * scipy.special.gamma(k)
+        from scipy.special import gamma, gammainc
+
+        return gammainc(k, x) * gamma(k)
 
     def impl(self, k, x):
         return GammaL.st_impl(k, x)
@@ -1087,7 +1121,9 @@ class Jv(BinaryScalarOp):
 
     @staticmethod
     def st_impl(v, x):
-        return scipy.special.jv(v, x)
+        from scipy.special import jv
+
+        return jv(v, x)
 
     def impl(self, v, x):
         return self.st_impl(v, x)
@@ -1116,7 +1152,9 @@ class J1(UnaryScalarOp):
 
     @staticmethod
     def st_impl(x):
-        return scipy.special.j1(x)
+        from scipy.special import j1
+
+        return j1(x)
 
     def impl(self, x):
         return self.st_impl(x)
@@ -1147,7 +1185,9 @@ class J0(UnaryScalarOp):
 
     @staticmethod
     def st_impl(x):
-        return scipy.special.j0(x)
+        from scipy.special import j0
+
+        return j0(x)
 
     def impl(self, x):
         return self.st_impl(x)
@@ -1178,7 +1218,9 @@ class Iv(BinaryScalarOp):
 
     @staticmethod
     def st_impl(v, x):
-        return scipy.special.iv(v, x)
+        from scipy.special import iv
+
+        return iv(v, x)
 
     def impl(self, v, x):
         return self.st_impl(v, x)
@@ -1207,7 +1249,9 @@ class I1(UnaryScalarOp):
 
     @staticmethod
     def st_impl(x):
-        return scipy.special.i1(x)
+        from scipy.special import i1
+
+        return i1(x)
 
     def impl(self, x):
         return self.st_impl(x)
@@ -1233,7 +1277,9 @@ class I0(UnaryScalarOp):
 
     @staticmethod
     def st_impl(x):
-        return scipy.special.i0(x)
+        from scipy.special import i0
+
+        return i0(x)
 
     def impl(self, x):
         return self.st_impl(x)
@@ -1259,7 +1305,9 @@ class Ive(BinaryScalarOp):
 
     @staticmethod
     def st_impl(v, x):
-        return scipy.special.ive(v, x)
+        from scipy.special import ive
+
+        return ive(v, x)
 
     def impl(self, v, x):
         return self.st_impl(v, x)
@@ -1288,7 +1336,9 @@ class Kve(BinaryScalarOp):
 
     @staticmethod
     def st_impl(v, x):
-        return scipy.special.kve(v, x)
+        from scipy.special import kve
+
+        return kve(v, x)
 
     def impl(self, v, x):
         return self.st_impl(v, x)
@@ -1321,7 +1371,9 @@ class Sigmoid(UnaryScalarOp):
     nfunc_spec = ("scipy.special.expit", 1, 1)
 
     def impl(self, x):
-        return scipy.special.expit(x)
+        from scipy.special import expit
+
+        return expit(x)
 
     def grad(self, inp, grads):
         (x,) = inp
@@ -1496,7 +1548,9 @@ class BetaInc(ScalarOp):
     nfunc_spec = ("scipy.special.betainc", 3, 1)
 
     def impl(self, a, b, x):
-        return scipy.special.betainc(a, b, x)
+        from scipy.special import betainc
+
+        return betainc(a, b, x)
 
     def grad(self, inp, grads):
         a, b, x = inp
@@ -1756,7 +1810,9 @@ class BetaIncInv(ScalarOp):
     nfunc_spec = ("scipy.special.betaincinv", 3, 1)
 
     def impl(self, a, b, x):
-        return scipy.special.betaincinv(a, b, x)
+        from scipy.special import betaincinv
+
+        return betaincinv(a, b, x)
 
     def grad(self, inputs, grads):
         (a, b, x) = inputs
@@ -1796,7 +1852,9 @@ class Hyp2F1(ScalarOp):
 
     @staticmethod
     def st_impl(a, b, c, z):
-        return scipy.special.hyp2f1(a, b, c, z)
+        from scipy.special import hyp2f1
+
+        return hyp2f1(a, b, c, z)
 
     def impl(self, a, b, c, z):
         return Hyp2F1.st_impl(a, b, c, z)

--- a/pytensor/scan/op.py
+++ b/pytensor/scan/op.py
@@ -74,7 +74,6 @@ from pytensor.graph.op import HasInnerGraph, Op
 from pytensor.graph.replace import clone_replace
 from pytensor.graph.utils import InconsistencyError, MissingInputError
 from pytensor.link.c.basic import CLinker
-from pytensor.link.c.exceptions import MissingGXX
 from pytensor.printing import op_debug_information
 from pytensor.scan.utils import ScanProfileStats, Validator, forced_replace, safe_new
 from pytensor.tensor.basic import as_tensor_variable
@@ -1499,6 +1498,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         then it must not do so for variables in the no_recycling list.
 
         """
+        from pytensor.link.c.exceptions import MissingGXX
 
         # Before building the thunk, validate that the inner graph is
         # coherent

--- a/pytensor/sparse/rewriting.py
+++ b/pytensor/sparse/rewriting.py
@@ -1,5 +1,5 @@
 import numpy as np
-import scipy
+from scipy.sparse import csc_matrix, csr_matrix
 
 import pytensor
 import pytensor.scalar as ps
@@ -279,9 +279,7 @@ class StructuredDotCSC(COp):
     def perform(self, node, inputs, outputs):
         (a_val, a_ind, a_ptr, a_nrows, b) = inputs
         (out,) = outputs
-        a = scipy.sparse.csc_matrix(
-            (a_val, a_ind, a_ptr), (a_nrows, b.shape[0]), copy=False
-        )
+        a = csc_matrix((a_val, a_ind, a_ptr), (a_nrows, b.shape[0]), copy=False)
         # out[0] = a.dot(b)
         out[0] = np.asarray(a * b, dtype=node.outputs[0].type.dtype)
         assert _is_dense(out[0])  # scipy 0.7 automatically converts to dense
@@ -478,7 +476,7 @@ class StructuredDotCSR(COp):
     def perform(self, node, inputs, outputs):
         (a_val, a_ind, a_ptr, b) = inputs
         (out,) = outputs
-        a = scipy.sparse.csr_matrix(
+        a = csr_matrix(
             (a_val, a_ind, a_ptr), (len(a_ptr) - 1, b.shape[0]), copy=True
         )  # use view_map before setting this to False
         # out[0] = a.dot(b)

--- a/pytensor/sparse/sharedvar.py
+++ b/pytensor/sparse/sharedvar.py
@@ -1,6 +1,6 @@
 import copy
 
-import scipy.sparse
+from scipy.sparse import spmatrix
 
 from pytensor.compile import shared_constructor
 from pytensor.sparse.basic import SparseTensorType, SparseVariable
@@ -13,7 +13,7 @@ class SparseTensorSharedVariable(TensorSharedVariable, SparseVariable):
         return self.type.format
 
 
-@shared_constructor.register(scipy.sparse.spmatrix)
+@shared_constructor.register(spmatrix)
 def sparse_constructor(
     value, name=None, strict=False, allow_downcast=None, borrow=False, format=None
 ):

--- a/pytensor/tensor/blas.py
+++ b/pytensor/tensor/blas.py
@@ -111,50 +111,19 @@ from pytensor.tensor.type import DenseTensorType, TensorType, integer_dtypes, te
 
 _logger = logging.getLogger("pytensor.tensor.blas")
 
-try:
-    import scipy.linalg.blas
-
-    have_fblas = True
-    try:
-        fblas = scipy.linalg.blas.fblas
-    except AttributeError:
-        # A change merged in Scipy development version on 2012-12-02 replaced
-        # `scipy.linalg.blas.fblas` with `scipy.linalg.blas`.
-        # See http://github.com/scipy/scipy/pull/358
-        fblas = scipy.linalg.blas
-    _blas_gemv_fns = {
-        np.dtype("float32"): fblas.sgemv,
-        np.dtype("float64"): fblas.dgemv,
-        np.dtype("complex64"): fblas.cgemv,
-        np.dtype("complex128"): fblas.zgemv,
-    }
-except ImportError as e:
-    have_fblas = False
-    # This is used in Gemv and ScipyGer. We use CGemv and CGer
-    # when config.blas__ldflags is defined. So we don't need a
-    # warning in that case.
-    if not config.blas__ldflags:
-        _logger.warning(
-            "Failed to import scipy.linalg.blas, and "
-            "PyTensor flag blas__ldflags is empty. "
-            "Falling back on slower implementations for "
-            "dot(matrix, vector), dot(vector, matrix) and "
-            f"dot(vector, vector) ({e!s})"
-        )
-
 
 # If check_init_y() == True we need to initialize y when beta == 0.
 def check_init_y():
+    # TODO: What is going on here?
+    from scipy.linalg.blas import get_blas_funcs
+
     if check_init_y._result is None:
-        if not have_fblas:  # pragma: no cover
-            check_init_y._result = False
-        else:
-            y = float("NaN") * np.ones((2,))
-            x = np.ones((2,))
-            A = np.ones((2, 2))
-            gemv = _blas_gemv_fns[y.dtype]
-            gemv(1.0, A.T, x, 0.0, y, overwrite_y=True, trans=True)
-            check_init_y._result = np.isnan(y).any()
+        y = float("NaN") * np.ones((2,))
+        x = np.ones((2,))
+        A = np.ones((2, 2))
+        gemv = get_blas_funcs("gemv", dtype=y.dtype)
+        gemv(1.0, A.T, x, 0.0, y, overwrite_y=True, trans=True)
+        check_init_y._result = np.isnan(y).any()
 
     return check_init_y._result
 
@@ -211,14 +180,15 @@ class Gemv(Op):
         return Apply(self, inputs, [y.type()])
 
     def perform(self, node, inputs, out_storage):
+        from scipy.linalg.blas import get_blas_funcs
+
         y, alpha, A, x, beta = inputs
         if (
-            have_fblas
-            and y.shape[0] != 0
+            y.shape[0] != 0
             and x.shape[0] != 0
-            and y.dtype in _blas_gemv_fns
+            and y.dtype in {"float32", "float64", "complex64", "complex128"}
         ):
-            gemv = _blas_gemv_fns[y.dtype]
+            gemv = get_blas_funcs("gemv", dtype=y.dtype)
 
             if A.shape[0] != y.shape[0] or A.shape[1] != x.shape[0]:
                 raise ValueError(

--- a/pytensor/tensor/blas_scipy.py
+++ b/pytensor/tensor/blas_scipy.py
@@ -2,30 +2,19 @@
 Implementations of BLAS Ops based on scipy's BLAS bindings.
 """
 
-import numpy as np
-
-from pytensor.tensor.blas import Ger, have_fblas
-
-
-if have_fblas:
-    from pytensor.tensor.blas import fblas
-
-    _blas_ger_fns = {
-        np.dtype("float32"): fblas.sger,
-        np.dtype("float64"): fblas.dger,
-        np.dtype("complex64"): fblas.cgeru,
-        np.dtype("complex128"): fblas.zgeru,
-    }
+from pytensor.tensor.blas import Ger
 
 
 class ScipyGer(Ger):
     def perform(self, node, inputs, output_storage):
+        from scipy.linalg.blas import get_blas_funcs
+
         cA, calpha, cx, cy = inputs
         (cZ,) = output_storage
         # N.B. some versions of scipy (e.g. mine) don't actually work
         # in-place on a, even when I tell it to.
         A = cA
-        local_ger = _blas_ger_fns[cA.dtype]
+        local_ger = get_blas_funcs("ger", dtype=cA.dtype)
         if A.size == 0:
             # We don't have to compute anything, A is empty.
             # We need this special case because Numpy considers it

--- a/pytensor/tensor/random/basic.py
+++ b/pytensor/tensor/random/basic.py
@@ -2,7 +2,6 @@ import abc
 import warnings
 
 import numpy as np
-import scipy.stats as stats
 
 import pytensor
 from pytensor.tensor import get_vector_length, specify_shape
@@ -350,7 +349,9 @@ class HalfNormalRV(ScipyRandomVariable):
             is returned.
 
         """
-        return stats.halfnorm.rvs(loc, scale, random_state=rng, size=size)
+        from scipy.stats import halfnorm
+
+        return halfnorm.rvs(loc, scale, random_state=rng, size=size)
 
 
 halfnormal = HalfNormalRV()
@@ -583,7 +584,9 @@ class ParetoRV(ScipyRandomVariable):
 
     @classmethod
     def rng_fn_scipy(cls, rng, b, scale, size):
-        return stats.pareto.rvs(b, scale=scale, size=size, random_state=rng)
+        from scipy.stats import pareto
+
+        return pareto.rvs(b, scale=scale, size=size, random_state=rng)
 
 
 pareto = ParetoRV()
@@ -645,7 +648,9 @@ class GumbelRV(ScipyRandomVariable):
         scale: np.ndarray | float,
         size: list[int] | int | None,
     ) -> np.ndarray:
-        return stats.gumbel_r.rvs(loc=loc, scale=scale, size=size, random_state=rng)
+        from scipy.stats import gumbel_r
+
+        return gumbel_r.rvs(loc=loc, scale=scale, size=size, random_state=rng)
 
 
 gumbel = GumbelRV()
@@ -840,8 +845,10 @@ def safe_multivariate_normal(mean, cov, size=None, rng=None):
     variable.
 
     """
+    from scipy.stats import multivariate_normal
+
     res = np.atleast_1d(
-        stats.multivariate_normal(mean=mean, cov=cov, allow_singular=True).rvs(
+        multivariate_normal(mean=mean, cov=cov, allow_singular=True).rvs(
             size=size, random_state=rng
         )
     )
@@ -1173,7 +1180,9 @@ class CauchyRV(ScipyRandomVariable):
 
     @classmethod
     def rng_fn_scipy(cls, rng, loc, scale, size):
-        return stats.cauchy.rvs(loc=loc, scale=scale, random_state=rng, size=size)
+        from scipy.stats import cauchy
+
+        return cauchy.rvs(loc=loc, scale=scale, random_state=rng, size=size)
 
 
 cauchy = CauchyRV()
@@ -1223,7 +1232,9 @@ class HalfCauchyRV(ScipyRandomVariable):
 
     @classmethod
     def rng_fn_scipy(cls, rng, loc, scale, size):
-        return stats.halfcauchy.rvs(loc=loc, scale=scale, random_state=rng, size=size)
+        from scipy.stats import halfcauchy
+
+        return halfcauchy.rvs(loc=loc, scale=scale, random_state=rng, size=size)
 
 
 halfcauchy = HalfCauchyRV()
@@ -1277,7 +1288,9 @@ class InvGammaRV(ScipyRandomVariable):
 
     @classmethod
     def rng_fn_scipy(cls, rng, shape, scale, size):
-        return stats.invgamma.rvs(shape, scale=scale, size=size, random_state=rng)
+        from scipy.stats import invgamma
+
+        return invgamma.rvs(shape, scale=scale, size=size, random_state=rng)
 
 
 invgamma = InvGammaRV()
@@ -1376,9 +1389,9 @@ class TruncExponentialRV(ScipyRandomVariable):
 
     @classmethod
     def rng_fn_scipy(cls, rng, b, loc, scale, size):
-        return stats.truncexpon.rvs(
-            b, loc=loc, scale=scale, size=size, random_state=rng
-        )
+        from scipy.stats import truncexpon
+
+        return truncexpon.rvs(b, loc=loc, scale=scale, size=size, random_state=rng)
 
 
 truncexpon = TruncExponentialRV()
@@ -1432,7 +1445,9 @@ class StudentTRV(ScipyRandomVariable):
 
     @classmethod
     def rng_fn_scipy(cls, rng, df, loc, scale, size):
-        return stats.t.rvs(df, loc=loc, scale=scale, size=size, random_state=rng)
+        from scipy.stats import t
+
+        return t.rvs(df, loc=loc, scale=scale, size=size, random_state=rng)
 
 
 t = StudentTRV()
@@ -1485,7 +1500,9 @@ class BernoulliRV(ScipyRandomVariable):
 
     @classmethod
     def rng_fn_scipy(cls, rng, p, size):
-        return stats.bernoulli.rvs(p, size=size, random_state=rng)
+        from scipy.stats import bernoulli
+
+        return bernoulli.rvs(p, size=size, random_state=rng)
 
 
 bernoulli = BernoulliRV()
@@ -1624,7 +1641,9 @@ class NegBinomialRV(ScipyRandomVariable):
 
     @classmethod
     def rng_fn_scipy(cls, rng, n, p, size):
-        return stats.nbinom.rvs(n, p, size=size, random_state=rng)
+        from scipy.stats import nbinom
+
+        return nbinom.rvs(n, p, size=size, random_state=rng)
 
 
 nbinom = NegBinomialRV()
@@ -1681,7 +1700,9 @@ class BetaBinomialRV(ScipyRandomVariable):
 
     @classmethod
     def rng_fn_scipy(cls, rng, n, a, b, size):
-        return stats.betabinom.rvs(n, a, b, size=size, random_state=rng)
+        from scipy.stats import betabinom
+
+        return betabinom.rvs(n, a, b, size=size, random_state=rng)
 
 
 betabinom = BetaBinomialRV()
@@ -1733,9 +1754,9 @@ class GenGammaRV(ScipyRandomVariable):
 
     @classmethod
     def rng_fn_scipy(cls, rng, alpha, p, lambd, size):
-        return stats.gengamma.rvs(
-            alpha / p, p, scale=lambd, size=size, random_state=rng
-        )
+        from scipy.stats import gengamma
+
+        return gengamma.rvs(alpha / p, p, scale=lambd, size=size, random_state=rng)
 
 
 gengamma = GenGammaRV()

--- a/pytensor/tensor/rewriting/blas_scipy.py
+++ b/pytensor/tensor/rewriting/blas_scipy.py
@@ -1,5 +1,5 @@
 from pytensor.graph.rewriting.basic import in2out
-from pytensor.tensor.blas import ger, ger_destructive, have_fblas
+from pytensor.tensor.blas import ger, ger_destructive
 from pytensor.tensor.blas_scipy import scipy_ger_inplace, scipy_ger_no_inplace
 from pytensor.tensor.rewriting.blas import blas_optdb, node_rewriter, optdb
 
@@ -19,19 +19,19 @@ def make_ger_destructive(fgraph, node):
 use_scipy_blas = in2out(use_scipy_ger)
 make_scipy_blas_destructive = in2out(make_ger_destructive)
 
-if have_fblas:
-    # scipy_blas is scheduled in the blas_optdb very late, because scipy sortof
-    # sucks, but it is almost always present.
-    # C implementations should be scheduled earlier than this, so that they take
-    # precedence. Once the original Ger is replaced, then these optimizations
-    # have no effect.
-    blas_optdb.register("scipy_blas", use_scipy_blas, "fast_run", position=100)
 
-    # this matches the InplaceBlasOpt defined in blas.py
-    optdb.register(
-        "make_scipy_blas_destructive",
-        make_scipy_blas_destructive,
-        "fast_run",
-        "inplace",
-        position=50.2,
-    )
+# scipy_blas is scheduled in the blas_optdb very late, because scipy sortof
+# sucks [citation needed], but it is almost always present.
+# C implementations should be scheduled earlier than this, so that they take
+# precedence. Once the original Ger is replaced, then these optimizations
+# have no effect.
+blas_optdb.register("scipy_blas", use_scipy_blas, "fast_run", position=100)
+
+# this matches the InplaceBlasOpt defined in blas.py
+optdb.register(
+    "make_scipy_blas_destructive",
+    make_scipy_blas_destructive,
+    "fast_run",
+    "inplace",
+    position=50.2,
+)

--- a/pytensor/tensor/special.py
+++ b/pytensor/tensor/special.py
@@ -1,7 +1,6 @@
 from textwrap import dedent
 
 import numpy as np
-import scipy
 
 from pytensor.graph.basic import Apply
 from pytensor.graph.replace import _vectorize_node
@@ -267,9 +266,11 @@ class Softmax(COp):
         return Apply(self, [x], [x.type()])
 
     def perform(self, node, input_storage, output_storage):
+        from scipy.special import softmax
+
         (x,) = input_storage
         (z,) = output_storage
-        z[0] = scipy.special.softmax(x, axis=self.axis)
+        z[0] = softmax(x, axis=self.axis)
 
     def L_op(self, inp, outputs, grads):
         (x,) = inp
@@ -519,9 +520,11 @@ class LogSoftmax(COp):
         return Apply(self, [x], [x.type()])
 
     def perform(self, node, input_storage, output_storage):
+        from scipy.special import log_softmax
+
         (x,) = input_storage
         (z,) = output_storage
-        z[0] = scipy.special.log_softmax(x, axis=self.axis)
+        z[0] = log_softmax(x, axis=self.axis)
 
     def grad(self, inp, grads):
         (x,) = inp

--- a/tests/d3viz/test_d3viz.py
+++ b/tests/d3viz/test_d3viz.py
@@ -9,12 +9,14 @@ import pytensor.d3viz as d3v
 from pytensor import compile
 from pytensor.compile.function import function
 from pytensor.configdefaults import config
-from pytensor.printing import pydot_imported, pydot_imported_msg
+from pytensor.printing import _try_pydot_import
 from tests.d3viz import models
 
 
-if not pydot_imported:
-    pytest.skip("pydot not available: " + pydot_imported_msg, allow_module_level=True)
+try:
+    _try_pydot_import()
+except Exception as e:
+    pytest.skip(f"pydot not available: {e!s}", allow_module_level=True)
 
 
 class TestD3Viz:

--- a/tests/d3viz/test_formatting.py
+++ b/tests/d3viz/test_formatting.py
@@ -3,11 +3,13 @@ import pytest
 
 from pytensor import config, function
 from pytensor.d3viz.formatting import PyDotFormatter
-from pytensor.printing import pydot_imported, pydot_imported_msg
+from pytensor.printing import _try_pydot_import
 
 
-if not pydot_imported:
-    pytest.skip("pydot not available: " + pydot_imported_msg, allow_module_level=True)
+try:
+    _try_pydot_import()
+except Exception as e:
+    pytest.skip(f"pydot not available: {e!s}", allow_module_level=True)
 
 from tests.d3viz import models
 

--- a/tests/scan/test_printing.py
+++ b/tests/scan/test_printing.py
@@ -5,7 +5,7 @@ import pytensor
 import pytensor.tensor as pt
 from pytensor.configdefaults import config
 from pytensor.graph.fg import FunctionGraph
-from pytensor.printing import debugprint, pydot_imported, pydotprint
+from pytensor.printing import _try_pydot_import, debugprint, pydotprint
 from pytensor.tensor.type import dvector, iscalar, scalar, vector
 
 
@@ -684,6 +684,13 @@ def test_debugprint_compiled_fn():
 
     for truth, out in zip(expected_output.split("\n"), lines, strict=True):
         assert truth.strip() == out.strip()
+
+
+try:
+    _try_pydot_import()
+    pydot_imported = True
+except Exception:
+    pydot_imported = False
 
 
 @pytest.mark.skipif(not pydot_imported, reason="pydot not available")

--- a/tests/sparse/test_basic.py
+++ b/tests/sparse/test_basic.py
@@ -3,6 +3,7 @@ from itertools import product
 
 import numpy as np
 import pytest
+import scipy as sp
 from packaging import version
 
 import pytensor
@@ -82,7 +83,6 @@ from pytensor.sparse.basic import (
     _is_dense_variable,
     _is_sparse,
     _is_sparse_variable,
-    _mtypes,
 )
 from pytensor.sparse.rewriting import (
     AddSD_ccode,
@@ -115,8 +115,8 @@ from tests import unittest_tools as utt
 from tests.tensor.test_sharedvar import makeSharedTester
 
 
-sp = pytest.importorskip("scipy", minversion="0.7.0")
-
+sparse_formats = ["csc", "csr"]
+_mtypes = [sp.sparse.csc_matrix, sp.sparse.csr_matrix]
 
 # Probability distributions are currently tested in test_sp2.py
 # from pytensor.sparse import (
@@ -1997,7 +1997,7 @@ class TestColScaleCSC(utt.InferShapeTester):
         self.op = sparse.col_scale
 
     def test_op(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             variable, data = sparse_random_inputs(format, shape=(8, 10))
             variable.append(vector())
             data.append(np.random.random(10).astype(config.floatX))
@@ -2020,7 +2020,7 @@ class TestColScaleCSC(utt.InferShapeTester):
             self._compile_and_check(variable, [self.op(*variable)], data, cls)
 
     def test_grad(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             variable, data = sparse_random_inputs(format, shape=(8, 10))
             variable.append(vector())
             data.append(np.random.random(10).astype(config.floatX))
@@ -2034,7 +2034,7 @@ class TestRowScaleCSC(utt.InferShapeTester):
         self.op = sparse.row_scale
 
     def test_op(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             variable, data = sparse_random_inputs(format, shape=(8, 10))
             variable.append(vector())
             data.append(np.random.random(8).astype(config.floatX))
@@ -2057,7 +2057,7 @@ class TestRowScaleCSC(utt.InferShapeTester):
             self._compile_and_check(variable, [self.op(*variable)], data, cls)
 
     def test_grad(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             variable, data = sparse_random_inputs(format, shape=(8, 10))
             variable.append(vector())
             data.append(np.random.random(8).astype(config.floatX))
@@ -2075,7 +2075,7 @@ class TestSpSum(utt.InferShapeTester):
 
     @pytest.mark.parametrize("op_type", ["func", "method"])
     def test_op(self, op_type):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             for axis in self.possible_axis:
                 variable, data = sparse_random_inputs(format, shape=(10, 10))
 
@@ -2095,7 +2095,7 @@ class TestSpSum(utt.InferShapeTester):
                 utt.assert_allclose(expected, tested)
 
     def test_infer_shape(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             for axis in self.possible_axis:
                 variable, data = sparse_random_inputs(format, shape=(9, 10))
                 self._compile_and_check(
@@ -2103,7 +2103,7 @@ class TestSpSum(utt.InferShapeTester):
                 )
 
     def test_grad(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             for axis in self.possible_axis:
                 for struct in [True, False]:
                     variable, data = sparse_random_inputs(format, shape=(9, 10))
@@ -2121,7 +2121,7 @@ class TestDiag(utt.InferShapeTester):
         self.op = diag
 
     def test_op(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             variable, data = sparse_random_inputs(format, shape=(10, 10))
 
             z = self.op(*variable)
@@ -2134,14 +2134,14 @@ class TestDiag(utt.InferShapeTester):
             utt.assert_allclose(expected, tested)
 
     def test_infer_shape(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             variable, data = sparse_random_inputs(format, shape=(10, 10))
             self._compile_and_check(
                 variable, [self.op(*variable)], data, self.op_class, warn=False
             )
 
     def test_grad(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             variable, data = sparse_random_inputs(format, shape=(10, 10))
             verify_grad_sparse(self.op, data, structured=False)
 
@@ -2153,7 +2153,7 @@ class TestSquareDiagonal(utt.InferShapeTester):
         self.op = square_diagonal
 
     def test_op(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             for size in range(5, 9):
                 variable = [vector()]
                 data = [np.random.random(size).astype(config.floatX)]
@@ -2167,7 +2167,7 @@ class TestSquareDiagonal(utt.InferShapeTester):
                 assert tested.shape == expected.shape
 
     def test_infer_shape(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             for size in range(5, 9):
                 variable = [vector()]
                 data = [np.random.random(size).astype(config.floatX)]
@@ -2177,7 +2177,7 @@ class TestSquareDiagonal(utt.InferShapeTester):
                 )
 
     def test_grad(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             for size in range(5, 9):
                 data = [np.random.random(size).astype(config.floatX)]
 
@@ -2191,7 +2191,7 @@ class TestEnsureSortedIndices(utt.InferShapeTester):
         self.op = ensure_sorted_indices
 
     def test_op(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             for shape in zip(range(5, 9), range(3, 7)[::-1], strict=True):
                 variable, data = sparse_random_inputs(format, shape=shape)
 
@@ -2202,7 +2202,7 @@ class TestEnsureSortedIndices(utt.InferShapeTester):
                 utt.assert_allclose(expected, tested)
 
     def test_infer_shape(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             for shape in zip(range(5, 9), range(3, 7)[::-1], strict=True):
                 variable, data = sparse_random_inputs(format, shape=shape)
                 self._compile_and_check(
@@ -2210,7 +2210,7 @@ class TestEnsureSortedIndices(utt.InferShapeTester):
                 )
 
     def test_grad(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             for shape in zip(range(5, 9), range(3, 7)[::-1], strict=True):
                 variable, data = sparse_random_inputs(format, shape=shape)
                 verify_grad_sparse(self.op, data, structured=False)
@@ -2222,7 +2222,7 @@ class TestClean(utt.InferShapeTester):
         self.op = clean
 
     def test_op(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             for shape in zip(range(5, 9), range(3, 7)[::-1], strict=True):
                 variable, data = sparse_random_inputs(format, shape=shape)
 
@@ -2241,7 +2241,7 @@ class TestClean(utt.InferShapeTester):
                 utt.assert_allclose(expected, tested)
 
     def test_grad(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             for shape in zip(range(5, 9), range(3, 7)[::-1], strict=True):
                 variable, data = sparse_random_inputs(format, shape=shape)
                 verify_grad_sparse(self.op, data, structured=False)
@@ -2629,7 +2629,7 @@ class TestCasting(utt.InferShapeTester):
 
     # slow but only test
     def test_cast(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             for i_dtype in sparse.all_dtypes:
                 for o_dtype in sparse.all_dtypes:
                     (variable,), (data,) = sparse_random_inputs(
@@ -2658,7 +2658,7 @@ class TestCasting(utt.InferShapeTester):
 
     @pytest.mark.slow
     def test_infer_shape(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             for i_dtype in sparse.all_dtypes:
                 for o_dtype in sparse.all_dtypes:
                     variable, data = sparse_random_inputs(
@@ -2669,7 +2669,7 @@ class TestCasting(utt.InferShapeTester):
                     )
 
     def test_grad(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             for i_dtype in sparse.float_dtypes:
                 for o_dtype in float_dtypes:
                     if o_dtype == "float16":
@@ -2690,7 +2690,7 @@ def _format_info(nb):
     x = {}
     mat = {}
 
-    for format in sparse.sparse_formats:
+    for format in sparse_formats:
         variable = getattr(pytensor.sparse, format + "_matrix")
         spa = getattr(sp.sparse, format + "_matrix")
 
@@ -2710,8 +2710,8 @@ class _TestHVStack(utt.InferShapeTester):
     x, mat = _format_info(nb)
 
     def test_op(self):
-        for format in sparse.sparse_formats:
-            for out_f in sparse.sparse_formats:
+        for format in sparse_formats:
+            for out_f in sparse_formats:
                 for dtype in sparse.all_dtypes:
                     blocks = self.mat[format]
 
@@ -2729,7 +2729,7 @@ class _TestHVStack(utt.InferShapeTester):
                     assert tested.dtype == expected.dtype
 
     def test_infer_shape(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             self._compile_and_check(
                 self.x[format],
                 [self.op_class(dtype="float64")(*self.x[format])],
@@ -2738,8 +2738,8 @@ class _TestHVStack(utt.InferShapeTester):
             )
 
     def test_grad(self):
-        for format in sparse.sparse_formats:
-            for out_f in sparse.sparse_formats:
+        for format in sparse_formats:
+            for out_f in sparse_formats:
                 for dtype in sparse.float_dtypes:
                     verify_grad_sparse(
                         self.op_class(format=out_f, dtype=dtype),
@@ -2782,7 +2782,7 @@ class TestAddSSData(utt.InferShapeTester):
         super().setup_method()
         self.op_class = AddSSData
 
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             variable = getattr(pytensor.sparse, format + "_matrix")
 
             a_val = np.array(
@@ -2795,7 +2795,7 @@ class TestAddSSData(utt.InferShapeTester):
             self.a[format] = [constant for t in range(2)]
 
     def test_op(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             f = pytensor.function(self.x[format], add_s_s_data(*self.x[format]))
 
             tested = f(*self.a[format])
@@ -2806,7 +2806,7 @@ class TestAddSSData(utt.InferShapeTester):
             assert tested.dtype == expected.dtype
 
     def test_infer_shape(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             self._compile_and_check(
                 self.x[format],
                 [add_s_s_data(*self.x[format])],
@@ -2815,7 +2815,7 @@ class TestAddSSData(utt.InferShapeTester):
             )
 
     def test_grad(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             verify_grad_sparse(self.op_class(), self.a[format], structured=True)
 
 
@@ -2864,7 +2864,7 @@ def elemwise_checker(
             assert eval(self.__class__.__name__) is self.__class__
 
         def test_op(self):
-            for format in sparse.sparse_formats:
+            for format in sparse_formats:
                 for dtype in test_dtypes:
                     if dtype == "int8" or dtype == "uint8":
                         continue
@@ -2967,7 +2967,7 @@ def elemwise_checker(
         if grad_test:
 
             def test_grad(self):
-                for format in sparse.sparse_formats:
+                for format in sparse_formats:
                     for dtype in sparse.float_dtypes:
                         variable, data = sparse_random_inputs(
                             format, shape=(4, 7), out_dtype=dtype, gap=self.gap_grad
@@ -3244,7 +3244,7 @@ class TestTrueDot(utt.InferShapeTester):
         self.op_class = TrueDot
 
     def test_op_ss(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             for dtype in sparse.all_dtypes:
                 variable, data = sparse_random_inputs(
                     format, shape=(10, 10), out_dtype=dtype, n=2, p=0.1
@@ -3263,7 +3263,7 @@ class TestTrueDot(utt.InferShapeTester):
                 utt.assert_allclose(tested, expected)
 
     def test_op_sd(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             for dtype in sparse.all_dtypes:
                 variable, data = sparse_random_inputs(
                     format, shape=(10, 10), out_dtype=dtype, n=2, p=0.1
@@ -3282,7 +3282,7 @@ class TestTrueDot(utt.InferShapeTester):
                 utt.assert_allclose(tested, expected)
 
     def test_infer_shape(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             for dtype in sparse.all_dtypes:
                 (x,), (x_value,) = sparse_random_inputs(
                     format, shape=(9, 10), out_dtype=dtype, p=0.1
@@ -3297,7 +3297,7 @@ class TestTrueDot(utt.InferShapeTester):
                 )
 
     def test_grad(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             for dtype in sparse.float_dtypes:
                 (x,), (x_value,) = sparse_random_inputs(
                     format, shape=(9, 10), out_dtype=dtype, p=0.1

--- a/tests/sparse/test_rewriting.py
+++ b/tests/sparse/test_rewriting.py
@@ -14,6 +14,9 @@ from tests import unittest_tools as utt
 from tests.sparse.test_basic import random_lil
 
 
+sparse_formats = ["csc", "csr"]
+
+
 def test_local_csm_properties_csm():
     data = vector()
     indices, indptr, shape = (ivector(), ivector(), ivector())
@@ -71,7 +74,7 @@ def test_local_mul_s_d():
     mode = get_default_mode()
     mode = mode.including("specialize", "local_mul_s_d")
 
-    for sp_format in sparse.sparse_formats:
+    for sp_format in sparse_formats:
         inputs = [getattr(pytensor.sparse, sp_format + "_matrix")(), matrix()]
 
         f = pytensor.function(inputs, sparse.mul_s_d(*inputs), mode=mode)

--- a/tests/sparse/test_sp2.py
+++ b/tests/sparse/test_sp2.py
@@ -1,9 +1,5 @@
-import pytest
-
-
-sp = pytest.importorskip("scipy", minversion="0.7.0")
-
 import numpy as np
+import scipy as sp
 
 import pytensor
 from pytensor import sparse
@@ -20,11 +16,14 @@ from tests import unittest_tools as utt
 from tests.sparse.test_basic import as_sparse_format
 
 
+sparse_formats = ["csr", "csc"]
+
+
 class TestPoisson(utt.InferShapeTester):
     x = {}
     a = {}
 
-    for format in sparse.sparse_formats:
+    for format in sparse_formats:
         variable = getattr(pytensor.sparse, format + "_matrix")
 
         a_val = np.array(
@@ -40,7 +39,7 @@ class TestPoisson(utt.InferShapeTester):
         self.op_class = Poisson
 
     def test_op(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             f = pytensor.function([self.x[format]], poisson(self.x[format]))
 
             tested = f(self.a[format])
@@ -51,7 +50,7 @@ class TestPoisson(utt.InferShapeTester):
             assert tested.shape == self.a[format].shape
 
     def test_infer_shape(self):
-        for format in sparse.sparse_formats:
+        for format in sparse_formats:
             self._compile_and_check(
                 [self.x[format]],
                 [poisson(self.x[format])],
@@ -76,7 +75,7 @@ class TestBinomial(utt.InferShapeTester):
         self.op_class = Binomial
 
     def test_op(self):
-        for sp_format in sparse.sparse_formats:
+        for sp_format in sparse_formats:
             for o_type in sparse.float_dtypes:
                 f = pytensor.function(
                     self.inputs, Binomial(sp_format, o_type)(*self.inputs)
@@ -90,7 +89,7 @@ class TestBinomial(utt.InferShapeTester):
                 assert np.allclose(np.floor(tested.todense()), tested.todense())
 
     def test_infer_shape(self):
-        for sp_format in sparse.sparse_formats:
+        for sp_format in sparse_formats:
             for o_type in sparse.float_dtypes:
                 self._compile_and_check(
                     self.inputs,

--- a/tests/tensor/test_blas_scipy.py
+++ b/tests/tensor/test_blas_scipy.py
@@ -1,7 +1,6 @@
 import pickle
 
 import numpy as np
-import pytest
 
 import pytensor
 from pytensor import tensor as pt
@@ -12,7 +11,6 @@ from tests.tensor.test_blas import TestBlasStrides, gemm_no_inplace
 from tests.unittest_tools import OptimizationTestMixin
 
 
-@pytest.mark.skipif(not pytensor.tensor.blas_scipy.have_fblas, reason="fblas needed")
 class TestScipyGer(OptimizationTestMixin):
     def setup_method(self):
         self.mode = pytensor.compile.get_default_mode()

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -17,18 +17,25 @@ from pytensor.printing import (
     PatternPrinter,
     PPrinter,
     Print,
+    _try_pydot_import,
     char_from_number,
     debugprint,
     default_printer,
     get_node_by_id,
     min_informative_str,
     pp,
-    pydot_imported,
     pydotprint,
 )
 from pytensor.tensor import as_tensor_variable
 from pytensor.tensor.type import dmatrix, dvector, matrix
 from tests.graph.utils import MyInnerGraphOp, MyOp, MyVariable
+
+
+try:
+    _try_pydot_import()
+    pydot_imported = True
+except Exception:
+    pydot_imported = False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
If I provide the blas__ldflags to avoid #1160 I get these results running:

`python -m benchmark_imports pytensor`

## Before:
```
1.5028 root       pytensor                                
0.8698 project    pytensor.scalar                         
0.6148 project    pytensor.scalar.math                    
0.4898 dependency scipy.stats                             
0.3592 project    pytensor.tensor                         
0.3488 transitive scipy.stats._stats_py                    from scipy.stats
0.2696 project    pytensor.tensor.rewriting               
0.2544 project    pytensor.scalar.basic                   
0.2479 project    pytensor.printing                       
0.2077 transitive scipy.stats.distributions                from scipy.stats._stats_py
0.1850 project    pytensor.compile                        
0.1841 project    pytensor.compile.function               
0.1665 project    pytensor.compile.mode                   
0.1589 transitive scipy.stats._continuous_distns           from scipy.stats.distributions
0.1542 project    pytensor.link.c.basic                   
0.1317 project    pytensor.configdefaults                 
0.1116 project    pytensor.link.c.cmodule                 
0.0969 dependency numpy                                   
0.0939 dependency scipy.special                           
0.0863 project    pytensor.tensor.pad                     
0.0821 dependency setuptools                              
0.0808 project    pytensor.scan                           
0.0766 project    pytensor.tensor.rewriting.basic         
0.0760 project    pytensor.scan.rewriting                 
0.0732 project    pytensor.scan.op     
```

## After:
```
python -m benchmark_imports pytensor
0.3682 root       pytensor                                
0.1243 project    pytensor.sparse                         
0.1234 project    pytensor.sparse.rewriting               
0.1089 project    pytensor.configdefaults                 
0.0993 project    pytensor.sparse.basic                   
0.0950 dependency numpy                                   
0.0550 project    pytensor.tensor                         
0.0486 dependency scipy.sparse                            
0.0458 project    pytensor.tensor.rewriting               
0.0325 transitive numpy.__config__                         from numpy
0.0319 transitive numpy.core                               from numpy.__config__
0.0264 transitive scipy.sparse.csgraph                     from scipy.sparse
0.0238 transitive scipy.sparse.csgraph._laplacian          from scipy.sparse.csgraph
0.0236 transitive scipy.sparse.linalg                      from scipy.sparse.csgraph._laplacian
0.0201 transitive numpy.lib                                from numpy
0.0196 project    pytensor.scalar                         
0.0177 project    pytensor.tensor.rewriting.math          
0.0164 project    pytensor.scalar.basic                   
0.0151 project    pytensor.tensor.rewriting.basic         
0.0150 transitive scipy.sparse.linalg._isolve              from scipy.sparse.linalg
0.0139 transitive scipy.sparse.linalg._isolve.iterative    from scipy.sparse.linalg._isolve
0.0132 transitive scipy.linalg                             from scipy.sparse.linalg._isolve.iterative
0.0128 transitive numpy.random                             from numpy
0.0124 transitive numpy.random._pickle                     from numpy.random
0.0119 project    pytensor.printing         
```
For perspective numpy used to take 6.5% of the total import time, and now takes 25%.

***

I couldn't avoid importing scipy.sparse because we register the base `spmatrix` on the `as_symbolic` and `shared_constructor` dispatch functions. The import is messy: https://github.com/scipy/scipy/issues/22382



<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1161.org.readthedocs.build/en/1161/

<!-- readthedocs-preview pytensor end -->