### PR TITLE
Fix Blockwise and RandomVariable in Numba with repeated arguments

### DIFF
--- a/pytensor/tensor/blockwise.py
+++ b/pytensor/tensor/blockwise.py
@@ -443,6 +443,13 @@ _vectorize_node.register(Blockwise, _vectorize_not_needed)
 class OpWithCoreShape(OpFromGraph):
     """Generalizes an `Op` to include core shape as an additional input."""
 
+    def __init__(self, *args, on_unused_input="ignore", **kwargs):
+        # We set on_unused_inputs="ignore" so that we can easily wrap nodes with repeated inputs
+        # In this case the subsequent appearance of repeated inputs get disconnected in the inner graph
+        # I can't think of a scenario where this will backfire, but if there's one
+        # I bet on inplacing operations (time will tell)
+        return super().__init__(*args, on_unused_input=on_unused_input, **kwargs)
+
 
 class BlockwiseWithCoreShape(OpWithCoreShape):
     """Generalizes a Blockwise `Op` to include a core shape parameter."""


### PR DESCRIPTION
To implement Blockwise and RandomVariables in numba we use an `OpWithCoreShape` OpFromGraph subclass, that extends the original node with a core_shape input. This approach would fail whenever the original node had repeated inputs, as OpFromGraph raises by default when that's the case.

For now I think simply allowing OpFromGraph to ignore those disconnected inputs should work fine. We can revisit later and use a `node.clone_with_new_inputs` or whatever is called to mask the fact the inputs are identical. I have a 90% confidence this won't be needed so I'm trying the simple approach until reality proves it wrong.

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1222.org.readthedocs.build/en/1222/

<!-- readthedocs-preview pytensor end -->