### PR TITLE
Don't run the PyPi job all the time

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -41,10 +41,11 @@ jobs:
         id: set_should_run
         run: |
           if [[ "${{ github.event_name == 'release' || 
+                github.ref == 'refs/heads/main' ||
                 (
-                  github.ref == 'refs/heads/main' || 
-                  github.event_name == 'pull_request' 
-                ) && steps.filter.outputs.any_changed == 'true' 
+                  github.event_name == 'pull_request'
+                  && steps.filter.outputs.any_changed == 'true'
+                )
               }}" == "true" ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - auto-release
   pull_request:
     branches: [main]
   release:
@@ -16,14 +15,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   check_changes:
     runs-on: ubuntu-latest
     outputs:
-      should_run: ${{ steps.filter.outputs.any_changed }}
+      should_run: ${{ steps.set_should_run.outputs.should_run }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v2
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
         id: filter
         with:
           filters: |
@@ -34,17 +37,27 @@ jobs:
               - 'pytensor/_version.py'
               - 'pytensor/scan_perform.pyx'
               - 'pytensor/scan_perform_ext.py'
+      - name: Set should_run output
+        id: set_should_run
+        run: |
+          if [[ "${{ github.event_name == 'release' || 
+                (
+                  github.ref == 'refs/heads/main' || 
+                  github.event_name == 'pull_request' 
+                ) && steps.filter.outputs.any_changed == 'true' 
+              }}" == "true" ]]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_run=false" >> $GITHUB_OUTPUT
+          fi
 
   # The job to build precompiled pypi wheels.
   make_sdist:
     name: Make SDist
     needs: check_changes
-    # Run if it's a release, auto-release branch, or if relevant files changed on main
+    # Run if it's a release or if relevant files changed on main
     if: |
-      github.event_name == 'release' || 
-      github.ref == 'refs/heads/auto-release' || 
-      (github.ref == 'refs/heads/main' && needs.check_changes.outputs.should_run == 'true') ||
-      (github.event_name == 'pull_request' && needs.check_changes.outputs.should_run == 'true')
+      needs.check_changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     permissions:
       # write id-token and attestations are required to attest build provenance
@@ -75,12 +88,9 @@ jobs:
   run_checks:
     name: Build & inspect our package.
     needs: check_changes
-    # Run if it's a release, auto-release branch, or if relevant files changed on main
+    # Run if it's a release or if relevant files changed on main
     if: |
-      github.event_name == 'release' || 
-      github.ref == 'refs/heads/auto-release' || 
-      (github.ref == 'refs/heads/main' && needs.check_changes.outputs.should_run == 'true') ||
-      (github.event_name == 'pull_request' && needs.check_changes.outputs.should_run == 'true')
+      needs.check_changes.outputs.should_run == 'true'
     # Note: the resulting builds are not actually published.
     # This is purely for additional testing and diagnostic purposes.
     runs-on: ubuntu-latest
@@ -95,12 +105,9 @@ jobs:
   build_wheels:
     name: Build wheels for ${{ matrix.platform }}
     needs: check_changes
-    # Run if it's a release, auto-release branch, or if relevant files changed on main
+    # Run if it's a release or if relevant files changed on main
     if: |
-      github.event_name == 'release' || 
-      github.ref == 'refs/heads/auto-release' || 
-      (github.ref == 'refs/heads/main' && needs.check_changes.outputs.should_run == 'true') ||
-      (github.event_name == 'pull_request' && needs.check_changes.outputs.should_run == 'true')
+      needs.check_changes.outputs.should_run == 'true'
     runs-on: ${{ matrix.platform }}
     permissions:
       # write id-token and attestations are required to attest build provenance
@@ -136,12 +143,9 @@ jobs:
   build_universal_wheel:
     name: Build universal wheel for Pyodide
     needs: check_changes
-    # Run if it's a release, auto-release branch, or if relevant files changed on main
+    # Run if it's a release or if relevant files changed on main
     if: |
-      github.event_name == 'release' || 
-      github.ref == 'refs/heads/auto-release' || 
-      (github.ref == 'refs/heads/main' && needs.check_changes.outputs.should_run == 'true') ||
-      (github.event_name == 'pull_request' && needs.check_changes.outputs.should_run == 'true')
+      needs.check_changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     permissions:
       # write id-token and attestations are required to attest build provenance
@@ -180,11 +184,6 @@ jobs:
   check_dist:
     name: Check dist
     needs: [check_changes, make_sdist, build_wheels]
-    if: |
-      github.event_name == 'release' || 
-      github.ref == 'refs/heads/auto-release' || 
-      (github.ref == 'refs/heads/main' && needs.check_changes.outputs.should_run == 'true') ||
-      (github.event_name == 'pull_request' && needs.check_changes.outputs.should_run == 'true')
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -17,9 +17,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check_changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.filter.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            any_changed:
+              - '.github/workflows/pypi.yml'
+              - 'pyproject.toml'
+              - 'setup.py'
+              - 'pytensor/_version.py'
+              - 'pytensor/scan_perform.pyx'
+              - 'pytensor/scan_perform_ext.py'
+
   # The job to build precompiled pypi wheels.
   make_sdist:
     name: Make SDist
+    needs: check_changes
+    # Run if it's a release, auto-release branch, or if relevant files changed on main
+    if: |
+      github.event_name == 'release' || 
+      github.ref == 'refs/heads/auto-release' || 
+      (github.ref == 'refs/heads/main' && needs.check_changes.outputs.should_run == 'true') ||
+      (github.event_name == 'pull_request' && needs.check_changes.outputs.should_run == 'true')
     runs-on: ubuntu-latest
     permissions:
       # write id-token and attestations are required to attest build provenance
@@ -49,6 +74,13 @@ jobs:
 
   run_checks:
     name: Build & inspect our package.
+    needs: check_changes
+    # Run if it's a release, auto-release branch, or if relevant files changed on main
+    if: |
+      github.event_name == 'release' || 
+      github.ref == 'refs/heads/auto-release' || 
+      (github.ref == 'refs/heads/main' && needs.check_changes.outputs.should_run == 'true') ||
+      (github.event_name == 'pull_request' && needs.check_changes.outputs.should_run == 'true')
     # Note: the resulting builds are not actually published.
     # This is purely for additional testing and diagnostic purposes.
     runs-on: ubuntu-latest
@@ -62,6 +94,13 @@ jobs:
 
   build_wheels:
     name: Build wheels for ${{ matrix.platform }}
+    needs: check_changes
+    # Run if it's a release, auto-release branch, or if relevant files changed on main
+    if: |
+      github.event_name == 'release' || 
+      github.ref == 'refs/heads/auto-release' || 
+      (github.ref == 'refs/heads/main' && needs.check_changes.outputs.should_run == 'true') ||
+      (github.event_name == 'pull_request' && needs.check_changes.outputs.should_run == 'true')
     runs-on: ${{ matrix.platform }}
     permissions:
       # write id-token and attestations are required to attest build provenance
@@ -96,6 +135,13 @@ jobs:
 
   build_universal_wheel:
     name: Build universal wheel for Pyodide
+    needs: check_changes
+    # Run if it's a release, auto-release branch, or if relevant files changed on main
+    if: |
+      github.event_name == 'release' || 
+      github.ref == 'refs/heads/auto-release' || 
+      (github.ref == 'refs/heads/main' && needs.check_changes.outputs.should_run == 'true') ||
+      (github.event_name == 'pull_request' && needs.check_changes.outputs.should_run == 'true')
     runs-on: ubuntu-latest
     permissions:
       # write id-token and attestations are required to attest build provenance
@@ -133,7 +179,12 @@ jobs:
 
   check_dist:
     name: Check dist
-    needs: [make_sdist,build_wheels]
+    needs: [check_changes, make_sdist, build_wheels]
+    if: |
+      github.event_name == 'release' || 
+      github.ref == 'refs/heads/auto-release' || 
+      (github.ref == 'refs/heads/main' && needs.check_changes.outputs.should_run == 'true') ||
+      (github.event_name == 'pull_request' && needs.check_changes.outputs.should_run == 'true')
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
This was mostly Claude-generated changes, so appreciate careful review.

Trying to save tons of compute time we wast building the cython-scan extension on the ubuntu wheel for every PR and push to main. Closes #219 

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1363.org.readthedocs.build/en/1363/

<!-- readthedocs-preview pytensor end -->