### PR TITLE
Speedup DimShuffle and Reshape in C and Numba backends

### DIFF
--- a/pytensor/link/jax/dispatch/elemwise.py
+++ b/pytensor/link/jax/dispatch/elemwise.py
@@ -79,12 +79,7 @@ def jax_funcify_DimShuffle(op, **kwargs):
         for augm in op.augment:
             shape.insert(augm, 1)
 
-        res = jnp.reshape(res, shape)
-
-        if not op.inplace:
-            res = jnp.copy(res)
-
-        return res
+        return jnp.reshape(res, shape)
 
     return dimshuffle
 

--- a/pytensor/link/numba/dispatch/elemwise.py
+++ b/pytensor/link/numba/dispatch/elemwise.py
@@ -414,7 +414,6 @@ def numba_funcify_DimShuffle(op, node, **kwargs):
     shuffle = tuple(op.shuffle)
     transposition = tuple(op.transposition)
     augment = tuple(op.augment)
-    inplace = op.inplace
 
     ndim_new_shape = len(shuffle) + len(augment)
 
@@ -474,12 +473,7 @@ def numba_funcify_DimShuffle(op, node, **kwargs):
             new_shape = find_shape(shuffle_shape)
 
             # FIXME: Numba's `array.reshape` only accepts C arrays.
-            res_reshape = np.reshape(np.ascontiguousarray(x), new_shape)
-
-            if not inplace:
-                return res_reshape.copy()
-            else:
-                return res_reshape
+            return np.reshape(np.ascontiguousarray(x), new_shape)
 
     else:
 

--- a/pytensor/link/pytorch/dispatch/elemwise.py
+++ b/pytensor/link/pytorch/dispatch/elemwise.py
@@ -61,12 +61,7 @@ def pytorch_funcify_DimShuffle(op, **kwargs):
         for augm in op.augment:
             shape.insert(augm, 1)
 
-        res = torch.reshape(res, shape)
-
-        if not op.inplace:
-            res = res.clone()
-
-        return res
+        return torch.reshape(res, shape)
 
     return dimshuffle
 

