### PR TITLE
Use `shell=False` for `Popen` on Windows

### DIFF
--- a/pytensor/link/c/cmodule.py
+++ b/pytensor/link/c/cmodule.py
@@ -2105,7 +2105,7 @@ class GCC_compiler(Compiler):
             )
             detect_march = False
 
-        def get_lines(cmd: list[str] | str, parse: bool = True) -> list[str] | None:
+        def get_lines(cmd: list[str], parse: bool = True) -> list[str] | None:
             p = subprocess_Popen(
                 cmd,
                 stdout=subprocess.PIPE,

--- a/pytensor/link/c/cmodule.py
+++ b/pytensor/link/c/cmodule.py
@@ -2120,10 +2120,10 @@ class GCC_compiler(Compiler):
             if p.returncode != 0:
                 return None
 
-            lines = BytesIO(stdout + stderr).readlines()
-            lines = (l.decode() for l in lines)
+            lines_bytes = BytesIO(stdout + stderr).readlines()
+            lines = [l.decode() for l in lines_bytes]
             if parse:
-                selected_lines = []
+                selected_lines: list[str] = []
                 for line in lines:
                     if (
                         "COLLECT_GCC_OPTIONS=" in line

--- a/pytensor/link/c/cmodule.py
+++ b/pytensor/link/c/cmodule.py
@@ -10,6 +10,7 @@ import os
 import pickle
 import platform
 import re
+import shlex
 import shutil
 import stat
 import subprocess
@@ -2610,7 +2611,7 @@ class GCC_compiler(Compiler):
         cmd.append(f"{path_wrapper}{cppfilename}{path_wrapper}")
         cmd.extend(GCC_compiler.linking_patch(lib_dirs, libs))
         # print >> sys.stderr, 'COMPILING W CMD', cmd
-        _logger.debug(f"Running cmd: {' '.join(cmd)}")
+        _logger.debug(f"Running cmd: {shlex.join(cmd)}")
 
         def print_command_line_error():
             # Print command line when a problem occurred.
@@ -2618,7 +2619,7 @@ class GCC_compiler(Compiler):
                 ("Problem occurred during compilation with the command line below:"),
                 file=sys.stderr,
             )
-            print(" ".join(cmd), file=sys.stderr)
+            print(shlex.join(cmd), file=sys.stderr)
 
         try:
             p_out = output_subprocess_Popen(cmd)

--- a/pytensor/link/c/cmodule.py
+++ b/pytensor/link/c/cmodule.py
@@ -2104,7 +2104,7 @@ class GCC_compiler(Compiler):
             )
             detect_march = False
 
