### PR TITLE
Use sparse structured methods where possible

### DIFF
--- a/pytensor/sparse/variable.py
+++ b/pytensor/sparse/variable.py
@@ -24,8 +24,18 @@ from pytensor.sparse.math import (
     lt,
     mul,
     sp_sum,
+    structured_abs,
+    structured_arcsin,
+    structured_arcsinh,
+    structured_arctan,
     structured_conjugate,
+    structured_deg2rad,
     structured_dot,
+    structured_expm1,
+    structured_log1p,
+    structured_rad2deg,
+    structured_sinh,
+    structured_tanh,
     sub,
 )
 from pytensor.sparse.type import SparseTensorType
@@ -175,9 +185,8 @@ class _sparse_py_operators:
     def conj(self):
         return structured_conjugate(self)
 
-    @override_dense
     def __abs__(self):
-        raise NotImplementedError
+        return structured_abs(self)
 
     @override_dense
     def __ceil__(self):
@@ -191,9 +200,8 @@ class _sparse_py_operators:
     def __trunc__(self):
         raise NotImplementedError
 
-    @override_dense
     def transpose(self):
-        raise NotImplementedError
+        return self.T
 
     @override_dense
     def any(self, axis=None, keepdims=False):
@@ -223,21 +231,18 @@ class _sparse_py_operators:
     def arccos(self):
         raise NotImplementedError
 
-    @override_dense
     def arcsin(self):
-        raise NotImplementedError
+        return structured_arcsin(self)
 
-    @override_dense
     def arctan(self):
-        raise NotImplementedError
+        return structured_arctan(self)
 
     @override_dense
     def arccosh(self):
         raise NotImplementedError
 
-    @override_dense
     def arcsinh(self):
-        raise NotImplementedError
+        return structured_arcsinh(self)
 
     @override_dense
     def arctanh(self):
@@ -255,9 +260,8 @@ class _sparse_py_operators:
     def cosh(self):
         raise NotImplementedError
 
-    @override_dense
     def deg2rad(self):
-        raise NotImplementedError
+        return structured_deg2rad(self)
 
     @override_dense
     def exp(self):
@@ -267,9 +271,8 @@ class _sparse_py_operators:
     def exp2(self):
         raise NotImplementedError
 
-    @override_dense
     def expm1(self):
-        raise NotImplementedError
+        return structured_expm1(self)
 
     @override_dense
     def floor(self):
@@ -283,25 +286,22 @@ class _sparse_py_operators:
     def log10(self):
         raise NotImplementedError
 
-    @override_dense
     def log1p(self):
-        raise NotImplementedError
+        return structured_log1p(self)
 
     @override_dense
     def log2(self):
         raise NotImplementedError
 
-    @override_dense
     def rad2deg(self):
-        raise NotImplementedError
+        return structured_rad2deg(self)
 
     @override_dense
     def sin(self):
         raise NotImplementedError
 
-    @override_dense
     def sinh(self):
-        raise NotImplementedError
+        return structured_sinh(self)
 
     @override_dense
     def sqrt(self):
@@ -311,9 +311,8 @@ class _sparse_py_operators:
     def tan(self):
         raise NotImplementedError
 
-    @override_dense
     def tanh(self):
-        raise NotImplementedError
+        return structured_tanh(self)
 
     @override_dense
     def copy(self, name=None):

--- a/pytensor/sparse/variable.py
+++ b/pytensor/sparse/variable.py
@@ -3,6 +3,7 @@ from warnings import warn
 import numpy as np
 import scipy.sparse as scipy_sparse
 
+from pytensor.compile import ViewOp
 from pytensor.sparse.basic import (
     cast,
     csm_data,
@@ -83,6 +84,11 @@ def override_dense(method):
 class _sparse_py_operators:
     T = property(
         lambda self: transpose(self), doc="Return aliased transpose of self (read-only)"
+    )
+
+    mT = property(
+        lambda self: transpose(self),
+        doc="Return aliased matrix transpose of self (read-only)",
     )
 
     def astype(self, dtype):
@@ -316,7 +322,7 @@ class _sparse_py_operators:
 
     @override_dense
     def copy(self, name=None):
-        raise NotImplementedError
+        raise ViewOp()(self)
 
     @override_dense
     def prod(self, axis=None, dtype=None, keepdims=False, acc_dtype=None):

--- a/tests/sparse/test_variable.py
+++ b/tests/sparse/test_variable.py
@@ -89,20 +89,28 @@ class TestSparseVariable:
             [x], z, on_unused_input="ignore", allow_input_downcast=True
         )
 
-        res = f([[1.1, 0.0, 2.0], [-1.0, 0.0, 0.0]])
+        input_value = np.array([[1.1, 0.0, 2.0], [-1.0, 0.0, 0.0]])
+        res = f(input_value)
 
         if not isinstance(res, list):
             res_outs = [res]
         else:
             res_outs = res
 
-        # TODO: Make a separate test for methods that always reduce to dense (only sum for now)
         if getattr(method_to_call, "_is_dense_override", False) or method == "sum":
             assert all(isinstance(out.type, DenseTensorType) for out in z_outs)
             assert all(isinstance(out, np.ndarray) for out in res_outs)
+
         else:
             assert all(isinstance(out.type, SparseTensorType) for out in z_outs)
             assert all(isinstance(out, csr_matrix) for out in res_outs)
+
+            # If a built-in method returns sparse, its using a "structured" function. These ignore the zeros
+            # for performance, but should have the same result as calling the normal version on a dense matrix.
+            # (That is, we must have f(0) = 0 for these functions)
+            if method not in ["__neg__", "zeros_like", "ones_like", "copy"]:
+                f_np = getattr(np, method.replace("_", ""))
+                np.testing.assert_allclose(res.todense(), f_np(input_value))
 
     @pytest.mark.parametrize(
         "method",


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
For elemwise functions that are idempotent at 0 such that f(0) = 0, it is safe to always use a `structured_` function, rather than converting back to dense.

Such functions are `sinh`, `tanh`, `arcsin`, `arctan`, `arcsinh`, `deg2rad`, `rad2deg`, `expm1`, and `log1p`.

I also removed the dense_override on `.transpose`, which now calls `self.T`. I think this is fine for now, since we're only supporting sparse matrices, not general sparse arrays. Previously, `sparse.T` returned a sparse, but `sparse.transpose` returned a dense, which is baffling. 

`copy` seems like another low-hanging fruit, but I'm leaving it for another time because it was slightly harder to reason about than the functions in this PR.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #272 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
