### PR TITLE
Specialize away Split

### DIFF
--- a/pytensor/link/numba/dispatch/tensor_basic.py
+++ b/pytensor/link/numba/dispatch/tensor_basic.py
@@ -136,10 +136,7 @@ def numba_funcify_Join(op, **kwargs):
 def numba_funcify_Split(op, **kwargs):
     @numba_basic.numba_njit
     def split(tensor, axis, indices):
-        # Work around for https://github.com/numba/numba/issues/8257
-        axis = axis % tensor.ndim
-        axis = numba_basic.to_scalar(axis)
-        return np.split(tensor, np.cumsum(indices)[:-1], axis=axis)
+        return np.split(tensor, np.cumsum(indices)[:-1], axis=axis.item())
 
     return split
 

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -2201,8 +2201,26 @@ class Split(COp):
             raise TypeError("`axis` parameter must be an integer scalar")
 
         inputs = [x, axis, splits]
-        out_type = TensorType(dtype=x.dtype, shape=(None,) * x.type.ndim)
-        outputs = [out_type() for i in range(self.len_splits)]
+
+        x_dtype = x.type.dtype
+        if isinstance(axis, Constant):
+            # In this case we can preserve more static shape info
+            static_axis = axis.data.item()
+            outputs = []
+            x_static_shape = list(x.type.shape)
+            for i in range(self.len_splits):
+                try:
+                    static_split_size = int(get_scalar_constant_value(splits[i]))
+                except NotScalarConstantError:
+                    static_split_size = None
+                static_out_shape = x_static_shape.copy()
+                static_out_shape[static_axis] = static_split_size
+                outputs.append(tensor(shape=tuple(static_out_shape), dtype=x_dtype))
+        else:
+            outputs = [
+                tensor(shape=(None,) * x.type.ndim, dtype=x_dtype)
+                for i in range(self.len_splits)
+            ]
 
         return Apply(self, inputs, outputs)
 


### PR DESCRIPTION
Split shows up in the graph of Join. It's just a fancy sequence of slice operations. `np.split` is just a thin wrapper that does this:

https://github.com/numpy/numpy/blob/e7a123b2d3eca9897843791dd698c1803d9a39c2/numpy/lib/_shape_base_impl.py#L789-L796

If it was not for the possible dynamic axis (which Join also supports) we wouldn't need Split at all.

We may still want it for the second order derivatives of join graphs. The gradient over Split is more clean than the eager gradient over multiple subtensors, it's just the reverse join on the output gradients.

I added a specialization rewrite that converts Split to the respective Subtensor graph. I see speedups in all backends.

The C backend wasn't really capable of returning a view of the inputs, so this optimization avoids as many copies as there are splits:



```python
import numpy as np
import pytensor
import pytensor.tensor as pt
from pytensor.compile.mode import get_mode

x = pt.vector("x", shape=(1000,), dtype=int)
ys = pt.split(x, (250, 250, 500), 3)
fn = pytensor.function(
    # Avoid deepcopies
    [pytensor.In(x, borrow=True)],
    [pytensor.Out(y, borrow=True) for y in ys], 
    mode=get_mode("NUMBA"), #.excluding("split_to_subtensor"), 
    trust_input=True,
)
fn.dprint(print_view_map=True)

x_test = np.arange(1000)
fn(x_test)
%timeit fn(x_test)
```


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1334.org.readthedocs.build/en/1334/

<!-- readthedocs-preview pytensor end -->