### PR TITLE
Coerce dtype __props__ to string due to invalid hash of `np.dtype()` objects

### DIFF
--- a/pytensor/sparse/sandbox/sp2.py
+++ b/pytensor/sparse/sandbox/sp2.py
@@ -96,7 +96,7 @@ class Binomial(Op):
 
     def __init__(self, format, dtype):
         self.format = format
-        self.dtype = dtype
+        self.dtype = np.dtype(dtype).name
 
     def make_node(self, n, p, shape):
         n = pt.as_tensor_variable(n)

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -1090,6 +1090,8 @@ class Tri(Op):
     def __init__(self, dtype=None):
         if dtype is None:
             dtype = config.floatX
+        else:
+            dtype = np.dtype(dtype).name
         self.dtype = dtype
 
     def make_node(self, N, M, k):
@@ -1368,6 +1370,8 @@ class Eye(Op):
     def __init__(self, dtype=None):
         if dtype is None:
             dtype = config.floatX
+        else:
+            dtype = np.dtype(dtype).name
         self.dtype = dtype
 
     def make_node(self, n, m, k):
@@ -3225,7 +3229,7 @@ class ARange(COp):
     __props__ = ("dtype",)
 
     def __init__(self, dtype):
-        self.dtype = dtype
+        self.dtype = np.dtype(dtype).name
 
     def make_node(self, start, stop, step):
         from math import ceil
@@ -3407,7 +3411,8 @@ def arange(start, stop=None, step=1, dtype=None):
                     # We use the same dtype as numpy instead of the result of
                     # the upcast.
                     dtype = str(numpy_dtype)
-
+    else:
+        dtype = np.dtype(dtype).name
     if dtype not in _arange:
         _arange[dtype] = ARange(dtype)
     return _arange[dtype](start, stop, step)

--- a/pytensor/tensor/elemwise.py
+++ b/pytensor/tensor/elemwise.py
@@ -1234,8 +1234,8 @@ class CAReduce(COp):
             else:
                 self.axis = tuple(axis)
 
-        self.dtype = dtype
-        self.acc_dtype = acc_dtype
+        self.dtype = np.dtype(dtype).name
+        self.acc_dtype = np.dytpe(acc_dtype).name
         self.upcast_discrete_output = upcast_discrete_output
 
     @property

--- a/pytensor/tensor/io.py
+++ b/pytensor/tensor/io.py
@@ -25,7 +25,7 @@ class LoadFromDisk(Op):
     __props__ = ("dtype", "shape", "mmap_mode")
 
     def __init__(self, dtype, shape, mmap_mode=None):
-        self.dtype = np.dtype(dtype)  # turn "float64" into np.float64
+        self.dtype = np.dtype(dtype).name
         self.shape = shape
         if mmap_mode not in (None, "c"):
             raise ValueError(

--- a/pytensor/tensor/random/op.py
+++ b/pytensor/tensor/random/op.py
@@ -112,6 +112,8 @@ class RandomVariable(Op):
             else:
                 self.signature = safe_signature(self.ndims_params, [self.ndim_supp])
 
+        if dtype is not None:
+            dtype = np.dtype(dtype).name
         self.dtype = dtype or getattr(self, "dtype", None)
 
         self.inplace = (


### PR DESCRIPTION
There were some odd errors cropping up in [pymc-marketing](https://github.com/pymc-labs/pymc-marketing/pull/1728) and a private project.


The issue happened when you created an Arange with `float64` and another with `np.dtype("float64")` (or any combo of dtype and string), which evaluate to the same thing, but hash differently (see below why). The PyTensor C-cache has a sanity-check mechanism to make sure the eq and hash of our Ops is correctly implemented, as the validity of the cache depends on this.

PyTensor uses the properties of Op to define equality and hash automatically, and for Arange that is it's `dtype` argument. Surprisingly though, `np.dtype("float64") == "float64" and hash(np.dtype("float64")) != hash("float64")`, which seems to be a fundamental bug in Numpy: https://github.com/numpy/numpy/issues/17864

This only became a problem once we added a C-implementation to Arange in https://github.com/pymc-devs/pytensor/pull/1392 as this is where the automatic checks for hash/eq are performed.

I tried to look for other Ops parametrized by `dtype` of some form or another, and make sure those are always converted to the equivalent strings.

CC @lucianopaz and @juanitorduz 