### PR TITLE
Use lapack func instead of `scipy.linalg.cholesky`

### DIFF
--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -68,35 +68,38 @@ class Cholesky(Op):
         [x] = inputs
         [out] = outputs
 
+        (potrf,) = scipy_linalg.get_lapack_funcs(("potrf",), (x,))
+
         # Quick return for square empty array
         if x.size == 0:
-            eye = np.eye(1, dtype=x.dtype)
-            (potrf,) = scipy_linalg.get_lapack_funcs(("potrf",), (eye,))
-            c, _ = potrf(eye, lower=False, overwrite_a=False, clean=True)
-            out[0] = np.empty_like(x, dtype=c.dtype)
+            out[0] = np.empty_like(x, dtype=potrf.dtype)
             return
 
-        x1 = np.asarray_chkfinite(x) if self.check_finite else x
+        if self.check_finite and not np.isfinite(x).all():
+            if self.on_error == "nan":
+                out[0] = np.full(x.shape, np.nan, dtype=node.outputs[0].type.dtype)
+                return
+            else:
+                raise ValueError("array must not contain infs or NaNs")
 
         # Squareness check
-        if x1.shape[0] != x1.shape[1]:
+        if x.shape[0] != x.shape[1]:
             raise ValueError(
-                "Input array is expected to be square but has "
-                f"the shape: {x1.shape}."
+                "Input array is expected to be square but has " f"the shape: {x.shape}."
             )
 
         # Scipy cholesky only makes use of overwrite_a when it is F_CONTIGUOUS
         # If we have a `C_CONTIGUOUS` array we transpose to benefit from it
-        if self.overwrite_a and x.flags["C_CONTIGUOUS"]:
-            x1 = x1.T
+        c_contiguous_input = self.overwrite_a and x.flags["C_CONTIGUOUS"]
+        if c_contiguous_input:
+            x = x.T
             lower = not self.lower
             overwrite_a = True
         else:
             lower = self.lower
             overwrite_a = self.overwrite_a
 
-        (potrf,) = scipy_linalg.get_lapack_funcs(("potrf",), (x1,))
-        c, info = potrf(x1, lower=lower, overwrite_a=overwrite_a, clean=True)
+        c, info = potrf(x, lower=lower, overwrite_a=overwrite_a, clean=True)
 
         if info != 0:
             if self.on_error == "nan":
@@ -112,7 +115,7 @@ class Cholesky(Op):
                 )
         else:
             # Transpose result if input was transposed
-            out[0] = c.T if (self.overwrite_a and x.flags["C_CONTIGUOUS"]) else c
+            out[0] = c.T if c_contiguous_input else c
 
     def L_op(self, inputs, outputs, gradients):
         """

--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -77,7 +77,7 @@ class Cholesky(Op):
 
         if self.check_finite and not np.isfinite(x).all():
             if self.on_error == "nan":
-                out[0] = np.full(x.shape, np.nan, dtype=node.outputs[0].type.dtype)
+                out[0] = np.full(x.shape, np.nan, dtype=potrf.dtype)
                 return
             else:
                 raise ValueError("array must not contain infs or NaNs")

--- a/tests/link/numba/test_slinalg.py
+++ b/tests/link/numba/test_slinalg.py
@@ -465,7 +465,7 @@ def test_cholesky_raises_on_nan_input():
 
     x = pt.tensor(dtype=floatX, shape=(3, 3))
     x = x.T.dot(x)
-    g = pt.linalg.cholesky(x)
+    g = pt.linalg.cholesky(x, check_finite=True)
     f = pytensor.function([x], g, mode="NUMBA")
 
     with pytest.raises(np.linalg.LinAlgError, match=r"Non-numeric values"):

--- a/tests/tensor/test_slinalg.py
+++ b/tests/tensor/test_slinalg.py
@@ -84,6 +84,16 @@ def test_cholesky_performance(benchmark):
     benchmark(ch_f, pd)
 
 
+def test_cholesky_empty():
+    empty = np.empty([0, 0], dtype=config.floatX)
+    x = matrix()
+    chol = cholesky(x)
+    ch_f = function([x], chol)
+    ch = ch_f(empty)
+    assert ch.size == 0
+    assert ch.dtype == config.floatX
+
+
 def test_cholesky_indef():
     x = matrix()
     mat = np.array([[1, 0.2], [0.2, -2]]).astype(config.floatX)

--- a/tests/tensor/test_slinalg.py
+++ b/tests/tensor/test_slinalg.py
@@ -74,6 +74,16 @@ def test_cholesky():
     check_upper_triangular(pd, ch_f)
 
 
+def test_cholesky_performance(benchmark):
+    rng = np.random.default_rng(utt.fetch_seed())
+    r = rng.standard_normal((10, 10)).astype(config.floatX)
+    pd = np.dot(r, r.T)
+    x = matrix()
+    chol = cholesky(x)
+    ch_f = function([x], chol)
+    benchmark(ch_f, pd)
+
+
 def test_cholesky_indef():
     x = matrix()
     mat = np.array([[1, 0.2], [0.2, -2]]).astype(config.floatX)


### PR DESCRIPTION
* Now skips 2D checks in perform
* Updated the default arguments for `check_finite` to false to match documentation
* Add benchmark test case

<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
Adds `_cholesky` method to `slinalg.Cholesky` to replace the `scipy.linalg.cholesky` wrapper. It is almost identical to [the corresponding scipy function](https://github.com/scipy/scipy/blob/63025cd1028cdb46de42400df21c60aa13f68743/scipy/linalg/_decomp_cholesky.py#L15) but it skips the 2d check and the batching wrapper.

Previous performance (with `check_finite=False`):
```
benchmark: 5.1.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)

--------------------------------------------------- benchmark: 1 tests ---------------------------------------------------
Name (time in us)                Min      Max    Mean  StdDev  Median     IQR   Outliers  OPS (Kops/s)  Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------
test_cholesky_performance     5.6610  43.2910  6.8433  2.4983  5.9610  0.1810  1312;1574      146.1280    9487           1
--------------------------------------------------------------------------------------------------------------------------
```

After changes:
```
benchmark: 5.1.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)

--------------------------------------------------- benchmark: 1 tests --------------------------------------------------
Name (time in us)                Min      Max    Mean  StdDev  Median     IQR  Outliers  OPS (Kops/s)  Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------
test_cholesky_performance     5.1500  28.5640  5.5494  1.0101  5.4210  0.1100   262;628      180.2012   12753           1
-------------------------------------------------------------------------------------------------------------------------
```

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #1468

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [x] Other (please specify): performance
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1487.org.readthedocs.build/en/1487/

<!-- readthedocs-preview pytensor end -->