### PR TITLE
Avoid default allocation for taps of length 1 in ScanSaveMem

### DIFF
--- a/pytensor/tensor/rewriting/basic.py
+++ b/pytensor/tensor/rewriting/basic.py
@@ -95,9 +95,11 @@ def broadcasted_by(x: TensorVariable, y: TensorVariable) -> bool:
     """
     bx = x.type.broadcastable
     by = y.type.broadcastable
-    if len(bx) < len(by):
+    bx_len = len(bx)
+    by_len = len(by)
+    if bx_len < by_len:
         return True
-    bx = bx[-len(by) :]
+    bx = bx[bx_len - by_len :]
     return any(bx_dim and not by_dim for bx_dim, by_dim in zip(bx, by, strict=True))
 
 


### PR DESCRIPTION
The check we had for whether a variable was a default scan buffer (that's not also broadcasting the initval), always failed for single tapped outputs. There's a conservative check that the original value is not being broadcast to the number of initial taps, but that doesn't matter for single taps.

Also added some checks that we are actually only keeping buffers of the expected size in the test.

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1395.org.readthedocs.build/en/1395/

<!-- readthedocs-preview pytensor end -->