### PR TITLE
Fix backwards compatibility in ScalarOp hash

### DIFF
--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -1294,13 +1294,12 @@ class ScalarOp(COp):
         return self.grad(inputs, output_gradients)
 
     def __eq__(self, other):
-        test = type(self) is type(other) and getattr(
+        return type(self) is type(other) and getattr(
             self, "output_types_preference", None
         ) == getattr(other, "output_types_preference", None)
-        return test
 
     def __hash__(self):
-        return hash((type(self), getattr(self, "output_types_preference", 0)))
+        return hash((type(self), getattr(self, "output_types_preference", None)))
 
     def __str__(self):
         if hasattr(self, "name") and self.name:


### PR DESCRIPTION
This was detected in https://github.com/pymc-devs/pytensor/pull/1582#issuecomment-3315154963

It was a very subtle old inconsistency between the default value used in the hash and equality methods of ScalarOps

This fix should be a blocker for the next release.

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1616.org.readthedocs.build/en/1616/

<!-- readthedocs-preview pytensor end -->