### PR TITLE
Speedup pytensor import time with lazy import of scipy.stats

### DIFF
--- a/pytensor/tensor/random/basic.py
+++ b/pytensor/tensor/random/basic.py
@@ -3,7 +3,6 @@ import warnings
 from typing import Literal
 
 import numpy as np
-import scipy.stats as stats
 from numpy import broadcast_shapes as np_broadcast_shapes
 from numpy import einsum as np_einsum
 from numpy import sqrt as np_sqrt
@@ -19,6 +18,11 @@ from pytensor.tensor.random.utils import (
     broadcast_params,
     normalize_size_param,
 )
+
+
+# Scipy.stats is considerably slow to import
+# We import scipy.stats lazily inside `ScipyRandomVariable`
+stats = None
 
 
 try:
@@ -57,6 +61,9 @@ class ScipyRandomVariable(RandomVariable):
 
     @classmethod
     def rng_fn(cls, *args, **kwargs):
+        global stats
+        if stats is None:
+            import scipy.stats as stats
         size = args[-1]
         res = cls.rng_fn_scipy(*args, **kwargs)
 


### PR DESCRIPTION
This reduces pytensor import time from average 0.9 to 0.45s on my machine

Before:
```
python -m benchmark_imports pytensor
0.8324 root       pytensor                                
0.3692 project    pytensor.tensor.random                  
0.3689 project    pytensor.tensor.random.rewriting        
0.3649 project    pytensor.tensor.random.rewriting.jax    
0.3640 project    pytensor.tensor.random.basic            
0.3616 dependency scipy.stats                             
0.2857 transitive scipy.stats._stats_py                    from scipy.stats
0.2108 project    pytensor.scalar                         
0.1785 project    pytensor.scalar.math                    
0.1615 dependency scipy.special                           
0.1484 transitive scipy.stats.distributions                from scipy.stats._stats_py
0.1056 project    pytensor.configdefaults                 
0.1020 transitive scipy.stats._continuous_distns           from scipy.stats.distributions
0.0888 dependency numpy                                   
0.0794 transitive scipy.special._support_alternative_backends from scipy.special
0.0791 transitive scipy._lib._array_api                    from scipy.special._support_alternative_backends
0.0767 transitive scipy._lib.array_api_compat.numpy        from scipy._lib._array_api
0.0760 project    pytensor.tensor                         
0.0711 transitive scipy.optimize                           from scipy.stats._stats_py
0.0656 transitive scipy.special._orthogonal                from scipy.special
0.0649 transitive scipy.linalg                             from scipy.special._orthogonal
0.0645 project    pytensor.tensor.rewriting               
0.0477 transitive scipy.linalg._sketches                   from scipy.linalg
0.0474 transitive numpy.f2py                               from scipy._lib.array_api_compat.numpy
0.0470 transitive numpy.f2py.f2py2e                        from numpy.f2py
```
After:
```
python -m benchmark_imports pytensor
0.4396 root       pytensor                                
0.1776 project    pytensor.scalar                         
0.1490 project    pytensor.scalar.math                    
0.1348 dependency scipy.special                           
0.0836 project    pytensor.configdefaults                 
0.0766 project    pytensor.tensor                         
0.0733 transitive scipy.special._support_alternative_backends from scipy.special
0.0730 transitive scipy._lib._array_api                    from scipy.special._support_alternative_backends
0.0708 transitive scipy._lib.array_api_compat.numpy        from scipy._lib._array_api
0.0670 project    pytensor.tensor.rewriting               
0.0647 dependency numpy                                   
0.0466 transitive scipy.special._orthogonal                from scipy.special
0.0460 transitive scipy.linalg                             from scipy.special._orthogonal
0.0417 transitive numpy.f2py                               from scipy._lib.array_api_compat.numpy
0.0413 transitive numpy.f2py.f2py2e                        from numpy.f2py
0.0312 transitive scipy.linalg._sketches                   from scipy.linalg
0.0305 transitive scipy.sparse                             from scipy.linalg._sketches
0.0302 transitive numpy.__config__                         from numpy
0.0297 transitive numpy._core                              from numpy.__config__
0.0290 transitive numpy.f2py.crackfortran                  from numpy.f2py.f2py2e
0.0282 project    pytensor.scalar.basic                   
0.0262 project    pytensor.tensor.rewriting.basic         
0.0244 project    pytensor.tensor.random                  
0.0242 transitive numpy.lib                                from numpy
0.0241 project    pytensor.tensor.random.rewriting        
```
<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1268.org.readthedocs.build/en/1268/

<!-- readthedocs-preview pytensor end -->