### PR TITLE
Propagate static output shapes in Split and avoid copy in C-impl

### DIFF
--- a/pytensor/link/numba/dispatch/tensor_basic.py
+++ b/pytensor/link/numba/dispatch/tensor_basic.py
@@ -136,10 +136,7 @@ def numba_funcify_Join(op, **kwargs):
 def numba_funcify_Split(op, **kwargs):
     @numba_basic.numba_njit
     def split(tensor, axis, indices):
-        # Work around for https://github.com/numba/numba/issues/8257
-        axis = axis % tensor.ndim
-        axis = numba_basic.to_scalar(axis)
-        return np.split(tensor, np.cumsum(indices)[:-1], axis=axis)
+        return np.split(tensor, np.cumsum(indices)[:-1], axis=axis.item())
 
     return split
 

--- a/tests/link/jax/test_tensor_basic.py
+++ b/tests/link/jax/test_tensor_basic.py
@@ -150,12 +150,14 @@ class TestJaxSplit:
         ):
             fn(np.zeros((6, 4), dtype=pytensor.config.floatX))
 
-        a_splits = ptb.split(a, splits_size=[2, 4], n_splits=3, axis=0)
-        fn = pytensor.function([a], a_splits, mode="JAX")
+        # This check is triggered at compile time if splits_size has incompatible static length
+        splits_size = vector("splits_size", shape=(None,), dtype=int)
+        a_splits = ptb.split(a, splits_size=splits_size, n_splits=3, axis=0)
+        fn = pytensor.function([a, splits_size], a_splits, mode="JAX")
         with pytest.raises(
             ValueError, match="Length of splits is not equal to n_splits"
         ):
-            fn(np.zeros((6, 4), dtype=pytensor.config.floatX))
+            fn(np.zeros((6, 4), dtype=pytensor.config.floatX), [2, 2])
 
         a_splits = ptb.split(a, splits_size=[2, 4], n_splits=2, axis=0)
         fn = pytensor.function([a], a_splits, mode="JAX")

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -2172,11 +2172,7 @@ class TestJoinAndSplit:
         res = f(x_test)
         for r, expected in zip(res, ([], [0, 1, 2], [3, 4]), strict=True):
             assert np.allclose(r, expected)
-            if linker == "py":
-                assert r.base is x_test
-            else:
-                # C impl always makes a copy
-                assert r.base is not x_test
+            assert r.base is x_test
 
 
 def test_TensorFromScalar():


### PR DESCRIPTION
This makes Split (which shows up in the gradient of Join) much faster as it doesn't do useless copies.

I see a speedup of ~10x, obviously the comparison would scale with the ammount of copying that is now avoided

```python
import pytensor
import pytensor.tensor as pt
import numpy as np

x = pt.matrix("x", shape=(100, 200))
ys = pt.split(x, [10]*10, 10)
profile = None
fn = pytensor.function(
    [pytensor.In(x, borrow=True)], 
    [pytensor.Out(y, borrow=True) for y in ys],
    trust_input=True,
    profile=profile,
)
fn.dprint()
x_test = np.zeros((100, 200))
%timeit fn(x_test)
%timeit fn(x_test)
%timeit fn(x_test)
if profile:
    fn.profile.summary()
```

Also added static output shape and cleanup other methods of Split

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1343.org.readthedocs.build/en/1343/

<!-- readthedocs-preview pytensor end -->