### PR TITLE
Fix 1497

### DIFF
--- a/pytensor/graph/rewriting/basic.py
+++ b/pytensor/graph/rewriting/basic.py
@@ -1668,9 +1668,11 @@ class PatternNodeRewriter(NodeRewriter):
                 ):
                     return False
             else:
-                out_dtype = node.outputs[0].type.dtype
-                if self.allow_cast and ret.owner.outputs[0].type.dtype != out_dtype:
-                    ret = pytensor.tensor.basic.cast(ret, out_dtype)
+                if self.allow_cast:
+                    out_dtype = getattr(node.outputs[0].type, "dtype", None)
+                    ret_dtype = getattr(ret.owner.outputs[0].type, "dtype", None)
+                    if ret_dtype != out_dtype:
+                        ret = pytensor.tensor.basic.cast(ret, out_dtype)
                 if not node.outputs[0].type.is_super(ret.owner.outputs[0].type):
                     return False
         else:

--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -2385,7 +2385,7 @@ def local_log1p(fgraph, node):
             log_arg.owner.inputs, only_process_constants=True
         )
         # scalar_inputs are potentially dimshuffled and fill'd scalars
-        if scalars and np.allclose(np.sum(scalars), 1):
+        if scalars and isclose(np.sum(scalars), 1):
             if nonconsts:
                 ninp = variadic_add(*nonconsts)
                 if ninp.dtype != log_arg.type.dtype:
@@ -2990,6 +2990,19 @@ def local_grad_log_erfc_neg(fgraph, node):
     return [ret]
 
 
+def isclose(x, ref, rtol=0, atol=0, num_ulps=10):
+    """
+
+    Returns
+    -------
+    bool
+        True iff x is a constant close to ref (by default 10 ULPs).
+
+    """
+    atol = atol + num_ulps * np.spacing(x)
+    return np.allclose(x, ref, rtol=rtol, atol=atol)
+
+
 def _skip_mul_1(r):
     if r.owner and r.owner.op == mul:
         not_is_1 = [i for i in r.owner.inputs if not _is_1(i)]
@@ -3008,7 +3021,7 @@ def _is_1(expr):
     """
     try:
         v = get_underlying_scalar_constant_value(expr)
-        return np.isclose(v, 1)
+        return isclose(v, 1)
     except NotScalarConstantError:
         return False
 
@@ -3069,7 +3082,7 @@ def is_1pexp(t, only_process_constants=True):
                     scal_sum = scalars[0]
                     for s in scalars[1:]:
                         scal_sum = scal_sum + s
-                    if np.allclose(scal_sum, 1):
+                    if isclose(scal_sum, 1):
                         return False, maybe_exp.owner.inputs[0]
     return None
 
@@ -3169,7 +3182,7 @@ def is_neg(var):
         for idx, mul_input in enumerate(var_node.inputs):
             try:
                 constant = get_underlying_scalar_constant_value(mul_input)
-                is_minus_1 = np.isclose(constant, -1)
+                is_minus_1 = isclose(constant, -1)
             except NotScalarConstantError:
                 is_minus_1 = False
             if is_minus_1:
@@ -3577,7 +3590,7 @@ def local_reciprocal_1_plus_exp(fgraph, node):
         # scalar_inputs are potentially dimshuffled and fill'd scalars
         if len(nonconsts) == 1:
             if nonconsts[0].owner and nonconsts[0].owner.op == exp:
-                if scalars_ and np.allclose(np.sum(scalars_), 1):
+                if scalars_ and isclose(np.sum(scalars_), 1):
                     out = [
                         alloc_like(
                             sigmoid(neg(nonconsts[0].owner.inputs[0])),

--- a/tests/tensor/rewriting/test_math.py
+++ b/tests/tensor/rewriting/test_math.py
@@ -4299,7 +4299,7 @@ class TestSoftplusRewrites:
         f(np.random.random((54, 11)).astype(config.floatX))
 
         # Test close to 1
-        out = log(1.000001 - sigmoid(x))
+        out = log(np.nextafter(1.0, 2.0) - sigmoid(x))
         f = pytensor.function([x], out, mode=self.m)
         topo = f.maker.fgraph.toposort()
         assert len(topo) == 2

--- a/tests/tensor/rewriting/test_math.py
+++ b/tests/tensor/rewriting/test_math.py
@@ -124,6 +124,7 @@ from pytensor.tensor.type import (
     dvector,
     fmatrices,
     fmatrix,
+    fscalar,
     ftensor4,
     fvector,
     imatrices,
@@ -4115,8 +4116,8 @@ class TestSigmoidRewrites:
 
     def test_local_1msigmoid(self):
         m = self.get_mode(excluding=["fusion", "inplace"])
-        x = fmatrix()
-        xd = dmatrix()
+        x = fscalar()
+        xd = dscalar()
 
         # Test `exp_over_1_plus_exp`
         f = pytensor.function([x], 1 - exp(x) / (1 + exp(x)), mode=m)
@@ -4135,7 +4136,11 @@ class TestSigmoidRewrites:
             (np.array(1.0, "float32") - sigmoid(x), sigmoid(-x)),
             (np.array(1.0, "float64") - pt.sigmoid(x), cast(sigmoid(-x), "float64")),
             (np.array(1.0, "float32") - sigmoid(xd), sigmoid(-xd)),
-            (np.array([[1.0]], "float64") - sigmoid(xd), sigmoid(-xd)),
+            (np.array(1.0, "float64") - sigmoid(xd), sigmoid(-xd)),
+            (np.sum(1 / np.array([2, 3, 6], "float32")) - sigmoid(x), sigmoid(-x)),
+            (np.sum(1 / np.array([2, 3, 6], "float64")) - sigmoid(xd), sigmoid(-xd)),
+            (np.float32(1 - 9e-6) - sigmoid(x), np.float32(1 - 9e-6) - sigmoid(x)),
+            (np.float64(1 - 1e-9) - sigmoid(xd), np.float64(1 - 1e-9) - sigmoid(xd)),
         ]:
             f = pytensor.function([x, xd], out, m, on_unused_input="ignore")
             f_outs = f.maker.fgraph.outputs


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
The previous tolerance used within a rewrite to decide whether a constant is one (or minus one) is too large.
For example `c - sigmoid(x)` is rewritten as `sigmoid(-x)` even when $c=1 − p$ where p is 1 in 10000.
Many rewrites currently use np.isclose and np.allclose with the default tolerances (rtol=1e-05, atol=1e-08), which are unnecessarily large (and independent on the data type of the constant computed).

This PR implements a function `isclose` used within all rewrites in place of `np.isclose` and `np.allclose`. This new function uses a much smaller tolerance by default, i.e. 10 unit in the last place (ULPs). This tolerance is dtype dependent, so it's stricter for a float64 than a float32. See #1497 for a back of the envelope justification for choosing 10 ULPs.

This PR also implements `allow_cast` in PatternNodeRewriter to allow rewrites that would otherwise fail when the new and old dtype differ. For example, a rewrite attempt for `np.array(1., "float64") - sigmoid(x)` (where x is `fmatrix`) currently fails because in the rewrite `sigmoid(-x)` the type would change. This PR allows an automatic cast to be added so the expression is rewritten as `cast(sigmoid(-x), "float64")`.

Relevant tests added.


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1497


## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
