### PR TITLE
Add unstack for xtensors

### DIFF
--- a/pytensor/xtensor/type.py
+++ b/pytensor/xtensor/type.py
@@ -306,6 +306,9 @@ class XTensorVariable(Variable[_XTensorTypeType, OptionalApplyType]):
         new_out.name = new_name
         return new_out
 
+    def stack(self, dim, **dims):
+        return px.shape.stack(self, dim, **dims)
+
     # def swap_dims(self, *args, **kwargs):
     #     ...
     #

--- a/pytensor/xtensor/type.py
+++ b/pytensor/xtensor/type.py
@@ -309,6 +309,9 @@ class XTensorVariable(Variable[_XTensorTypeType, OptionalApplyType]):
     def stack(self, dim, **dims):
         return px.shape.stack(self, dim, **dims)
 
+    def unstack(self, dim, **dims):
+        return px.shape.unstack(self, dim, **dims)
+
     # def swap_dims(self, *args, **kwargs):
     #     ...
     #

--- a/tests/xtensor/test_shape.py
+++ b/tests/xtensor/test_shape.py
@@ -9,9 +9,10 @@ pytest.importorskip("xarray")
 from itertools import chain, combinations
 
 import numpy as np
+from xarray import DataArray
 from xarray import concat as xr_concat
 
-from pytensor.xtensor.shape import concat, stack, transpose
+from pytensor.xtensor.shape import concat, stack, transpose, unstack
 from pytensor.xtensor.type import xtensor
 from tests.xtensor.util import (
     xr_arange_like,
@@ -151,6 +152,50 @@ def test_multiple_stacks():
     res = fn(x_test)
     expected_res = x_test.stack(new_dim1=("a", "b"), new_dim2=("c", "d"))
     xr_assert_allclose(res[0], expected_res)
+
+
+def test_unstack_constant_size():
+    x = xtensor("x", dims=("a", "bc", "d"), shape=(2, 3 * 5, 7))
+    y = unstack(x, bc=dict(b=3, c=5))
+    assert y.type.dims == ("a", "d", "b", "c")
+    assert y.type.shape == (2, 7, 3, 5)
+
+    fn = xr_function([x], y)
+
+    x_test = xr_arange_like(x)
+    x_np = x_test.values
+    res = fn(x_test)
+    expected = (
+        DataArray(x_np.reshape(2, 3, 5, 7), dims=("a", "b", "c", "d"))
+        .stack(bc=("b", "c"))
+        .unstack("bc")
+    )
+    xr_assert_allclose(res, expected)
+
+
+def test_unstack_symbolic_size():
+    x = xtensor(dims=("a", "b", "c"))
+    y = stack(x, bc=("b", "c"))
+    y = y / y.sum("bc")
+    z = unstack(y, bc={"b": x.sizes["b"], "c": x.sizes["c"]})
+    x_test = xr_arange_like(xtensor(dims=x.dims, shape=(2, 3, 5)))
+    fn = xr_function([x], z)
+    res = fn(x_test)
+    b_idx, c_idx = np.unravel_index(np.arange(15)[::-1].reshape((3, 5)), (3, 5))
+    expected_res = x_test / x_test.sum(["b", "c"])
+    xr_assert_allclose(res, expected_res)
+
+
+def test_stack_unstack():
+    x = xtensor("x", dims=("a", "b", "c", "d"), shape=(2, 3, 5, 7))
+    stack_x = stack(x, bd=("b", "d"))
+    unstack_x = unstack(stack_x, bd=dict(b=3, d=7))
+
+    x_test = xr_arange_like(x)
+    fn = xr_function([x], unstack_x)
+    res = fn(x_test)
+    expected_res = x_test.transpose("a", "c", "b", "d")
+    xr_assert_allclose(res, expected_res)
 
 
 @pytest.mark.parametrize("dim", ("a", "b", "new"))


### PR DESCRIPTION
@OriolAbril I am opening a branch with your code here on PyTensor. It can be from your fork if you prefer, but that would have to be you doing it.

Copying your messages:

> First pass at unstack. It is working already, need to sort out tests and double check the order in which unstack happens.

> @ricardoV94 let me know if the PR should have been done in a different way and how the code looks. As I commented in the test code itself, tests currently pass but I am only checking matching shapes with xarray, the actual elements are different. I have to figure out if the idea I had of testing the complementary operation to circumvent the fact that xarray's unstack needs coordinates can't actually be used or if I am inverting some `stack(new_dim=["a", "b"]` while the other has `["b", "a"]`.

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1412.org.readthedocs.build/en/1412/

<!-- readthedocs-preview pytensor end -->