### PR TITLE
Adding expand_dims for xtensor

### DIFF
--- a/pytensor/xtensor/rewriting/shape.py
+++ b/pytensor/xtensor/rewriting/shape.py
@@ -123,7 +123,7 @@ def lower_transpose(fgraph, node):
 
 @register_lower_xtensor
 @node_rewriter([Squeeze])
-def local_squeeze_reshape(fgraph, node):
+def lower_squeeze(fgraph, node):
     """Rewrite Squeeze to tensor.squeeze."""
     [x] = node.inputs
     x_tensor = tensor_from_xtensor(x)
@@ -138,7 +138,7 @@ def local_squeeze_reshape(fgraph, node):
 
 @register_lower_xtensor
 @node_rewriter([ExpandDims])
-def local_expand_dims_reshape(fgraph, node):
+def lower_expand_dims(fgraph, node):
     """Rewrite ExpandDims using tensor operations."""
     x, size = node.inputs
     out = node.outputs[0]
@@ -155,10 +155,8 @@ def local_expand_dims_reshape(fgraph, node):
         # Simple case: just expand with size 1
         result_tensor = expand_dims(x_tensor, new_axis)
     else:
-        # First expand with size 1
-        expanded = expand_dims(x_tensor, new_axis)
-        # Then broadcast to the requested size
-        result_tensor = broadcast_to(expanded, (size_tensor, *x_tensor.shape))
+        # Otherwise broadcast to the requested size
+        result_tensor = broadcast_to(x_tensor, (size_tensor, *x_tensor.shape))
 
     # Preserve static shape information
     result_tensor = specify_shape(result_tensor, out.type.shape)

--- a/pytensor/xtensor/shape.py
+++ b/pytensor/xtensor/shape.py
@@ -505,6 +505,6 @@ def expand_dims(x, dim=None, create_index_for_new_dim=True, axis=None, **dim_kwa
             zip(new_dim_names, axis), key=lambda x: x[1]
         ):
             target_dims.insert(insert_axis, insert_dim)
-        x = transpose(x, *target_dims)
+        x = Transpose(dims=tuple(target_dims))(x)
 
     return x

--- a/pytensor/xtensor/shape.py
+++ b/pytensor/xtensor/shape.py
@@ -442,31 +442,15 @@ class ExpandDims(XOp):
 
 
 def expand_dims(x, dim=None, create_index_for_new_dim=True, **dim_kwargs):
-    """Add one or more new dimensions to an XTensorVariable.
-
-    Parameters
-    ----------
-    x : XTensorVariable
-        Input tensor.
-    dim : str | Sequence[str] | dict[str, int | Sequence] | None
-        If str or sequence of str, new dimensions with size 1.
-        If dict, keys are dimension names and values are either:
-            - int: the new size
-            - sequence: coordinates (length determines size)
-    create_index_for_new_dim : bool, default: True
-        (Ignored for now) Matches xarray API, reserved for future use.
-    **dim_kwargs : int | Sequence
-        Alternative to `dim` dict. Only used if `dim` is None.
-
-    Returns
-    -------
-    XTensorVariable
-        A tensor with additional dimensions inserted at the front.
-    """
+    """Add one or more new dimensions to an XTensorVariable."""
     x = as_xtensor(x)
 
     # Extract size from dim_kwargs if present
     size = dim_kwargs.pop("size", 1) if dim_kwargs else 1
+
+    # xarray compatibility: error if a sequence (list/tuple) of dims and size are given
+    if (isinstance(dim, list | tuple)) and ("size" in locals() and size != 1):
+        raise ValueError("cannot specify both keyword and positional arguments")
 
     if dim is None:
         dim = dim_kwargs

--- a/pytensor/xtensor/type.py
+++ b/pytensor/xtensor/type.py
@@ -481,6 +481,27 @@ class XTensorVariable(Variable[_XTensorTypeType, OptionalApplyType]):
             raise NotImplementedError("Squeeze with axis not Implemented")
         return px.shape.squeeze(self, dim)
 
