### PR TITLE
Pin libgcc for windows installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "scipy>=1,<2",
     "numpy>=1.17.0",
     "filelock>=3.15",
-    "libgcc<15",
+    "libgcc<15 ; platform_system == 'Windows'",
     "etuples",
     "logical-unification",
     "miniKanren",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "scipy>=1,<2",
     "numpy>=1.17.0",
     "filelock>=3.15",
+    "libgcc<15",
     "etuples",
     "logical-unification",
     "miniKanren",


### PR DESCRIPTION
Closes #1398 . Issue was reported and debugged by user DrEntropy [here](https://discourse.pymc.io/t/wierd-problem-installing-pymc/16984/13?u=jessegrabowski).

Maybe there's a better solution for this issue, but it's probably good to patch it quickly for now. We should also consider running the CI on windows -- testing linux and mac is a bit redundant?

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1399.org.readthedocs.build/en/1399/

<!-- readthedocs-preview pytensor end -->