### PR TITLE
Refactor `infer_shape` method of Ops to find output shapes using `gufunc_signature`

### DIFF
--- a/pytensor/graph/op.py
+++ b/pytensor/graph/op.py
@@ -602,7 +602,9 @@ class Op(MetaObject):
 
             return _gufunc_to_out_shape(self.gufunc_signature, input_shapes)
         else:
-            raise NotImplementedError(f"Op {self} does not implement infer_shape")
+            from pytensor.tensor.exceptions import ShapeError
+
+            raise ShapeError(f"Op {self} does not implement infer_shape")
 
     def __str__(self):
         return getattr(type(self), "__name__", super().__str__())

--- a/pytensor/graph/op.py
+++ b/pytensor/graph/op.py
@@ -20,6 +20,7 @@ from pytensor.graph.utils import (
     add_tag_trace,
     get_variable_trace_string,
 )
+from pytensor.tensor.utils import _gufunc_to_out_shape
 
 
 if TYPE_CHECKING:
@@ -595,6 +596,12 @@ class Op(MetaObject):
         # TODO: Document this in the Create your own Op docs
         # By default, do nothing
         return self
+
+    def infer_shape(self, fgraph, node, input_shapes):
+        if hasattr(self, "gufunc_signature"):
+            return _gufunc_to_out_shape(self.gufunc_signature, input_shapes)
+        else:
+            raise NotImplementedError(f"Op {self} does not implement infer_shape")
 
     def __str__(self):
         return getattr(type(self), "__name__", super().__str__())

--- a/pytensor/graph/op.py
+++ b/pytensor/graph/op.py
@@ -20,7 +20,6 @@ from pytensor.graph.utils import (
     add_tag_trace,
     get_variable_trace_string,
 )
-from pytensor.tensor.utils import _gufunc_to_out_shape
 
 
 if TYPE_CHECKING:
@@ -599,6 +598,8 @@ class Op(MetaObject):
 
     def infer_shape(self, fgraph, node, input_shapes):
         if hasattr(self, "gufunc_signature"):
+            from pytensor.tensor.utils import _gufunc_to_out_shape
+
             return _gufunc_to_out_shape(self.gufunc_signature, input_shapes)
         else:
             raise NotImplementedError(f"Op {self} does not implement infer_shape")

--- a/pytensor/tensor/nlinalg.py
+++ b/pytensor/tensor/nlinalg.py
@@ -17,7 +17,6 @@ from pytensor.tensor import math as ptm
 from pytensor.tensor.basic import as_tensor_variable, diagonal
 from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.type import Variable, dvector, lscalar, matrix, scalar, vector
-from pytensor.tensor.utils import _gufunc_to_out_shape
 
 
 class MatrixPinv(Op):
@@ -62,9 +61,6 @@ class MatrixPinv(Op):
             + matrix_dot((ptb.identity_like(z_dot_x) - z_dot_x), gz, z.T, z)
         ).T
         return [grad]
-
-    def infer_shape(self, fgraph, node, shapes):
-        return _gufunc_to_out_shape(self.gufunc_signature, shapes)
 
 
 def pinv(x, hermitian=False):
@@ -156,9 +152,6 @@ class MatrixInverse(Op):
             return [None]
         return [-matrix_dot(xi, ev, xi)]
 
-    def infer_shape(self, fgraph, node, shapes):
-        return _gufunc_to_out_shape(self.gufunc_signature, shapes)
-
 
 inv = matrix_inverse = Blockwise(MatrixInverse())
 
@@ -225,9 +218,6 @@ class Det(Op):
         (x,) = inputs
         return [gz * self(x) * matrix_inverse(x).T]
 
-    def infer_shape(self, fgraph, node, shapes):
-        return _gufunc_to_out_shape(self.gufunc_signature, shapes)
-
     def __str__(self):
         return "Det"
 
@@ -258,9 +248,6 @@ class SLogDet(Op):
             sign[0], det[0] = (np.array(z, dtype=x.dtype) for z in np.linalg.slogdet(x))
         except Exception as e:
             raise ValueError("Failed to compute determinant", x) from e
-
-    def infer_shape(self, fgraph, node, shapes):
-        return _gufunc_to_out_shape(self.gufunc_signature, shapes)
 
     def __str__(self):
         return "SLogDet"