+    def expand_dims(
+        self,
+        dim: str | None = None,
+        size: int | Variable = 1,
+    ):
+        """Add a new dimension to the tensor.
+
+        Parameters
+        ----------
+        dim : str or None
+            Name of new dimension. If None, returns self unchanged.
+        size : int or symbolic, optional
+            Size of the new dimension (default 1)
+
+        Returns
+        -------
+        XTensorVariable
+            Tensor with the new dimension inserted
+        """
+        return px.shape.expand_dims(self, dim, size=size)
+
     # ndarray methods
     # https://docs.xarray.dev/en/latest/api.html#id7
     def clip(self, min, max):

--- a/pytensor/xtensor/type.py
+++ b/pytensor/xtensor/type.py
@@ -485,6 +485,7 @@ class XTensorVariable(Variable[_XTensorTypeType, OptionalApplyType]):
         self,
         dim: str | Sequence[str] | dict[str, int | Sequence] | None = None,
         create_index_for_new_dim: bool = True,
+        axis: int | None = None,
         **dim_kwargs,
     ):
         """Add one or more new dimensions to the tensor.
@@ -497,7 +498,14 @@ class XTensorVariable(Variable[_XTensorTypeType, OptionalApplyType]):
                 - int: the new size
                 - sequence: coordinates (length determines size)
         create_index_for_new_dim : bool, default: True
-            (Ignored for now) Matches xarray API, reserved for future use.
+            Currently ignored. Reserved for future coordinate support.
+            In xarray, when True (default), creates a coordinate index for the new dimension
+            with values from 0 to size-1. When False, no coordinate index is created.
+        axis : int | None, default: None
+            Not implemented yet. In xarray, specifies where to insert the new dimension(s).
+            By default (None), new dimensions are inserted at the beginning (axis=0).
+            Symbolic axis is not supported yet.
+            Negative values count from the end.
         **dim_kwargs : int | Sequence
             Alternative to `dim` dict. Only used if `dim` is None.
 
@@ -507,7 +515,11 @@ class XTensorVariable(Variable[_XTensorTypeType, OptionalApplyType]):
             A tensor with additional dimensions inserted at the front.
         """
         return px.shape.expand_dims(
-            self, dim, create_index_for_new_dim=create_index_for_new_dim, **dim_kwargs
+            self,
+            dim,
+            create_index_for_new_dim=create_index_for_new_dim,
+            axis=axis,
+            **dim_kwargs,
         )
 
     # ndarray methods

--- a/pytensor/xtensor/type.py
+++ b/pytensor/xtensor/type.py
@@ -485,7 +485,7 @@ class XTensorVariable(Variable[_XTensorTypeType, OptionalApplyType]):
         self,
         dim: str | Sequence[str] | dict[str, int | Sequence] | None = None,
         create_index_for_new_dim: bool = True,
-        axis: int | None = None,
+        axis: int | Sequence[int] | None = None,
         **dim_kwargs,
     ):
         """Add one or more new dimensions to the tensor.
@@ -501,7 +501,7 @@ class XTensorVariable(Variable[_XTensorTypeType, OptionalApplyType]):
             Currently ignored. Reserved for future coordinate support.
             In xarray, when True (default), creates a coordinate index for the new dimension
             with values from 0 to size-1. When False, no coordinate index is created.
-        axis : int | None, default: None
+        axis : int | Sequence[int] | None, default: None
             Not implemented yet. In xarray, specifies where to insert the new dimension(s).
             By default (None), new dimensions are inserted at the beginning (axis=0).
             Symbolic axis is not supported yet.

--- a/pytensor/xtensor/type.py
+++ b/pytensor/xtensor/type.py
@@ -483,24 +483,32 @@ class XTensorVariable(Variable[_XTensorTypeType, OptionalApplyType]):
 
     def expand_dims(
         self,
-        dim: str | None = None,
-        size: int | Variable = 1,
+        dim: str | Sequence[str] | dict[str, int | Sequence] | None = None,
+        create_index_for_new_dim: bool = True,
+        **dim_kwargs,
     ):
-        """Add a new dimension to the tensor.
+        """Add one or more new dimensions to the tensor.
 
         Parameters
         ----------
-        dim : str or None
-            Name of new dimension. If None, returns self unchanged.
-        size : int or symbolic, optional
-            Size of the new dimension (default 1)
+        dim : str | Sequence[str] | dict[str, int | Sequence] | None
+            If str or sequence of str, new dimensions with size 1.
+            If dict, keys are dimension names and values are either:
+                - int: the new size
+                - sequence: coordinates (length determines size)
+        create_index_for_new_dim : bool, default: True
+            (Ignored for now) Matches xarray API, reserved for future use.
+        **dim_kwargs : int | Sequence
+            Alternative to `dim` dict. Only used if `dim` is None.
 
         Returns
         -------
         XTensorVariable
-            Tensor with the new dimension inserted
+            A tensor with additional dimensions inserted at the front.
         """
