### PR TITLE
Modify `arange` to directly determine the shape from the arguments if possible

### DIFF
--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -3234,7 +3234,7 @@ class ARange(Op):
             and isinstance(step, TensorConstant)
         ):
             length = max(
-                ceil((float(stop) - float(start.value)) / float(step.value)), 0
+                ceil((float(stop.value) - float(start.value)) / float(step.value)), 0
             )
             shape = (length,)
 

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -3232,7 +3232,6 @@ class ARange(Op):
         assert stop.ndim == 0
         assert step.ndim == 0
 
-        shape = (None,)
         # if it is possible to directly determine the shape i.e static shape is present, we find it.
         if (
             isinstance(start, TensorConstant)
@@ -3243,6 +3242,8 @@ class ARange(Op):
                 ceil((float(stop.data) - float(start.data)) / float(step.data)), 0
             )
             shape = (length,)
+        else:
+            shape = (None,)
 
         inputs = [start, stop, step]
         outputs = [tensor(dtype=self.dtype, shape=shape)]

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -3224,13 +3224,29 @@ class ARange(Op):
         self.dtype = dtype
 
     def make_node(self, start, stop, step):
+        types = TensorConstant
+        shape = (None,)
+        # if it is possible to directly determine the shape i.e static shape is present, we find it.
+        if (
+            isinstance(start, types)
+            and isinstance(stop, types)
+            and isinstance(step, types)
+        ):
+            length = max(
+                np.max(np.ceil((stop.value - start.value) / step.value))
+                .astype(int)
+                .item(),
+                0,
+            )
+            shape = (length,)
+
         start, stop, step = map(as_tensor_variable, (start, stop, step))
         assert start.ndim == 0
         assert stop.ndim == 0
         assert step.ndim == 0
 
         inputs = [start, stop, step]
-        outputs = [tensor(dtype=self.dtype, shape=(None,))]
+        outputs = [tensor(dtype=self.dtype, shape=shape)]
 
         return Apply(self, inputs, outputs)
 

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -3226,17 +3226,15 @@ class ARange(Op):
     def make_node(self, start, stop, step):
         from math import ceil
 
-        types = TensorConstant
         shape = (None,)
         # if it is possible to directly determine the shape i.e static shape is present, we find it.
         if (
-            isinstance(start, types)
-            and isinstance(stop, types)
-            and isinstance(step, types)
+            isinstance(start, TensorConstant)
+            and isinstance(stop, TensorConstant)
+            and isinstance(step, TensorConstant)
         ):
-            # Convert to int32 or int64 before calculation
             length = max(
-                ceil((float(stop.value) - float(start.value)) / float(step.value)), 0
+                ceil((float(stop) - float(start.value)) / float(step.value)), 0
             )
             shape = (length,)
 

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -3226,6 +3226,12 @@ class ARange(Op):
     def make_node(self, start, stop, step):
         from math import ceil
 
+        start, stop, step = map(as_tensor_variable, (start, stop, step))
+
+        assert start.ndim == 0
+        assert stop.ndim == 0
+        assert step.ndim == 0
+
         shape = (None,)
         # if it is possible to directly determine the shape i.e static shape is present, we find it.
         if (
@@ -3234,14 +3240,9 @@ class ARange(Op):
             and isinstance(step, TensorConstant)
         ):
             length = max(
-                ceil((float(stop.value) - float(start.value)) / float(step.value)), 0
+                ceil((float(stop.data) - float(start.data)) / float(step.data)), 0
             )
             shape = (length,)
-
-        start, stop, step = map(as_tensor_variable, (start, stop, step))
-        assert start.ndim == 0
-        assert stop.ndim == 0
-        assert step.ndim == 0
 
         inputs = [start, stop, step]
         outputs = [tensor(dtype=self.dtype, shape=shape)]

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -3224,6 +3224,8 @@ class ARange(Op):
         self.dtype = dtype
 
     def make_node(self, start, stop, step):
+        from math import ceil
+
         types = TensorConstant
         shape = (None,)
         # if it is possible to directly determine the shape i.e static shape is present, we find it.
@@ -3232,11 +3234,9 @@ class ARange(Op):
             and isinstance(stop, types)
             and isinstance(step, types)
         ):
+            # Convert to int32 or int64 before calculation
             length = max(
-                np.max(np.ceil((stop.value - start.value) / step.value))
-                .astype(int)
-                .item(),
-                0,
+                ceil((float(stop.value) - float(start.value)) / float(step.value)), 0
             )
             shape = (length,)
 

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -2861,6 +2861,12 @@ class TestARange:
             assert np.all(f(2) == len(np.arange(0, 2)))
             assert np.all(f(0) == len(np.arange(0, 0)))
 
+    def test_static_shape(self):
+        assert np.arange(1, 10).shape == arange(1, 10).type.shape
+        assert np.arange(10, 1, -1).shape == arange(10, 1, -1).type.shape
+        assert np.arange(1, -9, 2).shape == arange(1, -9, 2).type.shape
+        assert np.arange(1.3, 17.48, 2.67).shape == arange(1.3, 17.48, 2.67).type.shape
+
 
 class TestNdGrid:
     def setup_method(self):

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -2866,6 +2866,7 @@ class TestARange:
         assert np.arange(10, 1, -1).shape == arange(10, 1, -1).type.shape
         assert np.arange(1, -9, 2).shape == arange(1, -9, 2).type.shape
         assert np.arange(1.3, 17.48, 2.67).shape == arange(1.3, 17.48, 2.67).type.shape
+        assert np.arange(-64, 64).shape == arange(-64, 64).type.shape
 
 
 class TestNdGrid:


### PR DESCRIPTION


<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
Modified `arange` such that in scenarios where we are able to infer the shape from the arguments i.e the arguments are constant,  `type.shape` is updated accordingly.

For example : 

```python
import pytensor
import pytensor.tensor as pt

print(pt.arange(1,10,1).type.shape) #Returns (9, ). Earlier used to return (None, )

``` 

Tests are also added to test the new addition.
## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1301
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1302.org.readthedocs.build/en/1302/

<!-- readthedocs-preview pytensor end -->