### PR TITLE
Handle `lower` flag more carefully in Solve to CholeskySolve rewrite

### DIFF
--- a/pytensor/tensor/_linalg/solve/rewriting.py
+++ b/pytensor/tensor/_linalg/solve/rewriting.py
@@ -100,7 +100,6 @@ def _split_decomp_and_solve_steps(
             elif isinstance(cl.op, DimShuffle) and cl.op.is_left_expand_dims:
                 # If it's a left expand_dims, recurse on the output
                 clients.extend(find_solve_clients(cl.outputs[0], assume_a))
-
         return clients
 
     assume_a = node.op.core_op.assume_a
@@ -108,35 +107,33 @@ def _split_decomp_and_solve_steps(
     if assume_a not in allowed_assume_a:
         return None
 
-    root_A, root_A_transposed = get_root_A(node.inputs[0])
+    A, _ = get_root_A(node.inputs[0])
 
     # Find Solve using A (or left expand_dims of A)
     # TODO: We could handle arbitrary shuffle of the batch dimensions, just need to propagate
     #  that to the A_decomp outputs
-    root_A_solve_clients_and_transpose = [
-        (client, False) for client in find_solve_clients(root_A, assume_a)
+    A_solve_clients_and_transpose = [
+        (client, False) for client in find_solve_clients(A, assume_a)
     ]
 
     # Find Solves using A.T
-    for cl, _ in fgraph.clients[root_A]:
+    for cl, _ in fgraph.clients[A]:
         if isinstance(cl.op, DimShuffle) and is_matrix_transpose(cl.out):
             A_T = cl.out
-            root_A_solve_clients_and_transpose.extend(
+            A_solve_clients_and_transpose.extend(
                 (client, True) for client in find_solve_clients(A_T, assume_a)
             )
 
-    if not eager and len(root_A_solve_clients_and_transpose) == 1:
+    if not eager and len(A_solve_clients_and_transpose) == 1:
         # If theres' a single use don't do it... unless it's being broadcast in a Blockwise (or we're eager)
         # That's a "reuse" inside the inner vectorized loop
         batch_ndim = node.op.batch_ndim(node)
-        (client, _) = root_A_solve_clients_and_transpose[0]
-
-        A, b = client.inputs
-
+        (client, _) = A_solve_clients_and_transpose[0]
+        original_A, b = client.inputs
         if not any(
             a_bcast and not b_bcast
             for a_bcast, b_bcast in zip(
-                A.type.broadcastable[:batch_ndim],
+                original_A.type.broadcastable[:batch_ndim],
                 b.type.broadcastable[:batch_ndim],
                 strict=True,
             )
@@ -145,27 +142,19 @@ def _split_decomp_and_solve_steps(
 
     # If any Op had check_finite=True, we also do it for the LU decomposition
     check_finite_decomp = False
-    for client, _ in root_A_solve_clients_and_transpose:
+    for client, _ in A_solve_clients_and_transpose:
         if client.op.core_op.check_finite:
             check_finite_decomp = True
             break
 
-    (first_solve, transposed) = root_A_solve_clients_and_transpose[0]
-    lower = first_solve.op.core_op.lower
-    if transposed:
-        lower = not lower
-
+    lower = node.op.core_op.lower
     A_decomp = decompose_A(
-        root_A, assume_a=assume_a, check_finite=check_finite_decomp, lower=lower
+        A, assume_a=assume_a, check_finite=check_finite_decomp, lower=lower
     )
 
     replacements = {}
-    for client, transposed in root_A_solve_clients_and_transpose:
+    for client, transposed in A_solve_clients_and_transpose:
         _, b = client.inputs
-        lower = client.op.core_op.lower
-        if transposed:
-            lower = not lower
-
         new_x = solve_decomposed_system(
             A_decomp,
             b,


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
There was some discussion in #1467 about whether the `reuse_decomposition_multiple_solves` rewrite was doing the right thing with the `lower` flags, especially in the corner case where a user is being really clever and only storing half the symmetric matrix. 

This PR handles the case more carefully, and checks on a matrix with NaN values that we don't look at the wrong triangles after rewriting. 

It also forwards the `check_finite` argument in the `Cholesky` Op, which was not being respected previously. I think this is also being fixed in #1487 , so there's some undesirable overlap between these PRs.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #1467 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1492.org.readthedocs.build/en/1492/

<!-- readthedocs-preview pytensor end -->