### PR TITLE
Speedup FusionOptimizer

### DIFF
--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -779,9 +779,11 @@ def get_scalar_type(dtype, cache: dict[str, ScalarType] = {}) -> ScalarType:
     This caches objects to save allocation and run time.
 
     """
-    if dtype not in cache:
-        cache[dtype] = ScalarType(dtype=dtype)
-    return cache[dtype]
+    try:
+        return cache[dtype]
+    except KeyError:
+        cache[dtype] = res = ScalarType(dtype=dtype)
+    return res
 
 
 # Register C code for ViewOp on Scalars.

--- a/pytensor/tensor/rewriting/elemwise.py
+++ b/pytensor/tensor/rewriting/elemwise.py
@@ -569,8 +569,6 @@ class FusionOptimizer(GraphRewriter):
         return scalar_inputs, scalar_outputs
 
     def apply(self, fgraph):
-        nb_replacement = 0
-
         if fgraph.profile:
             validate_before = fgraph.profile.validate_time
             callbacks_before = fgraph.execute_callbacks_times.copy()
@@ -925,6 +923,8 @@ class FusionOptimizer(GraphRewriter):
                         starting_nodes=starting_nodes,
                     )
 
+        nb_fused = 0
+        nb_replacement = 0
         for inputs, outputs in find_next_fuseable_subgraph(fgraph):
             if (len(inputs) + len(outputs)) > max_operands:
                 warn(
@@ -943,11 +943,13 @@ class FusionOptimizer(GraphRewriter):
                 if old_out.name:
                     composite_out.name = old_out.name
 
+            starting_nodes = len(fgraph.apply_nodes)
             fgraph.replace_all_validate(
                 list(zip(outputs, composite_outputs, strict=True)),
                 reason=self.__class__.__name__,
             )
-            nb_replacement += 1
+            nb_fused += 1
+            nb_replacement += (starting_nodes - len(fgraph.apply_nodes)) + 1
 
         if fgraph.profile:
             validate_time = fgraph.profile.validate_time - validate_before
@@ -965,7 +967,7 @@ class FusionOptimizer(GraphRewriter):
 
         return (
             self,
-            1,  # nb_iter
+            nb_fused,
             nb_replacement,
             0,  # nb_inconsintency_replace
             validate_time,
@@ -978,7 +980,7 @@ class FusionOptimizer(GraphRewriter):
     def print_profile(stream, prof, level=0):
         blanc = "    " * level
         print(blanc, "FusionOptimizer", file=stream)
-        print(blanc, " nb_iter", prof[1], file=stream)
+        print(blanc, " nb_fused", prof[1], file=stream)
         print(blanc, " nb_replacement", prof[2], file=stream)
         print(blanc, " nb_inconsistency_replace", prof[3], file=stream)
         print(blanc, " validate_time", prof[4], file=stream)

--- a/pytensor/tensor/rewriting/elemwise.py
+++ b/pytensor/tensor/rewriting/elemwise.py
@@ -2,6 +2,7 @@ import abc
 import itertools
 import operator
 import sys
+import typing
 from collections import defaultdict, deque
 from collections.abc import Generator, Sequence
 from functools import cache, reduce
@@ -522,6 +523,43 @@ def elemwise_max_operands_fct(node) -> int:
     return 1024
 
 
+class CopyOnWriteDictOfSets:
+    __slots__ = ("d", "d_copy")
+
+    def __init__(self, d: dict[typing.Any, set]):
+        self.d = d
+        self.d_copy: dict[typing.Any, set] = {}
+
+    def __getitem__(self, key):
+        try:
+            return self.d_copy[key]
+        except KeyError:
+            return self.d[key]
+
+    def get(self, key, default=frozenset()):
+        try:
+            return self.d_copy[key]
+        except KeyError:
+            try:
+                return self.d[key]
+            except KeyError:
+                return default
+
+    def remove_from_key(self, key, value):
+        try:
+            self.d_copy[key].remove(value)
+        except KeyError:
+            self.d_copy[key] = copied_value = self.d[key].copy()
+            copied_value.remove(value)
+
+    def add_to_key(self, key, value):
+        try:
+            self.d_copy[key].add(value)
+        except KeyError:
+            self.d_copy[key] = copied_value = self.d[key].copy()
+            copied_value.add(value)
+
+
 class FusionOptimizer(GraphRewriter):
     """Graph optimizer that fuses consecutive Elemwise operations."""
 
@@ -644,15 +682,10 @@ class FusionOptimizer(GraphRewriter):
                     subgraph_outputs: dict[Variable, Literal[None]] = {}  # ordered set
                     unfuseable_clients_subgraph: set[Variable] = set()
 
-                    # Shallow cloning of maps so that they can be manipulated in place
-                    fuseable_clients_clone: FUSEABLE_MAPPING = defaultdict(set)
-                    fuseable_clients_clone.update(
-                        {k: v.copy() for k, v in fuseable_clients.items()}
-                    )
-                    unfuseable_clients_clone: UNFUSEABLE_MAPPING = defaultdict(set)
-                    unfuseable_clients_clone.update(
-                        {k: v.copy() for k, v in unfuseable_clients.items()}
-                    )
+                    # If we need to manipulate the maps in place, we'll do a shallow copy later
+                    # For now we query on the original ones
+                    fuseable_clients_clone = CopyOnWriteDictOfSets(fuseable_clients)
+                    unfuseable_clients_clone = CopyOnWriteDictOfSets(unfuseable_clients)
 
                     # We now try to expand as much as possible towards the potentially
                     # fuseable clients and ancestors to detect the largest possible
@@ -682,7 +715,7 @@ class FusionOptimizer(GraphRewriter):
                         required_unfuseable_inputs = [
                             inp
                             for inp in next_node.inputs
-                            if next_node in unfuseable_clients_clone.get(inp, ())
+                            if next_node in unfuseable_clients_clone.get(inp)
                         ]
                         new_required_unfuseable_inputs = [
                             inp
@@ -705,7 +738,7 @@ class FusionOptimizer(GraphRewriter):
                         if not must_backtrack:
                             implied_unfuseable_clients = {
                                 c
-                                for client in unfuseable_clients_clone.get(next_out, ())
+                                for client in unfuseable_clients_clone.get(next_out)
                                 if not isinstance(client.op, Output)
                                 for c in client.outputs
                             }
@@ -726,13 +759,15 @@ class FusionOptimizer(GraphRewriter):
 
                         if must_backtrack:
                             for inp in next_node.inputs:
-                                if (
-                                    inp.owner in visited_nodes
-                                    # next_node could have the same input repeated
-                                    and next_node in fuseable_clients_clone[inp]
-                                ):
-                                    fuseable_clients_clone[inp].remove(next_node)
-                                    unfuseable_clients_clone[inp].add(next_node)
+                                if inp.owner in visited_nodes:
+                                    if next_node not in fuseable_clients_clone[inp]:
+                                        # This can happen when next node has repeated inputs
+                                        continue
+                                    fuseable_clients_clone.remove_from_key(
+                                        inp, next_node
+                                    )
+                                    unfuseable_clients_clone.add_to_key(inp, next_node)
+
                                     # This input must become an output of the subgraph,
                                     # because it can't be merged with next_node.
                                     # We will revisit it to make sure this is safe.
@@ -741,8 +776,13 @@ class FusionOptimizer(GraphRewriter):
                             # need to convert to tuple not to change set size during iteration
                             for client in tuple(fuseable_clients_clone[next_out]):
                                 if client in visited_nodes:
-                                    fuseable_clients_clone[next_out].remove(client)
-                                    unfuseable_clients_clone[next_out].add(client)
+                                    fuseable_clients_clone.remove_from_key(
+                                        next_out, client
+                                    )
+                                    unfuseable_clients_clone.add_to_key(
+                                        next_out, client
+                                    )
+
                                     # next_out must become an input of the subgraph.
                                     # We will revisit any of its clients currently
                                     # in the subgraph to make sure this is safe.
@@ -785,7 +825,7 @@ class FusionOptimizer(GraphRewriter):
                             sorted(
                                 (
                                     node
-                                    for node in fuseable_clients_clone.get(next_out, ())
+                                    for node in fuseable_clients_clone.get(next_out)
                                     if node not in visited_nodes
                                 ),
                                 key=toposort_index.get,  # type: ignore[arg-type]

--- a/tests/tensor/rewriting/test_elemwise.py
+++ b/tests/tensor/rewriting/test_elemwise.py
@@ -273,7 +273,8 @@ class TestFusion:
     fwx = fw + fx
     ftanx = tan(fx)
 
-    def large_fuseable_graph(self, n):
+    @staticmethod
+    def large_fuseable_graph(n):
         factors = []
         sd = dscalar()
         means = dvector()
@@ -295,6 +296,28 @@ class TestFusion:
         vars = [sd, means]
         dlogp = [pytensor.grad(logp, v) for v in vars]
         return vars, dlogp
+
+    @staticmethod
+    def deep_small_kernels(n):
+        x = pt.matrix("x")
+        out = x
+        for _ in range(n):
+            out = pt.sin(out.T) + pt.cos(out)
+
+        return [x], [out]
+
+    @staticmethod
+    def test_diamond_graph():
+        a = pt.matrix("a")
+        b = pt.exp(a)
+        c = pt.log(b)
+        d = pt.sin(c)
+        e = c + d
+
+        fg = FunctionGraph([a], [e], clone=False)
+        _, nb_fused, nb_replacement, *_ = FusionOptimizer().apply(fg)
+        assert nb_fused == 1
+        assert nb_replacement == 4
 
     @pytest.mark.parametrize(
         "case",
@@ -1347,16 +1370,26 @@ class TestFusion:
         benchmark(func)
 
     @pytest.mark.skipif(not config.cxx, reason="No cxx compiler")
-    def test_rewrite_benchmark(self, benchmark):
-        inps, outs = self.large_fuseable_graph(n=25)
+    @pytest.mark.parametrize(
+        "graph_fn, n, expected_n_repl",
+        [
+            ("deep_small_kernels", 20, (20, 60)),
+            ("large_fuseable_graph", 25, (103, 876)),
+        ],
+    )
+    def test_rewrite_benchmark(self, graph_fn, n, expected_n_repl, benchmark):
+        inps, outs = getattr(self, graph_fn)(n)
         fg = FunctionGraph(inps, outs)
         opt = FusionOptimizer()
 
         def rewrite_func():
-            nb_replacement = opt.apply(fg.clone())[2]
-            return nb_replacement
+            fg_clone = fg.clone()
+            _, nb_fused, nb_replacement, *_ = opt.apply(fg_clone)
+            # fg_clone.dprint()
+            return nb_fused, nb_replacement
 
-        assert benchmark(rewrite_func) == 103
+        assert rewrite_func() == expected_n_repl
+        benchmark.pedantic(rewrite_func, rounds=7, iterations=5)
 
     def test_no_warning_from_old_client(self):
         # There used to be a warning issued when creating fuseable mapping

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -301,7 +301,8 @@ def test_debugprint():
     Gemv_op_name = "CGemv" if pytensor.config.blas__ldflags else "Gemv"
     exp_res = dedent(
         r"""
