### PR TITLE
Ignore `axis` argument in numba `CumOp` when input is 1d

### DIFF
--- a/pytensor/link/numba/dispatch/extra_ops.py
+++ b/pytensor/link/numba/dispatch/extra_ops.py
@@ -49,7 +49,7 @@ def numba_funcify_CumOp(op: CumOp, node: Apply, **kwargs):
 
             @numba_basic.numba_njit
             def cumop(x):
-                return np.cumsum(x, axis=axis)
+                return np.cumsum(x)
 
         else:
 
@@ -73,7 +73,7 @@ def numba_funcify_CumOp(op: CumOp, node: Apply, **kwargs):
 
             @numba_basic.numba_njit
             def cumop(x):
-                return np.cumprod(x, axis=axis)
+                return np.cumprod(x)
 
         else:
 

--- a/tests/link/numba/test_extra_ops.py
+++ b/tests/link/numba/test_extra_ops.py
@@ -58,6 +58,17 @@ def test_Bartlett(val):
             1,
             "mul",
         ),
+        # Regression tests for https://github.com/pymc-devs/pytensor/issues/1689
+        (
+            (pt.vector(), np.arange(6, dtype=config.floatX)),
+            0,
+            "add",
+        ),
+        (
+            (pt.vector(), np.arange(6, dtype=config.floatX)),
+            0,
+            "mul",
+        ),
     ],
 )
 def test_CumOp(val, axis, mode):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
Numba `CumOp` is passing the `axis` argument to `np.cumsum` and `np.cumprod` when `ndim == 1`, but the `axis` argument is not supported. Since there's only one dimension, we can just ignore it anyway, which this PR does.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #1689 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pytensor start -->
----
📚 Documentation preview 📚: https://pytensor--1691.org.readthedocs.build/en/1691/

<!-- readthedocs-preview pytensor end -->