### PR TITLE
Don't return tuple from `jax.scipy.linalg.qr` when `mode = 'r'`

### DIFF
--- a/pytensor/link/jax/dispatch/slinalg.py
+++ b/pytensor/link/jax/dispatch/slinalg.py
@@ -177,7 +177,8 @@ def jax_funcify_QR(op, **kwargs):
     mode = op.mode
 
     def qr(x, mode=mode):
-        return jax.scipy.linalg.qr(x, mode=mode)
+        res = jax.scipy.linalg.qr(x, mode=mode)
+        return res[0] if len(res) == 1 else res
 
     return qr
 

--- a/tests/link/jax/test_slinalg.py
+++ b/tests/link/jax/test_slinalg.py
@@ -370,3 +370,15 @@ def test_jax_expm():
     out = pt_slinalg.expm(A)
 
     compare_jax_and_py([A], [out], [A_val])
+
+
+@pytest.mark.parametrize("mode", ["full", "r"])
+def test_jax_qr(mode):
+    # "full" and "r" modes are tested because "full" returns two matrices (Q, R), while (R,) returns only one.
+    # Pytensor does not return a tuple when only one output is expected.
+    rng = np.random.default_rng(utt.fetch_seed())
+    A = pt.tensor(name="A", shape=(5, 5))
+    A_val = rng.normal(size=(5, 5)).astype(config.floatX)
+    out = pt_slinalg.qr(A, mode=mode)
+
+    compare_jax_and_py([A], out, [A_val])


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
Fixes a bug uncovered by https://github.com/pymc-devs/pymc-extras/pull/597 . When we switched from `jax.numpy.linalg.qr` to `jax.scipy.linalg.qr`, the return type changed from a matrix to a 1-tuple when `mode='r'`.

This PR fixes this by unpacking the return of `jax.scipy.linalg.qr` when only one value is returned.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1682.org.readthedocs.build/en/1682/

<!-- readthedocs-preview pytensor end -->