### PR TITLE
Speedup RNG copy in non-mutable RVs

### DIFF
--- a/pytensor/link/numba/dispatch/random.py
+++ b/pytensor/link/numba/dispatch/random.py
@@ -1,5 +1,4 @@
 from collections.abc import Callable
-from copy import deepcopy
 from functools import singledispatch
 from hashlib import sha256
 from textwrap import dedent
@@ -32,6 +31,7 @@ from pytensor.link.utils import (
 )
 from pytensor.tensor import get_vector_length
 from pytensor.tensor.random.op import RandomVariable, RandomVariableWithCoreShape
+from pytensor.tensor.random.utils import custom_rng_deepcopy
 from pytensor.tensor.type_other import NoneTypeT
 from pytensor.tensor.utils import _parse_gufunc_signature
 
@@ -42,7 +42,7 @@ def numba_deepcopy_random_generator(x):
 
         def random_generator_deepcopy(x):
             with numba.objmode(new_rng=types.npy_rng):
-                new_rng = deepcopy(x)
+                new_rng = custom_rng_deepcopy(x)
             return new_rng
 
         return random_generator_deepcopy

--- a/pytensor/tensor/random/op.py
+++ b/pytensor/tensor/random/op.py
@@ -1,7 +1,6 @@
 import abc
 import warnings
 from collections.abc import Sequence
-from copy import deepcopy
 from typing import Any, cast
 
 import numpy as np
@@ -23,6 +22,7 @@ from pytensor.tensor.blockwise import OpWithCoreShape
 from pytensor.tensor.random.type import RandomGeneratorType, RandomType
 from pytensor.tensor.random.utils import (
     compute_batch_shape,
+    custom_rng_deepcopy,
     explicit_expand_dims,
     normalize_size_param,
 )
@@ -423,7 +423,7 @@ class RandomVariable(RNGConsumerOp):
 
         # Draw from `rng` if `self.inplace` is `True`, and from a copy of `rng` otherwise.
         if not self.inplace:
-            rng = deepcopy(rng)
+            rng = custom_rng_deepcopy(rng)
 
         outputs[0][0] = rng
         outputs[1][0] = np.asarray(

--- a/pytensor/tensor/random/utils.py
+++ b/pytensor/tensor/random/utils.py
@@ -1,10 +1,12 @@
 from collections.abc import Callable, Sequence
+from copy import deepcopy
 from functools import wraps
 from itertools import zip_longest
 from types import ModuleType
 from typing import TYPE_CHECKING
 
 import numpy as np
+from numpy.random import Generator
 
 from pytensor.compile.sharedvalue import shared
 from pytensor.graph.basic import Variable
@@ -202,6 +204,16 @@ def normalize_size_param(
     assert shape.dtype in int_dtypes
 
     return shape
+
+
+def custom_rng_deepcopy(rng):
+    # This helper exists because copying numpy.random.Generator via deepcopy is slow.
+    # NumPy may implement a faster clone/copy API in the future:
+    # https://github.com/numpy/numpy/issues/24086
+    old_bitgen = rng.bit_generator
+    new_bitgen = type(old_bitgen)(deepcopy(old_bitgen._seed_seq))
+    new_bitgen.state = old_bitgen.state
+    return Generator(new_bitgen)
 
 
 class RandomStream:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
This PR improves how RandomVariable copies RNG state when inplace=False.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1708 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

@ricardoV94 I think this closes the #1708 using the code you provided, I just added some tests
