### PR TITLE
Implement symbolic `minimize` and `root` `Ops` 

### DIFF
--- a/pytensor/tensor/optimize.py
+++ b/pytensor/tensor/optimize.py
@@ -712,6 +712,15 @@ class RootOp(ScipyWrapperOp):
         jac: bool = True,
         optimizer_kwargs: dict | None = None,
     ):
+        if variables.ndim != equations.ndim:
+            raise ValueError(
+                "The variable `variables` must have the same number of dimensions as the equations."
+            )
+        if variables not in ancestors([equations]):
+            raise ValueError(
+                "The variable `variables` must be an input to the computational graph of the equations."
+            )
+
         self.fgraph = FunctionGraph([variables, *args], [equations])
 
         if jac:

--- a/pytensor/tensor/optimize.py
+++ b/pytensor/tensor/optimize.py
@@ -16,7 +16,6 @@ from pytensor.graph.op import ComputeMapType, HasInnerGraph, Op, StorageMapType
 from pytensor.scalar import bool as scalar_bool
 from pytensor.tensor import dot
 from pytensor.tensor.basic import atleast_2d, concatenate, zeros_like
-from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.slinalg import solve
 from pytensor.tensor.variable import TensorVariable
 
@@ -258,18 +257,7 @@ def minimize_scalar(
         optimizer_kwargs=optimizer_kwargs,
     )
 
-    input_core_ndim = [var.ndim for var in minimize_scalar_op.inner_inputs]
-    input_signatures = [
-        f'({",".join(f"i{i}{n}" for n in range(ndim))})'
-        for i, ndim in enumerate(input_core_ndim)
-    ]
-
-    # Output dimensions are always the same as the first input (the initial values for the optimizer),
-    # then a scalar for the success flag
-    output_signatures = [input_signatures[0], "()"]
-
-    signature = f"{','.join(input_signatures)}->{','.join(output_signatures)}"
-    return Blockwise(minimize_scalar_op, signature=signature)(x, *args)
+    return minimize_scalar_op(x, *args)
 
 
 class MinimizeOp(ScipyWrapperOp):
@@ -422,18 +410,7 @@ def minimize(
         optimizer_kwargs=optimizer_kwargs,
     )
 
-    input_core_ndim = [var.ndim for var in minimize_op.inner_inputs]
-    input_signatures = [
-        f'({",".join(f"i{i}{n}" for n in range(ndim))})'
-        for i, ndim in enumerate(input_core_ndim)
-    ]
-
-    # Output dimensions are always the same as the first input (the initial values for the optimizer),
-    # then a scalar for the success flag
-    output_signatures = [input_signatures[0], "()"]
-
-    signature = f"{','.join(input_signatures)}->{','.join(output_signatures)}"
-    return Blockwise(minimize_op, signature=signature)(x, *args)
+    return minimize_op(x, *args)
 
 
 class RootOp(ScipyWrapperOp):

--- a/pytensor/tensor/optimize.py
+++ b/pytensor/tensor/optimize.py
@@ -88,7 +88,7 @@ class ScipyWrapperOp(Op, HasInnerGraph):
 
 
 class MinimizeOp(ScipyWrapperOp):
-    __props__ = ("method", "jac", "hess", "hessp", "debug")
+    __props__ = ("method", "jac", "hess", "hessp")
 
     def __init__(
         self,
@@ -100,7 +100,6 @@ class MinimizeOp(ScipyWrapperOp):
         hess: bool = False,
         hessp: bool = False,
         optimizer_kwargs: dict | None = None,
-        debug: bool = False,
     ):
         self.fgraph = FunctionGraph([x, *args], [objective])
 
@@ -116,7 +115,6 @@ class MinimizeOp(ScipyWrapperOp):
 
         self.method = method
         self.optimizer_kwargs = optimizer_kwargs if optimizer_kwargs is not None else {}
-        self.debug = debug
         self._fn = None
         self._fn_wrapped = None
 