--- a/pytensor/tensor/c_code/dimshuffle.c
+++ b/pytensor/tensor/c_code/dimshuffle.c
@@ -7,10 +7,6 @@ int APPLY_SPECIFIC(cpu_dimshuffle)(PyArrayObject *input, PyArrayObject **res, PA
     npy_intp* dimensions;
     npy_intp* strides;
 
-    // This points to either the original input or a copy we create below.
-    // Either way, this is what we should be working on/with.
-    PyArrayObject *_input;
-
     if (!PyArray_IS_C_CONTIGUOUS(params->_new_order)) {
         PyErr_SetString(PyExc_RuntimeError, "DimShuffle: param _new_order must be C-contiguous.");
         return 1;
@@ -20,7 +16,7 @@ int APPLY_SPECIFIC(cpu_dimshuffle)(PyArrayObject *input, PyArrayObject **res, PA
     nd_out = PyArray_SIZE(params->_new_order);
 
     if (PyArray_NDIM(input) != nd_in) {
-        PyErr_SetString(PyExc_NotImplementedError, "DimShuffle: Input has less dimensions than expected.");
+        PyErr_SetString(PyExc_ValueError, "DimShuffle: Input has less dimensions than expected.");
         return 1;
     }
 
@@ -34,12 +30,12 @@ int APPLY_SPECIFIC(cpu_dimshuffle)(PyArrayObject *input, PyArrayObject **res, PA
         return 1;
     };
 
-    npy_intp original_size = PyArray_SIZE(_input);
+    npy_intp original_size = PyArray_SIZE(input);
     npy_intp new_size = 1;
     for (npy_intp i = 0; i < nd_out; ++i) {
         if (new_order[i] != -1) {
-            dimensions[i] = PyArray_DIMS(_input)[new_order[i]];
-            strides[i] = PyArray_DIMS(_input)[new_order[i]] == 1 ? 0 : PyArray_STRIDES(_input)[new_order[i]];
+            dimensions[i] = PyArray_DIMS(input)[new_order[i]];
+            strides[i] = PyArray_DIMS(input)[new_order[i]] == 1 ? 0 : PyArray_STRIDES(input)[new_order[i]];
         } else {
             dimensions[i] = 1;
             strides[i] = 0;
@@ -57,22 +53,13 @@ int APPLY_SPECIFIC(cpu_dimshuffle)(PyArrayObject *input, PyArrayObject **res, PA
     if (*res)
         Py_XDECREF(*res);
 
-    if (params->inplace) {
-        _input = input;
-        Py_INCREF((PyObject*)_input);
-    } else {
-        _input = (PyArrayObject *)PyArray_FromAny(
-            (PyObject *)input, NULL, 0, 0, NPY_ARRAY_ALIGNED | NPY_ARRAY_ENSURECOPY,
-            NULL);
-    }
-
     // Create the new array.
     *res = (PyArrayObject*)PyArray_New(&PyArray_Type, nd_out, dimensions,
-                                       PyArray_TYPE(_input), strides,
-                                       PyArray_DATA(_input), PyArray_ITEMSIZE(_input),
+                                       PyArray_TYPE(input), strides,
+                                       PyArray_DATA(input), PyArray_ITEMSIZE(input),
                                        // borrow only the writable flag from the base
                                        // the NPY_OWNDATA flag will default to 0.
-                                       (NPY_ARRAY_WRITEABLE * PyArray_ISWRITEABLE(_input)),
+                                       (NPY_ARRAY_WRITEABLE * PyArray_ISWRITEABLE(input)),
                                        NULL);
 
     if (*res == NULL) {
@@ -81,11 +68,12 @@ int APPLY_SPECIFIC(cpu_dimshuffle)(PyArrayObject *input, PyArrayObject **res, PA
         return 1;
     }
 
+    // Declare it a view of the original input
+    Py_INCREF((PyObject*)input);
+    PyArray_SetBaseObject(*res, (PyObject*)input);
+
     // recalculate flags: CONTIGUOUS, FORTRAN, ALIGNED
     PyArray_UpdateFlags(*res, NPY_ARRAY_UPDATE_ALL);
-
-    // we are making a view in both inplace and non-inplace cases
-    PyArray_SetBaseObject(*res, (PyObject*)_input);
 
     free(strides);
     free(dimensions);

--- a/tests/link/numba/test_elemwise.py
+++ b/tests/link/numba/test_elemwise.py
@@ -23,6 +23,7 @@ from tests.link.numba.test_basic import (
 from tests.tensor.test_elemwise import (
     careduce_benchmark_tester,
     check_elemwise_runtime_broadcast,
+    dimshuffle_benchmark,
 )
 
 
@@ -201,7 +202,7 @@ def test_Dimshuffle_returns_array():
 
 def test_Dimshuffle_non_contiguous():
     """The numba impl of reshape doesn't work with
-    non-contiguous arrays, make sure we work around thpt."""
+    non-contiguous arrays, make sure we work around that."""
     x = pt.dvector()
     idx = pt.vector(dtype="int64")
     op = DimShuffle(input_ndim=1, new_order=[])
@@ -643,3 +644,7 @@ class TestsBenchmark:
         return careduce_benchmark_tester(
             axis, c_contiguous, mode="NUMBA", benchmark=benchmark
         )
+
+    @pytest.mark.parametrize("c_contiguous", (True, False))
+    def test_dimshuffle(self, c_contiguous, benchmark):
+        dimshuffle_benchmark("NUMBA", c_contiguous, benchmark)

--- a/tests/tensor/test_extra_ops.py
+++ b/tests/tensor/test_extra_ops.py
@@ -480,10 +480,7 @@ class TestSqueeze(utt.InferShapeTester):
         assert f([0]) == 0
 
         # Test that we cannot squeeze dimensions whose length is greater than 1
-        with pytest.raises(
-            ValueError,
-            match="cannot reshape array of size 3 into shape ()",
-        ):
+        with pytest.raises(ValueError):
             f([0, 1, 2])
 
 


### PR DESCRIPTION
## TLDR: Make views cheap again!
### All backends
Remove the unused inplace option, less branching is always helpful

### Python backend
~~Implementation based on `as_strided` that mimicks the old (and now current again) C-backend approach. This is debatable since the Python implementation has historically been there more for readability than performance. However it's useful for fast compiling graphs not to suck?~~
`as_strided` is actually insanely slow in python, so I'm back to transpose+reshape. The removal of some checks and unnecessary `asarray` calls provide a small speedup, although this is obviously not critical.

### Numba backend
Use `as_strided` which simplifies the implementation by a ton with two benefits:
1. Much faster compilation / caching. The new benchmark runs on 1.6s (includes many runs) after caching, vs 4.6s. When checking a simple function directly I saw wall times going down from 1.2 vs 600ms (first time after starting the interpreter) and 300ms vs 100ms in subsequent runs. This seems to scale with the number of DimShuffles in the graph?
2. Slightly faster for contiguous arrays: the new benchmark roughly 1.1-1.3x faster

```python
import pytensor
import pytensor.tensor as pt
import numpy as np

x = pt.tensor("x", shape=(1, 2, 3))
y = x.dimshuffle(2, "x", 1, "x")

out = pytensor.function([pytensor.In(x, borrow=True)], pytensor.Out(y, borrow=True), mode="NUMBA")
out.trust_input = True

x_test = np.zeros((1, 2, 3))
out(x_test)
%timeit out(x_test)
```

The example with non-contiguous arrays in https://github.com/pymc-devs/pytensor/issues/1111 has no penalty now, which is a 10,000x speedup (example is exaggerated with a very large array)


### C backend
This was the original goal of this PR

There were two regressions caused by e593b0ac57a0d56d4f6ffdd08d52c3be78ebf961 and 223ee1548574b6bb8e73611ed605a97e29f13e7b.

The DimShuffle changes introduce a `PyArray_IntpConverter` to compute a new shape and used two calls to numpy C-functions `PyArray_Transpose` and `PyArray_NewShape`. I suspect the slowdown comes mostly from the introduction of `PyArray_IntPConverter` but I couldn't find anything wrong with the simpler logic from Theano times, other than...

The bug that motivated the changes had to do with a useless second pass on the dimensions calculations:
```C
    /* set the strides of the broadcasted dimensions.
     * This algorithm is from numpy: PyArray_Newshape() in
     * cvs/numpy/numpy/core/src/multiarraymodule.c */
    if (nd_out > 0) {
        if (strides[nd_out - 1] == 0)
            strides[nd_out - 1] = PyArray_DESCR(basename)->elsize;
        for (npy_intp i = nd_out - 2; i > -1; --i) {
            if (strides[i] == 0)
                strides[i] = strides[i + 1] * dimensions[i + 1];
        }
    }
```
Which is baffling in that DimShuffle is not doing any broadcasting behavior, othen than expand_dims, which the first pass already handles correctly. Removing this loop fixes the original bug. 

The Reshape changes were simpler, they introduced a generic `PyArray_IntpConverter` to convert the shape numpy vector into a simple C-array for the Reshape operation.  

The concern about strides in the commit message doesn't hold, because they were being used directly. I added a direct tests for odd strides just in case.

In the long term Reshape should take the separate shape entries as scalars, instead of a single vector. The user never defines a graph with a vector anyway, but with isolated entries, so the whole packing and unpacking is just overhead. This is tracked #881.

Profiling a simple function suggests the previous changes caused a 8.6-11x slowdown per Op call for the DimShuffle operation and a 5.4x slowdown for the Reshape operation. The new benchmarks detects only a 3.6x and 2.3x slowdown, respectively, due to the PyTensor call overhead.


```
## Op
### DimShuffle: (8.6x slowdown)
Before: 1.74e-06s per call (class)
After: 2.02e-07s

### Reshape: (5.4x slowdown)
Before: 1.50e-06s per call (class)
After: 2.78e-07s
```

