### PR TITLE
Speedup AdvancedSubtensor1 and AdvancedIncSubtensor1 in C backend

### DIFF
--- a/pytensor/link/jax/dispatch/subtensor.py
+++ b/pytensor/link/jax/dispatch/subtensor.py
@@ -67,6 +67,9 @@ def jax_funcify_IncSubtensor(op, node, **kwargs):
         if len(indices) == 1:
             indices = indices[0]
 
+        if isinstance(op, AdvancedIncSubtensor1):
+            op._check_runtime_broadcasting(node, x, y, indices)
+
         return jax_fn(x, indices, y)
 
     return incsubtensor

--- a/pytensor/link/numba/dispatch/slinalg.py
+++ b/pytensor/link/numba/dispatch/slinalg.py
@@ -83,7 +83,7 @@ def numba_funcify_Cholesky(op, node, **kwargs):
 @numba_funcify.register(PivotToPermutations)
 def pivot_to_permutation(op, node, **kwargs):
     inverse = op.inverse
-    dtype = node.inputs[0].dtype
+    dtype = node.outputs[0].dtype
 
     @numba_njit
     def numba_pivot_to_permutation(piv):

--- a/pytensor/link/numba/dispatch/subtensor.py
+++ b/pytensor/link/numba/dispatch/subtensor.py
@@ -287,11 +287,11 @@ def numba_funcify_AdvancedIncSubtensor1(op, node, **kwargs):
     inplace = op.inplace
     set_instead_of_inc = op.set_instead_of_inc
     x, vals, idxs = node.inputs
-    # TODO: Add explicit expand_dims in make_node so we don't need to worry about this here
-    broadcast = vals.type.ndim < x.type.ndim or vals.type.broadcastable[0]
+    broadcast_with_index = vals.type.ndim < x.type.ndim or vals.type.broadcastable[0]
+    # TODO: Add runtime_broadcast check
 
     if set_instead_of_inc:
-        if broadcast:
+        if broadcast_with_index:
 
             @numba_njit(boundscheck=True)
             def advancedincsubtensor1_inplace(x, val, idxs):
@@ -318,7 +318,7 @@ def numba_funcify_AdvancedIncSubtensor1(op, node, **kwargs):
                     x[idx] = val
                 return x
     else:
-        if broadcast:
+        if broadcast_with_index:
 
             @numba_njit(boundscheck=True)
             def advancedincsubtensor1_inplace(x, val, idxs):

--- a/pytensor/link/pytorch/dispatch/subtensor.py
+++ b/pytensor/link/pytorch/dispatch/subtensor.py
@@ -109,6 +109,8 @@ def pytorch_funcify_AdvancedIncSubtensor(op, node, **kwargs):
 
         def adv_set_subtensor(x, y, *indices):
             check_negative_steps(indices)
+            if isinstance(op, AdvancedIncSubtensor1):
+                op._check_runtime_broadcasting(node, x, y, indices)
             if not inplace:
                 x = x.clone()
             x[indices] = y.type_as(x)
@@ -120,6 +122,8 @@ def pytorch_funcify_AdvancedIncSubtensor(op, node, **kwargs):
 
         def adv_inc_subtensor_no_duplicates(x, y, *indices):
             check_negative_steps(indices)
+            if isinstance(op, AdvancedIncSubtensor1):
+                op._check_runtime_broadcasting(node, x, y, indices)
             if not inplace:
                 x = x.clone()
             x[indices] += y.type_as(x)

--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -604,7 +604,7 @@ class PivotToPermutations(Op):
 
     def perform(self, node, inputs, outputs):
         [pivots] = inputs
-        p_inv = np.arange(len(pivots), dtype=pivots.dtype)
+        p_inv = np.arange(len(pivots), dtype="int64")
 
         for i in range(len(pivots)):
             p_inv[i], p_inv[pivots[i]] = p_inv[pivots[i]], p_inv[i]
@@ -639,7 +639,7 @@ class LUFactor(Op):
             )
 
         LU = matrix(shape=A.type.shape, dtype=A.type.dtype)
-        pivots = vector(shape=(A.type.shape[0],), dtype="int64")
+        pivots = vector(shape=(A.type.shape[0],), dtype="int32")
 
         return Apply(self, [A], [LU, pivots])
 


