### PR TITLE
Fix (minor) typos in normalizing_flows_in_pytensor notebook

### DIFF
--- a/doc/gallery/applications/normalizing_flows_in_pytensor.ipynb
+++ b/doc/gallery/applications/normalizing_flows_in_pytensor.ipynb
@@ -34,7 +34,7 @@
     "- $f(\\cdot)$ if the (known!) PDF of the variable $X$\n",
     "- $G(\\cdot)$ is a function with nice properties.\n",
     "\n",
-    "The \"nice properties\" require (in the most general case) that $G(x)$ is a $C^1$ diffeomorphism, which means that it is 1) continuous and differentiable almost everywhere; 2) it is bijective, and 3) its derivaties are also bijective. \n",
+    "The \"nice properties\" require (in the most general case) that $G(x)$ is a $C^1$ diffeomorphism, which means that it is 1) continuous and differentiable almost everywhere; 2) it is bijective, and 3) its derivatives are also bijective. \n",
     "\n",
     "A simpler requirement is that $G(x)$ is continuous, bijective, and monotonic. That will get us 99% of the way there. Hey, $\\exp$ is continuous, bijective, and monotonic -- what a coincidence!\n"
    ]
@@ -412,7 +412,7 @@
    ],
    "source": [
     "z_values = pt.dvector(\"z_values\")\n",
-    "# The funtion `pm.logp` does the magic!\n",
+    "# The function `pm.logp` does the magic!\n",
     "z_logp = pm.logp(z, z_values, jacobian=True)\n",
     "# We do this rewrite to make the computation more stable.\n",
     "rewrite_graph(z_logp).dprint()"
@@ -668,7 +668,7 @@
    "id": "5f9a7a50",
    "metadata": {},
    "source": [
-    "Theese distribution are essentially the same."
+    "These distribution are essentially the same."
    ]
   },
   {
@@ -715,7 +715,7 @@
     "\n",
     "So, the inverse of their composition is $G^{-1} \\equiv (J^{-1} \\circ H^{-1}) = J^{-1}(H^{-1}(x)) = J^{-1}(\\ln(x)) = \\frac{\\ln(x) - a}{b}$\n",
     "\n",
-    "For the correction term, we need the determinant of the jacobian. Since $G$ is a scalar function, this is just the absolutel value of the gradient:\n",
+    "For the correction term, we need the determinant of the jacobian. Since $G$ is a scalar function, this is just the absolute value of the gradient:\n",
     "\n",
     "$$\\left | \\frac{\\partial}{\\partial x}G^{-1} \\right | = \\left | \\frac{\\partial}{\\partial x} \\frac{\\ln(x) - a}{b} \\right | = \\left | \\frac{1}{b} \\cdot \\frac{1}{x} \\right | $$\n",
     "\n",
@@ -733,7 +733,7 @@
    "source": [
     "### Solution by hand\n",
     "\n",
-    "We now implement theis analytic procesure in PyTensor:"
+    "We now implement this analytic procedure in PyTensor:"
    ]
   },
   {
@@ -803,7 +803,7 @@
    "id": "bcd081d3",
    "metadata": {},
    "source": [
-    "We can verify these values are exaclty what we are expecting:"
+    "We can verify these values are exactly what we are expecting:"
    ]
   },
   {
@@ -859,7 +859,7 @@
    "id": "46834a6f",
    "metadata": {},
    "source": [
-    "As above let's verify taht the results are consistent and correct:"
+    "As above let's verify that the results are consistent and correct:"
    ]
   },
   {


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description

Enjoyed reading this. Some very minor types

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #1588

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1611.org.readthedocs.build/en/1611/

<!-- readthedocs-preview pytensor end -->