### PR TITLE
Pytorch CI failing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -204,7 +204,7 @@ jobs:
           fi
           if [[ $INSTALL_NUMBA == "1" ]]; then micromamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}" "numba>=0.57"; fi
           if [[ $INSTALL_JAX == "1" ]]; then micromamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}" jax jaxlib numpyro equinox && pip install tfp-nightly; fi
-          if [[ $INSTALL_TORCH == "1" ]]; then micromamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}" pytorch pytorch-cuda=12.1 "mkl<=2024.0" -c pytorch -c nvidia; fi
+          if [[ $INSTALL_TORCH == "1" ]]; then micromamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}" pytorch pytorch-cuda=12.1 -c pytorch -c nvidia; fi
           if [[ $INSTALL_MLX == "1" ]]; then micromamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}" mlx; fi
           if [[ $INSTALL_XARRAY == "1" ]]; then micromamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}" xarray xarray-einstats; fi
 

--- a/pytensor/link/__init__.py
+++ b/pytensor/link/__init__.py
@@ -1,1 +1,0 @@
-from pytensor.link.pytorch.linker import PytorchLinker

--- a/pytensor/link/pytorch/__init__.py
+++ b/pytensor/link/pytorch/__init__.py
@@ -1,0 +1,1 @@
+from pytensor.link.pytorch.linker import PytorchLinker


### PR DESCRIPTION
PyTorch CI started failing in a recent PR. I guess they did some breaking changes. Strangely enough it can do `import torch.compiler`?

Other things are failing like it not liking numpy dtypes?

Closes #1723 