### PR TITLE
Handle non-constant NoneTypeT variables

### DIFF
--- a/pytensor/tensor/random/op.py
+++ b/pytensor/tensor/random/op.py
@@ -385,7 +385,9 @@ class RandomVariable(RNGConsumerOp):
         dist_params = explicit_expand_dims(
             dist_params,
             self.ndims_params,
-            size_length=None if NoneConst.equals(size) else get_vector_length(size),
+            size_length=None
+            if isinstance(size.type, NoneTypeT)
+            else get_vector_length(size),
         )
 
         inputs = (rng, size, *dist_params)

--- a/pytensor/tensor/rewriting/shape.py
+++ b/pytensor/tensor/rewriting/shape.py
@@ -47,7 +47,7 @@ from pytensor.tensor.shape import (
 )
 from pytensor.tensor.subtensor import Subtensor, get_idx_list
 from pytensor.tensor.type import TensorType, discrete_dtypes, integer_dtypes
-from pytensor.tensor.type_other import NoneConst, NoneTypeT
+from pytensor.tensor.type_other import NoneTypeT
 from pytensor.tensor.variable import TensorVariable
 
 
@@ -1137,7 +1137,7 @@ def local_merge_consecutive_specify_shape(fgraph, node):
 
     inner_obj, *shape = obj.owner.inputs
     for dim, sh in enumerate(node.inputs[1:]):
-        if not NoneConst.equals(sh):
+        if not isinstance(sh.type, NoneTypeT):
             shape[dim] = sh
 
     # TODO: We could make sure that the overlapping shapes of the two `SpecifyShape`s are
@@ -1183,7 +1183,7 @@ def local_Shape_of_SpecifyShape(fgraph, node):
 
     # Replace `NoneConst` by `shape_i`
     for i, sh in enumerate(shape):
-        if NoneConst.equals(sh):
+        if isinstance(sh.type, NoneTypeT):
             shape[i] = x.shape[i]
 
     return [stack(shape).astype(np.int64)]
@@ -1219,7 +1219,7 @@ def local_specify_shape_lift(fgraph, node):
                 for i, (dim, bcast) in enumerate(
                     zip(shape, out_broadcastable, strict=True)
                 )
-                if (not bcast and not NoneConst.equals(dim))
+                if (not bcast and not isinstance(dim.type, NoneTypeT))
             }
             new_elem_inps = elem_inps.copy()
             for i, elem_inp in enumerate(elem_inps):

--- a/pytensor/tensor/shape.py
+++ b/pytensor/tensor/shape.py
@@ -408,7 +408,9 @@ class SpecifyShape(COp):
 
         shape = tuple(
             NoneConst
-            if (s is None or NoneConst.equals(s))
+            if (
+                s is None or (isinstance(s, Variable) and isinstance(s.type, NoneTypeT))
+            )
             else ptb.as_tensor_variable(s, ndim=0)
             for s in shape
         )
@@ -506,7 +508,7 @@ class SpecifyShape(COp):
         for i, (shp_name, shp) in enumerate(
             zip(shape_names, node.inputs[1:], strict=True)
         ):
-            if NoneConst.equals(shp):
+            if isinstance(shp.type, NoneTypeT):
                 continue
             code += dedent(
                 f"""
@@ -594,7 +596,10 @@ def _vectorize_specify_shape(op, node, x, *shape):
     if any(
         as_tensor_variable(dim).type.ndim != 0
         for dim in shape
-        if not (NoneConst.equals(dim) or dim is None)
+        if not (
+            (isinstance(dim, Variable) and isinstance(dim.type, NoneTypeT))
+            or dim is None
+        )
     ):
         raise NotImplementedError(
             "It is not possible to vectorize the shape argument of SpecifyShape"

--- a/tests/tensor/random/test_op.py
+++ b/tests/tensor/random/test_op.py
@@ -11,6 +11,7 @@ from pytensor.tensor.random.basic import NormalRV
 from pytensor.tensor.random.op import RandomVariable, default_rng
 from pytensor.tensor.shape import specify_shape
 from pytensor.tensor.type import iscalar, tensor
+from pytensor.tensor.type_other import none_type_t
 
 
 @pytest.fixture(scope="function", autouse=False)
@@ -317,3 +318,12 @@ def test_size_none_vs_empty():
         ValueError, match="Size length is incompatible with batched dimensions"
     ):
         rv([0], [1], size=())
+
+
+def test_non_constant_none_size():
+    # Regression test for https://github.com/pymc-devs/pymc/issues/7901#issuecomment-3528479876
+    loc = pt.vector("loc", dtype="float64")
+    size = none_type_t("none_size")
+
+    rv = normal(loc, size=size)
+    rv.eval({loc: np.arange(5, dtype="float64"), size: None}, mode="FAST_COMPILE")

--- a/tests/tensor/random/test_utils.py
+++ b/tests/tensor/random/test_utils.py
@@ -7,9 +7,11 @@ from pytensor.graph.rewriting.db import RewriteDatabaseQuery
 from pytensor.tensor.random.utils import (
     RandomStream,
     broadcast_params,
+    normalize_size_param,
     supp_shape_from_ref_param_shape,
 )
-from pytensor.tensor.type import matrix, tensor
+from pytensor.tensor.type import TensorType, matrix, tensor
+from pytensor.tensor.type_other import NoneTypeT, none_type_t
 from tests import unittest_tools as utt
 
 
@@ -327,3 +329,22 @@ def test_supp_shape_from_ref_param_shape():
         ref_param_idx=1,
     )
     assert res == (3, 4)
+
+
+def test_normalize_size_param():
+    assert normalize_size_param(None).type == NoneTypeT()
+
+    sym_none_size = none_type_t()
+    assert normalize_size_param(sym_none_size) is sym_none_size
+
+    empty_size = normalize_size_param(())
+    assert empty_size.type == TensorType(dtype="int64", shape=(0,))
+
+    int_size = normalize_size_param(5)
+    assert int_size.type == TensorType(dtype="int64", shape=(1,))
+
+    seq_int_size = normalize_size_param((5, 3, 4))
+    assert seq_int_size.type == TensorType(dtype="int64", shape=(3,))
+
+    sym_tensor_size = tensor(shape=(3,), dtype="int64")
+    assert normalize_size_param(sym_tensor_size) is sym_tensor_size


### PR DESCRIPTION
Fixes https://github.com/pymc-devs/pymc/issues/7901

NoneType is a bit of an odd one. It can ever only have one value at runtime: None, so there is no much point in having it be symbolic. But sometimes it can be in the normal use of PyTensor, such as when creating OpFromGraph around RVs automatically. That was the problem in the related issue.

This PR changes all checks to be one the NoneTypeT of the variable, so it works regardless of whether it is a Constant or not. 