@@ -187,7 +185,6 @@ def minimize(
     x: TensorVariable,
     method: str = "BFGS",
     jac: bool = True,
-    debug: bool = False,
     optimizer_kwargs: dict | None = None,
 ):
     """
@@ -208,9 +205,6 @@ def minimize(
     jac : bool, optional
         Whether to compute and use the gradient of teh objective function with respect to x for optimization.
         Default is True.
-
-    debug : bool, optional
-        If True, prints raw scipy result after optimization. Default is False.
 
     optimizer_kwargs
         Additional keyword arguments to pass to scipy.optimize.minimize
@@ -233,7 +227,6 @@ def minimize(
         objective=objective,
         method=method,
         jac=jac,
-        debug=debug,
         optimizer_kwargs=optimizer_kwargs,
     )
 
@@ -241,7 +234,7 @@ def minimize(
 
 
 class RootOp(ScipyWrapperOp):
-    __props__ = ("method", "jac", "debug")
+    __props__ = ("method", "jac")
 
     def __init__(
         self,
@@ -251,7 +244,6 @@ class RootOp(ScipyWrapperOp):
         method: str = "hybr",
         jac: bool = True,
         optimizer_kwargs: dict | None = None,
-        debug: bool = False,
     ):
         self.fgraph = FunctionGraph([variables, *args], [equations])
 
@@ -263,7 +255,6 @@ class RootOp(ScipyWrapperOp):
 
         self.method = method
         self.optimizer_kwargs = optimizer_kwargs if optimizer_kwargs is not None else {}
-        self.debug = debug
         self._fn = None
         self._fn_wrapped = None
 
@@ -312,7 +303,6 @@ def root(
     variables: TensorVariable,
     method: str = "hybr",
     jac: bool = True,
-    debug: bool = False,
 ):
     """Find roots of a system of equations using scipy.optimize.root."""
 
@@ -322,9 +312,7 @@ def root(
         if (arg is not variables and not isinstance(arg, Constant))
     ]
 
-    root_op = RootOp(
-        variables, *args, equations=equations, method=method, jac=jac, debug=debug
-    )
+    root_op = RootOp(variables, *args, equations=equations, method=method, jac=jac)
 
     return root_op(variables, *args)
 

--- a/pytensor/tensor/optimize.py
+++ b/pytensor/tensor/optimize.py
@@ -503,7 +503,7 @@ class MinimizeOp(ScipyWrapperOp):
 
         f.clear_cache()
 
-        outputs[0][0] = res.x.astype(x0.dtype)
+        outputs[0][0] = res.x.reshape(x0.shape).astype(x0.dtype)
         outputs[1][0] = np.bool_(res.success)
 
     def L_op(self, inputs, outputs, output_grads):

--- a/pytensor/tensor/optimize.py
+++ b/pytensor/tensor/optimize.py
@@ -1,0 +1,159 @@
+from copy import copy
+
+from scipy.optimize import minimize as scipy_minimize
+
+from pytensor import function
+from pytensor.gradient import grad
+from pytensor.graph import Apply, Constant, FunctionGraph, clone_replace
+from pytensor.graph.basic import truncated_graph_inputs
+from pytensor.graph.op import HasInnerGraph, Op
+from pytensor.scalar import bool as scalar_bool
+
+
+class MinimizeOp(Op, HasInnerGraph):
+    def __init__(
+        self,
+        x,
+        *args,
+        output,
+        method="BFGS",
+        jac=False,
+        options: dict | None = None,
+        debug: bool = False,
+    ):
+        self.fgraph = FunctionGraph([x, *args], [output])
+
+        if jac:
+            grad_wrt_x = grad(self.fgraph.outputs[0], self.fgraph.inputs[0])
+            self.fgraph.add_output(grad_wrt_x)
+
+        self.jac = jac
+        # self.hess = hess
+        self.method = method
+        self.options = options if options is not None else {}
+        self.debug = debug
+        self._fn = None
+        self._fn_wrapped = None
+
+    def build_fn(self):
+        outputs = self.inner_outputs
+        if len(outputs) == 1:
+            outputs = outputs[0]
+        self._fn = fn = function(self.inner_inputs, outputs)
+        self.fgraph = (
+            fn.maker.fgraph
+        )  # So we see the compiled graph ater the first call
+
+        if self.inner_inputs[0].type.shape == ():
+            # Work-around for scipy changing the type of x
+            def fn_wrapper(x, *args):
+                return fn(x.squeeze(), *args)
+
+            self._fn_wrapped = fn_wrapper
+        else:
+            self._fn_wrapped = fn
+
+    @property
+    def fn(self):
+        if self._fn is None:
+            self.build_fn()
+        return self._fn
+
+    @property
+    def fn_wrapped(self):
+        if self._fn_wrapped is None:
+            self.build_fn()
+        return self._fn_wrapped
+
+    @property
+    def inner_inputs(self):
+        return self.fgraph.inputs
+
+    @property
+    def inner_outputs(self):
+        return self.fgraph.outputs
+
+    def clone(self):
+        copy_op = copy(self)
+        copy_op.fgraph = self.fgraph.clone()
+        return copy_op
+
+    # def prepare_node():
+    #     # ... trigger the compilation of the inner fgraph so it shows in the dprint before the first call
+    #     ...
+
+    def make_node(self, *inputs):
+        # print(inputs)
+        assert len(inputs) == len(self.inner_inputs)
+        # Assert type is correct.
+        return Apply(
+            self, inputs, [self.inner_outputs[0].type(), scalar_bool("success")]
+        )
+
+    def perform(self, node, inputs, outputs):
+        f = self.fn_wrapped
+        x0, *args = inputs
+
+        # print(f(*inputs))
+
+        res = scipy_minimize(
+            fun=f,
+            jac=self.jac,
+            x0=x0,
+            args=tuple(args),
+            method=self.method,
+            **self.options,
+        )
+        if self.debug:
+            print(res)
+        outputs[0][0] = res.x
+        outputs[1][0] = res.success
+
+    def L_op(self, inputs, outputs, output_grads):
+        x, *args = inputs
+        x_star, success = outputs
+        output_grad, _ = output_grads
+
+        # x_root, stats = root(func, x0, args=[arg], tol=1e-8)
+
+        inner_x, *inner_args = self.fgraph.inputs
+        inner_fx = self.fgraph.outputs[0]
+
+        # f_x_star = clone_replace(inner_fx, replace={inner_x: x_star})
+
+        inner_grads = grad(inner_fx, [inner_x, *inner_args])
+
+        # TODO: Does clone replace do what we want? It might need a merge optimization pass afterwards
+        replace = dict(zip(self.fgraph.inputs, (x_star, *args), strict=True))
+        grad_f_wrt_x_star, *grad_f_wrt_args = clone_replace(
+            inner_grads, replace=replace
+        )
+
+        # # TODO: If scipy optimizer uses hessian (or hessp), just store it from the inner function
+        # inner_hess = jacobian(inner_fx, inner_args)
+        # hess_f_x = clone_replace(inner_hess, replace=replace)
+
+        grad_wrt_args = [
+            -grad_f_wrt_arg / grad_f_wrt_x_star * output_grad
+            for grad_f_wrt_arg in grad_f_wrt_args
+        ]
+
+        return [x.zeros_like(), *grad_wrt_args]
+
+
+def minimize(
+    objective, x, jac: bool = True, debug: bool = False, options: dict | None = None
+):
+    args = [
+        arg
+        for arg in truncated_graph_inputs([objective], [x])
+        if (arg is not x and not isinstance(arg, Constant))
+    ]
+    # print(args)
+    minimize_op = MinimizeOp(
+        x, *args, output=objective, jac=jac, debug=debug, options=options
+    )
+    return minimize_op(x, *args)
+
+
+__all__ = ["minimize"]

--- a/pytensor/tensor/optimize.py
+++ b/pytensor/tensor/optimize.py
@@ -1,55 +1,43 @@
+from collections.abc import Sequence
 from copy import copy
 
 from scipy.optimize import minimize as scipy_minimize
+from scipy.optimize import root as scipy_root
 
-from pytensor import function, graph_replace
-from pytensor.gradient import grad
+from pytensor import Variable, function, graph_replace
+from pytensor.gradient import grad, jacobian
 from pytensor.graph import Apply, Constant, FunctionGraph
 from pytensor.graph.basic import truncated_graph_inputs
 from pytensor.graph.op import ComputeMapType, HasInnerGraph, Op, StorageMapType
 from pytensor.scalar import bool as scalar_bool
+from pytensor.tensor.basic import atleast_2d
+from pytensor.tensor.slinalg import solve
+from pytensor.tensor.variable import TensorVariable
 
 
-class MinimizeOp(Op, HasInnerGraph):
-    def __init__(
-        self,
-        x,
-        *args,
-        output,
-        method="BFGS",
-        jac=True,
-        hess=False,
-        hessp=False,
-        options: dict | None = None,
-        debug: bool = False,
-    ):
-        self.fgraph = FunctionGraph([x, *args], [output])
+class ScipyWrapperOp(Op, HasInnerGraph):
+    """Shared logic for scipy optimization ops"""
 
-        if jac:
-            grad_wrt_x = grad(self.fgraph.outputs[0], self.fgraph.inputs[0])
-            self.fgraph.add_output(grad_wrt_x)
-
-        self.jac = jac
-        self.hess = hess
-        self.hessp = hessp
-
-        self.method = method
-        self.options = options if options is not None else {}
-        self.debug = debug
-        self._fn = None
-        self._fn_wrapped = None
+    __props__ = ("method", "debug")
 
     def build_fn(self):
+        """
+        This is overloaded because scipy converts scalar inputs to lists, changing the return type. The
+        wrapper function logic is there to handle this.
+        """
+        # TODO: Introduce rewrites to change MinimizeOp to MinimizeScalarOp and RootOp to RootScalarOp
+        #  when x is scalar. That will remove the need for the wrapper.
+
         outputs = self.inner_outputs
         if len(outputs) == 1:
             outputs = outputs[0]
         self._fn = fn = function(self.inner_inputs, outputs)
-        self.fgraph = (
-            fn.maker.fgraph
-        )  # So we see the compiled graph ater the first call
+
+        # Do this reassignment to see the compiled graph in the dprint
+        self.fgraph = fn.maker.fgraph
 
         if self.inner_inputs[0].type.shape == ():
-            # Work-around for scipy changing the type of x
+
             def fn_wrapper(x, *args):
                 return fn(x.squeeze(), *args)
 
@@ -90,20 +78,50 @@ class MinimizeOp(Op, HasInnerGraph):
         impl: str | None,
     ):
         """Trigger the compilation of the inner fgraph so it shows in the dprint before the first call"""
-        # TODO: Implemet this method
+        self.build_fn()
 
     def make_node(self, *inputs):
         assert len(inputs) == len(self.inner_inputs)
 
         return Apply(
-            self, inputs, [self.inner_outputs[0].type(), scalar_bool("success")]
+            self, inputs, [self.inner_inputs[0].type(), scalar_bool("success")]
         )
+
+
+class MinimizeOp(ScipyWrapperOp):
+    __props__ = ("method", "jac", "hess", "hessp", "debug")
+
+    def __init__(
+        self,
+        x,
+        *args,
+        objective,
+        method="BFGS",
+        jac=True,
+        hess=False,
+        hessp=False,
+        options: dict | None = None,
+        debug: bool = False,
+    ):
+        self.fgraph = FunctionGraph([x, *args], [objective])
+
+        if jac:
+            grad_wrt_x = grad(self.fgraph.outputs[0], self.fgraph.inputs[0])
+            self.fgraph.add_output(grad_wrt_x)
+
+        self.jac = jac
+        self.hess = hess
+        self.hessp = hessp
+
+        self.method = method
+        self.options = options if options is not None else {}
+        self.debug = debug
+        self._fn = None
+        self._fn_wrapped = None
 
     def perform(self, node, inputs, outputs):
         f = self.fn_wrapped
         x0, *args = inputs
-
-        # print(f(*inputs))
 
         res = scipy_minimize(
             fun=f,
@@ -113,8 +131,10 @@ class MinimizeOp(Op, HasInnerGraph):
             method=self.method,
             **self.options,
         )
+
         if self.debug:
             print(res)
+
         outputs[0][0] = res.x
         outputs[1][0] = res.success
 
@@ -128,15 +148,11 @@ class MinimizeOp(Op, HasInnerGraph):
 
         inner_grads = grad(inner_fx, [inner_x, *inner_args])
 
-        # TODO: Does clone replace do what we want? It might need a merge optimization pass afterwards
         replace = dict(zip(self.fgraph.inputs, (x_star, *args), strict=True))
+
         grad_f_wrt_x_star, *grad_f_wrt_args = graph_replace(
             inner_grads, replace=replace
         )
-
-        # # TODO: If scipy optimizer uses hessian (or hessp), just store it from the inner function
-        # inner_hess = jacobian(inner_fx, inner_args)
-        # hess_f_x = clone_replace(inner_hess, replace=replace)
 
         grad_wrt_args = [
             -grad_f_wrt_arg / grad_f_wrt_x_star * output_grad
@@ -192,9 +208,108 @@ def minimize(
     ]
 
     minimize_op = MinimizeOp(
-        x, *args, output=objective, method=method, jac=jac, debug=debug, options=options
+        x,
+        *args,
+        objective=objective,
+        method=method,
+        jac=jac,
+        debug=debug,
+        options=options,
     )
+
     return minimize_op(x, *args)
 
 
-__all__ = ["minimize"]
+class RootOp(ScipyWrapperOp):
+    __props__ = ("method", "jac", "debug")
+
+    def __init__(
+        self,
+        variables,
+        *args,
+        equations,
+        method="hybr",
+        jac=True,
+        options: dict | None = None,
+        debug: bool = False,
+    ):
+        self.fgraph = FunctionGraph([variables, *args], [equations])
+
+        if jac:
+            jac_wrt_x = jacobian(self.fgraph.outputs[0], self.fgraph.inputs[0])
+            self.fgraph.add_output(atleast_2d(jac_wrt_x))
+
+        self.jac = jac
+
+        self.method = method
+        self.options = options if options is not None else {}
+        self.debug = debug
+        self._fn = None
+        self._fn_wrapped = None
+
+    def perform(self, node, inputs, outputs):
+        f = self.fn_wrapped
+        variables, *args = inputs
+
+        res = scipy_root(
+            fun=f,
+            jac=self.jac,
+            x0=variables,
+            args=tuple(args),
+            method=self.method,
+            **self.options,
+        )
+
+        if self.debug:
+            print(res)
+
+        outputs[0][0] = res.x
+        outputs[1][0] = res.success
+
+    def L_op(
+        self,
+        inputs: Sequence[Variable],
+        outputs: Sequence[Variable],
+        output_grads: Sequence[Variable],
+    ) -> list[Variable]:
+        # TODO: Broken
+        x, *args = inputs
+        x_star, success = outputs
+        output_grad, _ = output_grads
+
+        inner_x, *inner_args = self.fgraph.inputs
+        inner_fx = self.fgraph.outputs[0]
+
+        inner_jac = jacobian(inner_fx, [inner_x, *inner_args])
+
+        replace = dict(zip(self.fgraph.inputs, (x_star, *args), strict=True))
+        jac_f_wrt_x_star, *jac_f_wrt_args = graph_replace(inner_jac, replace=replace)
+
+        jac_wrt_args = solve(-jac_f_wrt_x_star, output_grad)
+
+        return [x.zeros_like(), jac_wrt_args]
+
+
+def root(
+    equations: TensorVariable,
+    variables: TensorVariable,
+    method: str = "hybr",
+    jac: bool = True,
+    debug: bool = False,
+):
+    """Find roots of a system of equations using scipy.optimize.root."""
+
+    args = [
+        arg
+        for arg in truncated_graph_inputs([equations], [variables])
+        if (arg is not variables and not isinstance(arg, Constant))
+    ]
+
+    root_op = RootOp(
+        variables, *args, equations=equations, method=method, jac=jac, debug=debug
+    )
+
+    return root_op(variables, *args)
+
+
+__all__ = ["minimize", "root"]

--- a/pytensor/tensor/optimize.py
+++ b/pytensor/tensor/optimize.py
@@ -362,11 +362,11 @@ class MinimizeScalarOp(ScipyScalarWrapperOp):
         method: str = "brent",
         optimizer_kwargs: dict | None = None,
     ):
-        if not x.ndim == 0:
+        if not cast(TensorVariable, x).ndim == 0:
             raise ValueError(
                 "The variable `x` must be a scalar (0-dimensional) tensor for minimize_scalar."
             )
-        if not objective.ndim == 0:
+        if not cast(TensorVariable, objective).ndim == 0:
             raise ValueError(
                 "The objective function must be a scalar (0-dimensional) tensor for minimize_scalar."
             )
@@ -455,11 +455,11 @@ class MinimizeOp(ScipyWrapperOp):
         hessp: bool = False,
         optimizer_kwargs: dict | None = None,
     ):
-        if not objective.ndim == 0:
+        if not cast(TensorVariable, objective).ndim == 0:
             raise ValueError(
                 "The objective function must be a scalar (0-dimensional) tensor for minimize."
             )
-        if not isinstance(x, Variable) and x not in ancestors([objective]):
+        if x not in ancestors([objective]):
             raise ValueError(
                 "The variable `x` must be an input to the computational graph of the objective function."
             )
@@ -712,7 +712,7 @@ class RootOp(ScipyWrapperOp):
         jac: bool = True,
         optimizer_kwargs: dict | None = None,
     ):
-        if variables.ndim != equations.ndim:
+        if cast(TensorVariable, variables).ndim != cast(TensorVariable, equations).ndim:
             raise ValueError(
                 "The variable `variables` must have the same number of dimensions as the equations."
             )

--- a/tests/tensor/test_optimize.py
+++ b/tests/tensor/test_optimize.py
@@ -142,7 +142,7 @@ def test_root_system_of_equations():
 
     f = pt.stack([a[0] * x[0] * pt.cos(x[1]) - b[0], x[0] * x[1] - a[1] * x[1] - b[1]])
 
-    root_f, success = root(f, x, debug=True)
+    root_f, success = root(f, x)
     func = pytensor.function([x, a, b], [root_f, success])
 
     x0 = np.array([1.0, 1.0])

--- a/tests/tensor/test_optimize.py
+++ b/tests/tensor/test_optimize.py
@@ -1,8 +1,15 @@
+import numpy as np
+
 import pytensor.tensor as pt
+from pytensor import config
 from pytensor.tensor.optimize import minimize
+from tests import unittest_tools as utt
 
 
-def test_minimize():
+floatX = config.floatX
+
+
+def test_simple_minimize():
     x = pt.scalar("x")
     a = pt.scalar("a")
     c = pt.scalar("c")
@@ -11,16 +18,42 @@ def test_minimize():
     b.name = "b"
     out = (x - b * c) ** 2
 
-    minimized_x, success = minimize(out, x, debug=False)
+    minimized_x, success = minimize(out, x)
 
-    a_val = 2
-    c_val = 3
+    a_val = 2.0
+    c_val = 3.0
 
     assert success
     assert minimized_x.eval({a: a_val, c: c_val, x: 0.0}) == (2 * a_val * c_val)
 
-    x_grad, a_grad, c_grad = pt.grad(minimized_x, [x, a, c])
+    def f(x, a, b):
+        objective = (x - a * b) ** 2
+        out = minimize(objective, x)[0]
+        return out
 
-    assert x_grad.eval({x: 0.0}) == 0.0
-    assert a_grad.eval({a: a_val, c: c_val, x: 0.0}) == 2 * c_val
-    assert c_grad.eval({a: a_val, c: c_val, x: 0.0}) == 2 * a_val
+    utt.verify_grad(f, [0.0, a_val, c_val], eps=1e-6)
+
+
+def test_minimize_vector_x():
+    def rosenbrock_shifted_scaled(x, a, b):
+        return (a * (x[1:] - x[:-1] ** 2) ** 2 + (1 - x[:-1]) ** 2).sum() + b
+
+    x = pt.dvector("x")
+    a = pt.scalar("a")
+    b = pt.scalar("b")
+
+    objective = rosenbrock_shifted_scaled(x, a, b)
+
+    minimized_x, success = minimize(objective, x, method="BFGS")
+
+    a_val = 0.5
+    b_val = 1.0
+    x0 = np.zeros(5).astype(floatX)
+    x_star_val = minimized_x.eval({a: a_val, b: b_val, x: x0})
+
+    assert success
+    np.testing.assert_allclose(
+        x_star_val, np.ones_like(x_star_val), atol=1e-6, rtol=1e-6
+    )
+
+    utt.verify_grad(rosenbrock_shifted_scaled, [x0, a_val, b_val], eps=1e-6)

--- a/tests/tensor/test_optimize.py
+++ b/tests/tensor/test_optimize.py
@@ -20,7 +20,6 @@ def test_simple_minimize():
     out = (x - b * c) ** 2
 
     minimized_x, success = minimize(out, x)
-    minimized_x.dprint()
 
     a_val = 2.0
     c_val = 3.0

--- a/tests/tensor/test_optimize.py
+++ b/tests/tensor/test_optimize.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import pytensor
 import pytensor.tensor as pt
-from pytensor import config
+from pytensor import config, function
 from pytensor.tensor.optimize import minimize, root
 from tests import unittest_tools as utt
 
@@ -24,8 +24,12 @@ def test_simple_minimize():
     a_val = 2.0
     c_val = 3.0
 
-    assert success
-    assert minimized_x.eval({a: a_val, c: c_val, x: 0.0}) == (2 * a_val * c_val)
+    f = function([a, c, x], [minimized_x, success])
+
+    minimized_x_val, success_val = f(a_val, c_val, 0.0)
+
+    assert success_val
+    assert minimized_x_val == (2 * a_val * c_val)
 
     def f(x, a, b):
         objective = (x - a * b) ** 2
@@ -51,7 +55,8 @@ def test_minimize_vector_x():
     x0 = np.zeros(5).astype(floatX)
     x_star_val = minimized_x.eval({a: a_val, b: b_val, x: x0})
 
-    assert success
+    assert success.eval({a: a_val, b: b_val, x: x0})
+
     np.testing.assert_allclose(
         x_star_val, np.ones_like(x_star_val), atol=1e-6, rtol=1e-6
     )

--- a/tests/tensor/test_optimize.py
+++ b/tests/tensor/test_optimize.py
@@ -1,0 +1,26 @@
+import pytensor.tensor as pt
+from pytensor.tensor.optimize import minimize
+
+
+def test_minimize():
+    x = pt.scalar("x")
+    a = pt.scalar("a")
+    c = pt.scalar("c")
+
+    b = a * 2
+    b.name = "b"
+    out = (x - b * c) ** 2
+
+    minimized_x, success = minimize(out, x, debug=False)
+
+    a_val = 2
+    c_val = 3
+
+    assert success
+    assert minimized_x.eval({a: a_val, c: c_val, x: 0.0}) == (2 * a_val * c_val)
+
+    x_grad, a_grad, c_grad = pt.grad(minimized_x, [x, a, c])
+
+    assert x_grad.eval({x: 0.0}) == 0.0
+    assert a_grad.eval({a: a_val, c: c_val, x: 0.0}) == 2 * c_val
+    assert c_grad.eval({a: a_val, c: c_val, x: 0.0}) == 2 * a_val

--- a/tests/tensor/test_optimize.py
+++ b/tests/tensor/test_optimize.py
@@ -3,11 +3,40 @@ import numpy as np
 import pytensor
 import pytensor.tensor as pt
 from pytensor import config, function
-from pytensor.tensor.optimize import minimize, root
+from pytensor.tensor.optimize import minimize, minimize_scalar, root
 from tests import unittest_tools as utt
 
 
 floatX = config.floatX
+
+
+def test_minimize_scalar():
+    x = pt.scalar("x")
+    a = pt.scalar("a")
+    c = pt.scalar("c")
+
+    b = a * 2
+    b.name = "b"
+    out = (x - b * c) ** 2
+
+    minimized_x, success = minimize_scalar(out, x)
+
+    a_val = 2.0
+    c_val = 3.0
+
+    f = function([a, c, x], [minimized_x, success])
+
+    minimized_x_val, success_val = f(a_val, c_val, 0.0)
+
+    assert success_val
+    np.testing.assert_allclose(minimized_x_val, (2 * a_val * c_val))
+
+    def f(x, a, b):
+        objective = (x - a * b) ** 2
+        out = minimize_scalar(objective, x)[0]
+        return out
+
+    utt.verify_grad(f, [0.0, a_val, c_val], eps=1e-6)
 
 
 def test_simple_minimize():

--- a/tests/tensor/test_optimize.py
+++ b/tests/tensor/test_optimize.py
@@ -1,8 +1,9 @@
 import numpy as np
 
+import pytensor
 import pytensor.tensor as pt
 from pytensor import config
-from pytensor.tensor.optimize import minimize
+from pytensor.tensor.optimize import minimize, root
 from tests import unittest_tools as utt
 
 
@@ -19,6 +20,7 @@ def test_simple_minimize():
     out = (x - b * c) ** 2
 
     minimized_x, success = minimize(out, x)
+    minimized_x.dprint()
 
     a_val = 2.0
     c_val = 3.0
@@ -43,7 +45,6 @@ def test_minimize_vector_x():
     b = pt.scalar("b")
 
     objective = rosenbrock_shifted_scaled(x, a, b)
-
     minimized_x, success = minimize(objective, x, method="BFGS")
 
     a_val = 0.5
@@ -56,4 +57,64 @@ def test_minimize_vector_x():
         x_star_val, np.ones_like(x_star_val), atol=1e-6, rtol=1e-6
     )
 
-    utt.verify_grad(rosenbrock_shifted_scaled, [x0, a_val, b_val], eps=1e-6)
+    def f(x, a, b):
+        objective = rosenbrock_shifted_scaled(x, a, b)
+        out = minimize(objective, x)[0]
+        return out
+
+    utt.verify_grad(f, [x0, a_val, b_val], eps=1e-6)
+
+
+def test_root_simple():
+    x = pt.scalar("x")
+    a = pt.scalar("a")
+
+    def fn(x, a):
+        return x + 2 * a * pt.cos(x)
+
+    f = fn(x, a)
+    root_f, success = root(f, x)
+    func = pytensor.function([x, a], [root_f, success])
+
+    x0 = 0.0
+    a_val = 1.0
+    solution, success = func(x0, a_val)
+
+    assert success
+    np.testing.assert_allclose(solution, -1.02986653, atol=1e-6, rtol=1e-6)
+
+    def root_fn(x, a):
+        f = fn(x, a)
+        return root(f, x)[0]
+
+    utt.verify_grad(root_fn, [x0, a_val], eps=1e-6)
+
+
+def test_root_system_of_equations():
+    x = pt.dvector("x")
+    a = pt.dvector("a")
+    b = pt.dvector("b")
+
+    f = pt.stack([a[0] * x[0] * pt.cos(x[1]) - b[0], x[0] * x[1] - a[1] * x[1] - b[1]])
+
+    root_f, success = root(f, x, debug=True)
+    func = pytensor.function([x, a, b], [root_f, success])
+
+    x0 = np.array([1.0, 1.0])
+    a_val = np.array([1.0, 1.0])
+    b_val = np.array([4.0, 5.0])
+    solution, success = func(x0, a_val, b_val)
+
+    assert success
+
+    np.testing.assert_allclose(
+        solution, np.array([6.50409711, 0.90841421]), atol=1e-6, rtol=1e-6
+    )
+
+    def root_fn(x, a, b):
+        f = pt.stack(
+            [a[0] * x[0] * pt.cos(x[1]) - b[0], x[0] * x[1] - a[1] * x[1] - b[1]]
+        )
+        return root(f, x)[0]
+
+    utt.verify_grad(root_fn, [x0, a_val, b_val], eps=1e-6)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
Implement scipy optimization routines, with implicit gradients. This PR should add:

- [x] `optimize.minimize`
- [x] `optimize.root`
- [x] `optimize.scalar_minimize`
- [x] `optimize.scalar_root`

It would also be nice to have rewrites to transform e.g. `root` to `scalar_root` when we know that there is only one input.

The implementation @ricardoV94 and I cooked up (ok ok it was mostly him) uses the graph to implicitly define the inputs to the objective function. For example:

```py
    import pytensor.tensor as pt
    from pytensor.tensor.optimize import minimize
    x = pt.scalar("x")
    a = pt.scalar("a")
    c = pt.scalar("c")

    b = a * 2
    b.name = "b"
    out = (x - b * c) ** 2

    minimized_x, success = minimize(out, x, debug=False)
```

We optimize `out` with respect to `x`, so `x` becomes the control variable. By graph inspection we find that `out` also depends on `a` and `c`, so the generated graph includes them as parameters. In scipy lingo, we end up with:

```py
minimize(fun=out, x0=x, args=(a, c)
```

We get the following graph. The inner graph includes the gradients of the cost function by default, which is automatically used by scipy.

```
MinimizeOp.0 [id A]
 ├─ x [id B]
 └─ Mul [id C]
    ├─ 2.0 [id D]
    ├─ a [id E]
    └─ c [id F]

Inner graphs:

MinimizeOp [id A]
 ← Pow [id G]
    ├─ Sub [id H]
    │  ├─ x [id I]
    │  └─ <Scalar(float64, shape=())> [id J]
    └─ 2 [id K]
 ← Mul [id L]
    ├─ Mul [id M]
    │  ├─ Second [id N]
    │  │  ├─ Pow [id G]
    │  │  │  └─ ···
    │  │  └─ 1.0 [id O]
    │  └─ 2 [id K]
    └─ Pow [id P]
       ├─ Sub [id H]
       │  └─ ···
       └─ Sub [id Q]
          ├─ 2 [id K]
          └─ DimShuffle{order=[]} [id R]
             └─ 1 [id S]
``` 

We can also ask for the gradients of the maximum value with respect to parameters:

```py 
x_grad, a_grad, c_grad = pt.grad(minimized_x, [x, a, c])

# x_grad.dprint()
0.0 [id A]

# a_grad.dprint()
Mul [id A]
 ├─ 2.0 [id B]
 └─ c [id C]

# c_grad.dprint()
Mul [id A]
 ├─ 2.0 [id B]
 └─ a [id C]
```


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #944
- [ ] Related to #978 #https://github.com/pymc-devs/pymc-extras/issues/342

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1182.org.readthedocs.build/en/1182/

<!-- readthedocs-preview pytensor end -->