### PR DESCRIPTION
These are some of the biggest drags in the C-backend. This PR does some tweaks that increase performance substantically.

### AdvancedSubtensor1 benchmark
<details>
<summary>Before</summary>

```
---------------------------------------------------------------------------------------------------- benchmark: 4 tests ---------------------------------------------------------------------------------------------------
Name (time in us)                                            Min                Max              Mean            StdDev            Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_advanced_subtensor1[gc=True-static_shape=False]      1.7730 (1.0)      62.5270 (5.48)     2.0225 (1.00)     0.6402 (2.22)     1.9640 (1.0)      0.0400 (1.00)    1785;6702      494.4466 (1.00)      83320           1
test_advanced_subtensor1[gc=True-static_shape=True]       1.7830 (1.01)     57.1570 (5.01)     2.0216 (1.0)      0.6144 (2.13)     1.9840 (1.01)     0.0400 (1.0)      690;2893      494.6573 (1.0)       73660           1
test_advanced_subtensor1[gc=False-static_shape=True]      2.1040 (1.19)     11.4020 (1.0)      2.3344 (1.15)     0.2878 (1.0)      2.3040 (1.17)     0.0500 (1.25)    1349;4021      428.3810 (0.87)     102691           1
test_advanced_subtensor1[gc=False-static_shape=False]     2.1140 (1.19)     19.3860 (1.70)     2.2857 (1.13)     0.2986 (1.04)     2.2740 (1.16)     0.0510 (1.27)       65;547      437.5102 (0.88)      11134           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
</details>

<details>
<summary>After</summary>

```
---------------------------------------------------------------------------------------------------- benchmark: 4 tests ----------------------------------------------------------------------------------------------------
Name (time in us)                                            Min                 Max              Mean            StdDev            Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_advanced_subtensor1[gc=False-static_shape=True]      1.2820 (1.0)       45.9260 (1.0)      1.4129 (1.0)      0.5339 (1.0)      1.3730 (1.0)      0.0490 (1.22)      783;971      707.7531 (1.0)       57594           1
test_advanced_subtensor1[gc=True-static_shape=True]       1.4620 (1.14)      87.1230 (1.90)     1.6104 (1.14)     0.5974 (1.12)     1.5630 (1.14)     0.0400 (1.0)     2326;3531      620.9714 (0.88)     115929           1
test_advanced_subtensor1[gc=False-static_shape=False]     1.7530 (1.37)      71.8950 (1.57)     1.9472 (1.38)     0.7248 (1.36)     1.9240 (1.40)     0.0400 (1.00)       65;408      513.5575 (0.73)      10931           1
test_advanced_subtensor1[gc=True-static_shape=False]      1.7730 (1.38)     282.6200 (6.15)     2.0129 (1.42)     1.1193 (2.10)     1.9540 (1.42)     0.0400 (1.0)     1410;6501      496.7973 (0.70)     113676           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
</details>

### AdvancedIncSubtensor1 benchmark
<details>
<summary>Before</summary>

```
------------------------------------------------------------------------------------------------------------- benchmark: 8 tests ------------------------------------------------------------------------------------------------------------
Name (time in us)                                                             Min                 Max              Mean            StdDev            Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_advanced_incsubtensor1[set_subtensor-gc=False-static_shape=True]      5.2000 (1.0)       80.1600 (2.73)     5.5870 (1.01)     1.7055 (2.56)     5.4600 (1.01)     0.1000 (1.64)     875;1577      178.9867 (0.99)      48810           1
test_advanced_incsubtensor1[set_subtensor-gc=False-static_shape=False]     5.2000 (1.00)     291.1850 (9.92)     5.5165 (1.0)      2.0229 (3.04)     5.4000 (1.0)      0.0610 (1.0)      744;1847      181.2759 (1.0)       50209           1
test_advanced_incsubtensor1[set_subtensor-gc=True-static_shape=True]       5.3200 (1.02)      71.1430 (2.42)     5.6233 (1.02)     1.3633 (2.05)     5.5210 (1.02)     0.0700 (1.15)     628;1601      177.8307 (0.98)      38184           1
test_advanced_incsubtensor1[set_subtensor-gc=True-static_shape=False]      5.4200 (1.04)      29.3550 (1.0)      5.6929 (1.03)     0.6650 (1.0)      5.6400 (1.04)     0.0700 (1.15)     702;1393      175.6585 (0.97)      47170           1
test_advanced_incsubtensor1[inc_subtensor-gc=False-static_shape=True]      5.8510 (1.13)     346.4190 (11.80)    6.2323 (1.13)     2.3741 (3.57)     6.1110 (1.13)     0.0800 (1.31)     579;1374      160.4549 (0.89)      46905           1
test_advanced_incsubtensor1[inc_subtensor-gc=False-static_shape=False]     5.9310 (1.14)      29.5250 (1.01)     6.2690 (1.14)     0.8971 (1.35)     6.1410 (1.14)     0.0800 (1.31)      377;584      159.5152 (0.88)      10442           1
test_advanced_incsubtensor1[inc_subtensor-gc=True-static_shape=True]       5.9720 (1.15)     111.7590 (3.81)     6.3686 (1.15)     1.8011 (2.71)     6.2510 (1.16)     0.0900 (1.48)     806;1734      157.0216 (0.87)      48265           1
test_advanced_incsubtensor1[inc_subtensor-gc=True-static_shape=False]      6.0720 (1.17)      86.5220 (2.95)     6.5262 (1.18)     1.9851 (2.99)     6.3420 (1.17)     0.1510 (2.48)    1039;1465      153.2284 (0.85)      42257           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
</details>

<details>
<summary>After</summary>

```