@@ -316,9 +303,6 @@ class Eig(Op):
         (x,) = inputs
         (w, v) = outputs
         w[0], v[0] = (z.astype(x.dtype) for z in np.linalg.eig(x))
-
-    def infer_shape(self, fgraph, node, shapes):
-        return _gufunc_to_out_shape(self.gufunc_signature, shapes)
 
 
 eig = Blockwise(Eig())

--- a/pytensor/tensor/nlinalg.py
+++ b/pytensor/tensor/nlinalg.py
@@ -619,7 +619,16 @@ class SVD(Op):
             s[0] = np.linalg.svd(x, self.full_matrices, self.compute_uv)
 
     def infer_shape(self, fgraph, node, shapes):
-        return _gufunc_to_out_shape(self.gufunc_signature, shapes)
+        (x_shape,) = shapes
+        M, N = x_shape
+        K = ptm.minimum(M, N)
+        s_shape = (K,)
+        if self.compute_uv:
+            u_shape = (M, M) if self.full_matrices else (M, K)
+            vt_shape = (N, N) if self.full_matrices else (K, N)
+            return [u_shape, s_shape, vt_shape]
+        else:
+            return [s_shape]
 
     def L_op(
         self,

--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -20,7 +20,6 @@ from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.nlinalg import kron, matrix_dot
 from pytensor.tensor.shape import reshape
 from pytensor.tensor.type import matrix, tensor, vector
-from pytensor.tensor.utils import _gufunc_to_out_shape
 from pytensor.tensor.variable import TensorVariable
 
 
@@ -50,9 +49,6 @@ class Cholesky(Op):
 
         if self.overwrite_a:
             self.destroy_map = {0: [0]}
-
-    def infer_shape(self, fgraph, node, shapes):
-        return _gufunc_to_out_shape(self.gufunc_signature, shapes)
 
     def make_node(self, x):
         x = as_tensor_variable(x)
@@ -268,9 +264,6 @@ class SolveBase(Op):
         ).dtype
         x = tensor(dtype=o_dtype, shape=b.type.shape)
         return Apply(self, [A, b], [x])
