### PR TITLE
Add debug mode to Numba linker

### DIFF
--- a/pytensor/link/numba/linker.py
+++ b/pytensor/link/numba/linker.py
@@ -4,9 +4,17 @@ from pytensor.link.basic import JITLinker
 class NumbaLinker(JITLinker):
     """A `Linker` that JIT-compiles NumPy-based operations using Numba."""
 
+    def __init__(self, *args, debug: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.debug = debug
+
     def fgraph_convert(self, fgraph, **kwargs):
         from pytensor.link.numba.dispatch import numba_funcify
 
+        if self.debug:
+            from pytensor.link.numba.dispatch.basic import numba_funcify_debug
+
+            kwargs.setdefault("op_conversion_fn", numba_funcify_debug)
         return numba_funcify(fgraph, **kwargs)
 
     def jit_compile(self, fn):

--- a/tests/link/numba/test_linker.py
+++ b/tests/link/numba/test_linker.py
@@ -1,0 +1,33 @@
+from textwrap import dedent
+
+import pytest
+
+from pytensor import function
+from pytensor.compile.mode import Mode
+from pytensor.link.numba import NumbaLinker
+from pytensor.tensor import vector
+
+
+pytest.importorskip("numba")
+
+
+def test_debug_mode(capsys):
+    x = vector("x")
+    y = (x + 1).sum()
+
+    debug_mode = Mode(linker=NumbaLinker(debug=True))
+    fn = function([x], y, mode=debug_mode)
+
+    assert fn([0, 1]) == 3.0
+    captured = capsys.readouterr()
+    assert captured.out == dedent(
+        """
+        Op:  Add
+            inputs:  [1.] [0. 1.]
+            outputs:  [1. 2.]
+
+        Op:  Sum{axes=None}
+            inputs:  [1. 2.]
+            outputs:  3.0
+        """
+    )


### PR DESCRIPTION
This was useful to figure out #1233 

Probably can be improved, so take it as a sandbox to be expanded in the future.

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1234.org.readthedocs.build/en/1234/

<!-- readthedocs-preview pytensor end -->