### PR TITLE
Move shared HStack and VStack methods to Stack superclass

### DIFF
--- a/pytensor/sparse/basic.py
+++ b/pytensor/sparse/basic.py
@@ -2794,7 +2794,7 @@ le = __ComparisonSwitch(less_equal_s_s, less_equal_s_d, greater_equal_s_d)
 ge = __ComparisonSwitch(greater_equal_s_s, greater_equal_s_d, less_equal_s_d)
 
 
-class HStack(Op):
+class Stack(Op):
     __props__ = ("format", "dtype")
 
     def __init__(self, format=None, dtype=None):
@@ -2819,6 +2819,11 @@ class HStack(Op):
             self, var, [SparseTensorType(dtype=self.dtype, format=self.format)()]
         )
 
+    def __str__(self):
+        return f"{self.__class__.__name__}({self.format},{self.dtype})"
+
+
+class HStack(Stack):
     def perform(self, node, block, outputs):
         (out,) = outputs
         for b in block:
@@ -2853,14 +2858,8 @@ class HStack(Op):
         return [choose(c, d) for c, d in zip(is_continuous, derivative, strict=True)]
 
     def infer_shape(self, fgraph, node, ins_shapes):
-        def _get(l):
-            return l[1]
-
-        d = sum(map(_get, ins_shapes))
+        d = sum(shape[1] for shape in ins_shapes)
         return [(ins_shapes[0][0], d)]
-
-    def __str__(self):
-        return f"{self.__class__.__name__}({self.format},{self.dtype})"
 
 
 def hstack(blocks, format=None, dtype=None):
@@ -2897,7 +2896,7 @@ def hstack(blocks, format=None, dtype=None):
     return HStack(format=format, dtype=dtype)(*blocks)
 
 
-class VStack(HStack):
+class VStack(Stack):
     def perform(self, node, block, outputs):
         (out,) = outputs
         for b in block:
@@ -2932,10 +2931,7 @@ class VStack(HStack):
         return [choose(c, d) for c, d in zip(is_continuous, derivative, strict=True)]
 
     def infer_shape(self, fgraph, node, ins_shapes):
-        def _get(l):
-            return l[0]
-
-        d = sum(map(_get, ins_shapes))
+        d = sum(shape[0] for shape in ins_shapes)
         return [(d, ins_shapes[0][1])]
 
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
Moves shared logic used by the `HStack` and `VStack` classes in `tensor.sparse.basic` into a new `Sparse` class. Should make rewrites easier (though we don't currently do any).

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1162
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1662.org.readthedocs.build/en/1662/

<!-- readthedocs-preview pytensor end -->