### PR TITLE
Implement multinomial and inverse gamma in numba backend

### DIFF
--- a/pytensor/tensor/random/basic.py
+++ b/pytensor/tensor/random/basic.py
@@ -1219,7 +1219,7 @@ class HalfCauchyRV(ScipyRandomVariable):
 halfcauchy = HalfCauchyRV()
 
 
-class InvGammaRV(ScipyRandomVariable):
+class InvGammaRV(RandomVariable):
     r"""An inverse-gamma continuous random variable.
 
     The probability density function for `invgamma` in terms of its shape
@@ -1266,8 +1266,8 @@ class InvGammaRV(ScipyRandomVariable):
         return super().__call__(shape, scale, size=size, **kwargs)
 
     @classmethod
-    def rng_fn_scipy(cls, rng, shape, scale, size):
-        return stats.invgamma.rvs(shape, scale=scale, size=size, random_state=rng)
+    def rng_fn(cls, rng, shape, scale, size):
+        return 1 / rng.gamma(shape, 1 / scale, size)
 
 
 invgamma = InvGammaRV()

--- a/tests/link/numba/test_random.py
+++ b/tests/link/numba/test_random.py
@@ -514,6 +514,31 @@ test_mvnormal_cov_decomposition_method = create_mvnormal_cov_decomposition_metho
             ],
             (pt.as_tensor([2, 1])),
         ),
+        (
+            ptr.invgamma,
+            [
+                (
+                    pt.dvector("shape"),
+                    np.array([1.0, 2.0], dtype=np.float64),
+                ),
+                (
+                    pt.dvector("scale"),
+                    np.array([0.5, 3.0], dtype=np.float64),
+                ),
+            ],
+            (2,),
+        ),
+        (
+            ptr.multinomial,
+            [
+                (
+                    pt.lvector("n"),
+                    np.array([1, 10, 1000], dtype=np.int64),
+                ),
+                (pt.dvector("p"), np.array([0.3, 0.7], dtype=np.float64)),
+            ],
+            None,
+        ),
     ],
     ids=str,
 )


### PR DESCRIPTION
Also changes the python implementation to use numpy instead of scipy. The overhead doesn't make sense for this trivial RV.

Long term we should replace these by OpFromGraph: #1221 

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1223.org.readthedocs.build/en/1223/

<!-- readthedocs-preview pytensor end -->