### PR TITLE
Add JAX dispatch for `CholeskySolve` `Op`

### DIFF
--- a/pytensor/link/jax/dispatch/slinalg.py
+++ b/pytensor/link/jax/dispatch/slinalg.py
@@ -7,6 +7,7 @@ from pytensor.tensor.slinalg import (
     LU,
     BlockDiagonal,
     Cholesky,
+    CholeskySolve,
     Eigvalsh,
     LUFactor,
     PivotToPermutations,
@@ -153,3 +154,17 @@ def jax_funcify_LUFactor(op, **kwargs):
         )
 
     return lu_factor
+
+
+@jax_funcify.register(CholeskySolve)
+def jax_funcify_ChoSolve(op, **kwargs):
+    lower = op.lower
+    check_finite = op.check_finite
+    overwrite_b = op.overwrite_b
+
+    def cho_solve(c, b):
+        return jax.scipy.linalg.cho_solve(
+            (c, lower), b, check_finite=check_finite, overwrite_b=overwrite_b
+        )
+
+    return cho_solve

--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -376,14 +376,20 @@ class CholeskySolve(SolveBase):
             return self
 
 
-def cho_solve(c_and_lower, b, *, check_finite=True, b_ndim: int | None = None):
+def cho_solve(
+    c_and_lower: tuple[TensorLike, bool],
+    b: TensorLike,
+    *,
+    check_finite: bool = True,
+    b_ndim: int | None = None,
+):
     """Solve the linear equations A x = b, given the Cholesky factorization of A.
 
     Parameters
     ----------
-    (c, lower) : tuple, (array, bool)
+    c_and_lower : tuple of (TensorLike, bool)
         Cholesky factorization of a, as given by cho_factor
-    b : array
+    b : TensorLike
         Right-hand side
     check_finite : bool, optional
         Whether to check that the input matrices contain only finite numbers.

--- a/tests/link/jax/test_slinalg.py
+++ b/tests/link/jax/test_slinalg.py
@@ -333,3 +333,19 @@ def test_jax_lu_solve(b_shape):
     out = pt_slinalg.lu_solve(lu_and_pivots, b)
 
     compare_jax_and_py([A, b], [out], [A_val, b_val])
+
+
+@pytest.mark.parametrize("b_shape, lower", [((5,), True), ((5, 5), False)])
+def test_jax_chosolve(b_shape, lower):
+    rng = np.random.default_rng(utt.fetch_seed())
+    L_val = rng.normal(size=(5, 5)).astype(config.floatX)
+    A_val = (L_val @ L_val.T).astype(config.floatX)
+
+    b_val = rng.normal(size=b_shape).astype(config.floatX)
+
+    A = pt.tensor(name="A", shape=(5, 5))
+    b = pt.tensor(name="b", shape=b_shape)
+    c = pt_slinalg.cholesky(A, lower=lower)
+    out = pt_slinalg.cho_solve((c, lower), b, b_ndim=len(b_shape))
+
+    compare_jax_and_py([A, b], [out], [A_val, b_val])


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
Adds a JAX dispatch for the `CholeskySolve` `Op`. Nobody ever uses this function (although it's quite nice), so nobody cared that we didn't have this. Now it matters because of the rewrites introduced in #1461. Graphs that benefit from this rewrite (basically any PyMC model with an MvNormal....) will error in JAX mode because the Op is missing.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #1484 
- [ ] Related to #1461 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
