### PR TITLE
Fix failure with narrowing of ssize_t to int in macos

### DIFF
--- a/pytensor/tensor/elemwise.py
+++ b/pytensor/tensor/elemwise.py
@@ -1098,7 +1098,7 @@ class Elemwise(OpenMPOp):
         return support_code
 
     def c_code_cache_version_apply(self, node):
-        version = [15]  # the version corresponding to the c code in this Op
+        version = [16]  # the version corresponding to the c code in this Op
 
         # now we insert versions for the ops on which we depend...
         scalar_node = Apply(
@@ -1589,7 +1589,7 @@ class CAReduce(COp):
 
     def c_code_cache_version_apply(self, node):
         # the version corresponding to the c code in this Op
-        version = [10]
+        version = [11]
 
         # now we insert versions for the ops on which we depend...
         scalar_node = Apply(


### PR DESCRIPTION
Everything is `npy_intp` now which is the type of numpy array shape and strides anyway. 

CI started failing recently in the macos test, because there the old ssize_t was a long, and we were trying to initialize an int array out of it.

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1602.org.readthedocs.build/en/1602/

<!-- readthedocs-preview pytensor end -->