-        Composite{(i2 + (i0 - i1))} 4
+        Composite{(i0 + (i1 - i2))} 4
+        ├─ A
         ├─ ExpandDims{axis=0} v={0: [0]} 3
         """
         f"        │  └─ {Gemv_op_name}{{inplace}} d={{0: [0]}} 2"
@@ -313,17 +314,16 @@ def test_debugprint():
         │     ├─ B
         │     ├─ <Vector(float64, shape=(?,))>
         │     └─ 0.0
-        ├─ D
-        └─ A
+        └─ D
 
         Inner graphs:
 
-        Composite{(i2 + (i0 - i1))}
+        Composite{(i0 + (i1 - i2))}
         ← add 'o0'
-            ├─ i2
-            └─ sub
             ├─ i0
-            └─ i1
+            └─ sub
+            ├─ i1
+            └─ i2
         """
     ).lstrip()
 


### PR DESCRIPTION
FusionOptimizer can be one of the slower rewrites during compilation. This PR speedups it up by a factor of 4-3x in the benchmarked graphs.

Each commit provides a substantial speedup (except maybe for 2-> 3).

The main speedups come from:
1. Reducing number of inner graph clonings when creating CompositeOp
2. Reducing number of toposort computation
3. Using bitsets and bitflags to efficiently compute multiset ancestor dependencies (to ask: do these variables depend on these others?)