------------------------------------------------------------------------------------------------------------- benchmark: 8 tests ------------------------------------------------------------------------------------------------------------
Name (time in us)                                                             Min                 Max              Mean            StdDev            Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_advanced_incsubtensor1[set_subtensor-gc=False-static_shape=True]      1.6530 (1.0)       58.8300 (7.25)     1.8268 (1.0)      0.6546 (3.03)     1.7930 (1.0)      0.0500 (1.22)     588;1745      547.4165 (1.0)       98727           1
test_advanced_incsubtensor1[set_subtensor-gc=False-static_shape=False]     1.7730 (1.07)     250.6090 (30.88)    1.9281 (1.06)     1.0618 (4.92)     1.8940 (1.06)     0.0500 (1.22)     290;1008      518.6360 (0.95)      81215           1
test_advanced_incsubtensor1[set_subtensor-gc=True-static_shape=True]       1.9040 (1.15)      92.4230 (11.39)    2.0656 (1.13)     0.7314 (3.39)     2.0040 (1.12)     0.0500 (1.22)    1165;5456      484.1202 (0.88)      93730           1
test_advanced_incsubtensor1[set_subtensor-gc=True-static_shape=False]      2.0840 (1.26)      53.9000 (6.64)     2.3187 (1.27)     0.5710 (2.65)     2.3040 (1.28)     0.0910 (2.22)     764;1078      431.2728 (0.79)      88645           1
test_advanced_incsubtensor1[inc_subtensor-gc=False-static_shape=True]      2.4540 (1.48)     163.9370 (20.20)    2.6131 (1.43)     0.8179 (3.79)     2.5750 (1.44)     0.0410 (1.0)      921;2552      382.6924 (0.70)      90827           1
test_advanced_incsubtensor1[inc_subtensor-gc=True-static_shape=True]       2.7160 (1.64)      51.4560 (6.34)     2.9719 (1.63)     0.7313 (3.39)     2.9150 (1.63)     0.0600 (1.46)    1406;4193      336.4881 (0.61)      95612           1
test_advanced_incsubtensor1[inc_subtensor-gc=False-static_shape=False]     2.9050 (1.76)       8.1160 (1.0)      3.0595 (1.67)     0.2158 (1.0)      3.0460 (1.70)     0.0600 (1.46)      120;249      326.8474 (0.60)      23965           1
test_advanced_incsubtensor1[inc_subtensor-gc=True-static_shape=False]      3.2560 (1.97)     229.7100 (28.30)    3.4273 (1.88)     1.3326 (6.17)     3.3760 (1.88)     0.0600 (1.46)     312;1105      291.7782 (0.53)      52149           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
</details>

I added a long-missing check for runtime broadcasting in the python/C/torch implementations (would require a bit more code-changes for numba), which moves towards #1348 

Provides a restricted case of #1325 

Alloc of zeros is also about twice as fast now, which is benchmarked indirectly in the `AdvancedIncSubtensor1` tests

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1346.org.readthedocs.build/en/1346/

<!-- readthedocs-preview pytensor end -->