### PR TITLE
Rewrite reshapes that only expand or squeeze dims

### DIFF
--- a/pytensor/graph/rewriting/basic.py
+++ b/pytensor/graph/rewriting/basic.py
@@ -2800,16 +2800,6 @@ def _check_chain(r, chain):
     return r is not None
 
 
-def check_chain(r, *chain):
-    """
-    WRITEME
-
-    """
-    if isinstance(r, Apply):
-        r = r.outputs[0]
-    return _check_chain(r, reduce(list.__iadd__, ([x, 0] for x in chain)))
-
-
 def pre_greedy_node_rewriter(
     fgraph: FunctionGraph, rewrites: Sequence[NodeRewriter], out: Variable
 ) -> Variable:

--- a/pytensor/tensor/rewriting/shape.py
+++ b/pytensor/tensor/rewriting/shape.py
@@ -897,7 +897,8 @@ def local_useless_reshape(fgraph, node):
         if nb_m1 <= 1 and all(shape_match):
             return [inp]
 
-        if (nb_m1 == 0) and (shape_match.count(False) == output.type.ndim - 1):
+        # There is one missing match, but all other dimensions match
+        if (nb_m1 == 0) and (shape_match.count(False) == 1):
             return [inp]
 
         return False

--- a/pytensor/tensor/shape.py
+++ b/pytensor/tensor/shape.py
@@ -644,6 +644,8 @@ class Reshape(COp):
         x = ptb.as_tensor_variable(x)
         shp_orig = shp
         shp = ptb.as_tensor_variable(shp, ndim=1)
