### PR TITLE
Speedup Scan in different backends

### DIFF
--- a/pytensor/compile/mode.py
+++ b/pytensor/compile/mode.py
@@ -454,6 +454,19 @@ else:
         RewriteDatabaseQuery(include=["fast_run", "py_only"]),
     )
 
+NUMBA = Mode(
+    NumbaLinker(),
+    RewriteDatabaseQuery(
+        include=["fast_run", "numba"],
+        exclude=[
+            "cxx_only",
+            "BlasOpt",
+            "local_careduce_fusion",
+            "scan_save_mem_prealloc",
+        ],
+    ),
+)
+
 JAX = Mode(
     JAXLinker(),
     RewriteDatabaseQuery(
@@ -463,6 +476,7 @@ JAX = Mode(
             "BlasOpt",
             "fusion",
             "inplace",
+            "scan_save_mem_prealloc",
         ],
     ),
 )
@@ -476,14 +490,8 @@ PYTORCH = Mode(
             "fusion",
             "inplace",
             "local_uint_constant_indices",
+            "scan_save_mem_prealloc",
         ],
-    ),
-)
-NUMBA = Mode(
-    NumbaLinker(),
-    RewriteDatabaseQuery(
-        include=["fast_run", "numba"],
-        exclude=["cxx_only", "BlasOpt", "local_careduce_fusion"],
     ),
 )
 

--- a/pytensor/configdefaults.py
+++ b/pytensor/configdefaults.py
@@ -1085,7 +1085,9 @@ def add_scan_configvars():
         "scan__allow_output_prealloc",
         "Allow/disallow memory preallocation for outputs inside of scan "
         "(default: True)",
-        BoolParam(True),
+        # Non-mutable because ScanSaveMem rewrite checks it,
+        # and we can't have the rewrite and the implementation mismatch
+        BoolParam(True, mutable=False),
         in_c_key=False,
     )
 

--- a/pytensor/link/jax/dispatch/scan.py
+++ b/pytensor/link/jax/dispatch/scan.py
@@ -29,7 +29,7 @@ def jax_funcify_Scan(op: Scan, **kwargs):
         # Extract JAX scan inputs
         outer_inputs = list(outer_inputs)
         n_steps = outer_inputs[0]  # JAX `length`
-        seqs = op.outer_seqs(outer_inputs)  # JAX `xs`
+        seqs = [seq[:n_steps] for seq in op.outer_seqs(outer_inputs)]  # JAX `xs`
 
         mit_sot_init = []
         for tap, seq in zip(

--- a/pytensor/scan/op.py
+++ b/pytensor/scan/op.py
@@ -321,6 +321,16 @@ class ScanMethodsMixin:
             self.info.n_seqs + n_mitmot_taps : self.info.n_seqs + ntaps_upto_sit_sot
         ]
 
+    def oldest_inner_mitsot(self, list_inputs):
+        inner_mitsot_inputs = self.inner_mitsot(list_inputs)
+        oldest_inner_mitsot_inputs = []
+        offset = 0
+        for taps in self.info.mit_sot_in_slices:
+            oldest_tap = np.argmin(taps)
+            oldest_inner_mitsot_inputs += [inner_mitsot_inputs[offset + oldest_tap]]
+            offset += len(taps)
+        return oldest_inner_mitsot_inputs
+
     def outer_mitsot(self, list_inputs):
         offset = 1 + self.info.n_seqs + self.info.n_mit_mot
         return list_inputs[offset : offset + self.info.n_mit_sot]

--- a/pytensor/scan/utils.py
+++ b/pytensor/scan/utils.py
@@ -231,8 +231,8 @@ def expand_empty(tensor_var, size):
 
     if size == 0:
         return tensor_var
-    shapes = [tensor_var.shape[x] for x in range(tensor_var.ndim)]
-    new_shape = [size + shapes[0]] + shapes[1:]
+    shapes = tuple(tensor_var.shape)
+    new_shape = (size + shapes[0], *shapes[1:])
     empty = AllocEmpty(tensor_var.dtype)(*new_shape)
 
     ret = set_subtensor(empty[: shapes[0]], tensor_var)

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -2943,6 +2943,8 @@ def stack(tensors: Sequence["TensorLike"], axis: int = 0):
     ):
         # In case there is direct scalar
         tensors = list(map(as_tensor_variable, tensors))
+        if len(tensors) == 1:
+            return atleast_1d(tensors[0])
         dtype = ps.upcast(*[i.dtype for i in tensors])
         return MakeVector(dtype)(*tensors)
     return join(axis, *[shape_padaxis(t, axis) for t in tensors])

--- a/pytensor/tensor/subtensor.py
+++ b/pytensor/tensor/subtensor.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 import warnings
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from itertools import chain, groupby
 from textwrap import dedent
 from typing import cast, overload
