### PR TITLE
Suppress numpy warnings in python implementation of Elemwise

### DIFF
--- a/pytensor/tensor/elemwise.py
+++ b/pytensor/tensor/elemwise.py
@@ -707,7 +707,8 @@ class Elemwise(OpenMPOp):
 
             nout = ufunc.nout
 
-        variables = ufunc(*ufunc_args, **ufunc_kwargs)
+        with np.errstate(all="ignore"):
+            variables = ufunc(*ufunc_args, **ufunc_kwargs)
 
         if nout == 1:
             variables = [variables]

--- a/tests/tensor/test_elemwise.py
+++ b/tests/tensor/test_elemwise.py
@@ -1093,3 +1093,11 @@ def test_gradient_mixed_discrete_output_scalar_op():
         np.ones((12,), dtype=config.floatX),
         strict=True,
     )
+
+
+@pytest.mark.filterwarnings("error")
+def test_numpy_warning_suppressed():
+    x = pt.scalar("x")
+    y = pt.log(x)
+    fn = pytensor.function([x], y, mode=Mode(linker="py"))
+    assert fn(0) == -np.inf


### PR DESCRIPTION
Closes #1577 

We don't warn in any of our other backends, so it doesn't make sense to warn when using Python. This is specially annoying because we constant-fold with Python but didn't use to. This led to failures in the pymc-extras CI: https://github.com/pymc-devs/pymc-extras/pull/597

<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1681.org.readthedocs.build/en/1681/

<!-- readthedocs-preview pytensor end -->