### PR TITLE
Fix inplace/layout bugs in Numba lapack routines

### DIFF
--- a/pytensor/link/numba/dispatch/slinalg.py
+++ b/pytensor/link/numba/dispatch/slinalg.py
@@ -24,6 +24,13 @@ from pytensor.tensor.slinalg import (
     Solve,
     SolveTriangular,
 )
+from pytensor.tensor.type import complex_dtypes
+
+
+_COMPLEX_DTYPE_NOT_SUPPORTED_MSG = (
+    "Complex dtype for {op} not supported in numba mode. "
+    "If you need this functionality, please open an issue at: https://github.com/pymc-devs/pytensor"
+)
 
 
 @numba_basic.numba_njit(inline="always")
@@ -199,9 +206,9 @@ def numba_funcify_SolveTriangular(op, node, **kwargs):
     b_ndim = op.b_ndim
 
     dtype = node.inputs[0].dtype
-    if str(dtype).startswith("complex"):
+    if dtype in complex_dtypes:
         raise NotImplementedError(
-            "Complex inputs not currently supported by solve_triangular in Numba mode"
+            _COMPLEX_DTYPE_NOT_SUPPORTED_MSG.format(op="Solve Triangular")
         )
 
     @numba_basic.numba_njit(inline="always")
@@ -299,10 +306,8 @@ def numba_funcify_Cholesky(op, node, **kwargs):
     on_error = op.on_error
 
     dtype = node.inputs[0].dtype
-    if str(dtype).startswith("complex"):
-        raise NotImplementedError(
-            "Complex inputs not currently supported by cholesky in Numba mode"
-        )
+    if dtype in complex_dtypes:
+        raise NotImplementedError(_COMPLEX_DTYPE_NOT_SUPPORTED_MSG.format(op=op))
 
     @numba_basic.numba_njit(inline="always")
     def nb_cholesky(a):
@@ -1089,10 +1094,8 @@ def numba_funcify_Solve(op, node, **kwargs):
     transposed = False  # TODO: Solve doesnt currently allow the transposed argument
 
     dtype = node.inputs[0].dtype
-    if str(dtype).startswith("complex"):
-        raise NotImplementedError(
-            "Complex inputs not currently supported by solve in Numba mode"
-        )
+    if dtype in complex_dtypes:
+        raise NotImplementedError(_COMPLEX_DTYPE_NOT_SUPPORTED_MSG.format(op=op))
 
     if assume_a == "gen":
         solve_fn = _solve_gen
@@ -1206,10 +1209,8 @@ def numba_funcify_CholeskySolve(op, node, **kwargs):
     check_finite = op.check_finite
 
     dtype = node.inputs[0].dtype
-    if str(dtype).startswith("complex"):
-        raise NotImplementedError(
-            "Complex inputs not currently supported by cho_solve in Numba mode"
-        )
+    if dtype in complex_dtypes:
+        raise NotImplementedError(_COMPLEX_DTYPE_NOT_SUPPORTED_MSG.format(op=op))
 
     @numba_basic.numba_njit(inline="always")
     def cho_solve(c, b):

--- a/tests/link/numba/test_basic.py
+++ b/tests/link/numba/test_basic.py
@@ -7,6 +7,7 @@ from unittest import mock
 import numpy as np
 import pytest
 
+from pytensor.compile import SymbolicInput
 from tests.tensor.test_math_scipy import scipy
 
 
