### PR TITLE
Fix numba 0.61 compatibility

### DIFF
--- a/pytensor/link/numba/dispatch/basic.py
+++ b/pytensor/link/numba/dispatch/basic.py
@@ -1,7 +1,6 @@
 import operator
 import sys
 import warnings
-from contextlib import contextmanager
 from copy import copy
 from functools import singledispatch
 from textwrap import dedent
@@ -360,23 +359,6 @@ def create_tuple_string(x):
 def create_arg_string(x):
     args = ", ".join(x)
     return args
-
-
-@contextmanager
-def use_optimized_cheap_pass(*args, **kwargs):
-    """Temporarily replace the cheap optimization pass with a better one."""
-    from numba.core.registry import cpu_target
-
-    context = cpu_target.target_context._internal_codegen
-    old_pm = context._mpm_cheap
-    new_pm = context._module_pass_manager(
-        loop_vectorize=True, slp_vectorize=True, opt=3, cost="cheap"
-    )
-    context._mpm_cheap = new_pm
-    try:
-        yield
-    finally:
-        context._mpm_cheap = old_pm
 
 
 @singledispatch


### PR DESCRIPTION
Did not see any change in performance running the existing benchmark tests on my machine

The `__mm_cheap` option was moved elsewhere in https://github.com/numba/numba/commit/a5e2195aac1906b5c8ebae95b37f4398bb829004

If anybody sees differences in performance it seems like the new internal API is controlled by setting `_loopvect` and `_opt_level` private attributes, so we could patch those, depending on the installed numba version (not very keen on this)