### PR TITLE
Add numba overload for Nonzero

### DIFF
--- a/pytensor/link/numba/dispatch/basic.py
+++ b/pytensor/link/numba/dispatch/basic.py
@@ -749,18 +749,11 @@ def numba_funcify_IfElse(op, **kwargs):
 
 @numba_funcify.register(Nonzero)
 def numba_funcify_Nonzero(op, node, **kwargs):
-    a = node.inputs[0]
-
-    if a.ndim == 0:
-        raise ValueError("Nonzero only supports non-scalar arrays.")
-
     @numba_njit
     def nonzero(a):
-        if a.ndim == 1:
-            indices = np.where(a != 0)[0]
-            return indices.astype(np.int64)
-
         result_tuple = np.nonzero(a)
+        if a.ndim == 1:
+            return result_tuple[0]
         return list(result_tuple)
 
     return nonzero

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -13,6 +13,7 @@ from numbers import Number
 from typing import TYPE_CHECKING, Union
 from typing import cast as type_cast
 
+import numba as nb
 import numpy as np
 from numpy.exceptions import AxisError
 
@@ -972,6 +973,7 @@ class Nonzero(Op):
         output = [TensorType(dtype="int64", shape=(None,))() for i in range(a.ndim)]
         return Apply(self, [a], output)
 
+    @nb.njit
     def perform(self, node, inp, out_):
         a = inp[0]
 

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -13,7 +13,6 @@ from numbers import Number
 from typing import TYPE_CHECKING, Union
 from typing import cast as type_cast
 
-import numba as nb
 import numpy as np
 from numpy.exceptions import AxisError
 
@@ -973,7 +972,6 @@ class Nonzero(Op):
         output = [TensorType(dtype="int64", shape=(None,))() for i in range(a.ndim)]
         return Apply(self, [a], output)
 
-    @nb.njit
     def perform(self, node, inp, out_):
         a = inp[0]
 

--- a/tests/link/numba/test_basic.py
+++ b/tests/link/numba/test_basic.py
@@ -31,7 +31,6 @@ from pytensor.link.numba.linker import NumbaLinker
 from pytensor.raise_op import assert_op
 from pytensor.scalar.basic import ScalarOp, as_scalar
 from pytensor.tensor import blas
-from pytensor.tensor.basic import Nonzero
 from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.shape import Reshape, Shape, Shape_i, SpecifyShape
 
@@ -288,7 +287,6 @@ def compare_numba_and_py(
     )
     test_inputs_copy = (inp.copy() for inp in test_inputs) if inplace else test_inputs
     numba_res = pytensor_numba_fn(*test_inputs_copy)
-
     if isinstance(graph_outputs, tuple | list):
         for j, p in zip(numba_res, py_res, strict=True):
             assert_fn(j, p)
@@ -901,17 +899,9 @@ def test_function_overhead(mode, benchmark):
     [np.array([1, 0, 3]), np.array([[0, 1], [2, 0]]), np.array([[0, 0], [0, 0]])],
 )
 def test_Nonzero(input_data):
-    if input_data.ndim == 0:
-        a = pt.scalar("a")
-    elif input_data.ndim == 1:
-        a = pt.vector("a")
-    elif input_data.ndim == 2:
-        a = pt.matrix("a")
+    a = pt.tensor("a", shape=(None,) * input_data.ndim)
 
-    nonzero_op = Nonzero()
-
-    node = nonzero_op.make_node(a)
-    graph_outputs = node.outputs
+    graph_outputs = pt.nonzero(a)
 
     compare_numba_and_py(
         graph_inputs=[a], graph_outputs=graph_outputs, test_inputs=[input_data]


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
Added a numba overload in `Nonzero` by adding the `@nb.njit` decorator as `np.nonzero` is supported by `numba` already.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1279
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1289.org.readthedocs.build/en/1289/

<!-- readthedocs-preview pytensor end -->