### PR TITLE
Expose vecdot, vecmat and matvec helpers

### DIFF
--- a/pytensor/tensor/math.py
+++ b/pytensor/tensor/math.py
@@ -4164,9 +4164,6 @@ def vecdot(
     >>> z_batch = pt.vecdot(x_batch, y_batch)  # shape (3,)
     >>> # Equivalent to numpy.vecdot(x_batch, y_batch)
     """
-    x1 = as_tensor_variable(x1)
-    x2 = as_tensor_variable(x2)
-
     out = _inner_prod(x1, x2)
 
     if dtype is not None:
@@ -4216,9 +4213,6 @@ def matvec(
     >>> result = pt.matvec(batched_A, batched_v)  # shape (2, 3)
     >>> # Equivalent to numpy.matvec(batched_A, batched_v)
     """
-    x1 = as_tensor_variable(x1)
-    x2 = as_tensor_variable(x2)
-
     out = _matrix_vec_prod(x1, x2)
 
     if dtype is not None:
@@ -4268,9 +4262,6 @@ def vecmat(
     >>> result = pt.vecmat(batched_v, batched_A)  # shape (2, 4)
     >>> # Equivalent to numpy.vecmat(batched_v, batched_A)
     """
-    x1 = as_tensor_variable(x1)
-    x2 = as_tensor_variable(x2)
-
     out = _vec_matrix_prod(x1, x2)
 
     if dtype is not None:

--- a/pytensor/tensor/math.py
+++ b/pytensor/tensor/math.py
@@ -4123,10 +4123,10 @@ def matmul(x1: "ArrayLike", x2: "ArrayLike", dtype: Optional["DTypeLike"] = None
 
 
 def vecdot(
-    x1: "TensorLike",
-    x2: "TensorLike",
+    x1: TensorLike,
+    x2: TensorLike,
     dtype: Optional["DTypeLike"] = None,
-) -> "TensorVariable":
+) -> TensorVariable:
     """Compute the vector dot product of two arrays.
 
     Parameters
@@ -4153,21 +4153,20 @@ def vecdot(
     --------
     >>> import pytensor.tensor as pt
     >>> # Vector dot product with shape (5,) inputs
-    >>> x = pt.vector("x")  # shape (5,)
-    >>> y = pt.vector("y")  # shape (5,)
+    >>> x = pt.vector("x", shape=(5,))  # shape (5,)
+    >>> y = pt.vector("y", shape=(5,))  # shape (5,)
     >>> z = pt.vecdot(x, y)  # scalar output
-    >>> # Equivalent to numpy.vecdot(x, y) or numpy.sum(x * y)
+    >>> # Equivalent to numpy.vecdot(x, y)
     >>>
     >>> # With batched inputs of shape (3, 5)
-    >>> x_batch = pt.matrix("x")  # shape (3, 5)
-    >>> y_batch = pt.matrix("y")  # shape (3, 5)
+    >>> x_batch = pt.matrix("x", shape=(3, 5))  # shape (3, 5)
+    >>> y_batch = pt.matrix("y", shape=(3, 5))  # shape (3, 5)
     >>> z_batch = pt.vecdot(x_batch, y_batch)  # shape (3,)
-    >>> # Equivalent to numpy.sum(x_batch * y_batch, axis=-1)
+    >>> # Equivalent to numpy.vecdot(x_batch, y_batch)
     """
     x1 = as_tensor_variable(x1)
     x2 = as_tensor_variable(x2)
 
-    # Use the inner product operation along the last axis
     out = _inner_prod(x1, x2)
 
     if dtype is not None:
@@ -4177,8 +4176,8 @@ def vecdot(
 
 
 def matvec(
-    x1: "TensorLike", x2: "TensorLike", dtype: Optional["DTypeLike"] = None
-) -> "TensorVariable":
+    x1: TensorLike, x2: TensorLike, dtype: Optional["DTypeLike"] = None
+) -> TensorVariable:
     """Compute the matrix-vector product.
 
     Parameters
@@ -4199,23 +4198,23 @@ def matvec(
 
     Notes
     -----
-    This is equivalent to `numpy.matmul` where the second argument is a vector,
-    but with more intuitive broadcasting rules. Broadcasting happens over all but
-    the last two dimensions of x1 and all dimensions of x2 except the last.
+    This is equivalent to `numpy.matvec` and computes the matrix-vector product
+    with broadcasting over batch dimensions.
 
     Examples
     --------
     >>> import pytensor.tensor as pt
     >>> # Matrix-vector product
-    >>> A = pt.matrix("A")  # shape (3, 4)
-    >>> v = pt.vector("v")  # shape (4,)
+    >>> A = pt.matrix("A", shape=(3, 4))  # shape (3, 4)
+    >>> v = pt.vector("v", shape=(4,))  # shape (4,)
     >>> result = pt.matvec(A, v)  # shape (3,)
-    >>> # Equivalent to numpy.matmul(A, v)
+    >>> # Equivalent to numpy.matvec(A, v)
     >>>
     >>> # Batched matrix-vector product
-    >>> batched_A = pt.tensor3("A")  # shape (2, 3, 4)
-    >>> batched_v = pt.matrix("v")  # shape (2, 4)
+    >>> batched_A = pt.tensor3("A", shape=(2, 3, 4))  # shape (2, 3, 4)
+    >>> batched_v = pt.matrix("v", shape=(2, 4))  # shape (2, 4)
     >>> result = pt.matvec(batched_A, batched_v)  # shape (2, 3)
+    >>> # Equivalent to numpy.matvec(batched_A, batched_v)
     """
     x1 = as_tensor_variable(x1)
     x2 = as_tensor_variable(x2)
@@ -4229,8 +4228,8 @@ def matvec(
 
 
 def vecmat(
-    x1: "TensorLike", x2: "TensorLike", dtype: Optional["DTypeLike"] = None
-) -> "TensorVariable":
+    x1: TensorLike, x2: TensorLike, dtype: Optional["DTypeLike"] = None
+) -> TensorVariable:
     """Compute the vector-matrix product.
 
     Parameters
@@ -4251,23 +4250,23 @@ def vecmat(
 
     Notes
     -----
-    This is equivalent to `numpy.matmul` where the first argument is a vector,
-    but with more intuitive broadcasting rules. Broadcasting happens over all but
-    the last dimension of x1 and all but the last two dimensions of x2.
+    This is equivalent to `numpy.vecmat` and computes the vector-matrix product
+    with broadcasting over batch dimensions.
 
     Examples
     --------
     >>> import pytensor.tensor as pt
     >>> # Vector-matrix product
-    >>> v = pt.vector("v")  # shape (3,)
-    >>> A = pt.matrix("A")  # shape (3, 4)
+    >>> v = pt.vector("v", shape=(3,))  # shape (3,)
+    >>> A = pt.matrix("A", shape=(3, 4))  # shape (3, 4)
     >>> result = pt.vecmat(v, A)  # shape (4,)
-    >>> # Equivalent to numpy.matmul(v, A)
+    >>> # Equivalent to numpy.vecmat(v, A)
     >>>
     >>> # Batched vector-matrix product
-    >>> batched_v = pt.matrix("v")  # shape (2, 3)
-    >>> batched_A = pt.tensor3("A")  # shape (2, 3, 4)
+    >>> batched_v = pt.matrix("v", shape=(2, 3))  # shape (2, 3)
+    >>> batched_A = pt.tensor3("A", shape=(2, 3, 4))  # shape (2, 3, 4)
     >>> result = pt.vecmat(batched_v, batched_A)  # shape (2, 4)
+    >>> # Equivalent to numpy.vecmat(batched_v, batched_A)
     """
     x1 = as_tensor_variable(x1)
     x2 = as_tensor_variable(x2)

--- a/pytensor/tensor/math.py
+++ b/pytensor/tensor/math.py
@@ -4145,17 +4145,24 @@ def vecdot(
 
     Notes
     -----
-    This is similar to `np.vecdot` and computes the dot product of
+    This is equivalent to `numpy.vecdot` and computes the dot product of
     vectors along the last axis of both inputs. Broadcasting is supported
     across all other dimensions.
 
     Examples
     --------
     >>> import pytensor.tensor as pt
-    >>> x = pt.matrix("x")
-    >>> y = pt.matrix("y")
-    >>> z = pt.vecdot(x, y)
-    >>> # Equivalent to np.sum(x * y, axis=-1)
+    >>> # Vector dot product with shape (5,) inputs
+    >>> x = pt.vector("x")  # shape (5,)
+    >>> y = pt.vector("y")  # shape (5,)
+    >>> z = pt.vecdot(x, y)  # scalar output
+    >>> # Equivalent to numpy.vecdot(x, y) or numpy.sum(x * y)
+    >>>
+    >>> # With batched inputs of shape (3, 5)
+    >>> x_batch = pt.matrix("x")  # shape (3, 5)
+    >>> y_batch = pt.matrix("y")  # shape (3, 5)
+    >>> z_batch = pt.vecdot(x_batch, y_batch)  # shape (3,)
+    >>> # Equivalent to numpy.sum(x_batch * y_batch, axis=-1)
     """
     x1 = as_tensor_variable(x1)
     x2 = as_tensor_variable(x2)
@@ -4199,17 +4206,16 @@ def matvec(
     Examples
     --------
     >>> import pytensor.tensor as pt
-    >>> import numpy as np
     >>> # Matrix-vector product
-    >>> A = pt.matrix("A")  # shape (M, K)
-    >>> v = pt.vector("v")  # shape (K,)
-    >>> result = pt.matvec(A, v)  # shape (M,)
-    >>> # Equivalent to np.matmul(A, v)
+    >>> A = pt.matrix("A")  # shape (3, 4)
+    >>> v = pt.vector("v")  # shape (4,)
+    >>> result = pt.matvec(A, v)  # shape (3,)
+    >>> # Equivalent to numpy.matmul(A, v)
     >>>
     >>> # Batched matrix-vector product
-    >>> batched_A = pt.tensor3("A")  # shape (B, M, K)
-    >>> batched_v = pt.matrix("v")  # shape (B, K)
-    >>> result = pt.matvec(batched_A, batched_v)  # shape (B, M)
+    >>> batched_A = pt.tensor3("A")  # shape (2, 3, 4)
+    >>> batched_v = pt.matrix("v")  # shape (2, 4)
+    >>> result = pt.matvec(batched_A, batched_v)  # shape (2, 3)
     """
     x1 = as_tensor_variable(x1)
     x2 = as_tensor_variable(x2)
@@ -4252,17 +4258,16 @@ def vecmat(
     Examples
     --------
     >>> import pytensor.tensor as pt
-    >>> import numpy as np
     >>> # Vector-matrix product
-    >>> v = pt.vector("v")  # shape (K,)
-    >>> A = pt.matrix("A")  # shape (K, N)
-    >>> result = pt.vecmat(v, A)  # shape (N,)
-    >>> # Equivalent to np.matmul(v, A)
+    >>> v = pt.vector("v")  # shape (3,)
+    >>> A = pt.matrix("A")  # shape (3, 4)
+    >>> result = pt.vecmat(v, A)  # shape (4,)
+    >>> # Equivalent to numpy.matmul(v, A)
     >>>
     >>> # Batched vector-matrix product
-    >>> batched_v = pt.matrix("v")  # shape (B, K)
-    >>> batched_A = pt.tensor3("A")  # shape (B, K, N)
-    >>> result = pt.vecmat(batched_v, batched_A)  # shape (B, N)
+    >>> batched_v = pt.matrix("v")  # shape (2, 3)
+    >>> batched_A = pt.tensor3("A")  # shape (2, 3, 4)
+    >>> result = pt.vecmat(batched_v, batched_A)  # shape (2, 4)
     """
     x1 = as_tensor_variable(x1)
     x2 = as_tensor_variable(x2)

--- a/pytensor/tensor/math.py
+++ b/pytensor/tensor/math.py
@@ -4122,6 +4122,176 @@ def matmul(x1: "ArrayLike", x2: "ArrayLike", dtype: Optional["DTypeLike"] = None
     return out
 
 
+def vecdot(
+    x1: "ArrayLike",
+    x2: "ArrayLike",
+    axis: int = -1,
+    dtype: Optional["DTypeLike"] = None,
+):
+    """Compute the dot product of two vectors along specified dimensions.
+
+    Parameters
+    ----------
+    x1, x2
+        Input arrays, scalars not allowed.
+    axis
+        The axis along which to compute the dot product. By default, the last
+        axes of the inputs are used.
+    dtype
+        The desired data-type for the array. If not given, then the type will
+        be determined as the minimum type required to hold the objects in the
+        sequence.
+
+    Returns
+    -------
+    out : ndarray
+        The vector dot product of the inputs computed along the specified axes.
+
+    Raises
+    ------
+    ValueError
+        If either input is a scalar value.
+
+    Notes
+    -----
+    This is similar to `dot` but with broadcasting. It computes the dot product
+    along the specified axes, treating these as vectors, and broadcasts across
+    the remaining axes.
+    """
+    x1 = as_tensor_variable(x1)
+    x2 = as_tensor_variable(x2)
+
+    if x1.type.ndim == 0 or x2.type.ndim == 0:
+        raise ValueError("vecdot operand cannot be scalar")
+
+    # Handle negative axis
+    if axis < 0:
+        x1_axis = axis % x1.type.ndim
+        x2_axis = axis % x2.type.ndim
+    else:
+        x1_axis = axis
+        x2_axis = axis
+
+    # Move the axes to the end for dot product calculation
+    x1_perm = list(range(x1.type.ndim))
+    x1_perm.append(x1_perm.pop(x1_axis))
+    x1_transposed = x1.transpose(x1_perm)
+
+    x2_perm = list(range(x2.type.ndim))
+    x2_perm.append(x2_perm.pop(x2_axis))
+    x2_transposed = x2.transpose(x2_perm)
+
+    # Use the inner product operation
+    out = _inner_prod(x1_transposed, x2_transposed)
+
+    if dtype is not None:
+        out = out.astype(dtype)
+
+    return out
+
+
+def matvec(x1: "ArrayLike", x2: "ArrayLike", dtype: Optional["DTypeLike"] = None):
+    """Compute the matrix-vector product.
+
+    Parameters
+    ----------
+    x1
+        Input array for the matrix with shape (..., M, K).
+    x2
+        Input array for the vector with shape (..., K).
+    dtype
+        The desired data-type for the array. If not given, then the type will
+        be determined as the minimum type required to hold the objects in the
+        sequence.
+
+    Returns
+    -------
+    out : ndarray
+        The matrix-vector product with shape (..., M).
+
+    Raises
+    ------
+    ValueError
+        If any input is a scalar or if the trailing dimension of x2 does not match
+        the second-to-last dimension of x1.
+
+    Notes
+    -----
+    This is similar to `matmul` where the second argument is a vector,
+    but with different broadcasting rules. Broadcasting happens over all but
+    the last dimension of x1 and all dimensions of x2 except the last.
+    """
+    x1 = as_tensor_variable(x1)
+    x2 = as_tensor_variable(x2)
+
+    if x1.type.ndim == 0 or x2.type.ndim == 0:
+        raise ValueError("matvec operand cannot be scalar")
+
+    if x1.type.ndim < 2:
+        raise ValueError("First input to matvec must have at least 2 dimensions")
+
+    if x2.type.ndim < 1:
+        raise ValueError("Second input to matvec must have at least 1 dimension")
+
+    out = _matrix_vec_prod(x1, x2)
+
+    if dtype is not None:
+        out = out.astype(dtype)
+
+    return out
+
+
+def vecmat(x1: "ArrayLike", x2: "ArrayLike", dtype: Optional["DTypeLike"] = None):
+    """Compute the vector-matrix product.
+
+    Parameters
+    ----------
+    x1
+        Input array for the vector with shape (..., K).
+    x2
+        Input array for the matrix with shape (..., K, N).
+    dtype
+        The desired data-type for the array. If not given, then the type will
+        be determined as the minimum type required to hold the objects in the
+        sequence.
+
+    Returns
+    -------
+    out : ndarray
+        The vector-matrix product with shape (..., N).
+
+    Raises
+    ------
+    ValueError
+        If any input is a scalar or if the last dimension of x1 does not match
+        the second-to-last dimension of x2.
+
+    Notes
+    -----
+    This is similar to `matmul` where the first argument is a vector,
+    but with different broadcasting rules. Broadcasting happens over all but
+    the last dimension of x1 and all but the last two dimensions of x2.
+    """
+    x1 = as_tensor_variable(x1)
+    x2 = as_tensor_variable(x2)
+
+    if x1.type.ndim == 0 or x2.type.ndim == 0:
+        raise ValueError("vecmat operand cannot be scalar")
+
+    if x1.type.ndim < 1:
+        raise ValueError("First input to vecmat must have at least 1 dimension")
+
+    if x2.type.ndim < 2:
+        raise ValueError("Second input to vecmat must have at least 2 dimensions")
+
+    out = _vec_matrix_prod(x1, x2)
+
+    if dtype is not None:
+        out = out.astype(dtype)
+
+    return out
+
+
 @_vectorize_node.register(Dot)
 def vectorize_node_dot(op, node, batched_x, batched_y):
     old_x, old_y = node.inputs
@@ -4218,6 +4388,9 @@ __all__ = [
     "max_and_argmax",
     "max",
     "matmul",
+    "vecdot",
+    "matvec",
+    "vecmat",
     "argmax",
     "min",
     "argmin",

--- a/pytensor/tensor/math.py
+++ b/pytensor/tensor/math.py
@@ -4147,11 +4147,6 @@ def vecdot(
     out : ndarray
         The vector dot product of the inputs computed along the specified axes.
 
-    Raises
-    ------
-    ValueError
-        If either input is a scalar value.
-
     Notes
     -----
     This is similar to `dot` but with broadcasting. It computes the dot product
@@ -4160,9 +4155,6 @@ def vecdot(
     """
     x1 = as_tensor_variable(x1)
     x2 = as_tensor_variable(x2)
-
-    if x1.type.ndim == 0 or x2.type.ndim == 0:
-        raise ValueError("vecdot operand cannot be scalar")
 
     # Handle negative axis
     if axis < 0:
@@ -4209,12 +4201,6 @@ def matvec(x1: "ArrayLike", x2: "ArrayLike", dtype: Optional["DTypeLike"] = None
     out : ndarray
         The matrix-vector product with shape (..., M).
 
-    Raises
-    ------
-    ValueError
-        If any input is a scalar or if the trailing dimension of x2 does not match
-        the second-to-last dimension of x1.
-
     Notes
     -----
     This is similar to `matmul` where the second argument is a vector,
@@ -4223,15 +4209,6 @@ def matvec(x1: "ArrayLike", x2: "ArrayLike", dtype: Optional["DTypeLike"] = None
     """
     x1 = as_tensor_variable(x1)
     x2 = as_tensor_variable(x2)
-
-    if x1.type.ndim == 0 or x2.type.ndim == 0:
-        raise ValueError("matvec operand cannot be scalar")
-
-    if x1.type.ndim < 2:
-        raise ValueError("First input to matvec must have at least 2 dimensions")
-
-    if x2.type.ndim < 1:
-        raise ValueError("Second input to matvec must have at least 1 dimension")
 
     out = _matrix_vec_prod(x1, x2)
 
@@ -4260,12 +4237,6 @@ def vecmat(x1: "ArrayLike", x2: "ArrayLike", dtype: Optional["DTypeLike"] = None
     out : ndarray
         The vector-matrix product with shape (..., N).
 
-    Raises
-    ------
-    ValueError
-        If any input is a scalar or if the last dimension of x1 does not match
-        the second-to-last dimension of x2.
-
     Notes
     -----
     This is similar to `matmul` where the first argument is a vector,
@@ -4274,15 +4245,6 @@ def vecmat(x1: "ArrayLike", x2: "ArrayLike", dtype: Optional["DTypeLike"] = None
     """
     x1 = as_tensor_variable(x1)
     x2 = as_tensor_variable(x2)
-
-    if x1.type.ndim == 0 or x2.type.ndim == 0:
-        raise ValueError("vecmat operand cannot be scalar")
-
-    if x1.type.ndim < 1:
-        raise ValueError("First input to vecmat must have at least 1 dimension")
-
-    if x2.type.ndim < 2:
-        raise ValueError("Second input to vecmat must have at least 2 dimensions")
 
     out = _vec_matrix_prod(x1, x2)
 

--- a/tests/tensor/test_math.py
+++ b/tests/tensor/test_math.py
@@ -2158,66 +2158,6 @@ class TestMatrixVectorOps:
         expected = make_expected(x_val, y_val)
         np.testing.assert_allclose(f(x_val, y_val), expected)
 
-    def test_matmul(self):
-        """Test matmul function with various input shapes."""
-        rng = np.random.default_rng(seed=utt.fetch_seed())
-
-        # Test matrix-matrix
-        x = matrix()
-        y = matrix()
-        z = matmul(x, y)
-        f = function([x, y], z)
-
-        x_val = random(3, 4, rng=rng).astype(config.floatX)
-        y_val = random(4, 5, rng=rng).astype(config.floatX)
-        np.testing.assert_allclose(f(x_val, y_val), np.matmul(x_val, y_val))
-
-        # Test vector-matrix
-        x = vector()
-        y = matrix()
-        z = matmul(x, y)
-        f = function([x, y], z)
-
-        x_val = random(3, rng=rng).astype(config.floatX)
-        y_val = random(3, 4, rng=rng).astype(config.floatX)
-        np.testing.assert_allclose(f(x_val, y_val), np.matmul(x_val, y_val))
-
-        # Test matrix-vector
-        x = matrix()
-        y = vector()
-        z = matmul(x, y)
-        f = function([x, y], z)
-
-        x_val = random(3, 4, rng=rng).astype(config.floatX)
-        y_val = random(4, rng=rng).astype(config.floatX)
-        np.testing.assert_allclose(f(x_val, y_val), np.matmul(x_val, y_val))
-
-        # Test vector-vector
-        x = vector()
-        y = vector()
-        z = matmul(x, y)
-        f = function([x, y], z)
-
-        x_val = random(3, rng=rng).astype(config.floatX)
-        y_val = random(3, rng=rng).astype(config.floatX)
-        np.testing.assert_allclose(f(x_val, y_val), np.matmul(x_val, y_val))
-
-        # Test batched
-        x = tensor3()
-        y = tensor3()
-        z = matmul(x, y)
-        f = function([x, y], z)
-
-        x_val = random(2, 3, 4, rng=rng).astype(config.floatX)
-        y_val = random(2, 4, 5, rng=rng).astype(config.floatX)
-        np.testing.assert_allclose(f(x_val, y_val), np.matmul(x_val, y_val))
-
-        # Test error cases
-        x = scalar()
-        y = scalar()
-        with pytest.raises(ValueError):
-            matmul(x, y)
-
 
 class TestTensordot:
     def TensorDot(self, axes):

--- a/tests/tensor/test_math.py
+++ b/tests/tensor/test_math.py
@@ -2116,12 +2116,6 @@ class TestMatrixVectorOps:
         y_val = random(2, 3, 4, rng=rng).astype(config.floatX)
         np.testing.assert_allclose(f(x_val, y_val), np.sum(x_val * y_val, axis=2))
 
-        # Test error cases
-        x = scalar()
-        y = scalar()
-        with pytest.raises(ValueError):
-            vecdot(x, y)
-
     def test_matvec(self):
         """Test matvec function with various input shapes."""
         rng = np.random.default_rng(seed=utt.fetch_seed())
@@ -2147,17 +2141,6 @@ class TestMatrixVectorOps:
         expected = np.array([np.dot(x_val[i], y_val[i]) for i in range(2)])
         np.testing.assert_allclose(f(x_val, y_val), expected)
 
-        # Test error cases
-        x = vector()
-        y = vector()
-        with pytest.raises(ValueError):
-            matvec(x, y)
-
-        x = scalar()
-        y = vector()
-        with pytest.raises(ValueError):
-            matvec(x, y)
-
     def test_vecmat(self):
         """Test vecmat function with various input shapes."""
         rng = np.random.default_rng(seed=utt.fetch_seed())
@@ -2182,17 +2165,6 @@ class TestMatrixVectorOps:
         y_val = random(2, 3, 4, rng=rng).astype(config.floatX)
         expected = np.array([np.dot(x_val[i], y_val[i]) for i in range(2)])
         np.testing.assert_allclose(f(x_val, y_val), expected)
-
-        # Test error cases
-        x = matrix()
-        y = vector()
-        with pytest.raises(ValueError):
-            vecmat(x, y)
-
-        x = scalar()
-        y = matrix()
-        with pytest.raises(ValueError):
-            vecmat(x, y)
 
     def test_matmul(self):
         """Test matmul function with various input shapes."""

--- a/tests/tensor/test_math.py
+++ b/tests/tensor/test_math.py
@@ -2093,15 +2093,19 @@ def test_matrix_vector_ops():
     # For matvec: x1(b,m,k) @ x2(b,k) -> out(b,m)
     # For vecmat: x1(b,k) @ x2(b,k,n) -> out(b,n)
 
-    # Create tensor variables
-    mat_mk = tensor(name="mat_mk", shape=(batch_size, dim_m, dim_k))
-    mat_kn = tensor(name="mat_kn", shape=(batch_size, dim_k, dim_n))
-    vec_k = tensor(name="vec_k", shape=(batch_size, dim_k))
+    # Create test values using config.floatX to match PyTensor's default dtype
+    mat_mk_val = random(batch_size, dim_m, dim_k, rng=rng).astype(config.floatX)
+    mat_kn_val = random(batch_size, dim_k, dim_n, rng=rng).astype(config.floatX)
+    vec_k_val = random(batch_size, dim_k, rng=rng).astype(config.floatX)
 
-    # Create test values
-    mat_mk_val = random(batch_size, dim_m, dim_k, rng=rng).astype("float64")
-    mat_kn_val = random(batch_size, dim_k, dim_n, rng=rng).astype("float64")
-    vec_k_val = random(batch_size, dim_k, rng=rng).astype("float64")
+    # Create tensor variables with matching dtype
+    mat_mk = tensor(
+        name="mat_mk", shape=(batch_size, dim_m, dim_k), dtype=config.floatX
+    )
+    mat_kn = tensor(
+        name="mat_kn", shape=(batch_size, dim_k, dim_n), dtype=config.floatX
+    )
+    vec_k = tensor(name="vec_k", shape=(batch_size, dim_k), dtype=config.floatX)
 
     # Test 1: vecdot with matching dimensions
     vecdot_out = vecdot(vec_k, vec_k, dtype="int32")
@@ -2123,7 +2127,7 @@ def test_matrix_vector_ops():
     result_matvec = matvec_fn(mat_mk_val, vec_k_val)
 
     # Calculate expected manually
-    expected_matvec = np.zeros((batch_size, dim_m), dtype=np.float64)
+    expected_matvec = np.zeros((batch_size, dim_m), dtype=config.floatX)
     for i in range(batch_size):
         expected_matvec[i] = np.dot(mat_mk_val[i], vec_k_val[i])
     np.testing.assert_allclose(result_matvec, expected_matvec)
@@ -2134,7 +2138,7 @@ def test_matrix_vector_ops():
     result_vecmat = vecmat_fn(vec_k_val, mat_kn_val)
 
     # Calculate expected manually
-    expected_vecmat = np.zeros((batch_size, dim_n), dtype=np.float64)
+    expected_vecmat = np.zeros((batch_size, dim_n), dtype=config.floatX)
     for i in range(batch_size):
         expected_vecmat[i] = np.dot(vec_k_val[i], mat_kn_val[i])
     np.testing.assert_allclose(result_vecmat, expected_vecmat)


### PR DESCRIPTION
## Summary
- Add vecdot, vecmat, and matvec helpers to match NumPy's API
- Use existing Blockwise operations but provide more intuitive interface
- Include comprehensive tests for all three functions

## Test plan
- Added a new TestMatrixVectorOps class with tests for all three functions
- Tests cover basic usage, batched operations, axis parameter, and error cases
- All tests pass

Fixes #1237

🤖 Generated with Claude Code

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1248.org.readthedocs.build/en/1248/

<!-- readthedocs-preview pytensor end -->
## Summary
- Remove redundant dimension checks that Blockwise already handles
- Streamline test cases while keeping essential coverage
- Based on PR feedback from Ricardo on PR #1248

## Test plan
- All existing tests still pass with simplified code

Fixes #1237 (continuation of #1248)

🤖 Generated with Claude Code

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1250.org.readthedocs.build/en/1250/

<!-- readthedocs-preview pytensor end -->