### PR TITLE
Fix get_vector_length incorrectly returning for shared variable without static shape

### DIFF
--- a/pytensor/tensor/sharedvar.py
+++ b/pytensor/tensor/sharedvar.py
@@ -3,7 +3,6 @@ import warnings
 import numpy as np
 
 from pytensor.compile import SharedVariable, shared_constructor
-from pytensor.tensor import _get_vector_length
 from pytensor.tensor.type import TensorType
 from pytensor.tensor.variable import TensorVariable
 
@@ -49,11 +48,6 @@ class TensorSharedVariable(SharedVariable, TensorVariable):
             self.container.value[...] = 0
         else:
             self.container.value = 0 * self.container.value
-
-
-@_get_vector_length.register(TensorSharedVariable)
-def _get_vector_length_TensorSharedVariable(var_inst, var):
-    return len(var.get_value(borrow=True))
 
 
 @shared_constructor.register(np.ndarray)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
Fixed `get_vector_length` returning a value when called with a shared variable which did not have static shape. This was done by removing a dispatch method implemented in `tensor/shared_var.py`. After the changes, a ValueError is raised when a shared variable without static shape is passed.
## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1239
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
