### PR TITLE
Fix MKL BLAS detection with renamed libiomp5md.lib

### DIFF
--- a/pytensor/link/c/cmodule.py
+++ b/pytensor/link/c/cmodule.py
@@ -2890,7 +2890,7 @@ def default_blas_ldflags() -> str:
     if rpath is not None:
         maybe_add_to_os_environ_pathlist("PATH", rpath)
     try:
-        # 1. Try to use MKL with INTEL OpenMP threading
+        # 1a. Try to use MKL with INTEL OpenMP threading
         _logger.debug("Checking MKL flags with intel threading")
         return _check_libs(
             all_libs,
@@ -2899,6 +2899,24 @@ def default_blas_ldflags() -> str:
                 "mkl_rt",
                 "mkl_intel_thread",
                 "iomp5",
+                "pthread",
+            ],
+            extra_compile_flags=[f"-Wl,-rpath,{rpath}"] if rpath is not None else [],
+            cxx_library_dirs=cxx_library_dirs,
+        )
+    except Exception as e:
+        _logger.debug(e)
+    try:
+        # 1b. Try to use MKL with INTEL OpenMP threading with renamed iomp5 library
+        # Ref: <https://www.intel.com/content/www/us/en/docs/onemkl/developer-guide-windows/2024-1/selecting-libraries-to-link-with.html>
+        _logger.debug("Checking MKL flags with intel threading, iomp5md")
+        return _check_libs(
+            all_libs,
+            required_libs=[
+                "mkl_core",
+                "mkl_rt",
+                "mkl_intel_thread",
+                "iomp5md",
                 "pthread",
             ],
             extra_compile_flags=[f"-Wl,-rpath,{rpath}"] if rpath is not None else [],


### PR DESCRIPTION


<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->

It seems that libiomp5.lib has been renamed to libiomp5md.lib, so the detection was failing. Add another search step with the new library name.

TODO: is there a more modern approach?

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1667.org.readthedocs.build/en/1667/

<!-- readthedocs-preview pytensor end -->