### PR TITLE
Fix pytensor_cache clear

### DIFF
--- a/pytensor/link/c/cmodule.py
+++ b/pytensor/link/c/cmodule.py
@@ -806,7 +806,7 @@ class ModuleCache:
                 to_delete_empty.append((args, kwargs))
 
         # add entries that are not in the entry_from_key dictionary
-        time_now = time.perf_counter()
+        time_now = time.time()
         # Go through directories in alphabetical order to ensure consistent
         # behavior.
         try:
@@ -976,7 +976,7 @@ class ModuleCache:
                             # directories in alphabetical order so as to make
                             # sure all new processes only use the first one.
                             if cleanup:
-                                age = time.perf_counter() - last_access_time(entry)
+                                age = time.time() - last_access_time(entry)
                                 if delete_if_problem or age > self.age_thresh_del:
                                     rmtree(
                                         root,
@@ -1528,7 +1528,7 @@ class ModuleCache:
             assert key[0]
 
         to_del = []
-        time_now = time.perf_counter()
+        time_now = time.time()
         for filename in os.listdir(self.dirname):
             if filename.startswith("tmp"):
                 try:


### PR DESCRIPTION
I noticed cache clear wasn't working and always used purge instead. It was a mistake introduced by  671a821d5d6ce33eb8ff3baa05d392c99da4133f (downstream of https://github.com/aesara-devs/aesara/pull/1312).

This changed many time.time() to to time.perf_counter(). But here it was a mistake. The units are wrong for the logic used in refresh to denote files that are "too old", as it compares the age of a file with the os stats:

https://github.com/pymc-devs/pytensor/blob/8ebff2687c550ec21082d9d2429b79eebab41886/pytensor/link/c/cmodule.py#L369-L375

The whole thing is a bit over-engineered but I don't want to touch it.