### PR TITLE
Implement gradient for vector repetitions

### DIFF
--- a/pytensor/link/vm.py
+++ b/pytensor/link/vm.py
@@ -118,7 +118,7 @@ def calculate_reallocate_info(
                     # where gc
                     for i in range(idx + 1, len(order)):
                         if reuse_out is not None:
-                            break  # type: ignore
+                            break
                         for out in order[i].outputs:
                             if (
                                 getattr(out.type, "ndim", None) == 0


### PR DESCRIPTION
Nobody asked for it, and nobody probably ever needed it (it exists since 2012), but it was a fun challenge.

Also cleaned up a bit the implementation by not allowing negative axis on the Op itself like we do in other cases (the helper repeat handles the conversion to positive axis)

doctest fails due to an unrelated print that should be solved by #1193 

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1192.org.readthedocs.build/en/1192/

<!-- readthedocs-preview pytensor end -->