### PR TITLE
Do not skip validation between consecutive Elemwise inplace replacements

### DIFF
--- a/pytensor/tensor/rewriting/elemwise.py
+++ b/pytensor/tensor/rewriting/elemwise.py
@@ -199,12 +199,14 @@ class InplaceGraphOptimizer(GraphRewriter):
                     prof["nb_eager_inconsistent"] += 1
                 else:
                     prof["nb_replaced"] += 1
+                    copy_stack_trace(node.outputs, inplace_node.outputs)
                     continue
 
             # If it fails or doesn't match the desired inplace pattern, try one output/input at a time
             tried_inputs = set()
             inplace_pattern = {}
             replaced = False
+            original_node = node
             for (o, _), (i, _) in sorted_candidate_pairs:
                 if o not in inplace_pattern and i not in tried_inputs:
                     inplace_pattern[o] = [i]
@@ -225,7 +227,9 @@ class InplaceGraphOptimizer(GraphRewriter):
                             prof["nb_inconsistent"] += 1
                             # The input, not the output caused inconsistencies
                             inplace_pattern.pop(o)
-            prof["nb_replaced"] += replaced
+            if replaced:
+                copy_stack_trace(original_node.outputs, node.outputs)
+                prof["nb_replaced"] += replaced
 
         return prof
 


### PR DESCRIPTION
Closes #1420 

There was a performance-related hack in the ElemwiseInplaceOptimizer where it tried to avoid validating the graph after replacing each node.

This is a bad idea because it may revert valid rewrites that happen to be caught in the same "check" window as an invalid rewrite. More importantly since we started inplacing on multi-output Elemwise, it could trigger an exception when trying to call `has_destroyers` on subsequent nodes, due to a previous invalid replacement.

It was hard to track down this issue because the special behavior was only triggered once a graph had more than 500 nodes.

After the refactor I noticed that most of the logic of the rewrite can be shared with Blockwise, so I went ahead and refactored it, which also closes #1457

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1494.org.readthedocs.build/en/1494/

<!-- readthedocs-preview pytensor end -->