@@ -645,7 +645,7 @@ def indexed_result_shape(array_shape, indices, indices_are_shapes=False):
 
 
 def get_slice_elements(
-    idxs: list,
+    idxs: Sequence,
     cond: Callable = lambda x: isinstance(x, Variable),
 ) -> list:
     """Extract slice elements conditional on a given predicate function.

--- a/tests/link/numba/test_scan.py
+++ b/tests/link/numba/test_scan.py
@@ -465,7 +465,7 @@ class TestScanSITSOTBuffer:
         )
         if buffer_size == "unit":
             xs_kept = xs[-1]  # Only last state is used
-            expected_buffer_size = 2
+            expected_buffer_size = 1
         elif buffer_size == "aligned":
             xs_kept = xs[-2:]  # The buffer will be aligned at the end of the 9 steps
             expected_buffer_size = 2
@@ -555,8 +555,7 @@ class TestScanMITSOTBuffer:
             accept_inplace=True,
             on_unused_input="ignore",
         )
-        assert tuple(mitsot_buffer_shape) == (3,)
-
+        assert tuple(mitsot_buffer_shape) == (2,)
         if benchmark is not None:
             numba_fn.trust_input = True
             benchmark(numba_fn, *test_vals)

--- a/tests/link/numba/test_scan.py
+++ b/tests/link/numba/test_scan.py
@@ -474,7 +474,7 @@ class TestScanSITSOTBuffer:
             expected_buffer_size = 3
         elif buffer_size == "whole":
             xs_kept = xs  # What users think is the whole buffer
-            expected_buffer_size = n_steps - 1
+            expected_buffer_size = n_steps
         elif buffer_size == "whole+init":
             xs_kept = xs.owner.inputs[0]  # Whole buffer actually used by Scan
             expected_buffer_size = n_steps

--- a/tests/scan/test_printing.py
+++ b/tests/scan/test_printing.py
@@ -643,35 +643,37 @@ def test_debugprint_compiled_fn():
     # (i.e. from `Scan._fn`)
     out = pytensor.function([M], out, updates=updates, mode="FAST_RUN")
 
-    expected_output = """Scan{scan_fn, while_loop=False, inplace=all} [id A] 2 (outer_out_sit_sot-0)
-     ├─ 20000 [id B] (n_steps)
-     ├─ [    0 ... 998 19999] [id C] (outer_in_seqs-0)
-     ├─ SetSubtensor{:stop} [id D] 1 (outer_in_sit_sot-0)
-     │  ├─ AllocEmpty{dtype='int64'} [id E] 0
-     │  │  └─ 20000 [id B]
-     │  ├─ [0] [id F]
-     │  └─ 1 [id G]
-     └─ <Tensor3(float64, shape=(20000, 2, 2))> [id H] (outer_in_non_seqs-0)
+    expected_output = """Subtensor{start:} [id A] 3
+ ├─ Scan{scan_fn, while_loop=False, inplace=all} [id B] 2 (outer_out_sit_sot-0)
+ │  ├─ 20000 [id C] (n_steps)
+ │  ├─ [    0 ... 998 19999] [id D] (outer_in_seqs-0)
+ │  ├─ SetSubtensor{:stop} [id E] 1 (outer_in_sit_sot-0)
+ │  │  ├─ AllocEmpty{dtype='int64'} [id F] 0
+ │  │  │  └─ 20001 [id G]
+ │  │  ├─ [0] [id H]
+ │  │  └─ 1 [id I]
+ │  └─ <Tensor3(float64, shape=(20000, 2, 2))> [id J] (outer_in_non_seqs-0)
+ └─ 1 [id I]
 
-    Inner graphs:
+Inner graphs:
 
-    Scan{scan_fn, while_loop=False, inplace=all} [id A]
-     ← Composite{switch(lt(0, i0), 1, 0)} [id I] (inner_out_sit_sot-0)
-        └─ Subtensor{i, j, k} [id J]
-           ├─ *2-<Tensor3(float64, shape=(20000, 2, 2))> [id K] -> [id H] (inner_in_non_seqs-0)
-           ├─ ScalarFromTensor [id L]
-           │  └─ *0-<Scalar(int64, shape=())> [id M] -> [id C] (inner_in_seqs-0)
-           ├─ ScalarFromTensor [id N]
-           │  └─ *1-<Scalar(int64, shape=())> [id O] -> [id D] (inner_in_sit_sot-0)
-           └─ 0 [id P]
+Scan{scan_fn, while_loop=False, inplace=all} [id B]
+ ← Composite{switch(lt(0, i0), 1, 0)} [id K] (inner_out_sit_sot-0)
+    └─ Subtensor{i, j, k} [id L]
+       ├─ *2-<Tensor3(float64, shape=(20000, 2, 2))> [id M] -> [id J] (inner_in_non_seqs-0)
+       ├─ ScalarFromTensor [id N]
+       │  └─ *0-<Scalar(int64, shape=())> [id O] -> [id D] (inner_in_seqs-0)
+       ├─ ScalarFromTensor [id P]
+       │  └─ *1-<Scalar(int64, shape=())> [id Q] -> [id E] (inner_in_sit_sot-0)
+       └─ 0 [id R]
 
-    Composite{switch(lt(0, i0), 1, 0)} [id I]
-     ← Switch [id Q] 'o0'
-        ├─ LT [id R]
-        │  ├─ 0 [id S]
-        │  └─ i0 [id T]
-        ├─ 1 [id U]
-        └─ 0 [id S]
+Composite{switch(lt(0, i0), 1, 0)} [id K]
+ ← Switch [id S] 'o0'
+    ├─ LT [id T]
+    │  ├─ 0 [id U]
+    │  └─ i0 [id V]
+    ├─ 1 [id W]
+    └─ 0 [id U]
     """
 
     output_str = debugprint(out, file="str", print_op_info=True)

--- a/tests/scan/test_printing.py
+++ b/tests/scan/test_printing.py
@@ -44,25 +44,24 @@ def test_debugprint_sitsot():
      │  │  │  │  │     │              └─ 1.0 [id O]
      │  │  │  │  │     └─ 0 [id P]
      │  │  │  │  └─ Subtensor{i} [id Q]
-     │  │  │  │     ├─ Shape [id R]
-     │  │  │  │     │  └─ Unbroadcast{0} [id J]
-     │  │  │  │     │     └─ ···
-     │  │  │  │     └─ 1 [id S]
+     │  │  │  │     ├─ Shape [id I]
+     │  │  │  │     │  └─ ···
+     │  │  │  │     └─ 1 [id R]
      │  │  │  ├─ Unbroadcast{0} [id J]
      │  │  │  │  └─ ···
-     │  │  │  └─ ScalarFromTensor [id T]
+     │  │  │  └─ ScalarFromTensor [id S]
      │  │  │     └─ Subtensor{i} [id H]
      │  │  │        └─ ···
      │  │  └─ A [id M] (outer_in_non_seqs-0)
-     │  └─ 1 [id U]
-     └─ -1 [id V]
+     │  └─ 1 [id T]
+     └─ -1 [id U]
 
     Inner graphs:
 
     Scan{scan_fn, while_loop=False, inplace=none} [id C]
-     ← Mul [id W] (inner_out_sit_sot-0)
-        ├─ *0-<Vector(float64, shape=(?,))> [id X] -> [id E] (inner_in_sit_sot-0)
-        └─ *1-<Vector(float64, shape=(?,))> [id Y] -> [id M] (inner_in_non_seqs-0)
+     ← Mul [id V] (inner_out_sit_sot-0)
+        ├─ *0-<Vector(float64, shape=(?,))> [id W] -> [id E] (inner_in_sit_sot-0)
+        └─ *1-<Vector(float64, shape=(?,))> [id X] -> [id M] (inner_in_non_seqs-0)
     """
 
     for truth, out in zip(expected_output.split("\n"), lines, strict=True):
@@ -103,25 +102,24 @@ def test_debugprint_sitsot_no_extra_info():
      │  │  │  │  │     │              └─ 1.0 [id O]
      │  │  │  │  │     └─ 0 [id P]
      │  │  │  │  └─ Subtensor{i} [id Q]
-     │  │  │  │     ├─ Shape [id R]
-     │  │  │  │     │  └─ Unbroadcast{0} [id J]
-     │  │  │  │     │     └─ ···
-     │  │  │  │     └─ 1 [id S]
+     │  │  │  │     ├─ Shape [id I]
+     │  │  │  │     │  └─ ···
+     │  │  │  │     └─ 1 [id R]
      │  │  │  ├─ Unbroadcast{0} [id J]
      │  │  │  │  └─ ···
-     │  │  │  └─ ScalarFromTensor [id T]
+     │  │  │  └─ ScalarFromTensor [id S]
      │  │  │     └─ Subtensor{i} [id H]
      │  │  │        └─ ···
      │  │  └─ A [id M]
-     │  └─ 1 [id U]
-     └─ -1 [id V]
+     │  └─ 1 [id T]
+     └─ -1 [id U]
 
     Inner graphs:
 
     Scan{scan_fn, while_loop=False, inplace=none} [id C]
-     ← Mul [id W]
-        ├─ *0-<Vector(float64, shape=(?,))> [id X] -> [id E]
-        └─ *1-<Vector(float64, shape=(?,))> [id Y] -> [id M]
+     ← Mul [id V]
+        ├─ *0-<Vector(float64, shape=(?,))> [id W] -> [id E]
+        └─ *1-<Vector(float64, shape=(?,))> [id X] -> [id M]
     """
 
     for truth, out in zip(expected_output.split("\n"), lines, strict=True):
@@ -288,25 +286,24 @@ def test_debugprint_nested_scans():
            │  │  │  │  │  │     │              └─ 1.0 [id BQ]
            │  │  │  │  │  │     └─ 0 [id BR]
            │  │  │  │  │  └─ Subtensor{i} [id BS]
