### PR TITLE
Handle MvNormal method in Op call

### DIFF
--- a/pytensor/tensor/random/basic.py
+++ b/pytensor/tensor/random/basic.py
@@ -865,7 +865,7 @@ class MvNormalRV(RandomVariable):
             )
         self.method = method
 
-    def __call__(self, mean, cov, size=None, **kwargs):
+    def __call__(self, mean, cov, size=None, method=None, **kwargs):
         r""" "Draw samples from a multivariate normal distribution.
 
         Signature
@@ -888,6 +888,12 @@ class MvNormalRV(RandomVariable):
             is specified, a single `N`-dimensional sample is returned.
 
         """
+        if method is not None and method != self.method:
+            # Recreate Op with the new method
+            props = self._props_dict()
+            props["method"] = method
+            new_op = type(self)(**props)
+            return new_op.__call__(mean, cov, size=size, method=method, **kwargs)
         return super().__call__(mean, cov, size=size, **kwargs)
 
     def rng_fn(self, rng, mean, cov, size):

--- a/tests/tensor/random/test_basic.py
+++ b/tests/tensor/random/test_basic.py
@@ -19,7 +19,6 @@ from pytensor.graph.rewriting.db import RewriteDatabaseQuery
 from pytensor.tensor import ones, stack
 from pytensor.tensor.random.basic import (
     ChoiceWithoutReplacement,
-    MvNormalRV,
     PermutationRV,
     _gamma,
     bernoulli,
@@ -707,7 +706,7 @@ def create_mvnormal_cov_decomposition_method_test(mode):
                 [0, 0, 0],
             ]
         rng = shared(np.random.default_rng(675))
-        draws = MvNormalRV(method=method)(mean, cov, rng=rng, size=(10_000,))
+        draws = multivariate_normal(mean, cov, method=method, size=(10_000,), rng=rng)
         assert draws.owner.op.method == method
 
         # JAX doesn't raise errors at runtime


### PR DESCRIPTION
So it's easier to integrate from PyMC and matches numpy API when using `RandomStream`

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1252.org.readthedocs.build/en/1252/

<!-- readthedocs-preview pytensor end -->