### PR TITLE
Resolve deprecation warnings of regex library

### DIFF
--- a/pytensor/tensor/random/rewriting/jax.py
+++ b/pytensor/tensor/random/rewriting/jax.py
@@ -174,7 +174,7 @@ def materialize_implicit_arange_choice_without_replacement(fgraph, node):
     new_props_dict = op._props_dict().copy()
     # Signature changes from something like "(),(a),(2)->(s0, s1)" to "(a),(a),(2)->(s0, s1)"
     # I.e., we substitute the first `()` by `(a)`
-    new_props_dict["signature"] = re.sub(r"\(\)", "(a)", op.signature, 1)
+    new_props_dict["signature"] = re.sub(r"\(\)", "(a)", op.signature, count=1)
     new_op = type(op)(**new_props_dict)
     return new_op.make_node(rng, size, a_vector_param, *other_params).outputs
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
This small PR resolves the `re` deprecation warnings:
```python
/home/runner/work/pytensor/pytensor/pytensor/tensor/random/rewriting/jax.py:177: DeprecationWarning: 'count' is passed as positional argument
```

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
