### PR TITLE
Use `tfp-nightly` to test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,7 +208,7 @@ jobs:
             micromamba install --yes -q "python~=${PYTHON_VERSION}" mkl "numpy${NUMPY_VERSION}" scipy pip mkl-service graphviz cython pytest coverage pytest-cov pytest-benchmark pytest-mock;
           fi
           if [[ $INSTALL_NUMBA == "1" ]]; then micromamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}" "numba>=0.57"; fi
-          if [[ $INSTALL_JAX == "1" ]]; then micromamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}" "jax<0.7.0" jaxlib numpyro && pip install tensorflow-probability; fi
+          if [[ $INSTALL_JAX == "1" ]]; then micromamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}" jax jaxlib numpyro && pip install tfp-nightly; fi
           if [[ $INSTALL_TORCH == "1" ]]; then micromamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}" pytorch pytorch-cuda=12.1 "mkl<=2024.0" -c pytorch -c nvidia; fi
           if [[ $INSTALL_XARRAY == "1" ]]; then micromamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}" xarray xarray-einstats; fi
           pip install pytest-sphinx


### PR DESCRIPTION
Related to https://github.com/pymc-devs/pytensor/pull/1567

Motivated by https://github.com/pyro-ppl/numpyro/pull/2056 and in  view of the comment https://github.com/tensorflow/probability/issues/1994#issuecomment-3129033043

> For TFP on JAX I would strongly advise using tfp-nightly. It's tested continuously against the latest JAX, and you can pin to a particular date's release if you need your dependencies to remain fixed.

(also by the fact that the last stable release of `tensorflow-probability` was like 9 months ago), I suggest using `tfp-nightly` in our test suite :) 
