### PR TITLE
Add `compiler_verbose` config flag

### DIFF
--- a/doc/library/config.rst
+++ b/doc/library/config.rst
@@ -556,6 +556,15 @@ import ``pytensor`` and print the config variable, as in:
 
     When ``True``, print the rewrites applied to stdout.
 
+.. attribute:: compiler_verbose
+
+    Bool value: either ``True`` or ``False``
+
+    Default: ``False``
+
+    When ``True``, print detailed information about the compilation of a graph. The type of information printed will
+    vary depending on the computational backend, and some backends may not provide additional information.
+
 .. attribute:: nocleanup
 
     Bool value: either ``True`` or ``False``

--- a/pytensor/configdefaults.py
+++ b/pytensor/configdefaults.py
@@ -431,6 +431,13 @@ def add_compile_configvars():
     )
 
     config.add(
+        "compiler_verbose",
+        "Print information about compilation steps.",
+        BoolParam(False),
+        in_c_key=False,
+    )
+
+    config.add(
         "on_opt_error",
         (
             "What to do when an optimization crashes: warn and skip it, raise "

--- a/pytensor/configparser.py
+++ b/pytensor/configparser.py
@@ -82,6 +82,7 @@ class PyTensorConfigParser:
     optimizer: str
     optimizer_verbose: bool
     optimizer_verbose_ignore: str
+    compiler_verbose: bool
     on_opt_error: str
     nocleanup: bool
     on_unused_input: str

--- a/pytensor/link/numba/dispatch/basic.py
+++ b/pytensor/link/numba/dispatch/basic.py
@@ -285,9 +285,13 @@ def generate_fallback_impl(op, node=None, storage_map=None, **kwargs):
     """Create a Numba compatible function from a Pytensor `Op`."""
 
     warnings.warn(
-        f"Numba will use object mode to run {op}'s perform method",
+        f"Numba will use object mode to run {op}'s perform method. "
+        f"Set `pytensor.config.compiler_verbose = True` to see more details.",
         UserWarning,
     )
+
+    if config.compiler_verbose:
+        node.dprint(depth=5, print_type=True)
 
     n_outputs = len(node.outputs)
 


### PR DESCRIPTION
It makes it easier for users to let us know what kind of graph isn't actually compiling this way.

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1520.org.readthedocs.build/en/1520/

<!-- readthedocs-preview pytensor end -->