### PR TITLE
Support more cases of numba advanced indexing

### DIFF
--- a/pytensor/link/numba/dispatch/subtensor.py
+++ b/pytensor/link/numba/dispatch/subtensor.py
@@ -150,7 +150,7 @@ def numba_funcify_AdvancedSubtensor(op, node, **kwargs):
             for adv_idx in adv_idxs
         )
         # Must be consecutive
-        and not op.non_contiguous_adv_indexing(node)
+        and not op.non_consecutive_adv_indexing(node)
         # y in set/inc_subtensor cannot be broadcasted
         and (
             y is None

--- a/scripts/mypy-failing.txt
+++ b/scripts/mypy-failing.txt
@@ -11,7 +11,6 @@ pytensor/link/numba/dispatch/scan.py
 pytensor/printing.py
 pytensor/raise_op.py
 pytensor/sparse/basic.py
-pytensor/sparse/type.py
 pytensor/tensor/basic.py
 pytensor/tensor/blas_c.py
 pytensor/tensor/blas_headers.py

--- a/scripts/run_mypy.py
+++ b/scripts/run_mypy.py
@@ -142,7 +142,13 @@ if __name__ == "__main__":
         print(*missing, sep="\n")
         sys.exit(1)
     cp = subprocess.run(
-        ["mypy", "--show-error-codes", "pytensor"],
+        [
+            "mypy",
+            "--show-error-codes",
+            "--disable-error-code",
+            "annotation-unchecked",
+            "pytensor",
+        ],
         capture_output=True,
     )
     output = cp.stdout.decode()

--- a/tests/link/jax/test_pad.py
+++ b/tests/link/jax/test_pad.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from packaging import version
 
 import pytensor.tensor as pt
 from pytensor import config
@@ -16,7 +17,14 @@ RTOL = ATOL = 1e-6 if floatX.endswith("64") else 1e-3
     "mode, kwargs",
     [
         ("constant", {"constant_values": 0}),
-        ("constant", {"constant_values": (1, 2)}),
+        pytest.param(
+            "constant",
+            {"constant_values": (1, 2)},
+            marks=pytest.mark.skipif(
+                version.parse(jax.__version__) > version.parse("0.4.35"),
+                reason="Bug in JAX: https://github.com/jax-ml/jax/issues/26888",
+            ),
+        ),
         ("edge", {}),
         ("linear_ramp", {"end_values": 0}),
         ("linear_ramp", {"end_values": (1, 2)}),


### PR DESCRIPTION
Support more cases of multi-dimensional advanced indexing and updating in Numba

Extends pre-existing rewrite to ravel multidimensional integer indices, to handle multiple inputs (if no broadcasting is needed) and to place them consecutively if they were not. It also extends it to Set/IncSubtensor as long as y is not broadcasted and advanced indices are consecutive. 

The following cases should now be supported without object mode:
* Advanced integer indexing (not mixed with basic or boolean indexing) that do not require broadcasting of indices
* Consecutive advanced integer indexing updating (set/inc) (not mixed with basic or boolean indexing) that do not require broadcasting of indices or y.

Also fixes bug in infer_shape of AdvancedIndexing with slices (which were mistakenly treated as NoneSlices)

Example of new kind of graphs that are supported.
```python
import pytensor
import pytensor.tensor as pt
import numpy as np

x = pt.tensor("x", shape=(10, 10, 3))
inds = pt.matrix("inds", shape=(50, 2), dtype=int)
y = x[inds, inds]
x_test = np.zeros((10, 10, 3)) 
inds_test = np.ones((50, 2), dtype=int)

fn = pytensor.function([x, inds], [y, pt.grad(y.sum(), x)], mode="NUMBA")
fn.dprint(print_shape=True)
fn.trust_input = True
print(fn(x_test, inds_test)[0].shape)
%timeit fn(x_test, inds_test)
```

On my machine that runs in 8us, and before with object mode it was 60us.

A case with a single matrix advanced indexing shows up in the logp of the Categorical, the gradient of which was not supported by numba without object mode before and now is.


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1254.org.readthedocs.build/en/1254/

<!-- readthedocs-preview pytensor end -->