### PR TITLE
Modify atleast_Nd to accept only one positional argument

### DIFF
--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -4355,7 +4355,7 @@ def empty_like(
 
 
 def atleast_Nd(
-    arry: np.ndarray | TensorVariable, n: int = 1, left: bool = True
+    arry: np.ndarray | TensorVariable, *, n: int = 1, left: bool = True
 ) -> TensorVariable:
     """Convert input to an array with at least `n` dimensions."""
 

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -4355,28 +4355,22 @@ def empty_like(
 
 
 def atleast_Nd(
-    *arys: np.ndarray | TensorVariable, n: int = 1, left: bool = True
+    arry: np.ndarray | TensorVariable, n: int = 1, left: bool = True
 ) -> TensorVariable:
-    """Convert inputs to arrays with at least `n` dimensions."""
-    res = []
-    for ary in arys:
-        ary = as_tensor(ary)
+    """Convert input to an array with at least `n` dimensions."""
 
-        if ary.ndim >= n:
-            result = ary
-        else:
-            result = (
-                shape_padleft(ary, n - ary.ndim)
-                if left
-                else shape_padright(ary, n - ary.ndim)
-            )
+    arry = as_tensor(arry)
 
-        res.append(result)
-
-    if len(res) == 1:
-        return res[0]
+    if arry.ndim >= n:
+        result = arry
     else:
-        return res
+        result = (
+            shape_padleft(arry, n - arry.ndim)
+            if left
+            else shape_padright(arry, n - arry.ndim)
+        )
+
+    return result
 
 
 atleast_1d = partial(atleast_Nd, n=1)

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -4364,8 +4364,8 @@ def test_atleast_Nd():
 
     for n in range(1, 3):
         ary1, ary2 = dscalar(), dvector()
-        res_ary1 = atleast_Nd(ary1, n)
-        res_ary2 = atleast_Nd(ary2, n)
+        res_ary1 = atleast_Nd(ary1, n=n)
+        res_ary2 = atleast_Nd(ary2, n=n)
 
         assert res_ary1.ndim == n
         if n == ary2.ndim:

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -4364,7 +4364,8 @@ def test_atleast_Nd():
 
     for n in range(1, 3):
         ary1, ary2 = dscalar(), dvector()
-        res_ary1, res_ary2 = atleast_Nd(ary1, ary2, n=n)
+        res_ary1 = atleast_Nd(ary1, n=n)
+        res_ary2 = atleast_Nd(ary2, n=n)
 
         assert res_ary1.ndim == n
         if n == ary2.ndim:

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -4364,8 +4364,8 @@ def test_atleast_Nd():
 
     for n in range(1, 3):
         ary1, ary2 = dscalar(), dvector()
-        res_ary1 = atleast_Nd(ary1, n=n)
-        res_ary2 = atleast_Nd(ary2, n=n)
+        res_ary1 = atleast_Nd(ary1, n)
+        res_ary2 = atleast_Nd(ary2, n)
 
         assert res_ary1.ndim == n
         if n == ary2.ndim:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
Modified `atleast_Nd` to accept only one positional argument. Also modified the tests to account for this change.

After the changes, in `atleast_Nd(x, 1)`, `x` is interpreted as an array and 1 is interpreted as the dimension. This change is reflected in the tests too.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1290
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1291.org.readthedocs.build/en/1291/

<!-- readthedocs-preview pytensor end -->