### PR TITLE
Inplace join

### DIFF
--- a/pytensor/link/numba/dispatch/subtensor.py
+++ b/pytensor/link/numba/dispatch/subtensor.py
@@ -5,6 +5,7 @@ from pytensor.link.numba.dispatch import numba_funcify
 from pytensor.link.numba.dispatch.basic import generate_fallback_impl, numba_njit
 from pytensor.link.utils import compile_function_src, unique_name_generator
 from pytensor.tensor import TensorType
+from pytensor.tensor.rewriting.basic import BufferJoin
 from pytensor.tensor.rewriting.subtensor import is_full_slice
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
@@ -101,6 +102,15 @@ def {function_name}({", ".join(input_names)}):
         global_env=globals() | {"np": np},
     )
     return numba_njit(func, boundscheck=True)
+
+
+@numba_funcify.register(BufferJoin)
+def numba_funcify_buffer_join(op, node, **kwargs):
+    @numba_njit
+    def buffer_join(x, *args):
+        return x
+
+    return buffer_join
 
 
 @numba_funcify.register(AdvancedSubtensor)


### PR DESCRIPTION
This was a failed attempt to create an inplace join of multiple Elemwise, that pre-allocates an output and passes views to the elemwise inputs to store them inplace. I could only see speedups with insanely large inputs.

```python
import pytensor
import pytensor.tensor as pt
from pytensor.compile.mode import get_mode
import numpy as np

x = pt.vector("x", shape=(1000,))
out = pt.join(0, pt.abs(x), -pt.abs(x), pt.exp(x), pt.cos(x), x + 1, x  * 2)
out.dprint()
fn = pytensor.function([x], out, trust_input=True, mode=get_mode(None).excluding("fusion",))
fn.dprint(print_memory_map=True)

x_test = np.random.normal(size=x.type.shape)
fn(x_test)
%timeit fn(x_test)
```

```
Join [id A]
 ├─ 0 [id B]
 ├─ Abs [id C]
 │  └─ x [id D]
 ├─ Neg [id E]
 │  └─ Abs [id F]
 │     └─ x [id D]
 ├─ Exp [id G]
 │  └─ x [id D]
 ├─ Cos [id H]
 │  └─ x [id D]
 ├─ Add [id I]
 │  ├─ x [id D]
 │  └─ ExpandDims{axis=0} [id J]
 │     └─ 1 [id K]
 └─ Mul [id L]
    ├─ x [id D]
    └─ ExpandDims{axis=0} [id M]
       └─ 2 [id N]
```
```
BufferJoin [id A] d={0: [0]} 14
 ├─ AllocEmpty{dtype='float64'} [id B] 0
 │  └─ 6000 [id C]
 ├─ Composite{abs(i0)} [id D] d={0: [1]} 8
 │  ├─ x [id E]
 │  └─ BufferSplit{:stop} [id F] 2
 │     ├─ AllocEmpty{dtype='float64'} [id B] 0
 │     │  └─ ···
 │     └─ 1000 [id G]
 ├─ Composite{(-i0)} [id H] d={0: [1]} 9
 │  ├─ Abs [id I] 1
 │  │  └─ x [id E]
 │  └─ BufferSplit{start:stop} [id J] 3
 │     ├─ AllocEmpty{dtype='float64'} [id B] 0
 │     │  └─ ···
 │     ├─ 1000 [id G]
 │     └─ 2000 [id K]
 ├─ Composite{exp(i0)} [id L] d={0: [1]} 10
 │  ├─ x [id E]
 │  └─ BufferSplit{start:stop} [id M] 4
 │     ├─ AllocEmpty{dtype='float64'} [id B] 0
 │     │  └─ ···
 │     ├─ 2000 [id K]
 │     └─ 3000 [id N]
 ├─ Composite{cos(i0)} [id O] d={0: [1]} 11
 │  ├─ x [id E]
 │  └─ BufferSplit{start:stop} [id P] 5
 │     ├─ AllocEmpty{dtype='float64'} [id B] 0
 │     │  └─ ···
 │     ├─ 3000 [id N]
 │     └─ 4000 [id Q]
 ├─ Composite{(i0 + i1)} [id R] d={0: [2]} 12
 │  ├─ [1.] [id S]
 │  ├─ x [id E]
 │  └─ BufferSplit{start:stop} [id T] 6
 │     ├─ AllocEmpty{dtype='float64'} [id B] 0
 │     │  └─ ···
 │     ├─ 4000 [id Q]
 │     └─ 5000 [id U]
 └─ Composite{(i0 * i1)} [id V] d={0: [2]} 13
    ├─ [2.] [id W]
    ├─ x [id E]
    └─ BufferSplit{start:} [id X] 7
       ├─ AllocEmpty{dtype='float64'} [id B] 0
       │  └─ ···
       └─ 5000 [id U]
```

Perhaps if I fused the buffer_splits with the buffer_alloc it would be faster, but that was more work than I was willing to take.