### PR TITLE
Add rewrite to fuse nested BlockDiag Ops

### DIFF
--- a/pytensor/tensor/rewriting/linalg.py
+++ b/pytensor/tensor/rewriting/linalg.py
@@ -70,9 +70,6 @@ MATRIX_INVERSE_OPS = (MatrixInverse, MatrixPinv)
 def fuse_blockdiagonal(fgraph, node):
     """Fuse nested BlockDiagonal ops into a single BlockDiagonal."""
 
-    if not isinstance(node.op, BlockDiagonal):
-        return None
-
     new_inputs = []
     changed = False
 
@@ -86,6 +83,7 @@ def fuse_blockdiagonal(fgraph, node):
     if changed:
         fused_op = BlockDiagonal(len(new_inputs))
         new_output = fused_op(*new_inputs)
+        copy_stack_trace(node.outputs[0], new_output)
         return [new_output]
 
     return None


### PR DESCRIPTION
## Description
This is a draft PR for issue #1593.
I’m setting up the local environment and exploring how to implement a rewrite that fuses nested BlockDiag Ops into a single one.
I’ll update this PR with code once the setup is complete and I have an initial version of the rewrite.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1593 


## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1671.org.readthedocs.build/en/1671/

<!-- readthedocs-preview pytensor end -->