-        return px.shape.expand_dims(self, dim, size=size)
+        return px.shape.expand_dims(
+            self, dim, create_index_for_new_dim=create_index_for_new_dim, **dim_kwargs
+        )
 
     # ndarray methods
     # https://docs.xarray.dev/en/latest/api.html#id7

--- a/tests/xtensor/test_shape.py
+++ b/tests/xtensor/test_shape.py
@@ -437,6 +437,18 @@ def test_expand_dims():
     fn = xr_function([x, size_sym_1, size_sym_2], y)
     xr_assert_allclose(fn(x_test, 2, 3), x_test.expand_dims({"country": 2, "state": 3}))
 
+    # Test with axis parameter
+    y = x.expand_dims("country", axis=1)
+    fn = xr_function([x], y)
+    xr_assert_allclose(fn(x_test), x_test.expand_dims("country", axis=1))
+
+    # Add two new dims at axis=[1, 2]
+    y = x.expand_dims(["country", "state"], axis=[1, 2])
+    fn = xr_function([x], y)
+    xr_assert_allclose(
+        fn(x_test), x_test.expand_dims(["country", "state"], axis=[1, 2])
+    )
+
 
 def test_expand_dims_errors():
     """Test error handling in expand_dims."""

--- a/tests/xtensor/test_shape.py
+++ b/tests/xtensor/test_shape.py
@@ -463,10 +463,6 @@ def test_expand_dims_errors():
     with pytest.raises(TypeError, match="Invalid type for `dim`"):
         x.expand_dims(123)
 
-    # Invalid size type
-    with pytest.raises(TypeError, match="size must be an int or scalar variable"):
-        x.expand_dims("new", size=[1])
-
     # Duplicate dimension creation
     y = x.expand_dims("new")
     with pytest.raises(ValueError, match="already exists"):

--- a/tests/xtensor/test_shape.py
+++ b/tests/xtensor/test_shape.py
@@ -376,7 +376,7 @@ def test_expand_dims():
     x = xtensor("x", dims=("city", "year"), shape=(2, 2))
     x_test = xr_arange_like(x)
 
-    # Implicit size=1
+    # Implicit size 1
     y = x.expand_dims("country")
     fn = xr_function([x], y)
     xr_assert_allclose(fn(x_test), x_test.expand_dims("country"))
@@ -386,7 +386,7 @@ def test_expand_dims():
     fn = xr_function([x], y)
     xr_assert_allclose(fn(x_test), x_test.expand_dims(["country", "state"]))
 
-    # Test with a dict of sizes
+    # Test with a dict of name-size pairs
     y = x.expand_dims({"country": 2, "state": 3})
     fn = xr_function([x], y)
     xr_assert_allclose(fn(x_test), x_test.expand_dims({"country": 2, "state": 3}))
@@ -396,7 +396,15 @@ def test_expand_dims():
     fn = xr_function([x], y)
     xr_assert_allclose(fn(x_test), x_test.expand_dims(country=2, state=3))
 
