### PR TITLE
Add option to print inner graphs in debugprint function

### DIFF
--- a/pytensor/printing.py
+++ b/pytensor/printing.py
@@ -102,7 +102,6 @@ def debugprint(
     print_view_map: bool = False,
     print_memory_map: bool = False,
     print_fgraph_inputs: bool = False,
-    print_inner_graphs: bool = True,
 ) -> str | TextIO:
     r"""Print a graph as text.
 
@@ -125,6 +124,8 @@ def debugprint(
         The object(s) to be printed.
     depth
         Print graph to this depth (``-1`` for unlimited).
+    inner_depth
+        Print inner graph to this depth (``-1`` for unlimited).
     print_type
         If ``True``, print the `Type`\s of each `Variable` in the graph.
     print_shape
@@ -302,7 +303,7 @@ N.B.:
                     or hasattr(var.owner.op, "scalar_op")
                     and isinstance(var.owner.op.scalar_op, HasInnerGraph)
                 )
-                and not inner_depth
+                and inner_depth
                 and var not in inner_graph_vars
             ):
                 inner_graph_vars.append(var)

--- a/pytensor/printing.py
+++ b/pytensor/printing.py
@@ -88,6 +88,7 @@ def debugprint(
     | FunctionGraph
     | Sequence[Variable | Apply | Function | FunctionGraph],
     depth: int = -1,
+    inner_depth: int = -1,
     print_type: bool = False,
     print_shape: bool = False,
     file: Literal["str"] | TextIO | None = None,
@@ -299,7 +300,7 @@ N.B.:
                 isinstance(var.owner.op, HasInnerGraph)
                 or hasattr(var.owner.op, "scalar_op")
                 and isinstance(var.owner.op.scalar_op, HasInnerGraph)
-            ) and var not in inner_graph_vars:
+            ) and not inner_depth and var not in inner_graph_vars:
                 inner_graph_vars.append(var)
             if print_op_info:
                 op_information.update(op_debug_information(var.owner.op, var.owner))
@@ -325,7 +326,7 @@ N.B.:
             print_view_map=print_view_map,
         )
 
-    if len(inner_graph_vars) > 0 and print_inner_graphs:
+    if len(inner_graph_vars) > 0 and inner_depth:
         print("", file=_file)
         prefix = ""
         new_prefix = prefix + " ← "
@@ -377,7 +378,7 @@ N.B.:
             _debugprint(
                 ig_var,
                 prefix=prefix,
-                depth=depth,
+                depth=inner_depth,
                 done=done,
                 print_type=print_type,
                 print_shape=print_shape,
@@ -400,7 +401,7 @@ N.B.:
                     _debugprint(
                         inp,
                         prefix=" → ",
-                        depth=depth,
+                        depth=inner_depth,
                         done=done,
                         print_type=print_type,
                         print_shape=print_shape,
@@ -435,7 +436,7 @@ N.B.:
                 _debugprint(
                     out,
                     prefix=new_prefix,
-                    depth=depth,
+                    depth=inner_depth,
                     done=done,
                     print_type=print_type,
                     print_shape=print_shape,

--- a/pytensor/printing.py
+++ b/pytensor/printing.py
@@ -101,6 +101,7 @@ def debugprint(
     print_view_map: bool = False,
     print_memory_map: bool = False,
     print_fgraph_inputs: bool = False,
+    print_inner_graphs: bool = True,
 ) -> str | TextIO:
     r"""Print a graph as text.
 
@@ -161,6 +162,8 @@ def debugprint(
         Whether to set both `print_destroy_map` and `print_view_map` to ``True``.
     print_fgraph_inputs
         Print the inputs of `FunctionGraph`\s.
+    print_inner_graphs
+        Whether to print the inner graphs of `Op`\s
 
     Returns
     -------
@@ -322,7 +325,7 @@ N.B.:
             print_view_map=print_view_map,
         )
 
-    if len(inner_graph_vars) > 0:
+    if len(inner_graph_vars) > 0 and print_inner_graphs:
         print("", file=_file)
         prefix = ""
         new_prefix = prefix + " ← "

