### PR TITLE
Renamed output_type_depends_on_input_value to data_dependent_output_shapes

### DIFF
--- a/pytensor/graph/basic.py
+++ b/pytensor/graph/basic.py
@@ -270,11 +270,11 @@ class Apply(Node, Generic[OpType]):
 
         # Some Ops like Alloc require the node to always be rebuilt in non-strict mode
         # as the output type depends on the input values and not just their types
-        output_type_depends_on_input_value = self.op._output_type_depends_on_input_value
+        data_dependent_output_shapes = self.op._data_dependent_output_shapes
 
         for i, (curr, new) in enumerate(zip(self.inputs, new_inputs, strict=True)):
             # Check if the input type changed or if the Op has output types that depend on input values
-            if (curr.type != new.type) or output_type_depends_on_input_value:
+            if (curr.type != new.type) or data_dependent_output_shapes:
                 # In strict mode, the cloned graph is assumed to be mathematically equivalent to the original one.
                 # We only need to rebuild a node when the new input has a different, but compatible, type.
                 # This can happen e.g., when we provide a new input with a more specialized static shape.

--- a/pytensor/graph/basic.py
+++ b/pytensor/graph/basic.py
@@ -270,11 +270,11 @@ class Apply(Node, Generic[OpType]):
 
         # Some Ops like Alloc require the node to always be rebuilt in non-strict mode
         # as the output type depends on the input values and not just their types
-        data_dependent_output_shapes = self.op._data_dependent_output_shapes
+        data_dependent_output_shape = self.op.data_dependent_output_shape
 
         for i, (curr, new) in enumerate(zip(self.inputs, new_inputs, strict=True)):
             # Check if the input type changed or if the Op has output types that depend on input values
-            if (curr.type != new.type) or data_dependent_output_shapes:
+            if (curr.type != new.type) or data_dependent_output_shape:
                 # In strict mode, the cloned graph is assumed to be mathematically equivalent to the original one.
                 # We only need to rebuild a node when the new input has a different, but compatible, type.
                 # This can happen e.g., when we provide a new input with a more specialized static shape.

--- a/pytensor/graph/op.py
+++ b/pytensor/graph/op.py
@@ -195,7 +195,7 @@ class Op(MetaObject):
     itypes: Sequence["Type"] | None = None
     otypes: Sequence["Type"] | None = None
 
-    _output_type_depends_on_input_value = False
+    _data_dependent_output_shapes = False
     """
     Whether the static output type depends on the inferred value of one of the inputs.
     (e.g, via constant folding or static shape inference).

--- a/pytensor/graph/op.py
+++ b/pytensor/graph/op.py
@@ -195,7 +195,7 @@ class Op(MetaObject):
     itypes: Sequence["Type"] | None = None
     otypes: Sequence["Type"] | None = None
 
-    _data_dependent_output_shapes = False
+    data_dependent_output_shape = False
     """
     Whether the static output type depends on the inferred value of one of the inputs.
     (e.g, via constant folding or static shape inference).

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -1362,7 +1362,7 @@ def triu_indices_from(
 
 
 class Eye(Op):
-    _output_type_depends_on_input_value = True
+    _data_dependent_output_shapes = True
     __props__ = ("dtype",)
 
     def __init__(self, dtype=None):
@@ -1577,7 +1577,7 @@ class Alloc(COp):
     """
 
     _f16_ok = True
-    _output_type_depends_on_input_value = True
+    _data_dependent_output_shapes = True
 
     __props__ = ()
 
@@ -4213,7 +4213,7 @@ class Choose(Op):
 class AllocEmpty(COp):
     """Implement Alloc on the cpu, but without initializing memory."""
 
-    _output_type_depends_on_input_value = True
+    _data_dependent_output_shapes = True
 
     __props__ = ("dtype",)
     params_type = ParamsType(typecode=int32)

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -1362,7 +1362,7 @@ def triu_indices_from(
 
 
 class Eye(Op):
-    _data_dependent_output_shapes = True
+    data_dependent_output_shape = True
     __props__ = ("dtype",)
 
     def __init__(self, dtype=None):
@@ -1577,7 +1577,7 @@ class Alloc(COp):
     """
 
     _f16_ok = True
-    _data_dependent_output_shapes = True
+    data_dependent_output_shape = True
 
     __props__ = ()
 
@@ -4213,7 +4213,7 @@ class Choose(Op):
 class AllocEmpty(COp):
     """Implement Alloc on the cpu, but without initializing memory."""
 
-    _data_dependent_output_shapes = True
+    data_dependent_output_shape = True
 
     __props__ = ("dtype",)
     params_type = ParamsType(typecode=int32)

--- a/pytensor/tensor/random/op.py
+++ b/pytensor/tensor/random/op.py
@@ -41,7 +41,7 @@ class RandomVariable(Op):
 
     """
 
-    _output_type_depends_on_input_value = True
+    _data_dependent_output_shapes = True
 
     __props__ = ("name", "signature", "dtype", "inplace")
     default_output = 1

--- a/pytensor/tensor/random/op.py
+++ b/pytensor/tensor/random/op.py
@@ -41,7 +41,7 @@ class RandomVariable(Op):
 
     """
 
-    _data_dependent_output_shapes = True
+    data_dependent_output_shape = True
 
     __props__ = ("name", "signature", "dtype", "inplace")
     default_output = 1

--- a/pytensor/tensor/shape.py
+++ b/pytensor/tensor/shape.py
@@ -398,7 +398,7 @@ class SpecifyShape(COp):
     view_map = {0: [0]}
     __props__ = ()
     _f16_ok = True
-    _output_type_depends_on_input_value = True
+    _data_dependent_output_shapes = True
 
     def make_node(self, x, *shape):
         x = ptb.as_tensor_variable(x)
@@ -619,7 +619,7 @@ class Reshape(COp):
 
     view_map = {0: [0]}  # output 0 is potentially aliased to inputs [0]
     _f16_ok = True
-    _output_type_depends_on_input_value = True
+    _data_dependent_output_shapes = True
 
     check_input = False
     __props__ = ("ndim",)

--- a/pytensor/tensor/shape.py
+++ b/pytensor/tensor/shape.py
@@ -398,7 +398,7 @@ class SpecifyShape(COp):
     view_map = {0: [0]}
     __props__ = ()
     _f16_ok = True
-    _data_dependent_output_shapes = True
+    data_dependent_output_shape = True
 
     def make_node(self, x, *shape):
         x = ptb.as_tensor_variable(x)
@@ -619,7 +619,7 @@ class Reshape(COp):
 
     view_map = {0: [0]}  # output 0 is potentially aliased to inputs [0]
     _f16_ok = True
-    _data_dependent_output_shapes = True
+    data_dependent_output_shape = True
 
     check_input = False
     __props__ = ("ndim",)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
Replaced all instances of `output_type_depends_on_input_value` with `data_dependent_output_shapes` for discoverability / standardization. Follows the Aarray API standard for this: https://data-apis.org/array-api/draft/design_topics/data_dependent_output_shapes.html
## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1188 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1209.org.readthedocs.build/en/1209/

<!-- readthedocs-preview pytensor end -->