@@ -120,6 +121,7 @@ opts = RewriteDatabaseQuery(
 numba_mode = Mode(
     NumbaLinker(), opts.including("numba", "local_useless_unbatched_blockwise")
 )
+numba_inplace_mode = numba_mode.including("inplace")
 py_mode = Mode("py", opts)
 
 rng = np.random.default_rng(42849)
@@ -261,7 +263,11 @@ def compare_numba_and_py(
                 x, y
             )
 
-    if any(inp.owner is not None for inp in graph_inputs):
+    if any(
+        inp.owner is not None
+        for inp in graph_inputs
+        if not isinstance(inp, SymbolicInput)
+    ):
         raise ValueError("Inputs must be root variables")
 
     pytensor_py_fn = function(

--- a/tests/link/numba/test_slinalg.py
+++ b/tests/link/numba/test_slinalg.py
@@ -169,7 +169,8 @@ class TestSolves:
         b_val_c_contig = np.copy(b_val, order="C")
         res_c_contig = f(A_val_c_contig, b_val_c_contig)
         np.testing.assert_allclose(res_c_contig, res)
-        np.testing.assert_allclose(A_val_c_contig, A_val)
+        # We can destroy C-contiguous A arrays by inverting `tranpose/lower` at runtime
+        assert np.allclose(A_val_c_contig, A_val) == (not overwrite_a)
         # b vectors are always f_contiguous if also c_contiguous
         assert np.allclose(b_val_c_contig, b_val) == (
             not (overwrite_b and b_val_c_contig.flags.f_contiguous)

--- a/tests/link/numba/test_slinalg.py
+++ b/tests/link/numba/test_slinalg.py
@@ -1,17 +1,15 @@
 import re
-from functools import partial
 from typing import Literal
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
+import scipy
 
 import pytensor
 import pytensor.tensor as pt
-from pytensor import config
-from pytensor.tensor.slinalg import SolveTriangular
-from tests import unittest_tools as utt
-from tests.link.numba.test_basic import compare_numba_and_py
+from pytensor import In, config
+from pytensor.tensor.slinalg import Cholesky, CholeskySolve, Solve, SolveTriangular
+from tests.link.numba.test_basic import compare_numba_and_py, numba_inplace_mode
 
 
 numba = pytest.importorskip("numba")
@@ -19,250 +17,6 @@ numba = pytest.importorskip("numba")
 floatX = config.floatX
 
 rng = np.random.default_rng(42849)
-
-
-def transpose_func(x, trans):
-    if trans == 0:
-        return x
-    if trans == 1:
-        return x.T
-    if trans == 2:
-        return x.conj().T
-
-
-@pytest.mark.parametrize(
-    "b_shape",
-    [(5, 1), (5, 5), (5,)],
-    ids=["b_col_vec", "b_matrix", "b_vec"],
-)
-@pytest.mark.parametrize("lower", [True, False], ids=["lower=True", "lower=False"])
-@pytest.mark.parametrize("trans", [0, 1, 2], ids=["trans=N", "trans=C", "trans=T"])
-@pytest.mark.parametrize(
-    "unit_diag", [True, False], ids=["unit_diag=True", "unit_diag=False"]
-)
-@pytest.mark.parametrize("is_complex", [True, False], ids=["complex", "real"])
-@pytest.mark.filterwarnings(
-    'ignore:Cannot cache compiled function "numba_funcified_fgraph"'
-)
-def test_solve_triangular(b_shape: tuple[int], lower, trans, unit_diag, is_complex):
-    if is_complex:
-        # TODO: Complex raises ValueError: To change to a dtype of a different size, the last axis must be contiguous,
-        #  why?
-        pytest.skip("Complex inputs currently not supported to solve_triangular")
-
-    complex_dtype = "complex64" if floatX.endswith("32") else "complex128"
-    dtype = complex_dtype if is_complex else floatX
-
-    A = pt.matrix("A", dtype=dtype)
-    b = pt.tensor("b", shape=b_shape, dtype=dtype)
-
-    def A_func(x):
-        x = x @ x.conj().T
-        x_tri = pt.linalg.cholesky(x, lower=lower).astype(dtype)
-
-        if unit_diag:
-            x_tri = pt.fill_diagonal(x_tri, 1.0)
-
-        return x_tri
-
-    solve_op = partial(
-        pt.linalg.solve_triangular, lower=lower, trans=trans, unit_diagonal=unit_diag
-    )
-
-    X = solve_op(A_func(A), b)
-    f = pytensor.function([A, b], X, mode="NUMBA")
-
-    A_val = np.random.normal(size=(5, 5))
-    b_val = np.random.normal(size=b_shape)
-
-    if is_complex:
-        A_val = A_val + np.random.normal(size=(5, 5)) * 1j
-        b_val = b_val + np.random.normal(size=b_shape) * 1j
-
-    X_np = f(A_val.copy(), b_val.copy())
-    A_val_transformed = transpose_func(A_func(A_val), trans).eval()
-    np.testing.assert_allclose(
-        A_val_transformed @ X_np,
-        b_val,
-        atol=1e-8 if floatX.endswith("64") else 1e-4,
-        rtol=1e-8 if floatX.endswith("64") else 1e-4,
-    )
-
-    compiled_fgraph = f.maker.fgraph
-    compare_numba_and_py(
-        compiled_fgraph.inputs,
-        compiled_fgraph.outputs,
-        [A_val, b_val],
-    )
-
-
-@pytest.mark.parametrize(
-    "lower, unit_diag, trans",
-    [(True, True, True), (False, False, False)],
-    ids=["lower_unit_trans", "defaults"],
-)
-def test_solve_triangular_grad(lower, unit_diag, trans):
-    A_val = np.random.normal(size=(5, 5)).astype(floatX)
-    b_val = np.random.normal(size=(5, 5)).astype(floatX)
-
-    # utt.verify_grad uses small perturbations to the input matrix to calculate the finite difference gradient. When
-    # a non-triangular matrix is passed to scipy.linalg.solve_triangular, no error is raise, but the result will be
-    # wrong, resulting in wrong gradients. As a result, it is necessary to add a mapping from the space of all matrices
-    # to the space of triangular matrices, and test the gradient of that entire graph.
-    def A_func_pt(x):
-        x = x @ x.conj().T
-        x_tri = pt.linalg.cholesky(x, lower=lower).astype(floatX)
-
-        if unit_diag:
-            n = A_val.shape[0]
-            x_tri = x_tri[np.diag_indices(n)].set(1.0)
-
-        return transpose_func(x_tri.astype(floatX), trans)
-
-    solve_op = partial(
-        pt.linalg.solve_triangular, lower=lower, trans=trans, unit_diagonal=unit_diag
-    )
-
-    utt.verify_grad(
-        lambda A, b: solve_op(A_func_pt(A), b),
-        [A_val.copy(), b_val.copy()],
-        mode="NUMBA",
-    )
-
-
-@pytest.mark.parametrize("overwrite_b", [True, False], ids=["inplace", "not_inplace"])
-def test_solve_triangular_overwrite_b_correct(overwrite_b):
-    # Regression test for issue #1233
-
-    rng = np.random.default_rng(utt.fetch_seed())
-    a_test_py = np.asfortranarray(rng.normal(size=(3, 3)))
-    a_test_py = np.tril(a_test_py)
-    b_test_py = np.asfortranarray(rng.normal(size=(3, 2)))
-
-    # .T.copy().T creates an f-contiguous copy of an f-contiguous array (otherwise the copy is c-contiguous)
-    a_test_nb = a_test_py.copy(order="F")
-    b_test_nb = b_test_py.copy(order="F")
-
-    op = SolveTriangular(
-        unit_diagonal=False,
-        lower=False,
-        check_finite=True,
-        b_ndim=2,
-        overwrite_b=overwrite_b,
-    )
-
-    a_pt = pt.matrix("a", shape=(3, 3))
-    b_pt = pt.matrix("b", shape=(3, 2))
-    out = op(a_pt, b_pt)
-
-    py_fn = pytensor.function([a_pt, b_pt], out, accept_inplace=True)
-    numba_fn = pytensor.function([a_pt, b_pt], out, accept_inplace=True, mode="NUMBA")
-
-    x_py = py_fn(a_test_py, b_test_py)
-    x_nb = numba_fn(a_test_nb, b_test_nb)
-
-    np.testing.assert_allclose(
-        py_fn(a_test_py, b_test_py), numba_fn(a_test_nb, b_test_nb)
-    )
-    np.testing.assert_allclose(b_test_py, b_test_nb)
-
-    if overwrite_b:
-        np.testing.assert_allclose(b_test_py, x_py)
-        np.testing.assert_allclose(b_test_nb, x_nb)
-
-
-@pytest.mark.parametrize("value", [np.nan, np.inf])
-@pytest.mark.filterwarnings(
-    'ignore:Cannot cache compiled function "numba_funcified_fgraph"'
-)
-def test_solve_triangular_raises_on_nan_inf(value):
-    A = pt.matrix("A")
-    b = pt.matrix("b")
-
-    X = pt.linalg.solve_triangular(A, b, check_finite=True)
-    f = pytensor.function([A, b], X, mode="NUMBA")
-    A_val = np.random.normal(size=(5, 5)).astype(floatX)
-    A_sym = A_val @ A_val.conj().T
-
-    A_tri = np.linalg.cholesky(A_sym).astype(floatX)
-    b = np.full((5, 1), value).astype(floatX)
-
-    with pytest.raises(
-        np.linalg.LinAlgError,
-        match=re.escape("Non-numeric values"),
-    ):
-        f(A_tri, b)
-
-
-@pytest.mark.parametrize("lower", [True, False], ids=["lower=True", "lower=False"])
-@pytest.mark.parametrize("trans", [True, False], ids=["trans=True", "trans=False"])
-def test_numba_Cholesky(lower, trans):
-    cov = pt.matrix("cov")
-
-    if trans:
-        cov_ = cov.T
-    else:
-        cov_ = cov
-    chol = pt.linalg.cholesky(cov_, lower=lower)
-
-    x = np.array([0.1, 0.2, 0.3]).astype(floatX)
-    val = np.eye(3).astype(floatX) + x[None, :] * x[:, None]
-
-    compare_numba_and_py([cov], [chol], [val])
-
-
-def test_numba_Cholesky_raises_on_nan_input():
-    test_value = rng.random(size=(3, 3)).astype(floatX)
-    test_value[0, 0] = np.nan
-
-    x = pt.tensor(dtype=floatX, shape=(3, 3))
-    x = x.T.dot(x)
-    g = pt.linalg.cholesky(x)
-    f = pytensor.function([x], g, mode="NUMBA")
-
-    with pytest.raises(np.linalg.LinAlgError, match=r"Non-numeric values"):
-        f(test_value)
-
-
-@pytest.mark.parametrize("on_error", ["nan", "raise"])
-def test_numba_Cholesky_raise_on(on_error):
-    test_value = rng.random(size=(3, 3)).astype(floatX)
-
-    x = pt.tensor(dtype=floatX, shape=(3, 3))
-    g = pt.linalg.cholesky(x, on_error=on_error)
-    f = pytensor.function([x], g, mode="NUMBA")
-
-    if on_error == "raise":
-        with pytest.raises(
-            np.linalg.LinAlgError, match=r"Input to cholesky is not positive definite"
-        ):
-            f(test_value)
-    else:
-        assert np.all(np.isnan(f(test_value)))
-
-
-@pytest.mark.parametrize("lower", [True, False], ids=["lower=True", "lower=False"])
-def test_numba_Cholesky_grad(lower):
-    rng = np.random.default_rng(utt.fetch_seed())
-    L = rng.normal(size=(5, 5)).astype(floatX)
-    X = L @ L.T
-
-    chol_op = partial(pt.linalg.cholesky, lower=lower)
-    utt.verify_grad(chol_op, [X], mode="NUMBA")
-
-
-def test_block_diag():
-    A = pt.matrix("A")
-    B = pt.matrix("B")
-    C = pt.matrix("C")
-    D = pt.matrix("D")
-    X = pt.linalg.block_diag(A, B, C, D)
-
-    A_val = np.random.normal(size=(5, 5)).astype(floatX)
-    B_val = np.random.normal(size=(3, 3)).astype(floatX)
-    C_val = np.random.normal(size=(2, 2)).astype(floatX)
-    D_val = np.random.normal(size=(4, 4)).astype(floatX)
-    compare_numba_and_py([A, B, C, D], [X], [A_val, B_val, C_val, D_val])
 
 
 def test_lamch():
@@ -328,171 +82,396 @@ def test_xgecon(ord_numba, ord_scipy):
     np.testing.assert_allclose(rcond, rcond2)
 
 
-@pytest.mark.parametrize("overwrite_a", [True, False])
-def test_getrf(overwrite_a):
-    from scipy.linalg import lu_factor
-
-    from pytensor.link.numba.dispatch.slinalg import _getrf
-
-    # TODO: Refactor this test to use compare_numba_and_py after we implement lu_factor in pytensor
-
-    @numba.njit()
-    def getrf(x, overwrite_a):
-        return _getrf(x, overwrite_a=overwrite_a)
-
-    x = np.random.normal(size=(5, 5)).astype(floatX)
-    x = np.asfortranarray(
-        x
-    )  # x needs to be fortran-contiguous going into getrf for the overwrite option to work
-
-    lu, ipiv = lu_factor(x, overwrite_a=False)
-    LU, IPIV, info = getrf(x, overwrite_a=overwrite_a)
-
-    assert info == 0
-    assert_allclose(LU, lu)
-
-    if overwrite_a:
-        assert_allclose(x, LU)
-
-    # TODO: It seems IPIV is 1-indexed in FORTRAN, so we need to subtract 1. I can't find evidence that scipy is doing
-    #  this, though.
-    assert_allclose(IPIV - 1, ipiv)
-
-
-@pytest.mark.parametrize("trans", [0, 1])
-@pytest.mark.parametrize("overwrite_a", [True, False])
-@pytest.mark.parametrize("overwrite_b", [True, False])
-@pytest.mark.parametrize("b_shape", [(5,), (5, 3)], ids=["b_1d", "b_2d"])
-def test_getrs(trans, overwrite_a, overwrite_b, b_shape):
-    from scipy.linalg import lu_factor
-    from scipy.linalg import lu_solve as sp_lu_solve
-
-    from pytensor.link.numba.dispatch.slinalg import _getrf, _getrs
-
-    # TODO: Refactor this test to use compare_numba_and_py after we implement lu_solve in pytensor
-
-    @numba.njit()
-    def lu_solve(a, b, trans, overwrite_a, overwrite_b):
-        lu, ipiv, info = _getrf(a, overwrite_a=overwrite_a)
-        x, info = _getrs(lu, b, ipiv, trans=trans, overwrite_b=overwrite_b)
-        return x, lu, info
-
-    a = np.random.normal(size=(5, 5)).astype(floatX)
-    b = np.random.normal(size=b_shape).astype(floatX)
-
-    # inputs need to be fortran-contiguous going into getrf and getrs for the overwrite option to work
-    a = np.asfortranarray(a)
-    b = np.asfortranarray(b)
-
-    lu_and_piv = lu_factor(a, overwrite_a=False)
-    x_sp = sp_lu_solve(lu_and_piv, b, trans, overwrite_b=False)
-
-    x, lu, info = lu_solve(
-        a, b, trans, overwrite_a=overwrite_a, overwrite_b=overwrite_b
+class TestSolves:
+    @pytest.mark.parametrize("lower", [True, False], ids=lambda x: f"lower={x}")
+    @pytest.mark.parametrize(
+        "overwrite_a, overwrite_b",
+        [(False, False), (True, False), (False, True)],
+        ids=["no_overwrite", "overwrite_a", "overwrite_b"],
     )
-    assert info == 0
-    if overwrite_a:
-        assert_allclose(a, lu)
-    if overwrite_b:
-        assert_allclose(b, x)
+    @pytest.mark.parametrize(
+        "b_shape",
+        [(5, 1), (5, 5), (5,)],
+        ids=["b_col_vec", "b_matrix", "b_vec"],
+    )
+    @pytest.mark.parametrize("assume_a", ["gen", "sym", "pos"], ids=str)
+    def test_solve(
+        self,
+        b_shape: tuple[int],
+        assume_a: Literal["gen", "sym", "pos"],
+        lower: bool,
+        overwrite_a: bool,
+        overwrite_b: bool,
+    ):
+        if assume_a not in ("sym", "her", "pos") and not lower:
+            # Avoid redundant tests with lower=True and lower=False for non symmetric matrices
+            pytest.skip("Skipping redundant test already covered by lower=True")
 
-    assert_allclose(x, x_sp)
+        def A_func(x):
+            if assume_a == "pos":
+                x = x @ x.T
+                x = np.tril(x) if lower else np.triu(x)
+            elif assume_a == "sym":
+                x = (x + x.T) / 2
+                n = x.shape[0]
+                # We have to set the unused triangle to something other than zero
+                # to see lapack destroying it.
+                x[np.triu_indices(n, 1) if lower else np.tril_indices(n, 1)] = np.pi
+            return x
+
+        A = pt.matrix("A", dtype=floatX)
+        b = pt.tensor("b", shape=b_shape, dtype=floatX)
+
+        rng = np.random.default_rng(418)
+        A_val = A_func(rng.normal(size=(5, 5))).astype(floatX)
+        b_val = rng.normal(size=b_shape).astype(floatX)
+
+        X = pt.linalg.solve(
+            A,
+            b,
+            assume_a=assume_a,
+            b_ndim=len(b_shape),
+        )
+
+        f, res = compare_numba_and_py(
+            [In(A, mutable=overwrite_a), In(b, mutable=overwrite_b)],
+            X,
+            test_inputs=[A_val, b_val],
+            inplace=True,
+            numba_mode=numba_inplace_mode,
+        )
+
+        op = f.maker.fgraph.outputs[0].owner.op
+        assert isinstance(op, Solve)
+        destroy_map = op.destroy_map
+        if overwrite_a and overwrite_b:
+            raise NotImplementedError(
+                "Test not implemented for simultaneous overwrite_a and overwrite_b, as that's not currently supported by PyTensor"
+            )
+        elif overwrite_a:
+            assert destroy_map == {0: [0]}
+        elif overwrite_b:
+            assert destroy_map == {0: [1]}
+        else:
+            assert destroy_map == {}
+
+        # Test with F_contiguous inputs
+        A_val_f_contig = np.copy(A_val, order="F")
+        b_val_f_contig = np.copy(b_val, order="F")
+        res_f_contig = f(A_val_f_contig, b_val_f_contig)
+        np.testing.assert_allclose(res_f_contig, res)
+        # Should always be destroyable
+        assert (A_val == A_val_f_contig).all() == (not overwrite_a)
+        assert (b_val == b_val_f_contig).all() == (not overwrite_b)
+
+        # Test with C_contiguous inputs
+        A_val_c_contig = np.copy(A_val, order="C")
+        b_val_c_contig = np.copy(b_val, order="C")
+        res_c_contig = f(A_val_c_contig, b_val_c_contig)
+        np.testing.assert_allclose(res_c_contig, res)
+        np.testing.assert_allclose(A_val_c_contig, A_val)
+        # b vectors are always f_contiguous if also c_contiguous
+        assert np.allclose(b_val_c_contig, b_val) == (
+            not (overwrite_b and b_val_c_contig.flags.f_contiguous)
+        )
+
+        # Test right results if inputs are not contiguous in either format
+        A_val_not_contig = np.repeat(A_val, 2, axis=0)[::2]
+        b_val_not_contig = np.repeat(b_val, 2, axis=0)[::2]
+        res_not_contig = f(A_val_not_contig, b_val_not_contig)
+        np.testing.assert_allclose(res_not_contig, res)
+        # Can never destroy non-contiguous inputs
+        np.testing.assert_allclose(A_val_not_contig, A_val)
+        np.testing.assert_allclose(b_val_not_contig, b_val)
+
+    @pytest.mark.parametrize("lower", [True, False], ids=lambda x: f"lower={x}")
+    @pytest.mark.parametrize(
+        "transposed", [False, True], ids=lambda x: f"transposed={x}"
+    )
+    @pytest.mark.parametrize(
+        "overwrite_b", [False, True], ids=["no_overwrite", "overwrite_b"]
+    )
+    @pytest.mark.parametrize(
+        "unit_diagonal", [True, False], ids=lambda x: f"unit_diagonal={x}"
+    )
+    @pytest.mark.parametrize(
+        "b_shape",
+        [(5, 1), (5, 5), (5,)],
+        ids=["b_col_vec", "b_matrix", "b_vec"],
+    )
+    @pytest.mark.parametrize("is_complex", [True, False], ids=["complex", "real"])
+    def test_solve_triangular(
+        self,
+        b_shape: tuple[int],
+        lower: bool,
+        transposed: bool,
+        unit_diagonal: bool,
+        is_complex: bool,
+        overwrite_b: bool,
+    ):
+        if is_complex:
+            # TODO: Complex raises ValueError: To change to a dtype of a different size, the last axis must be contiguous,
+            #  why?
+            pytest.skip("Complex inputs currently not supported to solve_triangular")
+
+        def A_func(x):
+            complex_dtype = "complex64" if floatX.endswith("32") else "complex128"
+            dtype = complex_dtype if is_complex else floatX
+
+            x = x @ x.conj().T
+            x_tri = scipy.linalg.cholesky(x, lower=lower).astype(dtype)
+
+            if unit_diagonal:
+                x_tri[np.diag_indices(x_tri.shape[0])] = 1.0
+
+            return x_tri
+
+        A = pt.matrix("A", dtype=floatX)
+        b = pt.tensor("b", shape=b_shape, dtype=floatX)
+
+        rng = np.random.default_rng(418)
+        A_val = A_func(rng.normal(size=(5, 5))).astype(floatX)
+        b_val = rng.normal(size=b_shape).astype(floatX)
+
+        X = pt.linalg.solve_triangular(
+            A,
+            b,
+            lower=lower,
+            trans="N" if (not transposed) else ("C" if is_complex else "T"),
+            unit_diagonal=unit_diagonal,
+            b_ndim=len(b_shape),
+        )
+
+        f, res = compare_numba_and_py(
+            [A, In(b, mutable=overwrite_b)],
+            X,
+            test_inputs=[A_val, b_val],
+            inplace=True,
+            numba_mode=numba_inplace_mode,
+        )
+
+        op = f.maker.fgraph.outputs[0].owner.op
+        assert isinstance(op, SolveTriangular)
+        destroy_map = op.destroy_map
+        if overwrite_b:
+            assert destroy_map == {0: [1]}
+        else:
+            assert destroy_map == {}
+
+        # Test with F_contiguous inputs
+        A_val_f_contig = np.copy(A_val, order="F")
+        b_val_f_contig = np.copy(b_val, order="F")
+        res_f_contig = f(A_val_f_contig, b_val_f_contig)
+        np.testing.assert_allclose(res_f_contig, res)
+        # solve_triangular never destroys A
+        np.testing.assert_allclose(A_val, A_val_f_contig)
+        # b Should always be destroyable
+        assert (b_val == b_val_f_contig).all() == (not overwrite_b)
+
+        # Test with C_contiguous inputs
+        A_val_c_contig = np.copy(A_val, order="C")
+        b_val_c_contig = np.copy(b_val, order="C")
+        res_c_contig = f(A_val_c_contig, b_val_c_contig)
+        np.testing.assert_allclose(res_c_contig, res)
+        np.testing.assert_allclose(A_val_c_contig, A_val)
+        # b c_contiguous vectors are also f_contiguous and destroyable
+        assert np.allclose(b_val_c_contig, b_val) == (
+            not (overwrite_b and b_val_c_contig.flags.f_contiguous)
+        )
+
+        # Test with non-contiguous inputs
+        A_val_not_contig = np.repeat(A_val, 2, axis=0)[::2]
+        b_val_not_contig = np.repeat(b_val, 2, axis=0)[::2]
+        res_not_contig = f(A_val_not_contig, b_val_not_contig)
+        np.testing.assert_allclose(res_not_contig, res)
+        np.testing.assert_allclose(A_val_not_contig, A_val)
+        # Can never destroy non-contiguous inputs
+        np.testing.assert_allclose(b_val_not_contig, b_val)
+
+    @pytest.mark.parametrize("value", [np.nan, np.inf])
+    def test_solve_triangular_raises_on_nan_inf(self, value):
+        A = pt.matrix("A")
+        b = pt.matrix("b")
+
+        X = pt.linalg.solve_triangular(A, b, check_finite=True)
+        f = pytensor.function([A, b], X, mode="NUMBA")
+        A_val = np.random.normal(size=(5, 5)).astype(floatX)
+        A_sym = A_val @ A_val.conj().T
+
+        A_tri = np.linalg.cholesky(A_sym).astype(floatX)
+        b = np.full((5, 1), value).astype(floatX)
+
+        with pytest.raises(
+            np.linalg.LinAlgError,
+            match=re.escape("Non-numeric values"),
+        ):
+            f(A_tri, b)
+
+    @pytest.mark.parametrize("lower", [True, False], ids=lambda x: f"lower = {x}")
+    @pytest.mark.parametrize(
+        "overwrite_b", [False, True], ids=["no_overwrite", "overwrite_b"]
+    )
+    @pytest.mark.parametrize(
+        "b_func, b_shape",
+        [(pt.matrix, (5, 1)), (pt.matrix, (5, 5)), (pt.vector, (5,))],
+        ids=["b_col_vec", "b_matrix", "b_vec"],
+    )
+    def test_cho_solve(
+        self, b_func, b_shape: tuple[int, ...], lower: bool, overwrite_b: bool
+    ):
+        def A_func(x):
+            x = x @ x.conj().T
+            x = scipy.linalg.cholesky(x, lower=lower)
+            return x
+
+        A = pt.matrix("A", dtype=floatX)
+        b = pt.tensor("b", shape=b_shape, dtype=floatX)
+
+        rng = np.random.default_rng(418)
+        A_val = A_func(rng.normal(size=(5, 5))).astype(floatX)
+        b_val = rng.normal(size=b_shape).astype(floatX)
+
+        X = pt.linalg.cho_solve(
+            (A, lower),
+            b,
+            b_ndim=len(b_shape),
+        )
+
+        f, res = compare_numba_and_py(
+            [A, In(b, mutable=overwrite_b)],
+            X,
+            test_inputs=[A_val, b_val],
+            inplace=True,
+            numba_mode=numba_inplace_mode,
+        )
+
+        op = f.maker.fgraph.outputs[0].owner.op
+        assert isinstance(op, CholeskySolve)
+        destroy_map = op.destroy_map
+        if overwrite_b:
+            assert destroy_map == {0: [1]}
+        else:
+            assert destroy_map == {}
+
+        # Test with F_contiguous inputs
+        A_val_f_contig = np.copy(A_val, order="F")
+        b_val_f_contig = np.copy(b_val, order="F")
+        res_f_contig = f(A_val_f_contig, b_val_f_contig)
+        np.testing.assert_allclose(res_f_contig, res)
+        # cho_solve never destroys A
+        np.testing.assert_allclose(A_val, A_val_f_contig)
+        # b Should always be destroyable
+        assert (b_val == b_val_f_contig).all() == (not overwrite_b)
+
+        # Test with C_contiguous inputs
+        A_val_c_contig = np.copy(A_val, order="C")
+        b_val_c_contig = np.copy(b_val, order="C")
+        res_c_contig = f(A_val_c_contig, b_val_c_contig)
+        np.testing.assert_allclose(res_c_contig, res)
+        np.testing.assert_allclose(A_val_c_contig, A_val)
+        # b c_contiguous vectors are also f_contiguous and destroyable
+        assert np.allclose(b_val_c_contig, b_val) == (
+            not (overwrite_b and b_val_c_contig.flags.f_contiguous)
+        )
+
+        # Test with non-contiguous inputs
+        A_val_not_contig = np.repeat(A_val, 2, axis=0)[::2]
+        b_val_not_contig = np.repeat(b_val, 2, axis=0)[::2]
+        res_not_contig = f(A_val_not_contig, b_val_not_contig)
+        np.testing.assert_allclose(res_not_contig, res)
+        np.testing.assert_allclose(A_val_not_contig, A_val)
+        # Can never destroy non-contiguous inputs
+        np.testing.assert_allclose(b_val_not_contig, b_val)
 
 
+@pytest.mark.parametrize("lower", [True, False], ids=lambda x: f"lower={x}")
 @pytest.mark.parametrize(
-    "b_shape",
-    [(5, 1), (5, 5), (5,)],
-    ids=["b_col_vec", "b_matrix", "b_vec"],
+    "overwrite_a", [False, True], ids=["no_overwrite", "overwrite_a"]
 )
-@pytest.mark.parametrize("assume_a", ["gen", "sym", "pos"], ids=str)
-@pytest.mark.filterwarnings(
-    'ignore:Cannot cache compiled function "numba_funcified_fgraph"'
-)
-def test_solve(b_shape: tuple[int], assume_a: Literal["gen", "sym", "pos"]):
-    A = pt.matrix("A", dtype=floatX)
-    b = pt.tensor("b", shape=b_shape, dtype=floatX)
+def test_cholesky(lower: bool, overwrite_a: bool):
+    cov = pt.matrix("cov")
+    chol = pt.linalg.cholesky(cov, lower=lower)
 
-    A_val = np.asfortranarray(np.random.normal(size=(5, 5)).astype(floatX))
-    b_val = np.asfortranarray(np.random.normal(size=b_shape).astype(floatX))
+    x = np.array([0.1, 0.2, 0.3]).astype(floatX)
+    val = np.eye(3).astype(floatX) + x[None, :] * x[:, None]
 
-    def A_func(x):
-        if assume_a == "pos":
-            x = x @ x.T
-        elif assume_a == "sym":
-            x = (x + x.T) / 2
-        return x
-
-    X = pt.linalg.solve(
-        A_func(A),
-        b,
-        assume_a=assume_a,
-        b_ndim=len(b_shape),
-    )
-    f = pytensor.function(
-        [pytensor.In(A, mutable=True), pytensor.In(b, mutable=True)], X, mode="NUMBA"
-    )
-    op = f.maker.fgraph.outputs[0].owner.op
-
-    compare_numba_and_py([A, b], [X], test_inputs=[A_val, b_val], inplace=True)
-
-    # Calling this is destructive and will rewrite b_val to be the answer. Store copies of the inputs first.
-    A_val_copy = A_val.copy()
-    b_val_copy = b_val.copy()
-
-    X_np = f(A_val, b_val)
-
-    # overwrite_b is preferred when both inputs can be destroyed
-    assert op.destroy_map == {0: [1]}
-
-    # Confirm inputs were destroyed by checking against the copies
-    assert (A_val == A_val_copy).all() == (op.destroy_map.get(0, None) != [0])
-    assert (b_val == b_val_copy).all() == (op.destroy_map.get(0, None) != [1])
-
-    ATOL = 1e-8 if floatX.endswith("64") else 1e-4
-    RTOL = 1e-8 if floatX.endswith("64") else 1e-4
-
-    # Confirm b_val is used to store to solution
-    np.testing.assert_allclose(X_np, b_val, atol=ATOL, rtol=RTOL)
-    assert not np.allclose(b_val, b_val_copy)
-
-    # Test that the result is numerically correct. Need to use the unmodified copy
-    np.testing.assert_allclose(
-        A_func(A_val_copy) @ X_np, b_val_copy, atol=ATOL, rtol=RTOL
+    fn, res = compare_numba_and_py(
+        [In(cov, mutable=overwrite_a)],
+        [chol],
+        [val],
+        numba_mode=numba_inplace_mode,
+        inplace=True,
     )
 
-    # See the note in tensor/test_slinalg.py::test_solve_correctness for details about the setup here
-    utt.verify_grad(
-        lambda A, b: pt.linalg.solve(
-            A_func(A), b, lower=False, assume_a=assume_a, b_ndim=len(b_shape)
-        ),
-        [A_val_copy, b_val_copy],
-        mode="NUMBA",
-    )
+    op = fn.maker.fgraph.outputs[0].owner.op
+    assert isinstance(op, Cholesky)
+    destroy_map = op.destroy_map
+    if overwrite_a:
+        assert destroy_map == {0: [0]}
+    else:
+        assert destroy_map == {}
+
+    # Test F-contiguous input
+    val_f_contig = np.copy(val, order="F")
+    res_f_contig = fn(val_f_contig)
+    np.testing.assert_allclose(res_f_contig, res)
+    # Should always be destroyable
+    assert (val == val_f_contig).all() == (not overwrite_a)
+
+    # Test C-contiguous input
+    val_c_contig = np.copy(val, order="C")
+    res_c_contig = fn(val_c_contig)
+    np.testing.assert_allclose(res_c_contig, res)
+    # Cannot destroy C-contiguous input
+    np.testing.assert_allclose(val_c_contig, val)
+
+    # Test non-contiguous input
+    val_not_contig = np.repeat(val, 2, axis=0)[::2]
+    res_not_contig = fn(val_not_contig)
+    np.testing.assert_allclose(res_not_contig, res)
+    # Cannot destroy non-contiguous input
+    np.testing.assert_allclose(val_not_contig, val)
 
 
-@pytest.mark.parametrize(
-    "b_func, b_size",
-    [(pt.matrix, (5, 1)), (pt.matrix, (5, 5)), (pt.vector, (5,))],
-    ids=["b_col_vec", "b_matrix", "b_vec"],
-)
-@pytest.mark.parametrize("lower", [True, False], ids=lambda x: f"lower = {x}")
-def test_cho_solve(b_func, b_size, lower):
-    A = pt.matrix("A", dtype=floatX)
-    b = b_func("b", dtype=floatX)
+def test_cholesky_raises_on_nan_input():
+    test_value = rng.random(size=(3, 3)).astype(floatX)
+    test_value[0, 0] = np.nan
 
-    C = pt.linalg.cholesky(A, lower=lower)
-    X = pt.linalg.cho_solve((C, lower), b)
-    f = pytensor.function([A, b], X, mode="NUMBA")
+    x = pt.tensor(dtype=floatX, shape=(3, 3))
+    x = x.T.dot(x)
+    g = pt.linalg.cholesky(x)
+    f = pytensor.function([x], g, mode="NUMBA")
 
-    A = np.random.normal(size=(5, 5)).astype(floatX)
-    A = A @ A.conj().T
+    with pytest.raises(np.linalg.LinAlgError, match=r"Non-numeric values"):
+        f(test_value)
 
-    b = np.random.normal(size=b_size)
-    b = b.astype(floatX)
 
-    X_np = f(A, b)
+@pytest.mark.parametrize("on_error", ["nan", "raise"])
+def test_cholesky_raise_on(on_error):
+    test_value = rng.random(size=(3, 3)).astype(floatX)
 
-    ATOL = 1e-8 if floatX.endswith("64") else 1e-4
-    RTOL = 1e-8 if floatX.endswith("64") else 1e-4
+    x = pt.tensor(dtype=floatX, shape=(3, 3))
+    g = pt.linalg.cholesky(x, on_error=on_error)
+    f = pytensor.function([x], g, mode="NUMBA")
 
-    np.testing.assert_allclose(A @ X_np, b, atol=ATOL, rtol=RTOL)
+    if on_error == "raise":
+        with pytest.raises(
+            np.linalg.LinAlgError, match=r"Input to cholesky is not positive definite"
+        ):
+            f(test_value)
+    else:
+        assert np.all(np.isnan(f(test_value)))
+
+
+def test_block_diag():
+    A = pt.matrix("A")
+    B = pt.matrix("B")
+    C = pt.matrix("C")
+    D = pt.matrix("D")
+    X = pt.linalg.block_diag(A, B, C, D)
+
+    A_val = np.random.normal(size=(5, 5)).astype(floatX)
+    B_val = np.random.normal(size=(3, 3)).astype(floatX)
+    C_val = np.random.normal(size=(2, 2)).astype(floatX)
+    D_val = np.random.normal(size=(4, 4)).astype(floatX)
+    compare_numba_and_py([A, B, C, D], [X], [A_val, B_val, C_val, D_val])


### PR DESCRIPTION
1. Numba's `_copy_to_fortran_order` does not seem to do the right thing with vectors and doesn't always copy them. 
2. Most methods were forgetting inputs still need to be F-contiguous even if they don't need to be copied.

PR did some tricks to avoid copying C-contiguous arrays when not needed. 

Proof of the `_copy_to_fortran_order` thing:
```python
import numpy as np
import numba
from numba.np.linalg import _copy_to_fortran_order

@numba.njit
def foo(x):
    out = _copy_to_fortran_order(x)
    return out
    
# Actually copies if x is a matrix
x = np.zeros((10, 1))
y = foo(x)
y[0] = np.pi
assert (x == 0).all()

# Doesn't copy if it's a vector
x = np.zeros((10))
y = foo(x)
y[0] = np.pi
assert (x == 0).all()  # AssertionError
```