### PR TITLE
Tweakn rewrites in `infer_shape` dataset

### DIFF
--- a/pytensor/tensor/rewriting/basic.py
+++ b/pytensor/tensor/rewriting/basic.py
@@ -949,6 +949,7 @@ def equivalent_up_to_constant_casting(a, b) -> bool:
     return False
 
 
+@register_infer_shape
 @register_useless("shape_unsafe")
 @register_canonicalize("fast_compile", "shape_unsafe")
 @register_specialize("shape_unsafe")

--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -526,7 +526,6 @@ def local_subtensor_inc_subtensor(fgraph, node):
             return
 
 
-@register_infer_shape
 @register_useless
 @register_canonicalize
 @register_specialize
@@ -1263,7 +1262,6 @@ def local_adv_sub1_adv_inc_sub1(fgraph, node):
     return [r2]
 
 
-@register_infer_shape
 @register_specialize
 @register_stabilize
 @register_canonicalize


### PR DESCRIPTION
This PR removes some inc_subtensor rewrites from infer_shape database. These don't simplify shape inference as the shape of an inc_subtensor is always the shape of the input, regardless of whether it is useless or not. They are also not very common to begin with?

Instead we add the useless_switch rewrite. We want a subset of rewrites that quickly simplify the graph and reason about the shapes introduced by `infer_shape`