### PR TITLE
More stable fix for JAX Multinomial

### DIFF
--- a/pytensor/link/jax/dispatch/random.py
+++ b/pytensor/link/jax/dispatch/random.py
@@ -412,7 +412,9 @@ def jax_sample_fn_multinomial(op, node):
             remaining_n, remaining_p = carry
             p, rng = p_rng
             samples = jnp.where(
-                p == 0, 0, jax.random.binomial(rng, remaining_n, p / remaining_p)
+                remaining_n == 0,
+                0,
+                jax.random.binomial(rng, remaining_n, p / remaining_p),
             )
             remaining_n -= samples
             remaining_p -= p


### PR DESCRIPTION
#1328 was not good enough for the test in PyMC :(

I changed it to stop taking draws once `remaining_n` drops to zero. This should be more robust against numerical precision issues for valid parameters. It's also what our numba implementation is doing, so at least they are aligned:

https://github.com/pymc-devs/pytensor/blob/75789deba3f1e4514ad56c9922083a93542313f2/pytensor/link/numba/dispatch/random.py#L166-L167

Or I should perhaps just gone with the suggestion @educhesne gave.

I confirm PyMC is now happy

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1339.org.readthedocs.build/en/1339/

<!-- readthedocs-preview pytensor end -->