### PR TITLE
Make CAReduce more SIMD and memory friendly

### DIFF
--- a/tests/tensor/test_elemwise.py
+++ b/tests/tensor/test_elemwise.py
@@ -1045,7 +1045,7 @@ def careduce_benchmark_tester(axis, c_contiguous, mode, benchmark):
 
     x = pytensor.shared(x_test, name="x", shape=x_test.shape)
     out = x.transpose(transpose_axis).sum(axis=axis)
-    fn = pytensor.function([], out, mode=mode)
+    fn = pytensor.function([], out, mode=mode, trust_input=True)
 
     np.testing.assert_allclose(
         fn(),
@@ -1063,6 +1063,9 @@ def careduce_benchmark_tester(axis, c_contiguous, mode, benchmark):
     "c_contiguous",
     (True, False),
     ids=lambda x: f"c_contiguous={x}",
+)
+@pytensor.config.change_flags(
+    gcc__cxxflags="-freciprocal-math -ffp-contract=fast -funsafe-math-optimizations -fassociative-math -fno-signed-zeros -ftree-loop-distribution -funroll-loops -ftracer"
 )
 def test_c_careduce_benchmark(axis, c_contiguous, benchmark):
     return careduce_benchmark_tester(


### PR DESCRIPTION
This PR does two major changes:
  1. Adds a branch with intermediate allocators when reducing over a contiguous dimension that is SIMD friendly.
  2. Allocate output buffer aligned with input dimensions, instead of always allocating C-order.

Performance is now comparable or better than numpy

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1385.org.readthedocs.build/en/1385/

<!-- readthedocs-preview pytensor end -->