The logic for finding valid fused kernels is also more clear now imo, avoiding the need for backtracking. 

<details><summary>Benchmark per commit</summary>

```
HEAD is now at 774792356 Benchmark another FusionOptimizer graph
----------------------------------------------------------------------------------------------------------- benchmark: 2 tests -----------------------------------------------------------------------------------------------------------
Name (time in ms)                                                         Min                 Max                Mean             StdDev              Median                IQR            Outliers      OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_rewrite_benchmark[deep_small_kernels-20-expected_n_repl0]        23.0197 (1.0)       54.2629 (1.0)       36.1126 (1.0)      12.1105 (1.99)      41.8545 (1.0)      18.0821 (2.25)          2;0  27.6912 (1.0)           7           5
test_rewrite_benchmark[large_fuseable_graph-25-expected_n_repl1]     485.6301 (21.10)    503.2956 (9.28)     496.1585 (13.74)     6.0741 (1.0)      496.9919 (11.87)     8.0230 (1.0)           2;0   2.0155 (0.07)          7           5
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

HEAD is now at c7b287f39 Short-circuit `as_scalar` common cases faster
---------------------------------------------------------------------------------------------------------- benchmark: 2 tests ----------------------------------------------------------------------------------------------------------
Name (time in ms)                                                         Min                 Max                Mean            StdDev              Median               IQR            Outliers      OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_rewrite_benchmark[deep_small_kernels-20-expected_n_repl0]        23.2032 (1.0)       30.3229 (1.0)       27.0646 (1.0)      3.2161 (1.0)       28.9586 (1.0)      5.9681 (1.0)           3;0  36.9486 (1.0)           7           5
test_rewrite_benchmark[large_fuseable_graph-25-expected_n_repl1]     487.7418 (21.02)    499.8394 (16.48)    494.1633 (18.26)    4.6597 (1.45)     494.5370 (17.08)    8.1017 (1.36)          3;0   2.0236 (0.05)          7           5
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

HEAD is now at 598d9fcb9 Speedup supports c_code
---------------------------------------------------------------------------------------------------------- benchmark: 2 tests ----------------------------------------------------------------------------------------------------------
Name (time in ms)                                                         Min                 Max                Mean            StdDev              Median               IQR            Outliers      OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_rewrite_benchmark[deep_small_kernels-20-expected_n_repl0]        22.3723 (1.0)       30.8797 (1.0)       26.4816 (1.0)      3.6947 (1.0)       28.3610 (1.0)      6.6708 (1.0)           3;0  37.7620 (1.0)           7           5
test_rewrite_benchmark[large_fuseable_graph-25-expected_n_repl1]     489.3477 (21.87)    504.9612 (16.35)    495.2749 (18.70)    6.1049 (1.65)     492.2781 (17.36)    9.8775 (1.48)          1;0   2.0191 (0.05)          7           5
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

HEAD is now at 41707795b Speedup FusionOptimizer.elemwise_to_scalar
----------------------------------------------------------------------------------------------------------- benchmark: 2 tests ----------------------------------------------------------------------------------------------------------
Name (time in ms)                                                         Min                 Max                Mean             StdDev              Median               IQR            Outliers      OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_rewrite_benchmark[deep_small_kernels-20-expected_n_repl0]        19.5081 (1.0)       27.7007 (1.0)       21.9665 (1.0)       3.4888 (1.0)       20.2496 (1.0)      5.1938 (1.0)           2;0  45.5238 (1.0)           7           5
test_rewrite_benchmark[large_fuseable_graph-25-expected_n_repl1]     419.0247 (21.48)    617.6116 (22.30)    461.7518 (21.02)    69.2312 (19.84)    439.2438 (21.69)    9.9747 (1.92)          1;2   2.1657 (0.05)          7           5
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

HEAD is now at 34de75ff5 Avoid double cloning of Composite Ops created by FusionOptimizer
----------------------------------------------------------------------------------------------------------- benchmark: 2 tests -----------------------------------------------------------------------------------------------------------
Name (time in ms)                                                         Min                 Max                Mean             StdDev              Median                IQR            Outliers      OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_rewrite_benchmark[deep_small_kernels-20-expected_n_repl0]        17.0792 (1.0)       24.1214 (1.0)       19.3538 (1.0)       3.1298 (1.0)       17.6328 (1.0)       5.0325 (1.0)           2;0  51.6693 (1.0)           7           5
test_rewrite_benchmark[large_fuseable_graph-25-expected_n_repl1]     381.0516 (22.31)    455.6597 (18.89)    407.9326 (21.08)    27.3474 (8.74)     398.1366 (22.58)    37.5527 (7.46)          1;0   2.4514 (0.05)          7           5
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

HEAD is now at 543a8a23a Do not recompute toposort in every iteration of FusionOptimizer
----------------------------------------------------------------------------------------------------------- benchmark: 2 tests -----------------------------------------------------------------------------------------------------------
Name (time in ms)                                                         Min                 Max                Mean             StdDev              Median                IQR            Outliers      OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_rewrite_benchmark[deep_small_kernels-20-expected_n_repl0]        14.3812 (1.0)       21.8006 (1.0)       16.3498 (1.0)       3.1517 (1.0)       14.5783 (1.0)       4.2066 (1.0)           2;0  61.1627 (1.0)           7           5
test_rewrite_benchmark[large_fuseable_graph-25-expected_n_repl1]     244.2117 (16.98)    279.3751 (12.82)    261.6797 (16.01)    11.5636 (3.67)     264.0385 (18.11)    14.4312 (3.43)          2;0   3.8215 (0.06)          7           5
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

HEAD is now at dd75569a1 Cleanup FusionOptimizer code
----------------------------------------------------------------------------------------------------------- benchmark: 2 tests -----------------------------------------------------------------------------------------------------------
Name (time in ms)                                                         Min                 Max                Mean             StdDev              Median                IQR            Outliers      OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_rewrite_benchmark[deep_small_kernels-20-expected_n_repl0]        13.8777 (1.0)       21.8236 (1.0)       15.9468 (1.0)       3.5019 (1.0)       13.9371 (1.0)       4.7736 (1.0)           2;0  62.7085 (1.0)           7           5
test_rewrite_benchmark[large_fuseable_graph-25-expected_n_repl1]     243.7067 (17.56)    276.4169 (12.67)    257.8971 (16.17)    12.8118 (3.66)     256.3974 (18.40)    22.7781 (4.77)          3;0   3.8775 (0.06)          7           5
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

HEAD is now at 68ca3cf36 Copy on write in FusionOptimizer
----------------------------------------------------------------------------------------------------------- benchmark: 2 tests -----------------------------------------------------------------------------------------------------------
Name (time in ms)                                                         Min                 Max                Mean             StdDev              Median                IQR            Outliers      OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_rewrite_benchmark[deep_small_kernels-20-expected_n_repl0]        14.1523 (1.0)       20.7984 (1.0)       16.0264 (1.0)       2.8238 (1.0)       14.4556 (1.0)       3.9848 (1.0)           2;0  62.3970 (1.0)           7           5
test_rewrite_benchmark[large_fuseable_graph-25-expected_n_repl1]     195.4694 (13.81)    264.7950 (12.73)    221.6116 (13.83)    22.3072 (7.90)     213.4827 (14.77)    19.7748 (4.96)          2;1   4.5124 (0.07)          7           5
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

HEAD is now at bb3e54c57 Use bitset to check ancestors more efficiently
------------------------------------------------------------------------------------------------------------ benchmark: 2 tests -----------------------------------------------------------------------------------------------------------
Name (time in ms)                                                         Min                 Max                Mean             StdDev              Median                IQR            Outliers       OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_rewrite_benchmark[deep_small_kernels-20-expected_n_repl0]         8.1186 (1.0)       14.0557 (1.0)        9.9162 (1.0)       2.6646 (1.0)        8.5550 (1.0)       4.1075 (1.0)           2;0  100.8451 (1.0)           7           5
test_rewrite_benchmark[large_fuseable_graph-25-expected_n_repl1]     152.0318 (18.73)    176.6330 (12.57)    163.5286 (16.49)    10.0701 (3.78)     165.0426 (19.29)    18.2174 (4.44)          2;0    6.1151 (0.06)          7           5
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

HEAD is now at c392faec9 Avoid backtracking in FusionOptimizer
----------------------------------------------------------------------------------------------------------- benchmark: 2 tests ----------------------------------------------------------------------------------------------------------
Name (time in ms)                                                         Min                 Max                Mean            StdDev              Median               IQR            Outliers       OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_rewrite_benchmark[deep_small_kernels-20-expected_n_repl0]         6.9413 (1.0)       14.3935 (1.0)        8.9253 (1.0)      3.2081 (1.0)        7.1780 (1.0)      4.3681 (1.0)           2;0  112.0412 (1.0)           7           5
test_rewrite_benchmark[large_fuseable_graph-25-expected_n_repl1]     140.8090 (20.29)    155.4400 (10.80)    149.6261 (16.76)    5.7609 (1.80)     151.9854 (21.17)    9.8091 (2.25)          3;0    6.6833 (0.06)          7           5
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```
</details>