### PR TITLE
Get rid of pydot-ng because it's deprecated since 7 years

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ tests = [
     "pytest-mock",
     "pytest-sphinx",
 ]
-rtd = ["sphinx>=5.1.0,<6", "pygments", "pydot", "pydot2", "pydot-ng"]
+rtd = ["sphinx>=5.1.0,<6", "pygments", "pydot"]
 jax = ["jax", "jaxlib"]
 numba = ["numba>=0.57", "llvmlite"]
 

--- a/pytensor/printing.py
+++ b/pytensor/printing.py
@@ -1188,45 +1188,21 @@ default_colorCodes = {
 
 
 def _try_pydot_import():
-    pydot_imported = False
-    pydot_imported_msg = ""
     try:
-        # pydot-ng is a fork of pydot that is better maintained
-        import pydot_ng as pd
+        import pydot as pd
 
-        if pd.find_graphviz():
-            pydot_imported = True
-        else:
-            pydot_imported_msg = "pydot-ng can't find graphviz. Install graphviz."
+        pd.Dot.create(pd.Dot())
+        return pd
     except ImportError:
-        try:
-            # fall back on pydot if necessary
-            import pydot as pd
+        # tests should not fail on optional dependency
+        extra_msg = ""
+    except Exception as e:
+        extra_msg = f"\nAn error happened while importing/trying pydot: {e!r}"
 
-            if hasattr(pd, "find_graphviz"):
-                if pd.find_graphviz():
-                    pydot_imported = True
-                else:
-                    pydot_imported_msg = "pydot can't find graphviz"
-            else:
-                pd.Dot.create(pd.Dot())
-                pydot_imported = True
-        except ImportError:
-            # tests should not fail on optional dependency
-            pydot_imported_msg = (
-                "Install the python package pydot or pydot-ng. Install graphviz."
-            )
-        except Exception as e:
-            pydot_imported_msg = "An error happened while importing/trying pydot: "
-            pydot_imported_msg += str(e.args)
-
-    if not pydot_imported:
-        raise ImportError(
-            "Failed to import pydot. You must install graphviz "
-            "and either pydot or pydot-ng for "
-            f"`pydotprint` to work:\n {pydot_imported_msg}",
-        )
-    return pd
+    raise ImportError(
+        "Failed to import pydot. You must install graphviz and pydot for "
+        f"`pydotprint` to work.{extra_msg}",
+    )
 
 
 def pydotprint(


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
Get rid of pydot-ng because it's deprecated since 7 years



## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1534.org.readthedocs.build/en/1534/

<!-- readthedocs-preview pytensor end -->