### PR TITLE
Fix slow dot in numba

### DIFF
--- a/tests/link/numba/test_basic.py
+++ b/tests/link/numba/test_basic.py
@@ -30,7 +30,7 @@ from pytensor.link.numba.dispatch import basic as numba_basic
 from pytensor.link.numba.linker import NumbaLinker
 from pytensor.raise_op import assert_op
 from pytensor.scalar.basic import ScalarOp, as_scalar
-from pytensor.tensor import blas
+from pytensor.tensor import blas, tensor
 from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.shape import Reshape, Shape, Shape_i, SpecifyShape
 from pytensor.tensor.sort import ArgSortOp, SortOp
@@ -603,43 +603,41 @@ def test_perform_type_convert():
 
 
 @pytest.mark.parametrize(
-    "x, y, exc",
+    "x, y",
     [
         (
             (pt.matrix(), rng.random(size=(3, 2)).astype(config.floatX)),
             (pt.vector(), rng.random(size=(2,)).astype(config.floatX)),
-            None,
         ),
         (
             (pt.matrix(dtype="float64"), rng.random(size=(3, 2)).astype("float64")),
             (pt.vector(dtype="float32"), rng.random(size=(2,)).astype("float32")),
-            None,
         ),
         (
             (pt.lmatrix(), rng.poisson(size=(3, 2))),
             (pt.fvector(), rng.random(size=(2,)).astype("float32")),
-            None,
         ),
         (
             (pt.lvector(), rng.random(size=(2,)).astype(np.int64)),
             (pt.lvector(), rng.random(size=(2,)).astype(np.int64)),
-            None,
+        ),
+        (
+            (pt.vector(dtype="int16"), rng.random(size=(2,)).astype(np.int16)),
+            (pt.vector(dtype="uint8"), rng.random(size=(2,)).astype(np.uint8)),
         ),
     ],
 )
-def test_Dot(x, y, exc):
+def test_Dot(x, y):
     x, x_test_value = x
     y, y_test_value = y
 
     g = ptm.Dot()(x, y)
 
-    cm = contextlib.suppress() if exc is None else pytest.warns(exc)
-    with cm:
-        compare_numba_and_py(
-            [x, y],
-            [g],
-            [x_test_value, y_test_value],
-        )
+    compare_numba_and_py(
+        [x, y],
+        [g],
+        [x_test_value, y_test_value],
+    )
 
 
 @pytest.mark.parametrize(
@@ -937,3 +935,18 @@ def test_Nonzero(input_data):
     compare_numba_and_py(
         graph_inputs=[a], graph_outputs=graph_outputs, test_inputs=[input_data]
     )
+
+
+@pytest.mark.parametrize("dtype", ("float64", "float32", "mixed"))
+def test_mat_vec_dot_performance(dtype, benchmark):
+    A = tensor("A", shape=(512, 512), dtype="float64" if dtype == "mixed" else dtype)
+    x = tensor("x", shape=(512,), dtype="float32" if dtype == "mixed" else dtype)
+    out = ptm.dot(A, x)
+
+    fn = function([A, x], out, mode="NUMBA", trust_input=True)
+
+    rng = np.random.default_rng(948)
+    A_test = rng.standard_normal(size=A.type.shape, dtype=A.type.dtype)
+    x_test = rng.standard_normal(size=x.type.shape, dtype=x.type.dtype)
+    np.testing.assert_allclose(fn(A_test, x_test), np.dot(A_test, x_test), atol=1e-4)
+    benchmark(fn, A_test, x_test)


### PR DESCRIPTION
Closes #1418 

I confirmed with `perf` that numba is calling gemv, the problem was the castings `astype` to handle mixed or discrete dtypes always force a copy even when the cast dtype is the same as the input (discussed in https://github.com/numba/numba/issues/10085)

We should check the other functions that make use of `int_to_float_fn` (mostly linalg stuff), and adapt accordingly. This PR is just to fix the dot case.

Benchmark results
```
Before
------------------------------------------------------------------------------------------------- benchmark: 3 tests -------------------------------------------------------------------------------------------------
Name (time in us)                              Min                   Max                Mean             StdDev              Median                IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_mat_vec_dot_performance[float32]      48.5510 (1.0)      1,294.7070 (3.11)      61.3219 (1.0)      14.6329 (1.0)       60.6585 (1.0)       2.5140 (1.0)      231;2385       16.3074 (1.0)        9052           1
test_mat_vec_dot_performance[mixed]       150.2420 (3.09)       514.2840 (1.23)     172.9162 (2.82)     34.0547 (2.33)     159.1785 (2.62)     19.9170 (7.92)      298;300        5.7831 (0.35)       3162           1
test_mat_vec_dot_performance[float64]     158.5070 (3.26)       416.6410 (1.0)      181.0844 (2.95)     33.2207 (2.27)     165.9410 (2.74)     23.4185 (9.32)        73;59        5.5223 (0.34)        725           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

After
----------------------------------------------------------------------------------------------- benchmark: 3 tests ----------------------------------------------------------------------------------------------
Name (time in us)                             Min                 Max               Mean             StdDev             Median                IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_mat_vec_dot_performance[float32]     23.5340 (1.0)       69.0690 (1.0)      30.1434 (1.0)       3.2675 (1.0)      29.1650 (1.0)       0.5820 (1.0)     1465;3237       33.1748 (1.0)       16409           1
test_mat_vec_dot_performance[float64]     40.3260 (1.71)     159.3380 (2.31)     51.0019 (1.69)      8.8649 (2.71)     51.2260 (1.76)      9.6455 (16.57)    1587;272       19.6071 (0.59)       6019           1
test_mat_vec_dot_performance[mixed]       40.5660 (1.72)     180.4480 (2.61)     53.0003 (1.76)     16.4452 (5.03)     50.8750 (1.74)     11.4110 (19.61)     923;845       18.8678 (0.57)       9525           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
