### PR TITLE
Do not introduce 0 strides for broadcastable dimensions in DimShuffle

### DIFF
--- a/tests/tensor/test_elemwise.py
+++ b/tests/tensor/test_elemwise.py
@@ -185,14 +185,13 @@ class TestDimShuffle(unittest_tools.InferShapeTester):
         # as the broadcasted value; that way, we'll be able to tell that we're getting
         # junk data from a poorly constructed array view.
         x_val = np.broadcast_to(2039, (5000,))
-        expected_x_val = x_val[None]
         for i in range(1):
             inputs[0].storage[0] = x_val
             thunk()
             # Make sure it's a view of the original data
             assert np.shares_memory(x_val, outputs[0].storage[0])
             # Confirm the right strides
-            assert outputs[0].storage[0].strides == expected_x_val.strides
+            assert outputs[0].storage[0].strides[-1] == 0
             # Confirm the broadcasted value in the output
             assert np.array_equiv(outputs[0].storage[0], 2039)
 


### PR DESCRIPTION
Our changes in #1226 led to failures in the PyMC test suited due to our BLAS implementation (at least GEMV) not handling 0 strides well: #1262 

The value of the strides for length-1 dimensions is actually arbitrary. In that PR I set it to zero, in this one I set it to itemsize of the array. 1 would be odd? and I don't want to do a silly second loop to give the same sort of strides that `np.expand_dims` or `reshape` do.

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1267.org.readthedocs.build/en/1267/

<!-- readthedocs-preview pytensor end -->