### PR TITLE
Fix solve_triangular output when overwrite_b=True

### DIFF
--- a/pytensor/link/numba/dispatch/slinalg.py
+++ b/pytensor/link/numba/dispatch/slinalg.py
@@ -124,19 +124,25 @@ def solve_triangular_impl(A, B, trans, lower, unit_diagonal, b_ndim, overwrite_b
         _N = np.int32(A.shape[-1])
         _solve_check_input_shapes(A, B)
 
+        # Seems weird to not use the b_ndim input directly, but when I did that Numba complained that the output type
+        # could potentially be 3d (it didn't understand b_ndim was always equal to B.ndim)
         B_is_1d = B.ndim == 1
 
-        A_copy = _copy_to_fortran_order(A)
+        # This will only copy if A is not already fortran contiguous
+        A_f = np.asfortranarray(A)
 
-        # This list is exhaustive, but numba freaks out if we include a final else clause
-        if not overwrite_b and not B_is_1d:
-            B_copy = _copy_to_fortran_order(B)
-        elif overwrite_b and not B_is_1d:
-            B_copy = np.asfortranarray(B)
-        elif not overwrite_b and B_is_1d:
-            B_copy = np.copy(np.expand_dims(B, -1))
-        elif overwrite_b and B_is_1d:
-            B_copy = np.expand_dims(B, -1)
+        if overwrite_b:
+            if B_is_1d:
+                B_copy = np.expand_dims(B, -1)
+            else:
+                # This *will* allow inplace destruction of B, but only if it is already fortran contiguous.
+                # Otherwise, there's no way to get around the need to copy the data before going into TRTRS
+                B_copy = np.asfortranarray(B)
+        else:
+            if B_is_1d:
+                B_copy = np.copy(np.expand_dims(B, -1))
+            else:
+                B_copy = _copy_to_fortran_order(B)
 
         NRHS = 1 if B_is_1d else int(B_copy.shape[-1])
 
@@ -155,7 +161,7 @@ def solve_triangular_impl(A, B, trans, lower, unit_diagonal, b_ndim, overwrite_b
             DIAG,
             N,
             NRHS,
-            A_copy.view(w_type).ctypes,
+            A_f.view(w_type).ctypes,
             LDA,
             B_copy.view(w_type).ctypes,
             LDB,

--- a/tests/link/numba/test_slinalg.py
+++ b/tests/link/numba/test_slinalg.py
@@ -141,8 +141,8 @@ def test_solve_triangular_overwrite_b_correct(overwrite_b):
     b_test_py = np.asfortranarray(rng.normal(size=(3, 2)))
 
     # .T.copy().T creates an f-contiguous copy of an f-contiguous array (otherwise the copy is c-contiguous)
-    a_test_nb = a_test_py.T.copy().T
-    b_test_nb = b_test_py.T.copy().T
+    a_test_nb = a_test_py.copy(order="F")
+    b_test_nb = b_test_py.copy(order="F")
 
     op = SolveTriangular(
         trans=0,


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
Issue #1233 found a bug in the numba mode of `solve_triangular`. Basically, we can't get around copying the incoming matrices if they're not already F-contiguous. Also adds a regression test for this bug.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #1233 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1235.org.readthedocs.build/en/1235/

<!-- readthedocs-preview pytensor end -->