### PR TITLE
Add rewrite for `1 ** x = 1`

### DIFF
--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -1918,7 +1918,7 @@ def local_pow_canonicalize(fgraph, node):
         node.inputs[0], only_process_constants=True, raise_not_constant=False
     )
     if cst_base == 1:
-        return [alloc_like(1, node.outputs[0], fgraph)]
+        return [broadcast_arrays(*node.inputs)[0].astype(node.outputs[0].dtype)]
 
     cst_exponent = get_underlying_scalar_constant_value(
         node.inputs[1], only_process_constants=True, raise_not_constant=False

--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -1923,10 +1923,13 @@ def local_pow_canonicalize(fgraph, node):
     new_out = None
 
     if cst_base == 1:
+        # 1 ** x = 1
         new_out = broadcast_arrays(*node.inputs)[0]
     elif cst_exponent == 0:
+        # x ** 0 = 1
         new_out = broadcast_arrays(ones_like(node.inputs[0]), node.inputs[1])[0]
     elif cst_exponent == 1:
+        # x ** 1 = x
         new_out = broadcast_arrays(*node.inputs)[0]
 
     if not new_out:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
Small rewrite that simplifies powers of base 1, since `1 ** x = 1` for any x.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #1177 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
