### PR TITLE
Add logsumexp to xtensor

### DIFF
--- a/pytensor/xtensor/math.py
+++ b/pytensor/xtensor/math.py
@@ -512,6 +512,11 @@ def softmax(x, dim=None):
     return exp_x / exp_x.sum(dim=dim)
 
 
+def logsumexp(x, dim=None):
+    """Compute the logsumexp of an XTensorVariable along a specified dimension."""
+    return log(exp(x).sum(dim=dim))
+
+
 class Dot(XOp):
     """Matrix multiplication between two XTensorVariables.
 


### PR DESCRIPTION
## Description
This adds a dim aware `logsumexp` function to pytensor

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1629.org.readthedocs.build/en/1629/

<!-- readthedocs-preview pytensor end -->