### PR TITLE
Use `PyObject_CallNoArgs` to call thunks from VM

### DIFF
--- a/pytensor/link/c/c_code/lazylinker_c.c
+++ b/pytensor/link/c/c_code/lazylinker_c.c
@@ -477,7 +477,7 @@ static PyObject *pycall(CLazyLinker *self, Py_ssize_t node_idx, int verbose) {
     double t0 = pytime(NULL);
     if (verbose)
       fprintf(stderr, "calling via Python (node %i)\n", (int)node_idx);
-    rval = PyObject_CallObject(thunk, NULL);
+    rval = PyObject_CallNoArgs(thunk);
     if (rval) {
       double t1 = pytime(NULL);
       double ti = PyFloat_AsDouble(PyList_GetItem(self->call_times, node_idx));
@@ -491,7 +491,7 @@ static PyObject *pycall(CLazyLinker *self, Py_ssize_t node_idx, int verbose) {
     if (verbose) {
       fprintf(stderr, "calling via Python (node %i)\n", (int)node_idx);
     }
-    rval = PyObject_CallObject(thunk, NULL);
+    rval = PyObject_CallNoArgs(thunk);
   }
   return rval;
 }
@@ -981,7 +981,7 @@ static PyTypeObject lazylinker_ext_CLazyLinkerType = {
 };
 
 static PyObject *get_version(PyObject *dummy, PyObject *args) {
-  PyObject *result = PyFloat_FromDouble(0.3);
+  PyObject *result = PyFloat_FromDouble(0.31);
   return result;
 }
 

--- a/pytensor/link/c/lazylinker_c.py
+++ b/pytensor/link/c/lazylinker_c.py
@@ -14,7 +14,7 @@ from pytensor.link.c.cmodule import GCC_compiler
 _logger = logging.getLogger(__file__)
 
 force_compile = False
-version = 0.3  # must match constant returned in function get_version()
+version = 0.31  # must match constant returned in function get_version()
 lazylinker_ext: ModuleType | None = None
 
 


### PR DESCRIPTION
This is part of the Python ABI since 3.9. It saves a tiny ~20ns per thunk call, but costs us nothing :).

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1383.org.readthedocs.build/en/1383/

<!-- readthedocs-preview pytensor end -->