--- a/pytensor/printing.py
+++ b/pytensor/printing.py
@@ -297,10 +297,14 @@ N.B.:
     ):
         if hasattr(var.owner, "op"):
             if (
-                isinstance(var.owner.op, HasInnerGraph)
-                or hasattr(var.owner.op, "scalar_op")
-                and isinstance(var.owner.op.scalar_op, HasInnerGraph)
-            ) and not inner_depth and var not in inner_graph_vars:
+                (
+                    isinstance(var.owner.op, HasInnerGraph)
+                    or hasattr(var.owner.op, "scalar_op")
+                    and isinstance(var.owner.op.scalar_op, HasInnerGraph)
+                )
+                and not inner_depth
+                and var not in inner_graph_vars
+            ):
                 inner_graph_vars.append(var)
             if print_op_info:
                 op_information.update(op_debug_information(var.owner.op, var.owner))


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->
I added an option `print_inner_graphs` to print inner graphs in the debugprint function.
## Description
<!--- Describe your changes in detail -->
A boolean argument `print_inner_graphs` is provided to the debugprint function, which defaults to True. In case we don't want to print the inner graphs, we can set it to False.
For example:
```python
import pytensor
import pytensor.tensor as pt
from pytensor.compile.mode import get_default_mode

n = pt.iscalar("n")
x0 = pt.vector("x0")
xs, _ = pytensor.scan(lambda xtm1: xtm1 + 1, outputs_info=[x0], n_steps=n)

mode = get_default_mode().including("scan_save_mem")
fn = pytensor.function([n, x0], xs, mode=mode, on_unused_input="ignore")
fn.dprint()
```
```
# Output:
  Subtensor{start:stop} [id A] 9
   ├─ Scan{scan_fn, while_loop=False, inplace=all} [id B] 8
   │  ├─ n [id C]
   │  └─ SetSubtensor{:stop} [id D] 7
   │     ├─ AllocEmpty{dtype='float64'} [id E] 6
   │     │  ├─ Composite{...}.2 [id F] 0
   │     │  │  └─ n [id C]
   │     │  └─ Shape_i{0} [id G] 5
   │     │     └─ x0 [id H]
   │     ├─ Unbroadcast{0} [id I] 4
   │     │  └─ ExpandDims{axis=0} [id J] 3
   │     │     └─ x0 [id H]
   │     └─ 1 [id K]
   ├─ ScalarFromTensor [id L] 2
   │  └─ Composite{...}.1 [id F] 0
   │     └─ ···
   └─ ScalarFromTensor [id M] 1
      └─ Composite{...}.0 [id F] 0
         └─ ···
  
  Inner graphs:
  
  Scan{scan_fn, while_loop=False, inplace=all} [id B]
   ← Add [id N]
      ├─ [1.] [id O]
  ...
      │     ├─ maximum [id X] 't8'
      │     │  └─ ···
      │     └─ 1 [id W]
      └─ 1 [id U]
```
```python
fn.dprint(print_inner_graphs = False)
```
```
# Output:
Subtensor{start:stop} [id A] 9
 ├─ Scan{scan_fn, while_loop=False, inplace=all} [id B] 8
 │  ├─ n [id C]
 │  └─ SetSubtensor{:stop} [id D] 7
 │     ├─ AllocEmpty{dtype='float64'} [id E] 6
 │     │  ├─ Composite{...}.2 [id F] 0
 │     │  │  └─ n [id C]
 │     │  └─ Shape_i{0} [id G] 5
 │     │     └─ x0 [id H]
 │     ├─ Unbroadcast{0} [id I] 4
 │     │  └─ ExpandDims{axis=0} [id J] 3
 │     │     └─ x0 [id H]
 │     └─ 1 [id K]
 ├─ ScalarFromTensor [id L] 2
 │  └─ Composite{...}.1 [id F] 0
 │     └─ ···
 └─ ScalarFromTensor [id M] 1
    └─ Composite{...}.0 [id F] 0
       └─ ···
```


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1285 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1293.org.readthedocs.build/en/1293/

<!-- readthedocs-preview pytensor end -->