### PR TITLE
Inplace Composite and ScalarLoop Ops with multiple outputs

### DIFF
--- a/pytensor/link/numba/dispatch/vectorize_codegen.py
+++ b/pytensor/link/numba/dispatch/vectorize_codegen.py
@@ -265,7 +265,7 @@ def _vectorized(
             ctx.nrt.incref(
                 builder,
                 sig.return_type.types[inplace_idx],
-                outputs[inplace_idx]._get_value(),
+                outputs[inplace_idx]._getvalue(),
             )
         return ctx.make_tuple(
             builder, sig.return_type, [out._getvalue() for out in outputs]

--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -1302,19 +1302,7 @@ class ScalarOp(COp):
     def __str__(self):
         if hasattr(self, "name") and self.name:
             return self.name
-        else:
-            param = [
-                (k, v)
-                for k, v in self.__dict__.items()
-                if k
-                not in ("name", "_op_use_c_code", "bool", "output_types_preference")
-            ]
-            if param:
-                classname = self.__class__.__name__
-                args = ", ".join(f"{k}={v}" for k, v in param)
-                return f"{classname}{{{args}}}"
-            else:
-                return self.__class__.__name__
+        return self.__class__.__name__
 
     def c_code_cache_version(self):
         return (4,)
@@ -4102,6 +4090,7 @@ class ScalarInnerGraphOp(ScalarOp, HasInnerGraph):
 
     def __init__(self, *args, **kwargs):
         self.prepare_node_called = set()
+        super().__init__(*args, **kwargs)
 
     def _cleanup_graph(self, inputs, outputs):
         # TODO: We could convert to TensorVariable, optimize graph,

--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -4333,9 +4333,9 @@ class Composite(ScalarInnerGraphOp):
 
         # Rename internal variables
         for i, r in enumerate(self.fgraph.inputs):
-            r.name = f"i{int(i)}"
+            r.name = f"i{i}"
         for i, r in enumerate(self.fgraph.outputs):
-            r.name = f"o{int(i)}"
+            r.name = f"o{i}"
         io = set(self.fgraph.inputs + self.fgraph.outputs)
         for i, r in enumerate(self.fgraph.variables):
             if (
@@ -4343,7 +4343,7 @@ class Composite(ScalarInnerGraphOp):
                 and r not in io
                 and len(self.fgraph.clients[r]) > 1
             ):
-                r.name = f"t{int(i)}"
+                r.name = f"t{i}"
 
         if len(self.fgraph.outputs) > 1 or len(self.fgraph.apply_nodes) > 10:
             self._name = "Composite{...}"
@@ -4431,7 +4431,7 @@ class Composite(ScalarInnerGraphOp):
             return self._c_code
 
         fg = self.fgraph
-        subd = {e: f"%(i{int(i)})s" for i, e in enumerate(fg.inputs)}
+        subd = {e: f"%(i{i})s" for i, e in enumerate(fg.inputs)}
 
         for var in fg.variables:
             if var.owner is None:
@@ -4458,11 +4458,11 @@ class Composite(ScalarInnerGraphOp):
             for output in node.outputs:
                 if output not in subd:
                     i += 1
-                    name = f"V%(id)s_tmp{int(i)}"
+                    name = f"V%(id)s_tmp{i}"
                     subd[output] = name
                     _c_code += f"{output.type.dtype_specs()[1]} {name};\n"
 
-            nodename = f"%(nodename)s_subnode{int(j)}"
+            nodename = f"%(nodename)s_subnode{j}"
             nodenames.append(nodename)
 
             s = node.op.c_code(
@@ -4470,14 +4470,14 @@ class Composite(ScalarInnerGraphOp):
                 nodename,
                 [subd[input] for input in node.inputs],
                 [subd[output] for output in node.outputs],
-                dict(fail="%(fail)s", id=f"%(id)s_{int(j)}"),
+                dict(fail="%(fail)s", id=f"%(id)s_{j}"),
             )
             _c_code += s
             _c_code += "\n"
 
         # Copy the temporary outputs to the real outputs
         for i, output in enumerate(fg.outputs):
-            _c_code += f"%(o{int(i)})s = {subd[output]};\n"
+            _c_code += f"%(o{i})s = {subd[output]};\n"
 
         _c_code += "}\n"
 
@@ -4488,8 +4488,8 @@ class Composite(ScalarInnerGraphOp):
     def c_code(self, node, nodename, inames, onames, sub):
         d = dict(
             chain(
-                zip((f"i{int(i)}" for i in range(len(inames))), inames, strict=True),
-                zip((f"o{int(i)}" for i in range(len(onames))), onames, strict=True),
+                zip((f"i{i}" for i in range(len(inames))), inames, strict=True),
+                zip((f"o{i}" for i in range(len(onames))), onames, strict=True),
             ),
             **sub,
         )

--- a/pytensor/scalar/loop.py
+++ b/pytensor/scalar/loop.py
@@ -212,15 +212,13 @@ class ScalarLoop(ScalarInnerGraphOp):
         # The first input is `n_steps` so we skip it in the mapping dictionary
         n_update = len(self.outputs) - (1 if self.is_while else 0)
         carry_subd = {
-            c: f"%(i{int(i)})s" for i, c in enumerate(fgraph.inputs[:n_update], start=1)
+            c: f"%(i{i})s" for i, c in enumerate(fgraph.inputs[:n_update], start=1)
         }
         constant_subd = {
-            c: f"%(i{int(i)})s"
+            c: f"%(i{i})s"
             for i, c in enumerate(fgraph.inputs[n_update:], start=n_update + 1)
         }
-        out_subd = {
-            u: f"%(o{int(i)})s" for i, u in enumerate(fgraph.outputs[:n_update])
-        }
+        out_subd = {u: f"%(o{i})s" for i, u in enumerate(fgraph.outputs[:n_update])}
         until_subd = {u: "until" for u in fgraph.outputs[n_update:]}
         subd = {**carry_subd, **constant_subd, **until_subd}
 
@@ -267,11 +265,11 @@ class ScalarLoop(ScalarInnerGraphOp):
             for output in node.outputs:
                 if output not in subd:
                     i += 1
-                    name = f"V%(id)s_tmp{int(i)}"
+                    name = f"V%(id)s_tmp{i}"
                     subd[output] = name
                     _c_code += f"{output.type.dtype_specs()[1]} {name};\n"
 
-            nodename = f"%(nodename)s_subnode{int(j)}"
+            nodename = f"%(nodename)s_subnode{j}"
             nodenames.append(nodename)
 
             s = node.op.c_code(
@@ -281,7 +279,7 @@ class ScalarLoop(ScalarInnerGraphOp):
                 # The initial value of `update` was set to `init` before the loop
                 [subd[input] for input in node.inputs],
                 [subd[output] for output in node.outputs],
-                dict(fail="%(fail)s", id=f"%(id)s_{int(j)}"),
+                dict(fail="%(fail)s", id=f"%(id)s_{j}"),
             )
             _c_code += s
             _c_code += "\n"
@@ -320,8 +318,8 @@ class ScalarLoop(ScalarInnerGraphOp):
     def c_code(self, node, nodename, inames, onames, sub):
         d = dict(
             chain(
-                zip((f"i{int(i)}" for i in range(len(inames))), inames, strict=True),
-                zip((f"o{int(i)}" for i in range(len(onames))), onames, strict=True),
+                zip((f"i{i}" for i in range(len(inames))), inames, strict=True),
+                zip((f"o{i}" for i in range(len(onames))), onames, strict=True),
             ),
             **sub,
         )

--- a/pytensor/tensor/rewriting/elemwise.py
+++ b/pytensor/tensor/rewriting/elemwise.py
@@ -80,8 +80,6 @@ class InplaceElemwiseOptimizer(GraphRewriter):
         #  and ScalarLoops
         if isinstance(node.op.scalar_op, ScalarLoop):
             return []
-        if isinstance(node.op.scalar_op, ps.Composite) and (len(node.outputs) > 1):
-            return []
         else:
             return range(len(node.outputs))
 

--- a/pytensor/tensor/rewriting/elemwise.py
+++ b/pytensor/tensor/rewriting/elemwise.py
@@ -24,7 +24,6 @@ from pytensor.graph.rewriting.basic import (
 )
 from pytensor.graph.rewriting.db import SequenceDB
 from pytensor.graph.utils import InconsistencyError, MethodNotDefined
-from pytensor.scalar.loop import ScalarLoop
 from pytensor.scalar.math import Grad2F1Loop, _grad_2f1_loop
 from pytensor.tensor.basic import (
     MakeVector,
@@ -73,15 +72,6 @@ class InplaceElemwiseOptimizer(GraphRewriter):
             print(blanc, "ndim", "nb", file=stream)
             for n in sorted(ndim):
                 print(blanc, n, ndim[n], file=stream)
-
-    def candidate_input_idxs(self, node):
-        # TODO: Implement specialized InplaceCompositeOptimizer with logic
-        #  needed to correctly assign inplace for multi-output Composites
-        #  and ScalarLoops
-        if isinstance(node.op.scalar_op, ScalarLoop):
-            return []
-        else:
-            return range(len(node.outputs))
 
     def apply(self, fgraph):
         r"""
@@ -173,7 +163,7 @@ class InplaceElemwiseOptimizer(GraphRewriter):
 
                 baseline = op.inplace_pattern
                 candidate_outputs = [
-                    i for i in self.candidate_input_idxs(node) if i not in baseline
+                    i for i in range(len(node.outputs)) if i not in baseline
                 ]
                 # node inputs that are Constant, already destroyed,
                 # or fgraph protected inputs and fgraph outputs can't be used as
@@ -190,7 +180,7 @@ class InplaceElemwiseOptimizer(GraphRewriter):
                 ]
             else:
                 baseline = []
-                candidate_outputs = self.candidate_input_idxs(node)
+                candidate_outputs = range(len(node.outputs))
                 # node inputs that are Constant, already destroyed,
                 # fgraph protected inputs and fgraph outputs can't be used as inplace
                 # target.

--- a/tests/tensor/test_math_scipy.py
+++ b/tests/tensor/test_math_scipy.py
@@ -431,11 +431,13 @@ def test_gammaincc_ddk_performance(benchmark):
     x = vector("x")
 
     out = gammaincc(k, x)
-    grad_fn = function([k, x], grad(out.sum(), wrt=[k]), mode="FAST_RUN")
+    grad_fn = function(
+        [k, x], grad(out.sum(), wrt=[k]), mode="FAST_RUN", trust_input=True
+    )
     vals = [
         # Values that hit the second branch of the gradient
-        np.full((1000,), 3.2),
-        np.full((1000,), 0.01),
+        np.full((1000,), 3.2, dtype=k.dtype),
+        np.full((1000,), 0.01, dtype=x.dtype),
     ]
 
     verify_grad(gammaincc, vals, rng=rng)
@@ -1127,9 +1129,13 @@ class TestHyp2F1Grad:
         a1, a2, b1, z = pt.scalars("a1", "a2", "b1", "z")
         hyp2f1_out = pt.hyp2f1(a1, a2, b1, z)
         hyp2f1_grad = pt.grad(hyp2f1_out, wrt=a1 if wrt == "a" else [a1, a2, b1, z])
-        f_grad = function([a1, a2, b1, z], hyp2f1_grad)
+        f_grad = function([a1, a2, b1, z], hyp2f1_grad, trust_input=True)
 
         (test_a1, test_a2, test_b1, test_z, *expected_dds) = case
+        test_a1 = np.array(test_a1, dtype=a1.dtype)
+        test_a2 = np.array(test_a2, dtype=a2.dtype)
+        test_b1 = np.array(test_b1, dtype=b1.dtype)
+        test_z = np.array(test_z, dtype=z.dtype)
 
         result = benchmark(f_grad, test_a1, test_a2, test_b1, test_z)
 


### PR DESCRIPTION
Closes #138 

This allows inplacing arbitrary number of inputs in Elemwise Composite (i.e., fused) Ops. The restriction was there because in the original codegen writing to the aliased outputs could affect the computations of other outputs that still referenced the just overridden aliased inputs.  

The fix was trivial, only use the output names in the end after all nodes are computed. Until then the variables are stored in temporary variables as already happens for regular intermediate nodes in the Composite.

Did the same for `ScalarLoop`. The final outputs are only defined once the inner loop is finished, so no worries about aliasing too soon.

Also a typo-bug in the Numba vectorize code that's fixed. 

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1322.org.readthedocs.build/en/1322/

<!-- readthedocs-preview pytensor end -->