### PR TITLE
Respect check_finite in LU decomposition rewrites

### DIFF
--- a/pytensor/tensor/type.py
+++ b/pytensor/tensor/type.py
@@ -793,7 +793,7 @@ def tensor(
         try:
             # Help catching errors with the new tensor API
             # Many single letter strings are valid sctypes
-            if str(name) == "floatX" or (len(str(name)) > 1 and np.dtype(name).type):
+            if str(name) == "floatX" or (len(str(name)) > 2 and np.dtype(name).type):
                 raise ValueError(
                     f"The first and only positional argument of tensor is now `name`. Got {name}.\n"
                     "This name looks like a dtype, which you should pass as a keyword argument only."


### PR DESCRIPTION
There is a test failing in PyMC that uses `check_finite=False` explicitly to test other stuff behaves correctly with NANs...

It's still a shame that scipy/we default to `check_finite=False`, wonder if there is a way to test once at runtime whether the involved lapack functions do crash/not-terminate with nan/infs...

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1417.org.readthedocs.build/en/1417/

<!-- readthedocs-preview pytensor end -->