-    # Symbolic size=1
+    # Test with a dict of name-coord array pairs
+    y = x.expand_dims({"country": np.array([1, 2]), "state": np.array([3, 4, 5])})
+    fn = xr_function([x], y)
+    xr_assert_allclose(
+        fn(x_test),
+        x_test.expand_dims({"country": np.array([1, 2]), "state": np.array([3, 4, 5])}),
+    )
+
+    # Symbolic size 1
     size_sym_1 = scalar("size_sym_1", dtype="int64")
     y = x.expand_dims({"country": size_sym_1})
     fn = xr_function([x, size_sym_1], y)
@@ -462,3 +470,12 @@ def test_expand_dims_errors():
     y = x.expand_dims("new")
     with pytest.raises(ValueError, match="already exists"):
         y.expand_dims("new")
+
+    # Find out what xarray does with a numpy array as dim
+    # x_test = xr_arange_like(x)
+    # x_test.expand_dims(np.array([1, 2]))
+    # TypeError: unhashable type: 'numpy.ndarray'
+
+    # Test with a numpy array as dim (not supported)
+    with pytest.raises(TypeError, match="unhashable type"):
+        y.expand_dims(np.array([1, 2]))

--- a/tests/xtensor/test_shape.py
+++ b/tests/xtensor/test_shape.py
@@ -540,10 +540,6 @@ def test_expand_dims_errors():
     with pytest.raises(ValueError, match="already exists"):
         expand_dims(y, "city")
 
-    # Size = 0 is invalid
-    with pytest.raises(ValueError, match="size must be.*positive"):
-        expand_dims(x, "batch", size=0)
-
     # Invalid dim type
     with pytest.raises(TypeError, match="Invalid type for `dim`"):
         expand_dims(x, 123)
@@ -556,13 +552,6 @@ def test_expand_dims_errors():
     y = expand_dims(x, "new")
     with pytest.raises(ValueError, match="already exists"):
         expand_dims(y, "new")
-
-    # Symbolic size with invalid runtime value
-    size_sym = scalar("size_sym", dtype="int64")
-    y = expand_dims(x, "batch", size=size_sym)
-    fn = xr_function([x, size_sym], y, on_unused_input="ignore")
-    with pytest.raises(Exception):
-        fn(xr_arange_like(x), 0)
 
 
 def test_expand_dims_multiple():


### PR DESCRIPTION
# Add expand_dims operation for labeled tensors

This PR adds support for the `expand_dims` operation in PyTensor's labeled tensor system, allowing users to add new dimensions to labeled tensors with explicit dimension names.

## Key Features

- New `ExpandDims` operation that adds a new dimension to an XTensorVariable
- Support for both static and symbolic dimension sizes
- Automatic broadcasting when size > 1
- Integration with existing tensor operations
- Full compatibility with xarray's expand_dims behavior

## Implementation Details

The implementation includes:

1. New `ExpandDims` class in `pytensor/xtensor/shape.py` that handles:
   - Adding new dimensions with specified names
   - Support for both static and symbolic sizes
   - Shape inference and validation

2. Rewriting rule in `pytensor/xtensor/rewriting/shape.py` that:
   - Converts labeled tensor operations to standard tensor operations
   - Handles broadcasting when needed
   - Validates symbolic sizes

3. Comprehensive test suite in `tests/xtensor/test_shape.py` covering:
   - Basic dimension expansion
   - Static and symbolic sizes
   - Error cases and edge cases
   - Compatibility with xarray operations
   - Integration with other labeled tensor operations

## Usage Example

```python
import pytensor.tensor as pt
from pytensor.xtensor import xtensor

# Create a labeled tensor
x = xtensor("x", dims=("city",), shape=(3,))

# Add a new dimension
y = expand_dims(x, "country")  # Adds a new dimension of size 1
z = expand_dims(x, "country", size=4)  # Adds a new dimension of size 4
```

## Testing

The implementation includes extensive tests that verify:
- Correct behavior with various input shapes
- Proper handling of symbolic sizes
- Error cases (invalid dimensions, sizes, etc.)
- Compatibility with xarray's expand_dims
- Integration with other labeled tensor operations


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1449.org.readthedocs.build/en/1449/

<!-- readthedocs-preview pytensor end -->