### PR TITLE
Converts negative constant axis to positive if present in `Join(COp)`

### DIFF
--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -2471,6 +2471,18 @@ class Join(COp):
         if axis.type.ndim > 0:
             raise TypeError(f"Axis {axis} must be 0-d.")
 
+        # Convert negative constant axis to positive during canonicalization
+        if isinstance(axis, Constant) and tensors:
+            # Get the axis value directly from the constant's data
+            axis_val = axis.data.item()
+            # Check if it's negative and needs normalization
+            if axis_val < 0:
+                ndim = tensors[0].ndim
+                # Convert negative axis to positive
+                axis_val = normalize_axis_index(axis_val, ndim)
+                # Replace the original axis with the normalized one
+                axis = constant(axis_val, dtype=axis.type.dtype)
+
         tensors = [as_tensor_variable(x) for x in tensors]
 
         if not builtins.all(targs.type.ndim > 0 for targs in tensors):

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -2188,17 +2188,7 @@ class TestJoinAndSplit:
         # Create join with negative axis
         s = join(-1, a, b)
 
-        # Get the actual Join op node from the graph
-        f = pytensor.function(
-            [], [s], mode=self.mode
-        )  # Use FAST_COMPILE to prevent optimizations from changing the graph structure
-
-        # Find the Join op node in the graph
-        join_nodes = [
-            node for node in f.maker.fgraph.toposort() if isinstance(node.op, Join)
-        ]
-        assert len(join_nodes) == 1, "Expected exactly one Join node in the graph"
-        join_node = join_nodes[0]
+        assert s.owner.op.axis == 1
 
         # Check that the axis input has been converted to a constant with value 1 (not -1)
         axis_input = join_node.inputs[0]

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -2185,34 +2185,8 @@ class TestJoinAndSplit:
         a = self.shared(v)
         b = as_tensor_variable(v)
 
-        # Create join with negative axis
-        s = join(-1, a, b)
-
-        assert isinstance(
-            s.owner.outputs[0].owner.op, Join
-        ), "Expected output node to be a Join op"
-
-        assert isinstance(
-            s.owner.inputs[0], ptb.Constant
-        ), "Expected axis to be a Constant"
-        assert (
-            s.owner.inputs[0].data == 1
-        ), f"Expected axis to be normalized to 1, got {s.owner.inputs[0].data}"
-
-        # Now test with axis -2 which should be rewritten to 0
-        s2 = join(-2, a, b)
-
-        assert isinstance(
-            s2.owner.outputs[0].owner.op, Join
-        ), "Expected output node to be a Join op"
-
-        # Check that the axis input has been converted to a constant with value 0 (not -2)
-        assert isinstance(
-            s2.owner.inputs[0], ptb.Constant
-        ), "Expected axis to be a Constant"
-        assert (
-            s2.owner.inputs[0].data == 0
-        ), f"Expected axis to be normalized to 0, got {s2.owner.inputs[0].data}"
+        equal_computations([join(-1, a, b)], [join(1, a, b)])
+        equal_computations([join(-2, a, b)], [join(0, a, b)])
 
 
 def test_TensorFromScalar():

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -2185,8 +2185,8 @@ class TestJoinAndSplit:
         a = self.shared(v)
         b = as_tensor_variable(v)
 
-        equal_computations([join(-1, a, b)], [join(1, a, b)])
-        equal_computations([join(-2, a, b)], [join(0, a, b)])
+        assert equal_computations([join(-1, a, b)], [join(1, a, b)])
+        assert equal_computations([join(-2, a, b)], [join(0, a, b)])
 
 
 def test_TensorFromScalar():

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -2188,33 +2188,31 @@ class TestJoinAndSplit:
         # Create join with negative axis
         s = join(-1, a, b)
 
-        # Get the actual Join op node from the graph
-        f = pytensor.function([], [s], mode=self.mode)
+        assert isinstance(
+            s.owner.outputs[0].owner.op, Join
+        ), "Expected output node to be a Join op"
 
-        # Directly access the Join node from the output's owner
-        join_node = f.maker.fgraph.outputs[0].owner
-        assert isinstance(join_node.op, Join), "Expected output node to be a Join op"
-
-        # Check that the axis input has been converted to a constant with value 1 (not -1)
-        axis_input = join_node.inputs[0]
-        assert isinstance(axis_input, ptb.Constant), "Expected axis to be a Constant"
+        assert isinstance(
+            s.owner.inputs[0], ptb.Constant
+        ), "Expected axis to be a Constant"
         assert (
-            axis_input.data == 1
-        ), f"Expected axis to be normalized to 1, got {axis_input.data}"
+            s.owner.inputs[0].data == 1
+        ), f"Expected axis to be normalized to 1, got {s.owner.inputs[0].data}"
 
         # Now test with axis -2 which should be rewritten to 0
         s2 = join(-2, a, b)
-        f2 = pytensor.function([], [s2], mode=self.mode)
 
-        join_node = f2.maker.fgraph.outputs[0].owner
-        assert isinstance(join_node.op, Join), "Expected output node to be a Join op"
+        assert isinstance(
+            s2.owner.outputs[0].owner.op, Join
+        ), "Expected output node to be a Join op"
 
         # Check that the axis input has been converted to a constant with value 0 (not -2)
-        axis_input = join_node.inputs[0]
-        assert isinstance(axis_input, ptb.Constant), "Expected axis to be a Constant"
+        assert isinstance(
+            s2.owner.inputs[0], ptb.Constant
+        ), "Expected axis to be a Constant"
         assert (
-            axis_input.data == 0
-        ), f"Expected axis to be normalized to 0, got {axis_input.data}"
+            s2.owner.inputs[0].data == 0
+        ), f"Expected axis to be normalized to 0, got {s2.owner.inputs[0].data}"
 
 
 def test_TensorFromScalar():

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -2180,7 +2180,7 @@ class TestJoinAndSplit:
         benchmark(fn, *test_values)
 
     def test_join_negative_axis_rewrite(self):
-        """Test that constant negative axis is rewritten to positive axis during canonicalization."""
+        """Test that constant negative axis is rewritten to positive axis in make_node."""
         v = np.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]], dtype=self.floatX)
         a = self.shared(v)
         b = as_tensor_variable(v)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
Converts negative constant axis to positive if present in `Join(COp)`

DISCLAIMER: Completely vibe coded in Claude Sonnet 3.7. May well be complete non-sense, and if so please close immediately. 

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1505 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