+        if shp.type.shape == (None,):
+            shp = specify_shape(shp, self.ndim)
         if not (
             shp.dtype in int_dtypes
             or (isinstance(shp, TensorConstant) and shp.data.size == 0)

--- a/pytensor/tensor/shape.py
+++ b/pytensor/tensor/shape.py
@@ -1,7 +1,9 @@
 import warnings
+from collections.abc import Sequence
 from numbers import Number
 from textwrap import dedent
-from typing import cast
+from typing import TYPE_CHECKING, Union, cast
+from typing import cast as typing_cast
 
 import numpy as np
 from numpy.core.numeric import normalize_axis_tuple  # type: ignore
@@ -23,6 +25,9 @@ from pytensor.tensor.type import DenseTensorType, TensorType, int_dtypes, tensor
 from pytensor.tensor.type_other import NoneConst, NoneTypeT
 from pytensor.tensor.variable import TensorConstant, TensorVariable
 
+
+if TYPE_CHECKING:
+    from pytensor.tensor import TensorLike
 
 ShapeValueType = None | np.integer | int | Variable
 
@@ -842,9 +847,14 @@ def _vectorize_reshape(op, node, x, shape):
     return reshape(x, new_shape, ndim=len(new_shape)).owner
 
 
-def reshape(x, newshape, ndim=None):
+def reshape(
+    x: "TensorLike",
+    newshape: Union["TensorLike", Sequence["TensorLike"]],
+    *,
+    ndim: int | None = None,
+) -> TensorVariable:
     if ndim is None:
-        newshape = ptb.as_tensor_variable(newshape)
+        newshape = ptb.as_tensor_variable(newshape)  # type: ignore
         if newshape.type.ndim != 1:
             raise TypeError(
                 "New shape in reshape must be a vector or a list/tuple of"
@@ -862,7 +872,7 @@ def reshape(x, newshape, ndim=None):
             )
     op = Reshape(ndim)
     rval = op(x, newshape)
-    return rval
+    return typing_cast(TensorVariable, rval)
 
 
 def shape_padleft(t, n_ones=1):

--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -918,7 +918,7 @@ def _direct_solve_discrete_lyapunov(
     vec_Q = Q.ravel()
     vec_X = solve(eye - AxA, vec_Q, b_ndim=1)
 
-    return cast(TensorVariable, reshape(vec_X, A.shape))
+    return reshape(vec_X, A.shape)
 
 
 def solve_discrete_lyapunov(

--- a/tests/tensor/rewriting/test_basic.py
+++ b/tests/tensor/rewriting/test_basic.py
@@ -332,7 +332,6 @@ class TestLocalCanonicalizeAlloc:
 
         mode = rewrite_mode.including(
             "local_dimshuffle_lift",
-            "local_useless_dimshuffle_in_reshape",
             "local_alloc_sink_dimshuffle",
         )
         f = function([x], [y], mode=mode)

--- a/tests/tensor/rewriting/test_shape.py
+++ b/tests/tensor/rewriting/test_shape.py
@@ -383,6 +383,13 @@ class TestLocalUselessReshape:
         new_out = rewrite_graph(out)
         assert new_out is out
 
+        # Or if more than one dimension cannot be matched
+        x = tensor(shape=(None, None, None))
+        shape = [x.shape[0], 3, 3]
+        out = reshape(x, shape)
+        new_out = rewrite_graph(out)
+        assert new_out is out
+
 
 class TestLocalReshapeToDimshuffle:
     def setup_method(self):

--- a/tests/tensor/test_shape.py
+++ b/tests/tensor/test_shape.py
@@ -98,6 +98,7 @@ class TestReshape(utt.InferShapeTester, utt.OptimizationTestMixin):
             Shape_i,
             DimShuffle,
             Elemwise,
+            SpecifyShape,
         )
         super().setup_method()
 
@@ -253,9 +254,7 @@ class TestReshape(utt.InferShapeTester, utt.OptimizationTestMixin):
             f(a_val, [7, 5])
         with pytest.raises(ValueError):
             f(a_val, [-1, -1])
-        with pytest.raises(
-            ValueError, match=".*Shape argument to Reshape has incorrect length.*"
-        ):
+        with pytest.raises(AssertionError):
             f(a_val, [3, 4, 1])
 
     def test_0(self):


### PR DESCRIPTION
We canonicalize so that reshape is only used for the behavior that is unique to it (mixing dimensions). Expand_dims and squeeze-like behavior are canonicalized into the respective forms of DimShuffle. This allows other rewrites that know how to reason about these (but not reshape, which is too flexible), such as in the following graph:

```python
import pytensor
import pytensor.tensor as pt

x = pt.vector("x", shape=(9,))
out = pt.repeat(x[None], 12, axis=0)
pytensor.function([x], out).dprint(print_type=True)   
```
Which before this PR generated this graph:
```
# Reshape{2} [id A] <Matrix(float64, shape=(12, 9))> 1
#  ├─ Alloc [id B] <Tensor3(float64, shape=(1, 12, 9))> 0
#  │  ├─ x [id C] <Vector(float64, shape=(9,))>
#  │  ├─ 1 [id D] <Scalar(int64, shape=())>
#  │  ├─ 12 [id E] <Scalar(int64, shape=())>
#  │  └─ 9 [id F] <Scalar(int64, shape=())>
#  └─ [12  9] [id G] <Vector(int64, shape=(2,))>
```
And now simplifies:
```
# Alloc [id A] <Matrix(float64, shape=(12, 9))> 0
#  ├─ x [id B] <Vector(float64, shape=(9,))>
#  ├─ 12 [id C] <Scalar(int64, shape=())>
#  └─ 9 [id D] <Scalar(int64, shape=())>
```

Or a naive broadcast + elemwise comparison:
```python
import pytensor
import pytensor.tensor as pt

x = pt.vector("x", shape=(3,))
y = pt.vector("y", shape=(9,))
out = x[None, :].repeat(9, axis=0) <= y[:, None].repeat(3, axis=1)
pytensor.function([x, y], out).dprint(print_type=True)   
```
Which used to generate this graph:
```
Le [id A] <Matrix(bool, shape=(9, 3))> 5
 ├─ Reshape{2} [id B] <Matrix(float64, shape=(9, 3))> 4
 │  ├─ Alloc [id C] <Tensor3(float64, shape=(1, 9, 3))> 3
 │  │  ├─ x [id D] <Vector(float64, shape=(3,))>
 │  │  ├─ 1 [id E] <Scalar(int64, shape=())>
 │  │  ├─ 9 [id F] <Scalar(int64, shape=())>
 │  │  └─ 3 [id G] <Scalar(int64, shape=())>
 │  └─ [9 3] [id H] <Vector(int64, shape=(2,))>
 └─ Reshape{2} [id I] <Matrix(float64, shape=(9, 3))> 2
    ├─ Alloc [id J] <Tensor3(float64, shape=(9, 1, 3))> 1
    │  ├─ ExpandDims{axes=[1, 2]} [id K] <Tensor3(float64, shape=(9, 1, 1))> 0
    │  │  └─ y [id L] <Vector(float64, shape=(9,))>
    │  ├─ 9 [id F] <Scalar(int64, shape=())>
    │  ├─ 1 [id E] <Scalar(int64, shape=())>
    │  └─ 3 [id G] <Scalar(int64, shape=())>
    └─ [9 3] [id H] <Vector(int64, shape=(2,))>
```
And now generates:
```
# Le [id A] <Matrix(bool, shape=(9, 3))> 2
#  ├─ ExpandDims{axis=0} [id B] <Matrix(float64, shape=(1, 3))> 1
#  │  └─ x [id C] <Vector(float64, shape=(3,))>
#  └─ ExpandDims{axis=1} [id D] <Matrix(float64, shape=(9, 1))> 0
#     └─ y [id E] <Vector(float64, shape=(9,))>
```
Which is great because it avoids materializing the full broadcasted inputs!

This example is not absurd, it showed up in this PyMC model: https://gist.github.com/ricardoV94/f986686ce86511b293c5dd6be374e51d

Also fixed a bug in local_useless_reshape, that may be behind some failures that @tanish1729 detected

Closes #845 
Closes #1123 
Related to #883

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1200.org.readthedocs.build/en/1200/

<!-- readthedocs-preview pytensor end -->