-           │  │  │  │  │     ├─ Shape [id BT]
-           │  │  │  │  │     │  └─ Unbroadcast{0} [id BL]
-           │  │  │  │  │     │     └─ ···
-           │  │  │  │  │     └─ 1 [id BU]
+           │  │  │  │  │     ├─ Shape [id BK]
+           │  │  │  │  │     │  └─ ···
+           │  │  │  │  │     └─ 1 [id BT]
            │  │  │  │  ├─ Unbroadcast{0} [id BL]
            │  │  │  │  │  └─ ···
-           │  │  │  │  └─ ScalarFromTensor [id BV]
+           │  │  │  │  └─ ScalarFromTensor [id BU]
            │  │  │  │     └─ Subtensor{i} [id BJ]
            │  │  │  │        └─ ···
            │  │  │  └─ *2-<Vector(float64, shape=(?,))> [id BO] -> [id W] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
-           │  │  └─ 1 [id BW]
-           │  └─ -1 [id BX]
-           └─ ExpandDims{axis=0} [id BY]
-              └─ *1-<Scalar(int64, shape=())> [id BZ] -> [id U] (inner_in_seqs-1)
+           │  │  └─ 1 [id BV]
+           │  └─ -1 [id BW]
+           └─ ExpandDims{axis=0} [id BX]
+              └─ *1-<Scalar(int64, shape=())> [id BY] -> [id U] (inner_in_seqs-1)
 
     Scan{scan_fn, while_loop=False, inplace=none} [id BE]
-     ← Mul [id CA] (inner_out_sit_sot-0)
-        ├─ *0-<Vector(float64, shape=(?,))> [id CB] -> [id BG] (inner_in_sit_sot-0)
-        └─ *1-<Vector(float64, shape=(?,))> [id CC] -> [id BO] (inner_in_non_seqs-0)
+     ← Mul [id BZ] (inner_out_sit_sot-0)
+        ├─ *0-<Vector(float64, shape=(?,))> [id CA] -> [id BG] (inner_in_sit_sot-0)
+        └─ *1-<Vector(float64, shape=(?,))> [id CB] -> [id BO] (inner_in_non_seqs-0)
     """
 
     for truth, out in zip(expected_output.split("\n"), lines, strict=True):
@@ -386,27 +383,26 @@ def test_debugprint_nested_scans():
            │  │  │  │  │  │     │              └─ 1.0 [id BR]
            │  │  │  │  │  │     └─ 0 [id BS]
            │  │  │  │  │  └─ Subtensor{i} [id BT]
-           │  │  │  │  │     ├─ Shape [id BU]
-           │  │  │  │  │     │  └─ Unbroadcast{0} [id BN]
-           │  │  │  │  │     │     └─ ···
-           │  │  │  │  │     └─ 1 [id BV]
+           │  │  │  │  │     ├─ Shape [id BM]
+           │  │  │  │  │     │  └─ ···
+           │  │  │  │  │     └─ 1 [id BU]
            │  │  │  │  ├─ Unbroadcast{0} [id BN]
            │  │  │  │  │  └─ ···
-           │  │  │  │  └─ ScalarFromTensor [id BW]
+           │  │  │  │  └─ ScalarFromTensor [id BV]
            │  │  │  │     └─ Subtensor{i} [id BL]
            │  │  │  │        └─ ···
            │  │  │  └─ *2-<Vector(float64, shape=(?,))> [id BA] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
-           │  │  └─ 1 [id BX]
-           │  └─ -1 [id BY]
-           └─ ExpandDims{axis=0} [id BZ]
+           │  │  └─ 1 [id BW]
+           │  └─ -1 [id BX]
+           └─ ExpandDims{axis=0} [id BY]
               └─ *1-<Scalar(int64, shape=())> [id Z] (inner_in_seqs-1)
 
     Scan{scan_fn, while_loop=False, inplace=none} [id BH]
-     → *0-<Vector(float64, shape=(?,))> [id CA] -> [id BI] (inner_in_sit_sot-0)
-     → *1-<Vector(float64, shape=(?,))> [id CB] -> [id BA] (inner_in_non_seqs-0)
-     ← Mul [id CC] (inner_out_sit_sot-0)
-        ├─ *0-<Vector(float64, shape=(?,))> [id CA] (inner_in_sit_sot-0)
-        └─ *1-<Vector(float64, shape=(?,))> [id CB] (inner_in_non_seqs-0)
+     → *0-<Vector(float64, shape=(?,))> [id BZ] -> [id BI] (inner_in_sit_sot-0)
+     → *1-<Vector(float64, shape=(?,))> [id CA] -> [id BA] (inner_in_non_seqs-0)
+     ← Mul [id CB] (inner_out_sit_sot-0)
+        ├─ *0-<Vector(float64, shape=(?,))> [id BZ] (inner_in_sit_sot-0)
+        └─ *1-<Vector(float64, shape=(?,))> [id CA] (inner_in_non_seqs-0)
     """
 
     for truth, out in zip(expected_output.split("\n"), lines, strict=True):
@@ -528,98 +524,97 @@ def test_debugprint_mitmot():
      │  │  │  │     │  │  │     │              └─ 1.0 [id R]
      │  │  │  │     │  │  │     └─ 0 [id S]
      │  │  │  │     │  │  └─ Subtensor{i} [id T]
-     │  │  │  │     │  │     ├─ Shape [id U]
-     │  │  │  │     │  │     │  └─ Unbroadcast{0} [id M]
-     │  │  │  │     │  │     │     └─ ···
-     │  │  │  │     │  │     └─ 1 [id V]
+     │  │  │  │     │  │     ├─ Shape [id L]
+     │  │  │  │     │  │     │  └─ ···
+     │  │  │  │     │  │     └─ 1 [id U]
      │  │  │  │     │  ├─ Unbroadcast{0} [id M]
      │  │  │  │     │  │  └─ ···
-     │  │  │  │     │  └─ ScalarFromTensor [id W]
+     │  │  │  │     │  └─ ScalarFromTensor [id V]
      │  │  │  │     │     └─ Subtensor{i} [id K]
      │  │  │  │     │        └─ ···
      │  │  │  │     └─ A [id P] (outer_in_non_seqs-0)
-     │  │  │  └─ 0 [id X]
-     │  │  └─ 1 [id Y]
-     │  ├─ Subtensor{:stop} [id Z] (outer_in_seqs-0)
-     │  │  ├─ Subtensor{::step} [id BA]
-     │  │  │  ├─ Subtensor{:stop} [id BB]
+     │  │  │  └─ 0 [id W]
+     │  │  └─ 1 [id X]
+     │  ├─ Subtensor{:stop} [id Y] (outer_in_seqs-0)
+     │  │  ├─ Subtensor{::step} [id Z]
+     │  │  │  ├─ Subtensor{:stop} [id BA]
      │  │  │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  └─ ···
-     │  │  │  │  └─ -1 [id BC]
-     │  │  │  └─ -1 [id BD]
-     │  │  └─ ScalarFromTensor [id BE]
+     │  │  │  │  └─ -1 [id BB]
+     │  │  │  └─ -1 [id BC]
+     │  │  └─ ScalarFromTensor [id BD]
      │  │     └─ Sub [id C]
      │  │        └─ ···
-     │  ├─ Subtensor{:stop} [id BF] (outer_in_seqs-1)
-     │  │  ├─ Subtensor{:stop} [id BG]
-     │  │  │  ├─ Subtensor{::step} [id BH]
+     │  ├─ Subtensor{:stop} [id BE] (outer_in_seqs-1)
+     │  │  ├─ Subtensor{:stop} [id BF]
+     │  │  │  ├─ Subtensor{::step} [id BG]
      │  │  │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  └─ ···
