### PR TITLE
Fix typo in warning message

### DIFF
--- a/pytensor/tensor/blas.py
+++ b/pytensor/tensor/blas.py
@@ -1735,7 +1735,7 @@ def batched_dot(a, b):
     """
     warnings.warn(
         "batched_dot is deprecated. "
-        "Use `dot` in conjution with `tensor.vectorize` or `graph.replace.vectorize_graph`",
+        "Use `dot` in conjunction with `tensor.vectorize` or `graph.replace.vectorize_graph`",
         FutureWarning,
     )
     a, b = as_tensor_variable(a), as_tensor_variable(b)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
This is just a minor typo fix in the batched_tensordot deprecation warning message

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #



## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1364.org.readthedocs.build/en/1364/

<!-- readthedocs-preview pytensor end -->