### PR TITLE
Clean `test_Elemwise`

### DIFF
--- a/tests/link/numba/test_elemwise.py
+++ b/tests/link/numba/test_elemwise.py
@@ -31,55 +31,47 @@ rng = np.random.default_rng(42849)
 
 
 @pytest.mark.parametrize(
-    "inputs, input_vals, output_fn, exc",
+    "inputs, input_vals, output_fn",
     [
         (
             [pt.vector()],
             [rng.uniform(size=100).astype(config.floatX)],
             lambda x: pt.gammaln(x),
-            None,
         ),
         (
             [pt.vector()],
             [rng.standard_normal(100).astype(config.floatX)],
             lambda x: pt.sigmoid(x),
-            None,
         ),
         (
             [pt.vector()],
             [rng.standard_normal(100).astype(config.floatX)],
             lambda x: pt.log1mexp(x),
-            None,
         ),
         (
             [pt.vector()],
             [rng.standard_normal(100).astype(config.floatX)],
             lambda x: pt.erf(x),
-            None,
         ),
         (
             [pt.vector()],
             [rng.standard_normal(100).astype(config.floatX)],
             lambda x: pt.erfc(x),
-            None,
         ),
         (
             [pt.vector()],
             [rng.standard_normal(100).astype(config.floatX)],
             lambda x: pt.erfcx(x),
-            None,
         ),
         (
             [pt.vector() for i in range(4)],
             [rng.standard_normal(100).astype(config.floatX) for i in range(4)],
             lambda x, y, x1, y1: (x + y) * (x1 + y1) * y,
-            None,
         ),
         (
             [pt.matrix(), pt.scalar()],
             [rng.normal(size=(2, 2)).astype(config.floatX), 0.0],
             lambda a, b: pt.switch(a, b, a),
-            None,
         ),
         (
             [pt.scalar(), pt.scalar()],
@@ -88,7 +80,6 @@ rng = np.random.default_rng(42849)
                 np.array(1.0, dtype=config.floatX),
             ],
             lambda x, y: pti.add_inplace(deep_copy_op(x), deep_copy_op(y)),
-            None,
         ),
         (
             [pt.vector(), pt.vector()],
@@ -97,7 +88,6 @@ rng = np.random.default_rng(42849)
                 rng.standard_normal(100).astype(config.floatX),
             ],
             lambda x, y: pti.add_inplace(deep_copy_op(x), deep_copy_op(y)),
-            None,
         ),
         (
             [pt.vector(), pt.vector()],
@@ -106,20 +96,30 @@ rng = np.random.default_rng(42849)
                 rng.standard_normal(100).astype(config.floatX),
             ],
             lambda x, y: scalar_my_multi_out(x, y),
-            None,
         ),
     ],
+    ids=[
+        "gammaln",
+        "sigmoid",
+        "log1mexp",
+        "erf",
+        "erfc",
+        "erfcx",
+        "complex_arithmetic",
+        "switch",
+        "add_inplace_scalar",
+        "add_inplace_vector",
+        "scalar_multi_out",
+    ],
 )
-def test_Elemwise(inputs, input_vals, output_fn, exc):
+def test_Elemwise(inputs, input_vals, output_fn):
     outputs = output_fn(*inputs)
 
-    cm = contextlib.suppress() if exc is None else pytest.raises(exc)
-    with cm:
-        compare_numba_and_py(
-            inputs,
-            outputs,
-            input_vals,
-        )
+    compare_numba_and_py(
+        inputs,
+        outputs,
+        input_vals,
+    )
 
 
 @pytest.mark.xfail(reason="Logic had to be reversed due to surprising segfaults")


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
Minor cleanup of `test_Elemwise`. Carryover from #1535.

1) Removes a constant `exec` param since it never changes
2) Introduce ids to improve test readability
3) Removes a dangling context manager


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #1535 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1536.org.readthedocs.build/en/1536/

<!-- readthedocs-preview pytensor end -->