### PR TITLE
Remove xfail from uint64 case of `TestMinMax`

### DIFF
--- a/tests/tensor/test_math.py
+++ b/tests/tensor/test_math.py
@@ -1409,12 +1409,7 @@ class TestMinMax:
             "uint8",
             "uint16",
             "uint32",
-            pytest.param(
-                "uint64",
-                marks=pytest.mark.xfail(
-                    condition=config.mode != "FAST_COMPILE", reason="Fails due to #770"
-                ),
-            ),
+            "uint64",
         ),
     )
     def test_uint(self, dtype):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
This test is flakey and responsible for a lot of random headaches. It does not appear to be required to fail? The test links to issue #770, but I ran the test 200 times locally without the xfail, and never had any issues.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #770 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