-     │  │  │  │  └─ -1 [id BI]
-     │  │  │  └─ -1 [id BJ]
-     │  │  └─ ScalarFromTensor [id BK]
+     │  │  │  │  └─ -1 [id BH]
+     │  │  │  └─ -1 [id BI]
+     │  │  └─ ScalarFromTensor [id BJ]
      │  │     └─ Sub [id C]
      │  │        └─ ···
-     │  ├─ Subtensor{::step} [id BL] (outer_in_mit_mot-0)
-     │  │  ├─ IncSubtensor{start:} [id BM]
-     │  │  │  ├─ Second [id BN]
+     │  ├─ Subtensor{::step} [id BK] (outer_in_mit_mot-0)
+     │  │  ├─ IncSubtensor{start:} [id BL]
+     │  │  │  ├─ Second [id BM]
      │  │  │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  └─ ···
-     │  │  │  │  └─ ExpandDims{axes=[0, 1]} [id BO]
-     │  │  │  │     └─ 0.0 [id BP]
-     │  │  │  ├─ IncSubtensor{i} [id BQ]
-     │  │  │  │  ├─ Second [id BR]
-     │  │  │  │  │  ├─ Subtensor{start:} [id BS]
+     │  │  │  │  └─ ExpandDims{axes=[0, 1]} [id BN]
+     │  │  │  │     └─ 0.0 [id BO]
+     │  │  │  ├─ IncSubtensor{i} [id BP]
+     │  │  │  │  ├─ Second [id BQ]
+     │  │  │  │  │  ├─ Subtensor{start:} [id BR]
      │  │  │  │  │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  │  │  └─ ···
-     │  │  │  │  │  │  └─ 1 [id BT]
-     │  │  │  │  │  └─ ExpandDims{axes=[0, 1]} [id BU]
-     │  │  │  │  │     └─ 0.0 [id BV]
-     │  │  │  │  ├─ Second [id BW]
-     │  │  │  │  │  ├─ Subtensor{i} [id BX]
-     │  │  │  │  │  │  ├─ Subtensor{start:} [id BS]
+     │  │  │  │  │  │  └─ 1 [id BS]
+     │  │  │  │  │  └─ ExpandDims{axes=[0, 1]} [id BT]
+     │  │  │  │  │     └─ 0.0 [id BU]
+     │  │  │  │  ├─ Second [id BV]
+     │  │  │  │  │  ├─ Subtensor{i} [id BW]
+     │  │  │  │  │  │  ├─ Subtensor{start:} [id BR]
      │  │  │  │  │  │  │  └─ ···
-     │  │  │  │  │  │  └─ -1 [id BY]
-     │  │  │  │  │  └─ ExpandDims{axis=0} [id BZ]
-     │  │  │  │  │     └─ Second [id CA]
-     │  │  │  │  │        ├─ Sum{axes=None} [id CB]
-     │  │  │  │  │        │  └─ Subtensor{i} [id BX]
+     │  │  │  │  │  │  └─ -1 [id BX]
+     │  │  │  │  │  └─ ExpandDims{axis=0} [id BY]
+     │  │  │  │  │     └─ Second [id BZ]
+     │  │  │  │  │        ├─ Sum{axes=None} [id CA]
+     │  │  │  │  │        │  └─ Subtensor{i} [id BW]
      │  │  │  │  │        │     └─ ···
-     │  │  │  │  │        └─ 1.0 [id CC]
-     │  │  │  │  └─ -1 [id BY]
-     │  │  │  └─ 1 [id BT]
-     │  │  └─ -1 [id CD]
-     │  ├─ Alloc [id CE] (outer_in_sit_sot-0)
-     │  │  ├─ 0.0 [id CF]
-     │  │  ├─ Add [id CG]
+     │  │  │  │  │        └─ 1.0 [id CB]
+     │  │  │  │  └─ -1 [id BX]
+     │  │  │  └─ 1 [id BS]
+     │  │  └─ -1 [id CC]
+     │  ├─ Alloc [id CD] (outer_in_sit_sot-0)
+     │  │  ├─ 0.0 [id CE]
+     │  │  ├─ Add [id CF]
      │  │  │  ├─ Sub [id C]
      │  │  │  │  └─ ···
-     │  │  │  └─ 1 [id CH]
-     │  │  └─ Subtensor{i} [id CI]
-     │  │     ├─ Shape [id CJ]
+     │  │  │  └─ 1 [id CG]
+     │  │  └─ Subtensor{i} [id CH]
+     │  │     ├─ Shape [id CI]
      │  │     │  └─ A [id P]
-     │  │     └─ 0 [id CK]
+     │  │     └─ 0 [id CJ]
      │  └─ A [id P] (outer_in_non_seqs-0)
-     └─ -1 [id CL]
+     └─ -1 [id CK]
 
     Inner graphs:
 
     Scan{grad_of_scan_fn, while_loop=False, inplace=none} [id B]
-     ← Add [id CM] (inner_out_mit_mot-0-0)
-        ├─ Mul [id CN]
-        │  ├─ *2-<Vector(float64, shape=(?,))> [id CO] -> [id BL] (inner_in_mit_mot-0-0)
-        │  └─ *5-<Vector(float64, shape=(?,))> [id CP] -> [id P] (inner_in_non_seqs-0)
-        └─ *3-<Vector(float64, shape=(?,))> [id CQ] -> [id BL] (inner_in_mit_mot-0-1)
-     ← Add [id CR] (inner_out_sit_sot-0)
-        ├─ Mul [id CS]
-        │  ├─ *2-<Vector(float64, shape=(?,))> [id CO] -> [id BL] (inner_in_mit_mot-0-0)
-        │  └─ *0-<Vector(float64, shape=(?,))> [id CT] -> [id Z] (inner_in_seqs-0)
-        └─ *4-<Vector(float64, shape=(?,))> [id CU] -> [id CE] (inner_in_sit_sot-0)
+     ← Add [id CL] (inner_out_mit_mot-0-0)
+        ├─ Mul [id CM]
+        │  ├─ *2-<Vector(float64, shape=(?,))> [id CN] -> [id BK] (inner_in_mit_mot-0-0)
+        │  └─ *5-<Vector(float64, shape=(?,))> [id CO] -> [id P] (inner_in_non_seqs-0)
+        └─ *3-<Vector(float64, shape=(?,))> [id CP] -> [id BK] (inner_in_mit_mot-0-1)
+     ← Add [id CQ] (inner_out_sit_sot-0)
+        ├─ Mul [id CR]
+        │  ├─ *2-<Vector(float64, shape=(?,))> [id CN] -> [id BK] (inner_in_mit_mot-0-0)
+        │  └─ *0-<Vector(float64, shape=(?,))> [id CS] -> [id Y] (inner_in_seqs-0)
+        └─ *4-<Vector(float64, shape=(?,))> [id CT] -> [id CD] (inner_in_sit_sot-0)
 
     Scan{scan_fn, while_loop=False, inplace=none} [id F]