-        def get_lines(cmd, parse=True):
+        def get_lines(cmd: list[str] | str, parse: bool = True) -> list[str] | None:
             p = subprocess_Popen(
                 cmd,
                 stdout=subprocess.PIPE,

--- a/pytensor/link/c/cmodule.py
+++ b/pytensor/link/c/cmodule.py
@@ -2147,7 +2147,7 @@ class GCC_compiler(Compiler):
 
             # The '-' at the end is needed. Otherwise, g++ do not output
             # enough information.
-            native_lines = get_lines(f"{config.cxx} -march=native -E -v -")
+            native_lines = get_lines([config.cxx, "-march=native", "-E", "-v", "-"])
             if native_lines is None:
                 _logger.info(
                     "Call to 'g++ -march=native' failed, not setting -march flag"
@@ -2162,7 +2162,7 @@ class GCC_compiler(Compiler):
                     # That means we did not select the right lines, so
                     # we have to report all the lines instead
                     reported_lines = get_lines(
-                        f"{config.cxx} -march=native -E -v -", parse=False
+                        [config.cxx, "-march=native", "-E", "-v", "-"], parse=False
                     )
                 else:
                     reported_lines = native_lines
@@ -2175,10 +2175,12 @@ class GCC_compiler(Compiler):
                     f" problem:\n {reported_lines}"
                 )
             else:
-                default_lines = get_lines(f"{config.cxx} -E -v -")
+                default_lines = get_lines([config.cxx, "-E", "-v", "-"])
                 _logger.info(f"g++ default lines: {default_lines}")
                 if len(default_lines) < 1:
-                    reported_lines = get_lines(f"{config.cxx} -E -v -", parse=False)
+                    reported_lines = get_lines(
+                        [config.cxx, "-E", "-v", "-"], parse=False
+                    )
                     warnings.warn(
                         "PyTensor was not able to find the "
                         "default g++ parameters. This is needed to tune "
@@ -2778,7 +2780,7 @@ def default_blas_ldflags() -> str:
         return libs
 
     def get_cxx_library_dirs():
-        cmd = f"{config.cxx} -print-search-dirs"
+        cmd = [config.cxx, "-print-search-dirs"]
         p = subprocess_Popen(
             cmd,
             stdout=subprocess.PIPE,

--- a/pytensor/link/c/cmodule.py
+++ b/pytensor/link/c/cmodule.py
@@ -2111,7 +2111,6 @@ class GCC_compiler(Compiler):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 stdin=subprocess.PIPE,
-                shell=True,
             )
             # For mingw64 with GCC >= 4.7, passing os.devnull
             # as stdin (which is the default) results in the process
@@ -2786,7 +2785,6 @@ def default_blas_ldflags() -> str:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             stdin=subprocess.PIPE,
-            shell=True,
         )
         (stdout, stderr) = p.communicate(input=b"")
         if p.returncode != 0:

--- a/pytensor/utils.py
+++ b/pytensor/utils.py
@@ -123,7 +123,7 @@ def maybe_add_to_os_environ_pathlist(var: str, newpath: Path | str) -> None:
         pass
 
 
-def subprocess_Popen(command: str | list[str], **params):
+def subprocess_Popen(command: list[str], **params) -> subprocess.Popen:
     """
     Utility function to work around windows behavior that open windows.
 
@@ -142,12 +142,12 @@ def subprocess_Popen(command: str | list[str], **params):
         # in "The filename, directory name, or volume label syntax is incorrect" error message.
         # Passing the command as a single string solves this problem.
         if isinstance(command, list):
-            command = " ".join(command)
+            command = " ".join(command)  # type: ignore[assignment]
 
     return subprocess.Popen(command, startupinfo=startupinfo, **params)
 
 
-def call_subprocess_Popen(command, **params):
+def call_subprocess_Popen(command: list[str], **params) -> int:
     """
     Calls subprocess_Popen and discards the output, returning only the
     exit code.
@@ -165,13 +165,17 @@ def call_subprocess_Popen(command, **params):
     return returncode
 
 
-def output_subprocess_Popen(command, **params):
+def output_subprocess_Popen(command: list[str], **params) -> tuple[bytes, bytes, int]:
     """
     Calls subprocess_Popen, returning the output, error and exit code
     in a tuple.
     """
     if "stdout" in params or "stderr" in params:
         raise TypeError("don't use stderr or stdout with output_subprocess_Popen")
+    if "encoding" in params:
+        raise TypeError(
+            "adjust the output_subprocess_Popen type annotation to support str"
+        )
     params["stdout"] = subprocess.PIPE
     params["stderr"] = subprocess.PIPE
     p = subprocess_Popen(command, **params)

--- a/pytensor/utils.py
+++ b/pytensor/utils.py
@@ -137,13 +137,6 @@ def subprocess_Popen(command: str | list[str], **params):
         except AttributeError:
             startupinfo.dwFlags |= subprocess._subprocess.STARTF_USESHOWWINDOW  # type: ignore[attr-defined]
 
-        # Anaconda for Windows does not always provide .exe files
-        # in the PATH, they also have .bat files that call the corresponding
-        # executable. For instance, "g++.bat" is in the PATH, not "g++.exe"
-        # Unless "shell=True", "g++.bat" is not executed when trying to
-        # execute "g++" without extensions.
-        # (Executing "g++.bat" explicitly would also work.)
-        params["shell"] = True
         # "If shell is True, it is recommended to pass args as a string rather than as a sequence." (cite taken from https://docs.python.org/2/library/subprocess.html#frequently-used-arguments)
         # In case when command arguments have spaces, passing a command as a list will result in incorrect arguments break down, and consequently
         # in "The filename, directory name, or volume label syntax is incorrect" error message.
@@ -151,20 +144,7 @@ def subprocess_Popen(command: str | list[str], **params):
         if isinstance(command, list):
             command = " ".join(command)
 
-    # Using the dummy file descriptors below is a workaround for a
-    # crash experienced in an unusual Python 2.4.4 Windows environment
-    # with the default None values.
-    stdin = None
-    if "stdin" not in params:
-        stdin = Path(os.devnull).open()
-        params["stdin"] = stdin.fileno()
-
-    try:
-        proc = subprocess.Popen(command, startupinfo=startupinfo, **params)
-    finally:
-        if stdin is not None:
-            stdin.close()
-    return proc
+    return subprocess.Popen(command, startupinfo=startupinfo, **params)
 
 
 def call_subprocess_Popen(command, **params):

--- a/tests/compile/function/test_function.py
+++ b/tests/compile/function/test_function.py
@@ -1,5 +1,4 @@
 import pickle
-import re
 import shutil
 import tempfile
 from pathlib import Path

--- a/tests/compile/function/test_function.py
+++ b/tests/compile/function/test_function.py
@@ -50,8 +50,7 @@ def test_function_name():
     x = vector("x")
     func = function([x], x + 1.0)
 
-    regex = re.compile(f".*{__file__}c?")
-    assert regex.match(func.name) is not None
+    assert __file__ in func.name
 
 
 def test_trust_input():

--- a/tests/link/c/test_cmodule.py
+++ b/tests/link/c/test_cmodule.py
@@ -128,7 +128,7 @@ def test_cache_versioning():
     z = my_add(x)
     z_v = my_add_ver(x)
 
-    with tempfile.TemporaryDirectory() as dir_name:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as dir_name:
         cache = ModuleCache(dir_name)
 
         lnk = CLinker().accept(FunctionGraph(outputs=[z]))

--- a/tests/link/c/test_cmodule.py
+++ b/tests/link/c/test_cmodule.py
@@ -228,23 +228,19 @@ def cxx_search_dirs(blas_libs, mock_system):
         )
 
 
