### PR TITLE
Allow slow-tests-issue workflow to skip on script failure

### DIFF
--- a/.github/workflows/slow-tests-issue.yml
+++ b/.github/workflows/slow-tests-issue.yml
@@ -6,7 +6,7 @@ name: Slow Tests Issue Body
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */6 * * *'
+    - cron: "0 */6 * * *"
 
 permissions:
   issues: write
@@ -24,6 +24,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Trigger the script
+        continue-on-error: true
         working-directory: scripts/slowest_tests
         shell: zsh {0}
         run: source update-slowest-times-issue.sh


### PR DESCRIPTION
This PR modifies the slow-tests-issue workflow to gracefully handle script failures by adding `continue-on-error: true` to the script execution step.

## Changes
- Added `continue-on-error: true` to the "Trigger the script" step in `.github/workflows/slow-tests-issue.yml`

## Rationale
The scheduled workflow should not fail entirely when the script encounters an error. With this change, the workflow will complete successfully and mark the step as skipped if the script fails, preventing unnecessary workflow failures.