-     ← Mul [id CV] (inner_out_sit_sot-0)
-        ├─ *0-<Vector(float64, shape=(?,))> [id CT] -> [id H] (inner_in_sit_sot-0)
-        └─ *1-<Vector(float64, shape=(?,))> [id CW] -> [id P] (inner_in_non_seqs-0)
+     ← Mul [id CU] (inner_out_sit_sot-0)
+        ├─ *0-<Vector(float64, shape=(?,))> [id CS] -> [id H] (inner_in_sit_sot-0)
+        └─ *1-<Vector(float64, shape=(?,))> [id CV] -> [id P] (inner_in_non_seqs-0)
     """
 
     for truth, out in zip(expected_output.split("\n"), lines, strict=True):

--- a/tests/scan/test_rewriting.py
+++ b/tests/scan/test_rewriting.py
@@ -742,7 +742,7 @@ class TestPushOutAddScan:
         utt.assert_allclose(f_opt_output, f_no_opt_output)
 
     def test_non_zero_init(self):
-        """Test the case where the initial value for the nitsot output is non-zero."""
+        """Test the case where the initial value for the sitsot output is non-zero."""
 
         input1 = tensor3()
         input2 = tensor3()
@@ -759,8 +759,7 @@ class TestPushOutAddScan:
 
         init = pt.as_tensor_variable(np.random.normal(size=(3, 7)))
 
-        # Compile the function twice, once with the optimization and once
-        # without
+        # Compile the function twice, once with the optimization and once without
         opt_mode = mode.including("scan")
         h, _ = pytensor.scan(
             inner_fct,
@@ -792,7 +791,7 @@ class TestPushOutAddScan:
         output_opt = f_opt(input1_value, input2_value, input3_value)
         output_no_opt = f_no_opt(input1_value, input2_value, input3_value)
 
-        utt.assert_allclose(output_opt, output_no_opt)
+        np.testing.assert_allclose(output_opt, output_no_opt)
 
 
 class TestScanMerge:


### PR DESCRIPTION
This PR does a bunch of small optimizations for the Scan, mostly in the Numba backend, but to a lesser extent also in the C and  JAX backends.

Tweaks:

0. Fix failure in trimming number of steps  in Scan when the new n_step would be a constant integer. The isinstance(x, int) does not work for `np.integer`.

1. Do not try to reduce buffer size just to save the space occupied by the initial values. Scan is always created with a buffer size for the recurring inputs with a size of taps + steps. The scan returned to the user slices away the taps, so the user doesn't see the initial values there. When the user wants the whole returned trace (instead of say only the last state) AND no gradient is requested (the gradient makes use of the initial taps in the trace), the Scan save memory would trim into a buffer with size steps. This however, always requires a roll at the end of the Scan, because the discarded entries (the taps) are at the beginning. After this PR the scan save memory doesn't optimize this specific case, as the default slice is likely better than the roll which requires a copy. Benchmarks confirm this.

3. Be more aggressive in the buffer memory save in the JIT backends. As described in #787 Scan is keeping one more entry in the circular buffer for recurring states than strictly needed. This happens because the Python-C implementation make clever use of the inner compiled pytensor function to manually specify the output buffers. In this case it's not always safe for PyTensor to override the buffer, because the inputs may still be needed to compute other outputs. An extra entry was provided for the output. This is not a concern in the JIT backends because there's no such machinery to exploit. As such the scan save memory rewrite was split to be more aggressive in the JIT backends.

4. Minor tweaks in the Numba dispatch of Scan to not try to roll when the buffer size is already aligned. I didn't see any stable changes but seems more clean. Also set checkbounds explicitly to False, but I think that may be the deault. Neither mattered in my benchmarks

5. Allow inplacing in the inner function for sitsot and the last mitsot when our buffer is so small that the last tap gets discarded immediately anyway (happens when users asks for trace[-1] of a scan). This provides substantial speedups in some cases. We should do the same for mit-mots but I haven't yet groked how they are supposed to behave. Issue to track it #1282 

Note this inplace doesn't work right now when n_steps is symbolic as it relies on PyTensor having figured out the static shape of the buffer matches the size of the taps. We need more work for this: #1282 

6. Try to simplify the symbolic graph for the bufer/n-steps size when the scan doesn't have a constant nsteps. The graph is a mess, due to how `subtensor_merge` works: #112. This is mostly because we can not know if the number of steps will be zero in which case it's invalid for the user to select `trace[-1]`. The graph is overly complicated, it is perhaps better to just add an assert that n_steps > 0 like we do for the while scan optimization. Anyway, the graph was even worse before this PR because of a bunch of ScalarFromTensor and TensorFromScalar that would show up in the buffer size logic. This PR cleans it up, so at least everything happens in one single fused graph. Graph before for the mitsot test:

<details>
<summary>Before</summary>

```python
Subtensor{i} [id A] 25
 ├─ Scan{scan_fn, while_loop=False, inplace=all} [id B] 24
 │  ├─ Composite{...}.0 [id C] 16
 │  │  ├─ Composite{...}.0 [id D] 6
 │  │  │  ├─ Composite{...}.1 [id E] 0
 │  │  │  │  └─ n_steps [id F]
 │  │  │  ├─ TensorFromScalar [id G] 5
 │  │  │  │  └─ mul [id H] 4
 │  │  │  │     ├─ add [id I] 2
 │  │  │  │     │  ├─ -1 [id J]
 │  │  │  │     │  └─ ScalarFromTensor [id K] 1
 │  │  │  │     │     └─ Composite{...}.2 [id E] 0
 │  │  │  │     │        └─ ···
 │  │  │  │     └─ 1 [id L]
 │  │  │  ├─ Composite{...}.3 [id E] 0
 │  │  │  │  └─ ···
 │  │  │  ├─ Composite{...}.4 [id E] 0
 │  │  │  │  └─ ···
 │  │  │  ├─ TensorFromScalar [id M] 3
 │  │  │  │  └─ add [id I] 2
 │  │  │  │     └─ ···
 │  │  │  ├─ Composite{...}.2 [id E] 0
 │  │  │  │  └─ ···
 │  │  │  └─ Composite{...}.5 [id E] 0
 │  │  │     └─ ···
 │  │  ├─ TensorFromScalar [id N] 10
 │  │  │  └─ add [id O] 9
 │  │  │     ├─ ScalarFromTensor [id P] 8
 │  │  │     │  └─ Composite{...}.1 [id D] 6
 │  │  │     │     └─ ···
 │  │  │     └─ ScalarFromTensor [id Q] 7
 │  │  │        └─ Composite{...}.0 [id E] 0
 │  │  │           └─ ···
 │  │  ├─ Composite{...}.1 [id D] 6
 │  │  │  └─ ···
 │  │  ├─ TensorFromScalar [id R] 15
 │  │  │  └─ sub [id S] 14
 │  │  │     ├─ add [id T] 13
 │  │  │     │  ├─ ScalarFromTensor [id U] 12
 │  │  │     │  │  └─ Switch [id V] 11
 │  │  │     │  │     ├─ Composite{...}.2 [id D] 6
 │  │  │     │  │     │  └─ ···
 │  │  │     │  │     ├─ TensorFromScalar [id N] 10
 │  │  │     │  │     │  └─ ···
 │  │  │     │  │     └─ Composite{...}.1 [id D] 6
 │  │  │     │  │        └─ ···
 │  │  │     │  └─ 1 [id L]
 │  │  │     └─ 2 [id W]
 │  │  └─ n_steps [id F]
 │  └─ SetSubtensor{:stop} [id X] 23
 │     ├─ AllocEmpty{dtype='float64'} [id Y] 22
 │     │  └─ Composite{...}.2 [id C] 16
 │     │     └─ ···
 │     ├─ init_x [id Z]
 │     └─ 2 [id BA]
 └─ add [id BB] 21
    ├─ sub [id BC] 20
    │  ├─ sub [id BD] 19
    │  │  ├─ ScalarFromTensor [id U] 12
    │  │  │  └─ ···
    │  │  └─ ScalarFromTensor [id BE] 18
    │  │     └─ Composite{...}.0 [id C] 16
    │  │        └─ ···
    │  └─ 2 [id W]
    └─ ScalarFromTensor [id BF] 17
       └─ Composite{...}.1 [id C] 16
          └─ ···

Inner graphs:

Scan{scan_fn, while_loop=False, inplace=all} [id B]
 ← Composite{((2.0 * i0) + i1)} [id BG]
    ├─ *1-<Scalar(float64, shape=())> [id BH] -> [id X]
    └─ *0-<Scalar(float64, shape=())> [id BI] -> [id X]

Composite{...} [id C]
 ← maximum [id BJ] 'o0'
    ├─ minimum [id BK]
    │  ├─ i3 [id BL]
    │  └─ i4 [id BM]
    └─ 1 [id BN]
 ← maximum [id BO] 'o1'
    ├─ add [id BP]
    │  ├─ sub [id BQ]
    │  │  ├─ maximum [id BJ] 'o0'
    │  │  │  └─ ···
    │  │  └─ Switch [id BR]
    │  │     ├─ i0 [id BS]
    │  │     ├─ i1 [id BT]
    │  │     └─ i2 [id BU]
    │  └─ 2 [id BV]
    └─ 2 [id BV]
 ← add [id BW] 'o2'
    ├─ Switch [id BX]
    │  ├─ GT [id BY]
    │  │  ├─ 2 [id BV]
    │  │  └─ maximum [id BO] 'o1'
    │  │     └─ ···
    │  ├─ add [id BZ]
    │  │  ├─ maximum [id BO] 'o1'
    │  │  │  └─ ···
    │  │  └─ 2 [id BV]
    │  └─ sub [id CA]
    │     ├─ maximum [id BO] 'o1'
    │     │  └─ ···
    │     └─ 2 [id BV]
    └─ 2 [id CB]

Composite{...} [id D]
 ← LT [id CC] 'o0'
    ├─ Switch [id CD] 'o1'
    │  ├─ LT [id CE]
    │  │  ├─ i4 [id CF]
    │  │  └─ 0 [id CG]
    │  ├─ i6 [id CH]
    │  └─ Switch [id CI]
    │     ├─ GE [id CJ]
    │     │  ├─ i4 [id CF]
    │     │  └─ i5 [id CK]
    │     ├─ i3 [id CL]
    │     └─ Switch [id CM]
    │        ├─ i2 [id CN]
    │        ├─ i3 [id CL]
    │        └─ add [id CO]
    │           ├─ i0 [id CP]
    │           └─ i1 [id CQ]
    └─ 0 [id CG]
 ← Switch [id CD] 'o1'
    └─ ···
 ← LT [id CR] 'o2'
    ├─ Switch [id CD] 'o1'
    │  └─ ···
    └─ 0 [id CG]

Composite{...} [id E]
 ← add [id CS] 'o0'
    ├─ 2 [id CT]
    └─ i0 [id CU]
 ← Switch [id CV] 'o1'
    ├─ LT [id CW]
    │  ├─ 2 [id CT]
    │  └─ add [id CS] 'o0'
    │     └─ ···
    ├─ 2 [id CT]
    └─ add [id CS] 'o0'
       └─ ···
 ← sub [id CX] 'o2'
    ├─ add [id CS] 'o0'
    │  └─ ···
    └─ Switch [id CV] 'o1'
       └─ ···
 ← LE [id CY] 'o3'
    ├─ sub [id CX] 'o2'
    │  └─ ···
    └─ 0 [id CZ]
 ← add [id DA] 'o4'
    ├─ 3 [id DB]
    └─ i0 [id CU]
 ← sub [id DC] 'o5'
    ├─ -3 [id DD]
    └─ i0 [id CU]

Composite{((2.0 * i0) + i1)} [id BG]
 ← add [id DE] 'o0'
    ├─ mul [id DF]
    │  ├─ 2.0 [id DG]
    │  └─ i0 [id DH]
    └─ i1 [id DI]

```
</details>

<details>
<summary>After</summary>

```python
Subtensor{i} [id A] 5
 ├─ Scan{scan_fn, while_loop=False, inplace=all} [id B] 4
 │  ├─ Composite{...}.0 [id C] 0
 │  │  └─ n_steps [id D]
 │  └─ SetSubtensor{:stop} [id E] 3
 │     ├─ AllocEmpty{dtype='float64'} [id F] 2
 │     │  └─ Composite{...}.2 [id C] 0
 │     │     └─ ···
 │     ├─ init_x [id G]
 │     └─ 2 [id H]
 └─ ScalarFromTensor [id I] 1
    └─ Composite{...}.1 [id C] 0
       └─ ···

Inner graphs:

Scan{scan_fn, while_loop=False, inplace=all} [id B]
 ← Composite{((2.0 * i0) + i1)} [id J]
    ├─ *1-<Scalar(float64, shape=())> [id K] -> [id E]
    └─ *0-<Scalar(float64, shape=())> [id L] -> [id E]

Composite{...} [id C]
 ← maximum [id M] 'o0'
    ├─ minimum [id N]
    │  ├─ sub [id O]
    │  │  ├─ add [id P]
    │  │  │  ├─ Switch [id Q] 't24'
    │  │  │  │  ├─ LT [id R]
    │  │  │  │  │  ├─ Switch [id S] 't5'
    │  │  │  │  │  │  ├─ LT [id T]
    │  │  │  │  │  │  │  ├─ sub [id U] 't16'
    │  │  │  │  │  │  │  │  ├─ add [id V] 't20'
    │  │  │  │  │  │  │  │  │  ├─ 1 [id W]
    │  │  │  │  │  │  │  │  │  └─ i0 [id X]
    │  │  │  │  │  │  │  │  └─ Switch [id Y] 't35'
    │  │  │  │  │  │  │  │     ├─ LT [id Z]
    │  │  │  │  │  │  │  │     │  ├─ 2 [id BA]
    │  │  │  │  │  │  │  │     │  └─ add [id BB] 't37'
    │  │  │  │  │  │  │  │     │     ├─ 2 [id BA]
    │  │  │  │  │  │  │  │     │     └─ i0 [id X]
    │  │  │  │  │  │  │  │     ├─ 2 [id BA]
    │  │  │  │  │  │  │  │     └─ add [id BB] 't37'
    │  │  │  │  │  │  │  │        └─ ···
    │  │  │  │  │  │  │  └─ 0 [id BC]
    │  │  │  │  │  │  ├─ sub [id BD]
    │  │  │  │  │  │  │  ├─ -3 [id BE]
    │  │  │  │  │  │  │  └─ i0 [id X]
    │  │  │  │  │  │  └─ Switch [id BF]
    │  │  │  │  │  │     ├─ GE [id BG]
    │  │  │  │  │  │     │  ├─ sub [id U] 't16'
    │  │  │  │  │  │     │  │  └─ ···
    │  │  │  │  │  │     │  └─ sub [id BH] 't2'
    │  │  │  │  │  │     │     ├─ add [id BB] 't37'
    │  │  │  │  │  │     │     │  └─ ···
    │  │  │  │  │  │     │     └─ Switch [id Y] 't35'
    │  │  │  │  │  │     │        └─ ···
    │  │  │  │  │  │     ├─ add [id BI] 't12'
    │  │  │  │  │  │     │  ├─ 3 [id BJ]
    │  │  │  │  │  │     │  └─ i0 [id X]
    │  │  │  │  │  │     └─ Switch [id BK]
    │  │  │  │  │  │        ├─ LE [id BL]
    │  │  │  │  │  │        │  ├─ sub [id BH] 't2'
    │  │  │  │  │  │        │  │  └─ ···
    │  │  │  │  │  │        │  └─ 0 [id BC]
    │  │  │  │  │  │        ├─ add [id BI] 't12'
    │  │  │  │  │  │        │  └─ ···
    │  │  │  │  │  │        └─ add [id V] 't20'
    │  │  │  │  │  │           └─ ···
    │  │  │  │  │  └─ 0 [id BC]
    │  │  │  │  ├─ add [id BM]
    │  │  │  │  │  ├─ Switch [id S] 't5'
    │  │  │  │  │  │  └─ ···
    │  │  │  │  │  └─ add [id BB] 't37'
    │  │  │  │  │     └─ ···
    │  │  │  │  └─ Switch [id S] 't5'
    │  │  │  │     └─ ···
    │  │  │  └─ 1 [id BN]
    │  │  └─ 2 [id BO]
    │  └─ i0 [id X]
    └─ 1 [id BN]
 ← add [id BP] 'o1'
    ├─ sub [id BQ]
    │  ├─ sub [id BR]
    │  │  ├─ Switch [id Q] 't24'
    │  │  │  └─ ···
    │  │  └─ maximum [id M] 'o0'
    │  │     └─ ···
    │  └─ 2 [id BO]
    └─ maximum [id BS] 't21'
       ├─ add [id BT]
       │  ├─ sub [id BU]
       │  │  ├─ maximum [id M] 'o0'
       │  │  │  └─ ···
       │  │  └─ Switch [id Q] 't24'
       │  │     └─ ···
       │  └─ 2 [id BO]
       └─ 2 [id BO]
 ← add [id BV] 'o2'
    ├─ Switch [id BW]
    │  ├─ GT [id BX]
    │  │  ├─ 2 [id BO]
    │  │  └─ maximum [id BS] 't21'
    │  │     └─ ···
    │  ├─ add [id BY]
    │  │  ├─ maximum [id BS] 't21'
    │  │  │  └─ ···
    │  │  └─ 2 [id BO]
    │  └─ sub [id BZ]
    │     ├─ maximum [id BS] 't21'
    │     │  └─ ···
    │     └─ 2 [id BO]
    └─ 2 [id BA]

Composite{((2.0 * i0) + i1)} [id J]
 ← add [id CA] 'o0'
    ├─ mul [id CB]
    │  ├─ 2.0 [id CC]
    │  └─ i0 [id CD]
    └─ i1 [id CE]
```
</details>


## Benchmarks
You can see meaningful gains in the following conditions:

**Due to inplacing on the inner graph:**
* test_sit_sot_buffer_benchmark[512-2-unit] (2.25x faster median)
* test_mit_sot_buffer_benchmark[1000-True] (1.95x faster median)

Note test_mit_sot_buffer_benchmark[1000-False] doesn't show difference, because the buffer size is not known statically. Tracked in #1283 

**Due to not trimming away the taps when the whole (user-facing) trace is requested:**
* test_sit_sot_buffer_benchmark[512-256-whole] (1.5x faster median)

### Before
```
----------------------------------------------------------------------------------------------------- benchmark: 20 tests ------------------------------------------------------------------------------------------------------
Name (time in us)                                          Min                 Max                Mean             StdDev              Median                IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_sit_sot_buffer_benchmark[10-2-whole+init]          3.8770 (1.0)       66.8960 (1.87)       4.5554 (1.06)      1.1789 (1.56)       4.2780 (1.04)      0.5610 (6.23)    3001;3787      219.5211 (0.94)      54307           1
test_sit_sot_buffer_benchmark[10-2-aligned]             3.9080 (1.01)      35.8180 (1.0)        4.2945 (1.0)       0.7580 (1.0)        4.1170 (1.0)       0.1410 (1.57)    2528;9835      232.8580 (1.0)       67079           1
test_sit_sot_buffer_benchmark[10-2-misaligned]          3.9080 (1.01)      56.5660 (1.58)       4.4659 (1.04)      0.9656 (1.27)       4.1380 (1.01)      0.6810 (7.57)    4298;3823      223.9209 (0.96)      63984           1
test_sit_sot_buffer_benchmark[10-2-whole]               3.9170 (1.01)      50.4640 (1.41)       4.4979 (1.05)      1.0227 (1.35)       4.1480 (1.01)      0.6210 (6.90)    4653;4466      222.3239 (0.95)      59446           1
test_sit_sot_buffer_benchmark[10-2-unit]                3.9470 (1.02)     157.8550 (4.41)       4.3113 (1.00)      1.3718 (1.81)       4.1380 (1.01)      0.0900 (1.0)     1978;4611      231.9495 (1.00)      53982           1
test_sit_sot_buffer_benchmark[512-2-whole+init]        41.8180 (10.79)    177.1510 (4.95)      46.0673 (10.73)     4.6780 (6.17)      44.5440 (10.82)     4.8192 (53.55)    1270;520       21.7074 (0.09)      17353           1
test_sit_sot_buffer_benchmark[512-2-misaligned]        41.9580 (10.82)     94.9780 (2.65)      45.2083 (10.53)     4.2844 (5.65)      42.4600 (10.31)     5.1900 (57.67)    1807;637       22.1198 (0.09)      17949           1
test_sit_sot_buffer_benchmark[512-2-unit]              41.9590 (10.82)     98.9660 (2.76)      44.1287 (10.28)     3.8746 (5.11)      42.4700 (10.32)     1.0223 (11.36)   1805;4116       22.6610 (0.10)      18717           1
test_sit_sot_buffer_benchmark[512-2-aligned]           42.3590 (10.93)    115.2060 (3.22)      46.1430 (10.74)     4.2601 (5.62)      44.8840 (10.90)     0.3510 (3.90)    1460;3471       21.6717 (0.09)      18511           1
test_sit_sot_buffer_benchmark[512-2-whole]             43.0510 (11.10)    206.8370 (5.77)      47.1326 (10.98)     4.2129 (5.56)      45.6160 (11.08)     0.5510 (6.12)    1338;3636       21.2167 (0.09)      16529           1
test_sit_sot_buffer_benchmark[512-256-misaligned]     101.9010 (26.28)    410.7290 (11.47)    118.6487 (27.63)    20.9061 (27.58)    110.5570 (26.85)     6.7223 (74.69)    713;1557        8.4282 (0.04)       8409           1
test_sit_sot_buffer_benchmark[512-256-aligned]        111.2180 (28.69)    453.5300 (12.66)    126.8957 (29.55)    15.6212 (20.61)    118.3620 (28.75)    13.4450 (149.39)   1692;534        7.8805 (0.03)       7750           1
test_sit_sot_buffer_benchmark[512-256-whole+init]     112.6810 (29.06)    299.4810 (8.36)     132.7842 (30.92)    18.8627 (24.88)    121.3370 (29.47)    28.7640 (319.60)   1068;109        7.5310 (0.03)       6934           1
test_sit_sot_buffer_benchmark[512-256-unit]           114.5450 (29.54)    807.0400 (22.53)    131.1149 (30.53)    21.1005 (27.84)    120.2350 (29.20)    23.3340 (259.27)    637;229        7.6269 (0.03)       6618           1
test_sit_sot_buffer_benchmark[512-256-whole]          139.1810 (35.90)    631.2920 (17.62)    182.8883 (42.59)    34.8052 (45.91)    179.6315 (43.63)    12.8540 (142.82)  1005;1368        5.4678 (0.02)       4444           1

test_mit_sot_buffer_benchmark[1-False]                  4.7290 (1.22)      64.0800 (1.79)       5.1788 (1.21)      1.3283 (1.75)       4.9990 (1.21)      0.1110 (1.23)    1335;3921      193.0949 (0.83)      40976           1
test_mit_sot_buffer_benchmark[1000-True]              131.0860 (33.81)    325.9300 (9.10)     137.4081 (32.00)     9.6476 (12.73)    132.3770 (32.15)     8.9045 (98.94)     731;309        7.2776 (0.03)       6785           1
test_mit_sot_buffer_benchmark[1000-False]             132.2880 (34.12)    241.2920 (6.74)     139.4650 (32.48)    10.2454 (13.52)    133.7705 (32.49)     9.3020 (103.36)    790;446        7.1703 (0.03)       6176           1

test_scan_multiple_output                              68.3980 (17.64)    414.0350 (11.56)     95.3713 (22.21)    25.3289 (33.41)     84.4630 (20.52)    32.4210 (360.23)     535;54       10.4853 (0.05)       3278           1
test_vector_taps_benchmark                            321.8020 (83.00)    498.2430 (13.91)    338.0677 (78.72)    17.4038 (22.96)    330.5240 (80.28)    27.1010 (301.12)     507;29        2.9580 (0.01)       2740           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```
### After
```
----------------------------------------------------------------------------------------------------- benchmark: 20 tests ------------------------------------------------------------------------------------------------------
Name (time in us)                                          Min                 Max                Mean             StdDev              Median                IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_sit_sot_buffer_benchmark[10-2-unit]                3.5460 (1.0)       30.9580 (1.0)        4.2143 (1.0)       0.8748 (1.03)       3.8870 (1.0)       0.6100 (5.08)    4511;4073      237.2855 (1.0)       58786           1
test_sit_sot_buffer_benchmark[10-2-aligned]             3.9480 (1.11)      60.8740 (1.97)       4.5460 (1.08)      1.1993 (1.41)       4.2480 (1.09)      0.5210 (4.34)    3571;3929      219.9745 (0.93)      58748           1
test_sit_sot_buffer_benchmark[10-2-misaligned]          4.0470 (1.14)      65.7730 (2.12)       4.5319 (1.08)      1.1273 (1.33)       4.2780 (1.10)      0.2610 (2.18)    2999;6837      220.6601 (0.93)      62074           1
test_sit_sot_buffer_benchmark[10-2-whole]               4.0770 (1.15)      50.5450 (1.63)       4.6089 (1.09)      1.0177 (1.20)       4.3380 (1.12)      0.1200 (1.0)     4726;9100      216.9707 (0.91)      56393           1
test_sit_sot_buffer_benchmark[10-2-whole+init]          4.0870 (1.15)      62.8380 (2.03)       4.5927 (1.09)      1.1138 (1.31)       4.3280 (1.11)      0.1700 (1.42)   3271;11037      217.7381 (0.92)      53749           1
test_sit_sot_buffer_benchmark[512-2-unit]              18.5050 (5.22)      82.6150 (2.67)      21.1160 (5.01)      4.4988 (5.30)      18.8750 (4.86)      4.2680 (35.57)   3554;2332       47.3576 (0.20)      31687           1
test_sit_sot_buffer_benchmark[512-2-whole]             44.9340 (12.67)    799.0560 (25.81)     48.7547 (11.57)     8.9102 (10.50)     45.9560 (11.82)     2.9060 (24.22)    963;1910       20.5109 (0.09)      14211           1
test_sit_sot_buffer_benchmark[512-2-whole+init]        44.9540 (12.68)    170.6100 (5.51)      48.7200 (11.56)     6.3039 (7.43)      46.3470 (11.92)     2.0450 (17.04)   1532;2643       20.5255 (0.09)      16528           1
test_sit_sot_buffer_benchmark[512-2-aligned]           46.1160 (13.01)    156.8040 (5.07)      48.4194 (11.49)     3.7840 (4.46)      46.8080 (12.04)     2.0340 (16.95)   1597;1777       20.6529 (0.09)      17057           1
test_sit_sot_buffer_benchmark[512-2-misaligned]        46.1960 (13.03)    125.4850 (4.05)      48.3574 (11.47)     3.7634 (4.44)      46.7580 (12.03)     1.8640 (15.53)   1820;2029       20.6794 (0.09)      17159           1
test_sit_sot_buffer_benchmark[512-256-aligned]        101.7210 (28.69)    248.5050 (8.03)     115.9539 (27.51)    14.5836 (17.19)    109.2740 (28.11)     6.3492 (52.91)   1489;1583        8.6241 (0.04)       8587           1
test_sit_sot_buffer_benchmark[512-256-misaligned]     112.8110 (31.81)    259.5560 (8.38)     125.5590 (29.79)    17.0010 (20.04)    118.3720 (30.45)     5.5700 (46.42)   1052;1289        7.9644 (0.03)       8056           1
test_sit_sot_buffer_benchmark[512-256-whole]          113.4730 (32.00)    291.7460 (9.42)     131.2832 (31.15)    18.1112 (21.35)    120.8060 (31.08)    25.2845 (210.70)   1683;117        7.6171 (0.03)       6953           1
test_sit_sot_buffer_benchmark[512-256-unit]           117.1990 (33.05)    282.5890 (9.13)     137.9032 (32.72)    21.3947 (25.22)    126.0060 (32.42)    26.6100 (221.75)    922;243        7.2515 (0.03)       7317           1
test_sit_sot_buffer_benchmark[512-256-whole+init]     118.4920 (33.42)    299.9210 (9.69)     126.3285 (29.98)    16.2633 (19.17)    120.1050 (30.90)     5.6185 (46.82)     714;892        7.9159 (0.03)       6859           1

test_mit_sot_buffer_benchmark[1-False]                  4.1180 (1.16)      70.0510 (2.26)       4.5866 (1.09)      0.8482 (1.0)        4.4190 (1.14)      0.1510 (1.26)    1522;6659      218.0249 (0.92)      45702           1
test_mit_sot_buffer_benchmark[1000-True]               66.8950 (18.86)    145.5430 (4.70)      69.4895 (16.49)     4.9975 (5.89)      67.5870 (17.39)     1.0120 (8.43)    1272;2391       14.3907 (0.06)      12095           1
test_mit_sot_buffer_benchmark[1000-False]             144.9420 (40.87)    307.1260 (9.92)     151.2527 (35.89)     9.9623 (11.74)    147.0650 (37.84)     6.0610 (50.51)     558;553        6.6115 (0.03)       5809           1

test_scan_multiple_output                              69.3700 (19.56)    458.3890 (14.81)     77.6957 (18.44)    13.1526 (15.51)     72.2860 (18.60)     7.7642 (64.70)     439;448       12.8707 (0.05)       4729           1
test_vector_taps_benchmark                            328.4050 (92.61)    531.9460 (17.18)    344.4654 (81.74)    18.5545 (21.87)    337.0910 (86.72)    23.8542 (198.78)     407;60        2.9030 (0.01)       2529           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1281.org.readthedocs.build/en/1281/

<!-- readthedocs-preview pytensor end -->