-
-    def infer_shape(self, fgraph, node, shapes):
-        return _gufunc_to_out_shape(self.gufunc_signature, shapes)
 
     def L_op(self, inputs, outputs, output_gradients):
         r"""Reverse-mode gradient updates for matrix solve operation :math:`c = A^{-1} b`.
@@ -885,9 +878,6 @@ class SolveContinuousLyapunov(Op):
         out_dtype = node.outputs[0].type.dtype
         X[0] = scipy_linalg.solve_continuous_lyapunov(A, B).astype(out_dtype)
 
-    def infer_shape(self, fgraph, node, shapes):
-        return _gufunc_to_out_shape(self.gufunc_signature, shapes)
-
     def grad(self, inputs, output_grads):
         # Gradient computations come from Kao and Hennequin (2020), https://arxiv.org/pdf/2011.11430.pdf
         # Note that they write the equation as AX + XA.H + Q = 0, while scipy uses AX + XA^H = Q,
@@ -956,9 +946,6 @@ class BilinearSolveDiscreteLyapunov(Op):
         X[0] = scipy_linalg.solve_discrete_lyapunov(A, B, method="bilinear").astype(
             out_dtype
         )
-
-    def infer_shape(self, fgraph, node, shapes):
-        return _gufunc_to_out_shape(self.gufunc_signature, shapes)
 
     def grad(self, inputs, output_grads):
         # Gradient computations come from Kao and Hennequin (2020), https://arxiv.org/pdf/2011.11430.pdf
@@ -1076,9 +1063,6 @@ class SolveDiscreteARE(Op):
 
         out_dtype = node.outputs[0].type.dtype
         X[0] = scipy_linalg.solve_discrete_are(A, B, Q, R).astype(out_dtype)
-
-    def infer_shape(self, fgraph, node, shapes):
-        return _gufunc_to_out_shape(self.gufunc_signature, shapes)
 
     def grad(self, inputs, output_grads):
         # Gradient computations come from Kao and Hennequin (2020), https://arxiv.org/pdf/2011.11430.pdf

--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -20,8 +20,8 @@ from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.nlinalg import kron, matrix_dot
 from pytensor.tensor.shape import reshape
 from pytensor.tensor.type import matrix, tensor, vector
-from pytensor.tensor.utils import _gufunc_to_out_shape
 from pytensor.tensor.variable import TensorVariable
+from pytensor.tensor.utils import _gufunc_to_out_shape
 
 
 logger = logging.getLogger(__name__)
@@ -1176,7 +1176,8 @@ class BaseBlockDiagonal(Op):
         return [gout[0][slc] for slc in slices]
 
     def infer_shape(self, fgraph, nodes, shapes):
-        return _gufunc_to_out_shape(self.gufunc_signature, shapes)
+        first, second = zip(*shapes, strict=True)
+        return [(pt.add(*first), pt.add(*second))]
 
     def _validate_and_prepare_inputs(self, matrices, as_tensor_func):
         if len(matrices) != self.n_inputs:

--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -20,8 +20,8 @@ from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.nlinalg import kron, matrix_dot
 from pytensor.tensor.shape import reshape
 from pytensor.tensor.type import matrix, tensor, vector
-from pytensor.tensor.variable import TensorVariable
 from pytensor.tensor.utils import _gufunc_to_out_shape
+from pytensor.tensor.variable import TensorVariable
 
 
 logger = logging.getLogger(__name__)

--- a/pytensor/tensor/utils.py
+++ b/pytensor/tensor/utils.py
@@ -202,6 +202,39 @@ def _parse_gufunc_signature(
     )
 
 
+def _gufunc_to_out_shape(
+    signature: str, shapes: list[tuple[int, ...]]
+) -> list[tuple[int, ...]]:
+    """
+    Compute the shape of the output of an Op given its gufunc signature and the
+    shapes of its inputs.
+
+    Parameters
+    ----------
+    signature : str
+        The gufunc signature of the Op.
+        eg: "(m,n),(n,p)->(m,p)".
+
+    shapes : list of tuple of int
+        The list of shapes of the inputs.
+
+    Returns
+    -------
+    out_shape : list of tuple of int
+        The list of shapes of the outputs.
+    """
+    parsed = _parse_gufunc_signature(signature)
+    out_shape = []
+    dic = dict()
+    for i in range(len(parsed[0])):
+        for j in range(len(parsed[0][i])):
+            dic[parsed[0][i][j]] = shapes[i][j]
+    for i in range(len(parsed[1])):
+        temp_list = [dic[x] for x in parsed[1][i]]
+        out_shape.append(tuple(temp_list))
+    return out_shape
+
+
 def safe_signature(
     core_inputs_ndim: Sequence[int],
     core_outputs_ndim: Sequence[int],

--- a/pytensor/tensor/utils.py
+++ b/pytensor/tensor/utils.py
@@ -239,11 +239,7 @@ def _gufunc_to_out_shape(
             # Prefer constants
             elif not isinstance(prev_size, Constant):
                 dim_to_size[dim_name] = size
-            elif prev_size.data != size:
-                raise ValueError(
-                    f"Invalid signature {signature} for shapes {shapes}. "
-                    f"Dimension {dim_name} is not consistent across inputs."
-                )
+
     out_shapes = []
     for output_shape in output_sig:
         temp_list = []


### PR DESCRIPTION


<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->
Refactored `infer_shape` method of `Ops` to find output shapes using `gufunc_signature` using a newly defined function `_gufunc_to_out_shape`.

## Description
<!--- Describe your changes in detail -->
`Ops` have a method `infer_shape` which helps to find the shapes of the outputs given the input shapes. All `Ops` have their own implementations of `infer_shape`. However, many `Ops` have a `gufunc_signature` string which gives information about the input-output shape relations. In principle, this string is enough to find the output shapes given the input shapes. Thus, a function `_gufunc_to_out_shape` has been added in this PR, which calculates the output shapes list given the `gufunc_signature` and the input shapes list. This PR also replaces the Op specific implementations of `infer_shape` with the `_gufunc_to_out_shape` output.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1257 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1294.org.readthedocs.build/en/1294/

<!-- readthedocs-preview pytensor end -->