### PR TITLE
Fix bug in gemv c code

### DIFF
--- a/tests/tensor/test_blas.py
+++ b/tests/tensor/test_blas.py
@@ -2226,8 +2226,10 @@ class TestBlasStrides:
 
                 a.set_value(a_dev.copy()[::a_step], borrow=True)
                 b.set_value(b_dev.copy()[::b_step1, ::b_step2], borrow=True)
+                # Copy as C so that it becomes F after the transpose in the graph
                 b_t.set_value(
-                    np.transpose(b_dev.copy())[::b_step2, ::b_step1], borrow=True
+                    np.transpose(b_dev).copy(order="C")[::b_step2, ::b_step1],
+                    borrow=True,
                 )
                 c.set_value(c_dev.copy()[::c_step], borrow=True)
 
@@ -2244,6 +2246,7 @@ class TestBlasStrides:
         self.cmp_gemv(3, (3, 5), 5, rng)
         self.cmp_gemv(1, (1, 5), 5, rng)
         self.cmp_gemv(3, (3, 1), 1, rng)
+        self.cmp_gemv(1, (1, 1), 1, rng)
         self.cmp_gemv(0, (0, 5), 5, rng)
         self.cmp_gemv(3, (3, 0), 0, rng)
         self.cmp_gemv(0, (0, 1), 1, rng)
@@ -2301,6 +2304,7 @@ class TestBlasStrides:
         self.cmp_ger((3, 5), 3, 5, rng)
         self.cmp_ger((1, 5), 1, 5, rng)
         self.cmp_ger((3, 1), 3, 1, rng)
+        self.cmp_ger((1, 1), 1, 1, rng)
         self.cmp_ger((0, 5), 0, 5, rng)
         self.cmp_ger((3, 0), 3, 0, rng)
         self.cmp_ger((0, 1), 0, 1, rng)

--- a/tests/tensor/test_blas_c.py
+++ b/tests/tensor/test_blas_c.py
@@ -243,6 +243,7 @@ class TestCGemv(OptimizationTestMixin):
         self.t_gemv1((0, 2))
         self.t_gemv1((3, 1))
         self.t_gemv1((3, 0))
+        self.t_gemv1((1, 1))
         self.t_gemv1((1, 0))
         self.t_gemv1((0, 1))
         self.t_gemv1((0, 0))

--- a/tests/tensor/test_blas_c.py
+++ b/tests/tensor/test_blas_c.py
@@ -413,6 +413,32 @@ class TestBlasStridesC(TestBlasStrides):
     mode = mode_blas_opt
 
 
+def test_gemv_vector_dot_perf(benchmark):
+    n = 400_000
+    a = pt.vector("A", shape=(n,))
+    b = pt.vector("x", shape=(n,))
+
+    out = CGemv(inplace=True)(
+        pt.empty((1,)),
+        1.0,
+        a[None],
+        b,
+        0.0,
+    )
+    fn = pytensor.function([a, b], out, accept_inplace=True, trust_input=True)
+
+    rng = np.random.default_rng(430)
+    test_a = rng.normal(size=n)
+    test_b = rng.normal(size=n)
+
+    np.testing.assert_allclose(
+        fn(test_a, test_b),
+        np.dot(test_a, test_b),
+    )
+
+    benchmark(fn, test_a, test_b)
+
+
 @pytest.mark.parametrize(
     "neg_stride1", (True, False), ids=["neg_stride1", "pos_stride1"]
 )


### PR DESCRIPTION
Fix bug in handling of row/column matrices in GEMV c_code

Bug was caused by reusing the blas-friendly readjusted strides in the logic to decide whether the call to GEMV should be transposed or not.

Particularly the old +1 in the strides was causing the last error branch to be triggered when the matrix had shape (1, 1).  The +1 was supposedly there for the cases of matrix with length 0, but that has it's own branch where the adjusted strides are never used. [That branch is actually useless, and was also removed in this PR]

This bug was introduced in afe934b229f15be4dcd96bbd3960e7ed328d99fa, before it we were using the unadjusted strides, but that is also suboptimal since strides for length1 dimensions are meaningless and any value is valid by the numpy standard.

The bug showed up in https://github.com/pymc-devs/pymc/pull/7792

This PR also introduces a benchmark test for the special logic in the cases where the gemv is doing a vector-vector dot. This was previously in the C-contiguous branch (which comes after the F-contiguous branch), which is sub-optimal because if a vector is C-contiguous it's also F-contiguous. We should apply in those cases regardless of the values the strides happen to be.

