### PR TITLE
Make BLAS flags check lazy and more actionable

### DIFF
--- a/doc/library/compile/mode.rst
+++ b/doc/library/compile/mode.rst
@@ -20,6 +20,9 @@ PyTensor defines the following modes by name:
 
 - ``'FAST_COMPILE'``: Apply just a few graph rewrites and only use Python implementations.
 - ``'FAST_RUN'``: Apply all rewrites, and use C implementations where possible.
+- ``NUMBA``: Apply all relevant related rewrites and compile the whole graph using Numba.
+- ``JAX``: Apply all relevant rewrites and compile the whole graph using JAX.
+- ``PYTORCH`` Apply all relevant rewrites and compile the whole graph using PyTorch compile.
 - ``'DebugMode'``: A mode for debugging. See :ref:`DebugMode <debugmode>` for details.
 - ``'NanGuardMode``: :ref:`Nan detector <nanguardmode>`
 - ``'DEBUG_MODE'``: Deprecated. Use the string DebugMode.
@@ -27,6 +30,12 @@ PyTensor defines the following modes by name:
 The default mode is typically ``FAST_RUN``, but it can be controlled via the
 configuration variable :attr:`config.mode`, which can be
 overridden by passing the keyword argument to :func:`pytensor.function`.
+
+For Numba, JAX, and PyTorch, we exclude rewrites that introduce C-only Ops,
+as well as BLAS optimizations, as those are done automatically by the respective backends.
+
+For JAX we also exclude fusion and inplace optimizations, as JAX does not support them
+at the user level. They are performed automatically by JAX.
 
 .. TODO::
 

--- a/pytensor/link/c/cmodule.py
+++ b/pytensor/link/c/cmodule.py
@@ -1982,7 +1982,7 @@ class Compiler:
         )
 
 
-def try_blas_flag(flags):
+def try_blas_flag(flags) -> str:
     test_code = textwrap.dedent(
         """\
         extern "C" double ddot_(int*, double*, int*, double*, int*);
@@ -2743,12 +2743,30 @@ sure you have the right version you *will* get wrong results.
         )
 
 
-def default_blas_ldflags():
-    """Read local NumPy and MKL build settings and construct `ld` flags from them.
+def default_blas_ldflags() -> str:
+    """Look for an available BLAS implementation in the system.
+
+    This function tries to compile a simple C code that uses the BLAS
+    if the required files are found in the system.
+    It sequentially tries to link to the following implementations, until one is found:
+    1. Intel MKL with Intel OpenMP threading
+    2. Intel MKL with GNU OpenMP threading
+    3. Lapack + BLAS
+    4. BLAS alone
+    5. OpenBLAS
 
     Returns
     -------
-    str
+    blas flags: str
+        Blas flags needed to link to the BLAS implementation found in the system.
+        If no BLAS implementation is found, an empty string is returned.
+
+    Notes
+    -----
+    This function is triggered when `pytensor.config.blas__ldflags` is not given a user
+    default, and it is first accessed at runtime. It can be rather slow, so it is advised
+    to cache the results of this function in PYTENSORRC configuration file or
+    PyTensor environment flags.
 
     """
 
@@ -2797,7 +2815,7 @@ def default_blas_ldflags():
 
     def check_libs(
         all_libs, required_libs, extra_compile_flags=None, cxx_library_dirs=None
-    ):
+    ) -> str:
         if cxx_library_dirs is None:
             cxx_library_dirs = []
         if extra_compile_flags is None:
@@ -2947,6 +2965,14 @@ def default_blas_ldflags():
     except Exception as e:
         _logger.debug(e)
     _logger.debug("Failed to identify blas ldflags. Will leave them empty.")
+    warnings.warn(
+        "PyTensor could not link to a BLAS installation. Operations that might benefit from BLAS will be severely degraded.\n"
+        "This usually happens when PyTensor is installed via pip. We recommend it be installed via conda/mamba/pixi instead.\n"
+        "Alternatively, you can use an experimental backend such as Numba or JAX that perform their own BLAS optimizations, "
+        "by setting `pytensor.config.mode == 'NUMBA'` or passing `mode='NUMBA'` when compiling a PyTensor function.\n"
+        "For more options and details see https://pytensor.readthedocs.io/en/latest/troubleshooting.html#how-do-i-configure-test-my-blas-library",
+        UserWarning,
+    )
     return ""
 
 

--- a/pytensor/tensor/blas_headers.py
+++ b/pytensor/tensor/blas_headers.py
@@ -742,6 +742,11 @@ def blas_header_text():
 
     blas_code = ""
     if not config.blas__ldflags:
+        # This code can only be reached by compiling a function with a manually specified GEMM Op.
+        # Normal PyTensor usage will end up with Dot22 or Dot22Scalar instead,
+        # which opt out of C-code completely if the blas flags are missing
+        _logger.warning("Using NumPy C-API based implementation for BLAS functions.")
+
         # Include the Numpy version implementation of [sd]gemm_.
         current_filedir = Path(__file__).parent
         blas_common_filepath = current_filedir / "c_code/alt_blas_common.h"
@@ -1001,10 +1006,6 @@ def blas_header_text():
             )
 
     return header + blas_code
-
-
-if not config.blas__ldflags:
-    _logger.warning("Using NumPy C-API based implementation for BLAS functions.")
 
 
 def mkl_threads_text():


### PR DESCRIPTION
It replaces the old eager warning that does not actually apply by a lazy yet more informative and actionable warning.

This however means users won't notice something is wrong with their installation until PyTensor actually accesses the `config.blas__ldflags` to decide on some behavior. 

These flags are accessed to either not trigger the introduction of more efficient COps (CGEMv,  sparse Usmm, ...), or to use the Python or C implementation for Ops that have both (Dot22, BatchedDot, ...). 

**The new warning will happen only when a function is compiled that triggers those code-paths.**

***

*Technically the old warning was wrong:*
The specific warning message was about Ops that might use the alternative blas_headers, which rely on the Numpy C-API.

However, regular PyTensor user has not used this for a while. The only Op that would use C-code with this alternative headers is the GEMM Op which is not included in current rewrites. Instead Dot22 or Dot22Scalar are introduced, which refuse to generate C-code altogether if the BLAS flags are missing.

***

This complements #1161 and makes PyTensor a breeze to import compared to before. 
Closes #1160 (although we could still try to speed the check up)