### PR TITLE
Raise explicitly on Python methods that are incompatible with lazy variables

### DIFF
--- a/pytensor/compile/function/pfunc.py
+++ b/pytensor/compile/function/pfunc.py
@@ -569,7 +569,7 @@ def construct_pfunc_ins_and_outs(
     if not fgraph:
         # Extend the outputs with the updates on input variables so they are
         # also cloned
-        additional_outputs = [i.update for i in inputs if i.update]
+        additional_outputs = [i.update for i in inputs if i.update is not None]
         if outputs is None:
             out_list = []
         else:
@@ -608,7 +608,7 @@ def construct_pfunc_ins_and_outs(
             new_i.variable = iv
 
             # If needed, replace the input's update by its cloned equivalent
-            if i.update:
+            if i.update is not None:
                 new_i.update = clone_d[i.update]
 
             new_inputs.append(new_i)

--- a/pytensor/compile/function/types.py
+++ b/pytensor/compile/function/types.py
@@ -198,7 +198,7 @@ def std_fgraph(
     update_mapping = {}
     out_idx = len(output_specs)
     for idx, input_spec in enumerate(input_specs):
-        if input_spec.update:
+        if input_spec.update is not None:
             updates.append(input_spec.update)
             update_mapping[out_idx] = idx
             out_idx += 1
@@ -1195,7 +1195,7 @@ def insert_deepcopy(fgraph, wrapped_inputs, wrapped_outputs):
     updated_fgraph_inputs = {
         fgraph_i
         for i, fgraph_i in zip(wrapped_inputs, fgraph.inputs, strict=True)
-        if getattr(i, "update", False)
+        if getattr(i, "update", None) is not None
     }
 
     # We can't use fgraph.inputs as this don't include Constant Value.
@@ -1351,7 +1351,11 @@ class FunctionMaker:
             ancestors(
                 (
                     [o.variable for o in outputs]
-                    + [i.update for i in inputs if getattr(i, "update", False)]
+                    + [
+                        i.update
+                        for i in inputs
+                        if getattr(i, "update", None) is not None
+                    ]
                 ),
                 blockers=[i.variable for i in inputs],
             )

--- a/pytensor/compile/nanguardmode.py
+++ b/pytensor/compile/nanguardmode.py
@@ -36,7 +36,7 @@ def _is_numeric_value(arr, var):
         return False
     elif isinstance(arr, np.random.mtrand.RandomState | np.random.Generator):
         return False
-    elif var and isinstance(var.type, RandomType):
+    elif var is not None and isinstance(var.type, RandomType):
         return False
     elif isinstance(arr, slice):
         return False

--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -823,6 +823,37 @@ discrete_dtypes = tuple(t.dtype for t in discrete_types)
 
 
 class _scalar_py_operators:
+    # These can't work because Python requires native output types
+    def __bool__(self):
+        raise TypeError(
+            "ScalarVariable cannot be converted to Python boolean. "
+            "Call `.astype(bool)` for the symbolic equivalent."
+        )
+
+    def __index__(self):
+        raise TypeError(
+            "ScalarVariable cannot be converted to Python integer. "
+            "Call `.astype(int)` for the symbolic equivalent."
+        )
+
+    def __int__(self):
+        raise TypeError(
+            "ScalarVariable cannot be converted to Python integer. "
+            "Call `.astype(int)` for the symbolic equivalent."
+        )
+
+    def __float__(self):
+        raise TypeError(
+            "ScalarVariable cannot be converted to Python float. "
+            "Call `.astype(float)` for the symbolic equivalent."
+        )
+
+    def __complex__(self):
+        raise TypeError(
+            "ScalarVariable cannot be converted to Python complex number. "
+            "Call `.astype(complex)` for the symbolic equivalent."
+        )
+
     # So that we can simplify checking code when we have a mixture of ScalarType
     # variables and Tensor variables
     ndim = 0
@@ -842,11 +873,6 @@ class _scalar_py_operators:
 
     def __neg__(self):
         return neg(self)
-
-    # CASTS
-    # def __int__(self): return AsInt(self).out
-    # def __float__(self): return AsDouble(self).out
-    # def __complex__(self): return AsComplex(self).out
 
     # BITWISE
     def __invert__(self):

--- a/pytensor/scalar/loop.py
+++ b/pytensor/scalar/loop.py
@@ -60,12 +60,12 @@ class ScalarLoop(ScalarInnerGraphOp):
             constant = []
         if not len(init) == len(update):
             raise ValueError("An update must be given for each init variable")
-        if until:
+        if until is not None:
             inputs, outputs = clone([*init, *constant], [*update, until])
         else:
             inputs, outputs = clone([*init, *constant], update)
 
-        self.is_while = bool(until)
+        self.is_while = until is not None
         self.inputs, self.outputs = self._cleanup_graph(inputs, outputs)
         self._validate_updates(self.inputs, self.outputs)
 

--- a/pytensor/scalar/math.py
+++ b/pytensor/scalar/math.py
@@ -856,7 +856,7 @@ def gammaincc_grad(k, x, skip_loops=constant(False, dtype="bool")):
             dfac = k_minus_one_minus_n * dfac + fac
             fac *= k_minus_one_minus_n
             delta = dfac / xpow
-            return (sum_a, delta, xpow, k_minus_one_minus_n, fac, dfac), ()
+            return (sum_a, delta, xpow, k_minus_one_minus_n, fac, dfac), None
 
         init = [sum_a0, delta, xpow, k_minus_one_minus_n, fac, dfac]
         constant = [x]

--- a/pytensor/scan/basic.py
+++ b/pytensor/scan/basic.py
@@ -979,7 +979,7 @@ def scan(
         # user-specified within the inner-function (e.g. by returning an update
         # `dict`) or the `SharedVariable.default_update`s of a shared variable
         # created in the inner-function.
-        if input.update and (is_local or input.variable in updates):
+        if input.update is not None and (is_local or input.variable in updates):
             # We need to remove the `default_update`s on the shared
             # variables created within the context of the loop function
             # (e.g. via use of `RandomStream`); otherwise, they'll get

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -3430,7 +3430,14 @@ class _nd_grid:
                 raise NotImplementedError(
                     "Not implemented for slices whose step is complex"
                 )
-        ranges = [arange(sl.start or 0, sl.stop, sl.step or 1) for sl in args[0]]
+        ranges = [
+            arange(
+                sl.start if sl.start is not None else 0,
+                sl.stop,
+                sl.step if sl.step is not None else 1,
+            )
+            for sl in args[0]
+        ]
         shapes = [
             tuple([1] * j + [r.shape[0]] + [1] * (ndim - 1 - j))
             for j, r in enumerate(ranges)

--- a/pytensor/tensor/conv/abstract_conv.py
+++ b/pytensor/tensor/conv/abstract_conv.py
@@ -2199,7 +2199,7 @@ class BaseAbstractConv(Op):
         ):
             border_mode = "valid"
 
-        self.imshp = tuple(imshp) if imshp else (None,) * (2 + convdim)
+        self.imshp = tuple(imshp) if imshp is not None else (None,) * (2 + convdim)
         for imshp_i in self.imshp:
             if imshp_i is not None:
                 # Components of imshp should be constant or ints
@@ -2209,7 +2209,7 @@ class BaseAbstractConv(Op):
                     raise ValueError(
                         "imshp should be None or a tuple of constant int values"
                     ).with_traceback(sys.exc_info()[2])
-        if kshp:
+        if kshp is not None:
             self.kshp = tuple(kshp)
         else:
             self.kshp = (None,) * ((2 + 2 * convdim) if unshared else (2 + convdim))

--- a/pytensor/tensor/math.py
+++ b/pytensor/tensor/math.py
@@ -1811,14 +1811,14 @@ class Dot(Op):
         if eval_points[0] is None and eval_points[1] is None:
             return [None]
 
-        if eval_points[0]:
+        if eval_points[0] is not None:
             t1 = self(eval_points[0], inputs[1])
-        if eval_points[1]:
+        if eval_points[1] is not None:
             t2 = self(inputs[0], eval_points[1])
 
-        if eval_points[0] and eval_points[1]:
+        if eval_points[0] is not None and eval_points[1] is not None:
             return [t1 + t2]
-        elif eval_points[0]:
+        elif eval_points[0] is not None:
             return [t1]
         else:
             return [t2]

--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -1331,14 +1331,14 @@ def local_sum_prod_of_mul_or_div(fgraph, node):
 
     # If we have a `Prod`, then the outside terms need to be raised to the power of the number of elements
     # that were contracted in the input
-    if isinstance(node.op, Prod) and inner_term:
+    if isinstance(node.op, Prod) and inner_term is not None:
         dtype = inner_term.dtype
         n_reduced_elements = prod(
             [inner_term.shape[i].astype(dtype) for i in reduced_axes]
         )
         outer_term = outer_term**n_reduced_elements
 
-    if not inner_term:
+    if inner_term is None:
         # Sum/Prod is useless, just return the outer_term
         # (This can only happen for mul, not division)
         new_out = outer_term
@@ -1992,7 +1992,7 @@ def local_pow_canonicalize(fgraph, node):
         # x ** 1 = x
         new_out = broadcast_arrays(*node.inputs)[0]
 
-    if not new_out:
+    if new_out is None:
         return
 
     if new_out.dtype != node.out.dtype:
@@ -2119,7 +2119,7 @@ def local_pow_to_nested_squaring(fgraph, node):
             rval1_scal = None
             while y_to_do > 0:
                 log_to_do = int(np.log2(y_to_do))
-                if rval1:
+                if rval1 is not None:
                     rval1 *= pow2[log_to_do]
                     rval1_scal *= pow2_scal[log_to_do]
                 else:
@@ -2137,7 +2137,7 @@ def local_pow_to_nested_squaring(fgraph, node):
                 rval = [reciprocal(rval1)]
             else:
                 rval = [rval1]
-        if rval:
+        if rval is not None:
             rval[0] = cast(rval[0], odtype)
             return rval
 

--- a/pytensor/tensor/rewriting/special.py
+++ b/pytensor/tensor/rewriting/special.py
@@ -162,7 +162,7 @@ def softmax_simplifier(numerators, denominators):
                         matching_denom = denominator
                         break
 
-        if matching_denom:
+        if matching_denom is not None:
             softmax = Softmax(axis=sum_axis)(numerator.owner.inputs[0])
             copy_stack_trace(numerator, softmax)
             numerators.remove(numerator)

--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -1147,7 +1147,7 @@ def merge_two_slices(fgraph, slice1, len1, slice2, len2):
             val = switch(le(len2, 0), len1 + 1, val)
             val = switch(ge(sl2, len2), len1 + 1, val)
             val = switch(lt(sl2, 0), -len1 - 1, val)
-            if sl1.step:
+            if sl1.step is not None:
                 val = switch(eq(sl1.step, 0), len1 + 1, val)
             return val
     else:

--- a/pytensor/tensor/variable.py
+++ b/pytensor/tensor/variable.py
@@ -26,53 +26,54 @@ _TensorTypeType = TypeVar("_TensorTypeType", bound=TensorType)
 
 
 class _tensor_py_operators:
+    # These can't work because Python requires native output types
+    def __bool__(self):
+        raise TypeError(
+            "TensorVariable cannot be converted to Python boolean. "
+            "Call `.astype(bool)` for the symbolic equivalent."
+        )
+
+    def __index__(self):
+        raise TypeError(
+            "TensorVariable cannot be converted to Python integer. "
+            "Call `.astype(int)` for the symbolic equivalent."
+        )
+
+    def __int__(self):
+        raise TypeError(
+            "TensorVariable cannot be converted to Python integer. "
+            "Call `.astype(int)` for the symbolic equivalent."
+        )
+
+    def __float__(self):
+        raise TypeError(
+            "TensorVariables cannot be converted to Python float. "
+            "Call `.astype(float)` for the symbolic equivalent."
+        )
+
+    def __complex__(self):
+        raise TypeError(
+            "TensorVariables cannot be converted to Python complex number. "
+            "Call `.astype(complex)` for the symbolic equivalent."
+        )
+
     def __abs__(self):
         return pt.math.abs(self)
 
     def __neg__(self):
         return pt.math.neg(self)
 
-    # These won't work because Python requires an int return value
-    # def __int__(self): return convert_to_int32(self)
-    # def __float__(self): return convert_to_float64(self)
-    # def __complex__(self): return convert_to_complex128(self)
-
-    _is_nonzero = True
-
     def __lt__(self, other):
-        rval = pt.math.lt(self, other)
-        rval._is_nonzero = False
-        return rval
+        return pt.math.lt(self, other)
 
     def __le__(self, other):
-        rval = pt.math.le(self, other)
-        rval._is_nonzero = False
-        return rval
+        return pt.math.le(self, other)
 
     def __gt__(self, other):
-        rval = pt.math.gt(self, other)
-        rval._is_nonzero = False
-        return rval
+        return pt.math.gt(self, other)
 
     def __ge__(self, other):
-        rval = pt.math.ge(self, other)
-        rval._is_nonzero = False
-        return rval
-
-    def __bool__(self):
-        # This is meant to prohibit stuff like a < b < c, which is internally
-        # implemented as (a < b) and (b < c). The trouble with this is the
-        # side-effect that checking for a non-NULL a by typing "if a: ..."
-        # uses the same __nonzero__ method.  We want these both to work, but
-        # it seems impossible.  Currently, all vars evaluate to nonzero except
-        # the return values of comparison operators, which raise this
-        # exception.  If you can think of a better solution, go for it!
-        #
-        # __bool__ is Python 3.x data model. __nonzero__ is Python 2.x.
-        if self._is_nonzero:
-            return True
-        else:
-            raise TypeError("Variables do not support boolean operations.")
+        return pt.math.ge(self, other)
 
     def __invert__(self):
         return pt.math.invert(self)

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -3972,13 +3972,12 @@ class TestInferShape(utt.InferShapeTester):
         advec = dvector()
         aivec = ivector()
 
-        abool = True
         rng = np.random.default_rng(utt.fetch_seed())
         advec_val = random(5)
         aivec_val = rng.permutation(5).astype("int32")
         self._compile_and_check(
             [advec, aivec],
-            [PermuteRowElements()(advec, aivec, abool)],
+            [PermuteRowElements(inverse=True)(advec, aivec)],
             [advec_val, aivec_val],
             PermuteRowElements,
         )
@@ -3986,7 +3985,7 @@ class TestInferShape(utt.InferShapeTester):
         admat_val = random(3, 5)
         self._compile_and_check(
             [admat, aivec],
-            [PermuteRowElements()(admat, aivec, abool)],
+            [PermuteRowElements(inverse=False)(admat, aivec)],
             [admat_val, aivec_val],
             PermuteRowElements,
         )
@@ -3995,7 +3994,7 @@ class TestInferShape(utt.InferShapeTester):
         adtens3_val = random(3, 2, 5)
         self._compile_and_check(
             [adtens3, aivec],
-            [PermuteRowElements()(adtens3, aivec, abool)],
+            [PermuteRowElements(inverse=True)(adtens3, aivec)],
             [adtens3_val, aivec_val],
             PermuteRowElements,
         )
@@ -4008,7 +4007,7 @@ class TestInferShape(utt.InferShapeTester):
         admat_val = random(3, 5)
         self._compile_and_check(
             [admat, aimat],
-            [PermuteRowElements()(admat, aimat, abool)],
+            [PermuteRowElements(inverse=False)(admat, aimat)],
             [admat_val, aimat_val],
             PermuteRowElements,
         )
@@ -4023,7 +4022,7 @@ class TestInferShape(utt.InferShapeTester):
         aitens3_val[1, ::, ::] = bimat_val
         self._compile_and_check(
             [admat, aitens3],
-            [PermuteRowElements()(admat, aitens3, abool)],
+            [PermuteRowElements(inverse=True)(admat, aitens3)],
             [admat_val, aitens3_val],
             PermuteRowElements,
         )

--- a/tests/tensor/test_type.py
+++ b/tests/tensor/test_type.py
@@ -399,7 +399,7 @@ def test_tensor_creator_dtype_catch(dtype):
         tensor(dtype, shape=(None,))
 
     # This should work
-    assert tensor(dtype=dtype, shape=(None,))
+    assert tensor(dtype=dtype, shape=(None,)) is not None
 
 
 def test_tensor_creator_ignores_rare_dtype_name():


### PR DESCRIPTION
Notably changes the behavior of `__bool__` to always raise. Before there was a hack based on whether a variable had been compared to something before.

This should avoid surprising behavior such as:
```python
import pytensor.tensor as pt
x = pt.zeros(())
if x:
  print("Variable is nonzero!")  # Always triggered
else:
  print("Variable is zero")  # Never triggered
```
After this PR it raises
```
TypeError: TensorVariable cannot be converted to Python boolean. Call `.astype(bool)` for the symbolic equivalent.
```

The correct behavior as per the API standard is to raise in these cases: https://data-apis.org/array-api/latest/design_topics/lazy_eager.html

There is still surprising behavior with (in)equality checks, but we can't do anything about those as they are needed for Python hashing behavior. The default is `x == y: True if x is y else False`

```python
import pytensor.tensor as pt
x = pt.zeros(())
if x == 0:
  print("Variable is zero!")  # Only triggered when x == x
else:
  print("Variable is nonzero")  # Always triggered
``` 

Related to #1189


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1190.org.readthedocs.build/en/1190/

<!-- readthedocs-preview pytensor end -->