### PR TITLE
Modify np.tri Op to use _iota instead

### DIFF
--- a/pytensor/link/jax/dispatch/tensor_basic.py
+++ b/pytensor/link/jax/dispatch/tensor_basic.py
@@ -203,6 +203,6 @@ def jax_funcify_Tri(op, node, **kwargs):
             x if const_x is None else const_x
             for x, const_x in zip(args, const_args, strict=True)
         ]
-        return jnp.tri(*args, dtype=op.dtype)
+        return jnp.tri(*args)
 
     return tri

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -34,7 +34,7 @@ from pytensor.link.c.params_type import ParamsType
 from pytensor.npy_2_compat import normalize_axis_index, normalize_axis_tuple
 from pytensor.printing import Printer, min_informative_str, pprint, set_precedence
 from pytensor.raise_op import CheckAndRaise
-from pytensor.scalar import int32
+from pytensor.scalar import int32, upcast
 from pytensor.scalar.basic import ScalarConstant, ScalarType, ScalarVariable
 from pytensor.tensor import (
     _as_tensor_variable,
@@ -1186,8 +1186,9 @@ def tri(N, M=None, k=0, dtype=None):
         dtype = config.floatX
     if M is None:
         M = N
+
     output = ((iota(as_tensor((N, 1)), 0) + k + 1) > iota(as_tensor((1, M)), 1)).astype(
-        int
+        dtype
     )
     N = as_tensor_variable(N)
     return Tri(inputs=[N], outputs=[output], M=M, k=k, dtype=dtype)(N)
@@ -1244,7 +1245,9 @@ def tril(m, k=0):
             [55, 56, 57, 58,  0]]])
 
     """
-    return m * tri(*m.shape[-2:], k=k, dtype=m.dtype)
+    N, M = m.shape[-2:]
+    dtype = upcast(m.dtype)
+    return m * tri(N, M=M, k=k, dtype=dtype)  # M is symbolic, while it shouldnt be
 
 
 def triu(m, k=0):

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -1268,7 +1268,7 @@ def triu(m, k=0):
            [ 0,  8,  9],
            [ 0,  0, 12]])
 
-    >>> pt.triu(np.arange(3 * 4 * 5).reshape((3, 4, 5))).eval()
+    >>> pt.triu(pt.arange(3 * 4 * 5).reshape((3, 4, 5))).eval()
     array([[[ 0,  1,  2,  3,  4],
             [ 0,  6,  7,  8,  9],
             [ 0,  0, 12, 13, 14],

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -58,6 +58,7 @@ from pytensor.tensor.basic import (
     identity_like,
     infer_static_shape,
     inverse_permutation,
+    iota,
     join,
     make_vector,
     mgrid,
@@ -978,6 +979,29 @@ class TestEye:
         l = lscalar("l")
         assert eye(5, 3, l).type.shape == (5, 3)
         assert eye(1, l, 3).type.shape == (1, None)
+
+
+def test_iota():
+    mode = Mode(linker="py", optimizer=None)
+    np.testing.assert_allclose(
+        iota((4, 8), 0).eval(mode=mode),
+        [
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [1, 1, 1, 1, 1, 1, 1, 1],
+            [2, 2, 2, 2, 2, 2, 2, 2],
+            [3, 3, 3, 3, 3, 3, 3, 3],
+        ],
+    )
+
+    np.testing.assert_allclose(
+        iota((4, 8), 1).eval(mode=mode),
+        [
+            [0, 1, 2, 3, 4, 5, 6, 7],
+            [0, 1, 2, 3, 4, 5, 6, 7],
+            [0, 1, 2, 3, 4, 5, 6, 7],
+            [0, 1, 2, 3, 4, 5, 6, 7],
+        ],
+    )
 
 
 class TestTriangle:

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -991,16 +991,19 @@ class TestTriangle:
             if M is None and config.mode in ["DebugMode", "DEBUG_MODE"]:
                 M = N
             N_symb = iscalar()
-            M_symb = iscalar()
-            k_symb = iscalar()
-            f = function(
-                [N_symb, M_symb, k_symb], tri(N_symb, M_symb, k_symb, dtype=dtype)
-            )
-            result = f(N, M, k)
+            f = function([N_symb], tri(N_symb, M=M, k=k, dtype=dtype))
+            # kwargs = {}
+            result = f(N)
             assert np.allclose(result, np.tri(N, M_, k, dtype=dtype))
             assert result.dtype == np.dtype(dtype)
 
-        for dtype in ["int32", "int64", "float32", "float64", "uint16", "complex64"]:
+        for dtype in [
+            "int32",
+            "int64",
+            "float32",
+            "float64",
+            "uint16",
+        ]:  # Handle "complex64" ?
             check(dtype, 3)
             # M != N, k = 0
             check(dtype, 3, 5)
@@ -1022,15 +1025,15 @@ class TestTriangle:
 
         def check_l(m, k=0):
             m_symb = matrix(dtype=m.dtype)
-            k_symb = iscalar()
-            f = function([m_symb, k_symb], tril(m_symb, k_symb))
+            # k_symb = iscalar()
+            f = function([m_symb], tril(m_symb, k=k))
             f_indx = function(
-                [m_symb, k_symb], tril_indices(m_symb.shape[0], k_symb, m_symb.shape[1])
+                [m_symb], tril_indices(m_symb.shape[0], k=k, m=m_symb.shape[1])
             )
-            f_indx_from = function([m_symb, k_symb], tril_indices_from(m_symb, k_symb))
-            result = f(m, k)
-            result_indx = f_indx(m, k)
-            result_from = f_indx_from(m, k)
+            f_indx_from = function([m_symb], tril_indices_from(m_symb))
+            result = f(m)
+            result_indx = f_indx(m, k=k)
+            result_from = f_indx_from(m, k=k)
             assert np.allclose(result, np.tril(m, k))
             assert np.allclose(result_indx, np.tril_indices(m.shape[0], k, m.shape[1]))
             assert np.allclose(result_from, np.tril_indices_from(m, k))
@@ -1040,7 +1043,7 @@ class TestTriangle:
         def check_u(m, k=0):
             m_symb = matrix(dtype=m.dtype)
             k_symb = iscalar()
-            f = function([m_symb, k_symb], triu(m_symb, k_symb))
+            f = function([m_symb, k_symb], triu(m_symb, k=k))
             f_indx = function(
                 [m_symb, k_symb], triu_indices(m_symb.shape[0], k_symb, m_symb.shape[1])
             )

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -1006,7 +1006,8 @@ class TestTriangle:
             "float32",
             "float64",
             "uint16",
-        ]:  # Handle "complex64" ?
+            "complex64",
+        ]:
             check(dtype, 3)
             # M != N, k = 0
             check(dtype, 3, 5)
@@ -1078,7 +1079,7 @@ class TestTriangle:
                 assert np.allclose(result, np.triu(m, k))
                 assert result.dtype == np.dtype(dtype)
 
-        for dtype in ["int32", "int64", "float32", "float64", "uint16"]:
+        for dtype in ["int32", "int64", "float32", "float64", "uint16", "complex64"]:
             m = random_of_dtype((10, 10), dtype)
             check_l(m, 0)
             check_l(m, 1)

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -3930,15 +3930,15 @@ class TestInferShape(utt.InferShapeTester):
         biscal = iscalar()
         ciscal = iscalar()
         self._compile_and_check(
-            [aiscal, biscal, ciscal], [Tri()(aiscal, biscal, ciscal)], [4, 4, 0], Tri
+            [aiscal, biscal, ciscal], [tri(aiscal, biscal, ciscal)], [4, 4, 0], Tri
         )
 
         self._compile_and_check(
-            [aiscal, biscal, ciscal], [Tri()(aiscal, biscal, ciscal)], [4, 5, 0], Tri
+            [aiscal, biscal, ciscal], [tri(aiscal, biscal, ciscal)], [4, 5, 0], Tri
         )
 
         self._compile_and_check(
-            [aiscal, biscal, ciscal], [Tri()(aiscal, biscal, ciscal)], [3, 5, 0], Tri
+            [aiscal, biscal, ciscal], [tri(aiscal, biscal, ciscal)], [3, 5, 0], Tri
         )
 
     def test_ExtractDiag(self):

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -988,12 +988,15 @@ class TestTriangle:
             M = M_
             # Currently DebugMode does not support None as inputs even if this is
             # allowed.
-            if M is None and config.mode in ["DebugMode", "DEBUG_MODE"]:
+            if M is None:  # and config.mode in ["DebugMode", "DEBUG_MODE"]:
                 M = N
             N_symb = iscalar()
-            f = function([N_symb], tri(N_symb, M=M, k=k, dtype=dtype))
-            # kwargs = {}
-            result = f(N)
+            M_symb = iscalar()
+            k_symb = iscalar()
+            f = function(
+                [N_symb, M_symb, k_symb], tri(N_symb, M_symb, k_symb, dtype=dtype)
+            )
+            result = f(N, M, k)
             assert np.allclose(result, np.tri(N, M_, k, dtype=dtype))
             assert result.dtype == np.dtype(dtype)
 
@@ -1025,15 +1028,15 @@ class TestTriangle:
 
         def check_l(m, k=0):
             m_symb = matrix(dtype=m.dtype)
-            # k_symb = iscalar()
-            f = function([m_symb], tril(m_symb, k=k))
+            k_symb = iscalar()
+            f = function([m_symb, k_symb], tril(m_symb, k_symb))
             f_indx = function(
-                [m_symb], tril_indices(m_symb.shape[0], k=k, m=m_symb.shape[1])
+                [m_symb, k_symb], tril_indices(m_symb.shape[0], k_symb, m_symb.shape[1])
             )
-            f_indx_from = function([m_symb], tril_indices_from(m_symb))
-            result = f(m)
-            result_indx = f_indx(m, k=k)
-            result_from = f_indx_from(m, k=k)
+            f_indx_from = function([m_symb, k_symb], tril_indices_from(m_symb, k_symb))
+            result = f(m, k)
+            result_indx = f_indx(m, k)
+            result_from = f_indx_from(m, k)
             assert np.allclose(result, np.tril(m, k))
             assert np.allclose(result_indx, np.tril_indices(m.shape[0], k, m.shape[1]))
             assert np.allclose(result_from, np.tril_indices_from(m, k))
@@ -1043,7 +1046,7 @@ class TestTriangle:
         def check_u(m, k=0):
             m_symb = matrix(dtype=m.dtype)
             k_symb = iscalar()
-            f = function([m_symb, k_symb], triu(m_symb, k=k))
+            f = function([m_symb, k_symb], triu(m_symb, k_symb))
             f_indx = function(
                 [m_symb, k_symb], triu_indices(m_symb.shape[0], k_symb, m_symb.shape[1])
             )
@@ -1075,7 +1078,7 @@ class TestTriangle:
                 assert np.allclose(result, np.triu(m, k))
                 assert result.dtype == np.dtype(dtype)
 
-        for dtype in ["int32", "int64", "float32", "float64", "uint16", "complex64"]:
+        for dtype in ["int32", "int64", "float32", "float64", "uint16"]:
             m = random_of_dtype((10, 10), dtype)
             check_l(m, 0)
             check_l(m, 1)

--- a/tests/tensor/test_einsum.py
+++ b/tests/tensor/test_einsum.py
@@ -10,7 +10,7 @@ from pytensor.graph import FunctionGraph
 from pytensor.graph.op import HasInnerGraph
 from pytensor.tensor.basic import moveaxis
 from pytensor.tensor.blockwise import Blockwise
-from pytensor.tensor.einsum import _delta, _general_dot, _iota, einsum
+from pytensor.tensor.einsum import _delta, _general_dot, einsum
 from pytensor.tensor.shape import Reshape
 from pytensor.tensor.type import tensor
 
@@ -36,29 +36,6 @@ def assert_no_blockwise_in_graph(fgraph: FunctionGraph, core_op=None) -> None:
             else:
                 inner_fgraph = node.op.fgraph
             assert_no_blockwise_in_graph(inner_fgraph, core_op=core_op)
-
-
-def test_iota():
-    mode = Mode(linker="py", optimizer=None)
-    np.testing.assert_allclose(
-        _iota((4, 8), 0).eval(mode=mode),
-        [
-            [0, 0, 0, 0, 0, 0, 0, 0],
-            [1, 1, 1, 1, 1, 1, 1, 1],
-            [2, 2, 2, 2, 2, 2, 2, 2],
-            [3, 3, 3, 3, 3, 3, 3, 3],
-        ],
-    )
-
-    np.testing.assert_allclose(
-        _iota((4, 8), 1).eval(mode=mode),
-        [
-            [0, 1, 2, 3, 4, 5, 6, 7],
-            [0, 1, 2, 3, 4, 5, 6, 7],
-            [0, 1, 2, 3, 4, 5, 6, 7],
-            [0, 1, 2, 3, 4, 5, 6, 7],
-        ],
-    )
 
 
 def test_delta():


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #1265

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1276.org.readthedocs.build/en/1276/

<!-- readthedocs-preview pytensor end -->