### PR TITLE
Allow more specialized solve routines

### DIFF
--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -4369,7 +4369,7 @@ atleast_2d = partial(atleast_Nd, n=2)
 atleast_3d = partial(atleast_Nd, n=3)
 
 
-def expand_dims(a: np.ndarray | TensorVariable, axis: Sequence[int]) -> TensorVariable:
+def expand_dims(a: "TensorLike", axis: Sequence[int] | int) -> TensorVariable:
     """Expand the shape of an array.
 
     Insert a new axis that will appear at the `axis` position in the expanded


### PR DESCRIPTION
Accompanying notebook: https://gist.github.com/ricardoV94/005fb4b48d274bcf383a3eb5456462d3

Also fixes #1271 

We want to implement solve_banded and solveh_banded, which allows working directly with the sparse representation of the matrix which is much more practical. Will do that in a follow up PR as it requires more work.

Would also be nice to implement the tridiagonal / banded solvers for numba.

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1273.org.readthedocs.build/en/1273/

<!-- readthedocs-preview pytensor end -->