### PR TITLE
Don't use numba objectmode with vector boolean `inc_subtensor`

### DIFF
--- a/tests/link/numba/test_subtensor.py
+++ b/tests/link/numba/test_subtensor.py
@@ -314,7 +314,15 @@ def test_AdvancedIncSubtensor1(x, y, indices):
             np.arange(3 * 4 * 5).reshape((3, 4, 5)),
             -np.arange(1 * 4 * 5).reshape(1, 4, 5),
             (np.array([True, False, False])),  # Broadcasted boolean index
+            False,  # It shouldn't matter what we set this to, boolean indices cannot be duplicate
             False,
+            False,
+        ),
+        (
+            np.arange(3 * 4 * 5).reshape((3, 4, 5)),
+            -np.arange(1 * 4 * 5).reshape(1, 4, 5),
+            (np.array([True, False, False])),  # Broadcasted boolean index
+            True,  # It shouldn't matter what we set this to, boolean indices cannot be duplicate
             False,
             False,
         ),


### PR DESCRIPTION
This shows up in some imputation models in PyMC. Numba supports this case, so no reason to block it.

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1243.org.readthedocs.build/en/1243/

<!-- readthedocs-preview pytensor end -->