### PR TITLE
Don't run local uint constant indices in C/Python backends

### DIFF
--- a/pytensor/compile/mode.py
+++ b/pytensor/compile/mode.py
@@ -489,7 +489,6 @@ PYTORCH = Mode(
             "BlasOpt",
             "fusion",
             "inplace",
-            "local_uint_constant_indices",
             "scan_save_mem_prealloc",
         ],
     ),


### PR DESCRIPTION
This optimization is actually a slow down, because the implementations always requset a cast of indices to intp. We used to do it explicitly in `AdvancedSubtensor1` but the underlying numpy C function also does it: https://github.com/numpy/numpy/blob/c23886c226012a50da11066d3be98fd94e571101/numpy/_core/src/multiarray/item_selection.c#L247-L251

Local benchmark on a PyMC model that uses AdavncedSubtensor1/Inc shows a slowdown compared to when the optimization is not used.

This PR removes the rewrite from these backends. It also makes the rewrite apply only after `specialization` to avoid too many passes when other rewrites introduce things like `x.shape[i]` which will be removed anyway.

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1335.org.readthedocs.build/en/1335/

<!-- readthedocs-preview pytensor end -->