-@pytest.fixture(
-    scope="function", params=[True, False], ids=["Working_CXX", "Broken_CXX"]
+@pytest.mark.parametrize(
+    "working_cxx", [True, False], ids=["Working_CXX", "Broken_CXX"]
 )
-def cxx_search_dirs_status(request):
-    return request.param
-
-
 @patch("pytensor.link.c.cmodule.std_lib_dirs", return_value=[])
 @patch("pytensor.link.c.cmodule.check_mkl_openmp", return_value=None)
 def test_default_blas_ldflags(
-    mock_std_lib_dirs, mock_check_mkl_openmp, cxx_search_dirs, cxx_search_dirs_status
+    mock_std_lib_dirs, mock_check_mkl_openmp, cxx_search_dirs, working_cxx
 ):
     cxx_search_dirs, expected_blas_ldflags, enabled_accelerate_framework = (
         cxx_search_dirs
     )
     mock_process = MagicMock()
-    if cxx_search_dirs_status:
+    if working_cxx:
         error_message = ""
         mock_process.communicate = lambda *args, **kwargs: (cxx_search_dirs, b"")
         mock_process.returncode = 0
@@ -273,7 +269,7 @@ def test_default_blas_ldflags(
             "try_compile_tmp",
             new_callable=patched_compile_tmp,
         ):
-            if cxx_search_dirs_status:
+            if working_cxx:
                 assert set(default_blas_ldflags().split(" ")) == set(
                     expected_blas_ldflags.split(" ")
                 )


### PR DESCRIPTION
## Description

I'm having hard times creating new environments with working compiler dependencies.

My debugging attempts show that `shell=False` could fix this, however this observation contradicts the comments next to that line.
~Further testing may be required.~ Tested on another machine.

I also removed an old workaround for Python 2..

## Related Issue

Hints?

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] ~Added necessary documentation (docstrings and/or example notebooks)~
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1324.org.readthedocs.build/en/1324/

<!-- readthedocs-preview pytensor end -->