### PR TITLE
Refactor advanced subtensor

### DIFF
--- a/pytensor/graph/destroyhandler.py
+++ b/pytensor/graph/destroyhandler.py
@@ -771,9 +771,9 @@ class DestroyHandler(Bookkeeper):
                     }
                     tolerated.add(destroyed_idx)
                     tolerate_aliased = getattr(
-                        app.op, "destroyhandler_tolerate_aliased", []
+                        app.op, "destroyhandler_tolerate_aliased", ()
                     )
-                    assert isinstance(tolerate_aliased, list)
+                    assert isinstance(tolerate_aliased, tuple | list)
                     ignored = {
                         idx1 for idx0, idx1 in tolerate_aliased if idx0 == destroyed_idx
                     }

--- a/pytensor/link/mlx/dispatch/subtensor.py
+++ b/pytensor/link/mlx/dispatch/subtensor.py
@@ -10,15 +10,14 @@ from pytensor.tensor.subtensor import (
     Subtensor,
     indices_from_subtensor,
 )
-from pytensor.tensor.type_other import MakeSlice
 
 
 @mlx_funcify.register(Subtensor)
 def mlx_funcify_Subtensor(op, node, **kwargs):
-    idx_list = getattr(op, "idx_list", None)
-
     def subtensor(x, *ilists):
-        indices = indices_from_subtensor([int(element) for element in ilists], idx_list)
+        indices = indices_from_subtensor(
+            [int(element) for element in ilists], op.idx_list
+        )
         if len(indices) == 1:
             indices = indices[0]
 
@@ -30,10 +29,8 @@ def mlx_funcify_Subtensor(op, node, **kwargs):
 @mlx_funcify.register(AdvancedSubtensor)
 @mlx_funcify.register(AdvancedSubtensor1)
 def mlx_funcify_AdvancedSubtensor(op, node, **kwargs):
-    idx_list = getattr(op, "idx_list", None)
-
     def advanced_subtensor(x, *ilists):
-        indices = indices_from_subtensor(ilists, idx_list)
+        indices = indices_from_subtensor(ilists, op.idx_list)
         if len(indices) == 1:
             indices = indices[0]
 
@@ -45,8 +42,6 @@ def mlx_funcify_AdvancedSubtensor(op, node, **kwargs):
 @mlx_funcify.register(IncSubtensor)
 @mlx_funcify.register(AdvancedIncSubtensor1)
 def mlx_funcify_IncSubtensor(op, node, **kwargs):
-    idx_list = getattr(op, "idx_list", None)
-
     if getattr(op, "set_instead_of_inc", False):
 
         def mlx_fn(x, indices, y):
@@ -63,7 +58,7 @@ def mlx_funcify_IncSubtensor(op, node, **kwargs):
             x[indices] += y
             return x
 
-    def incsubtensor(x, y, *ilist, mlx_fn=mlx_fn, idx_list=idx_list):
+    def incsubtensor(x, y, *ilist, mlx_fn=mlx_fn, idx_list=op.idx_list):
         indices = indices_from_subtensor(ilist, idx_list)
         if len(indices) == 1:
             indices = indices[0]
@@ -95,11 +90,3 @@ def mlx_funcify_AdvancedIncSubtensor(op, node, **kwargs):
         return mlx_fn(x, ilist, y)
 
     return advancedincsubtensor
-
-
-@mlx_funcify.register(MakeSlice)
-def mlx_funcify_MakeSlice(op, **kwargs):
-    def makeslice(*x):
-        return slice(*x)
-
-    return makeslice

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -29,7 +29,7 @@ from pytensor.graph.fg import FunctionGraph, Output
 from pytensor.graph.op import Op
 from pytensor.graph.replace import _vectorize_node
 from pytensor.graph.rewriting.db import EquilibriumDB
-from pytensor.graph.type import HasShape, Type
+from pytensor.graph.type import HasShape
 from pytensor.link.c.op import COp
 from pytensor.link.c.params_type import ParamsType
 from pytensor.printing import Printer, min_informative_str, pprint, set_precedence
@@ -433,7 +433,7 @@ def _get_underlying_scalar_constant_value(
                         var.ndim == 1 for var in v.owner.inputs[0].owner.inputs[1:]
                     ):
                         idx = v.owner.op.idx_list[0]
-                        if isinstance(idx, Type):
+                        if isinstance(idx, int):
                             idx = _get_underlying_scalar_constant_value(
                                 v.owner.inputs[1], max_recur=max_recur
                             )
@@ -467,7 +467,7 @@ def _get_underlying_scalar_constant_value(
                     and len(v.owner.op.idx_list) == 1
                 ):
                     idx = v.owner.op.idx_list[0]
-                    if isinstance(idx, Type):
+                    if isinstance(idx, int):
                         idx = _get_underlying_scalar_constant_value(
                             v.owner.inputs[1], max_recur=max_recur
                         )
@@ -488,7 +488,7 @@ def _get_underlying_scalar_constant_value(
                     op = owner.op
                     idx_list = op.idx_list
                     idx = idx_list[0]
-                    if isinstance(idx, Type):
+                    if isinstance(idx, int):
                         idx = _get_underlying_scalar_constant_value(
                             owner.inputs[1], max_recur=max_recur
                         )

--- a/pytensor/xtensor/rewriting/indexing.py
+++ b/pytensor/xtensor/rewriting/indexing.py
@@ -2,9 +2,10 @@ from itertools import zip_longest
 
 from pytensor import as_symbolic
 from pytensor.graph import Constant, node_rewriter
-from pytensor.tensor import TensorType, arange, specify_shape
+from pytensor.tensor import arange, specify_shape
 from pytensor.tensor.subtensor import _non_consecutive_adv_indexing, inc_subtensor
 from pytensor.tensor.type_other import NoneTypeT, SliceType
+from pytensor.tensor.variable import TensorVariable
 from pytensor.xtensor.basic import tensor_from_xtensor, xtensor_from_tensor
 from pytensor.xtensor.indexing import Index, IndexUpdate, index
 from pytensor.xtensor.rewriting.utils import register_lower_xtensor
@@ -106,7 +107,7 @@ def _lower_index(node):
                     # We can use basic indexing directly if no other index acts on this dimension
                     # This is an optimization that avoids creating an unnecessary arange tensor
                     # and facilitates the use of the specialized AdvancedSubtensor1 when possible
-                    aligned_idxs.append(idx)
+                    aligned_idxs.append(to_basic_idx(idx))
                     basic_idx_axis.append(out_dims.index(x_dim))
                 else:
                     # Otherwise we need to convert the basic index into an equivalent advanced indexing
@@ -131,7 +132,7 @@ def _lower_index(node):
         if basic_idx_axis:
             aligned_idxs = [
                 idx.squeeze(axis=basic_idx_axis)
-                if (isinstance(idx.type, TensorType) and idx.type.ndim > 0)
+                if (isinstance(idx, TensorVariable) and idx.type.ndim > 0)
                 else idx
                 for idx in aligned_idxs
             ]

--- a/tests/graph/rewriting/test_basic.py
+++ b/tests/graph/rewriting/test_basic.py
@@ -26,9 +26,7 @@ from pytensor.graph.rewriting.unify import LiteralString, OpPattern
 from pytensor.raise_op import assert_op
 from pytensor.tensor.math import Dot, add, dot, exp
 from pytensor.tensor.rewriting.basic import constant_folding
-from pytensor.tensor.subtensor import AdvancedSubtensor
 from pytensor.tensor.type import matrix, values_eq_approx_always_true, vector
-from pytensor.tensor.type_other import MakeSlice, SliceConstant, slicetype
 from tests.graph.utils import (
     MyOp,
     MyType,
@@ -629,21 +627,6 @@ def test_pre_constant_merge():
     assert res == [o2]
     assert o2.owner.inputs[2] is c2
 
-    # What is this supposed to test?
-    ms = MakeSlice()(1)
-    res = pre_constant_merge(empty_fgraph, [ms])
-
-    assert res == [ms]
-
-    const_slice = SliceConstant(type=slicetype, data=slice(1, None, 2))
-
-    assert isinstance(const_slice, Constant)
-
-    adv = AdvancedSubtensor()(matrix(), [2, 3], const_slice)
-
-    res = pre_constant_merge(empty_fgraph, adv)
-    assert res == [adv]
-
 
 def test_pre_greedy_node_rewriter():
     empty_fgraph = FunctionGraph([], [])
@@ -678,15 +661,6 @@ def test_pre_greedy_node_rewriter():
 
     assert cst.owner.inputs[0] is o1
     assert cst.owner.inputs[4] is cst.owner.inputs[0]
-
-    # What exactly is this supposed to test?
-    ms = MakeSlice()(1)
-    cst = pre_greedy_node_rewriter(empty_fgraph, [constant_folding], ms)
-
-    assert isinstance(cst, SliceConstant)
-
-    # Make sure constant of slice signature is hashable.
-    assert isinstance(hash(cst.signature()), int)
 
 
 @pytest.mark.parametrize("tracks", [True, False])

--- a/tests/link/mlx/test_subtensor.py
+++ b/tests/link/mlx/test_subtensor.py
@@ -187,27 +187,6 @@ def test_mlx_inplace_variants():
     compare_mlx_and_py([], [out_pt], [])
 
 
-@pytest.mark.xfail(
-    reason="MLX slice indices must be integers or None, dynamic slices not supported"
-)
-def test_mlx_MakeSlice():
-    """Test MakeSlice operation."""
-    # Test slice creation
-    start = pt.iscalar("start")
-    stop = pt.iscalar("stop")
-    step = pt.iscalar("step")
-
-    # Create a slice using MakeSlice
-    slice_op = pt_subtensor.MakeSlice()
-    slice_pt = slice_op(start, stop, step)
-
-    # Use simple constant array instead of arange
-    x_pt = pt.constant(np.arange(10, dtype=np.float32))
-    out_pt = x_pt[slice_pt]
-
-    compare_mlx_and_py([start, stop, step], [out_pt], [1, 8, 2])
-
-
 def test_mlx_subtensor_edge_cases():
     """Test edge cases and boundary conditions."""
     # Empty slices - use constant array

--- a/tests/tensor/rewriting/test_elemwise.py
+++ b/tests/tensor/rewriting/test_elemwise.py
@@ -1642,9 +1642,15 @@ def test_InplaceElemwiseOptimizer_bug():
     # with config.change_flags(tensor__insert_inplace_optimizer_validate_nb=10):
     rewrite_graph(fgraph, include=("inplace",))
 
-    pytensor.config.tensor__insert_inplace_optimizer_validate_nb = 1
-    with pytest.warns(
-        FutureWarning,
-        match="tensor__insert_inplace_optimizer_validate_nb config is deprecated",
-    ):
-        rewrite_graph(fgraph, include=("inplace",))
+    # Save original value to restore later
+    original_value = pytensor.config.tensor__insert_inplace_optimizer_validate_nb
+    try:
+        pytensor.config.tensor__insert_inplace_optimizer_validate_nb = 1
+        with pytest.warns(
+            FutureWarning,
+            match="tensor__insert_inplace_optimizer_validate_nb config is deprecated",
+        ):
+            rewrite_graph(fgraph, include=("inplace",))
+    finally:
+        # Restore original value to avoid affecting other tests
+        pytensor.config.tensor__insert_inplace_optimizer_validate_nb = original_value

--- a/tests/tensor/rewriting/test_subtensor_lift.py
+++ b/tests/tensor/rewriting/test_subtensor_lift.py
@@ -32,7 +32,6 @@ from pytensor.tensor import (
     lscalars,
     matrix,
     shape,
-    slicetype,
     specify_shape,
     tensor,
     tensor3,
@@ -557,7 +556,7 @@ class TestLocalSubtensorSpecifyShapeLift:
             (
                 matrix(),
                 (iscalar(), iscalar()),
-                (slicetype(),),
+                (slice(iscalar(), iscalar(), iscalar()),),
             ),
             (
                 matrix(),
@@ -789,12 +788,12 @@ def test_local_subtensor_shape_constant():
         (lambda x: x[:, [0, 1]][0], True),
         (lambda x: x[:, [0, 1], [0, 0]][1:], True),
         (lambda x: x[:, [[0, 1], [0, 0]]][1:], True),
+        (lambda x: x[:, None, [0, 1]][0], True),
         # Not supported, basic indexing on advanced indexing dim
         (lambda x: x[[0, 1]][0], False),
-        # Not implemented, basic indexing on the right of advanced indexing
+        # Not supported, basic indexing on the right of advanced indexing
         (lambda x: x[[0, 1]][:, 0], False),
         # Not implemented, complex flavors of advanced indexing
-        (lambda x: x[:, None, [0, 1]][0], False),
         (lambda x: x[:, 5:, [0, 1]][0], False),
         (lambda x: x[:, :, np.array([True, False, False])][0], False),
         (lambda x: x[[0, 1], :, [0, 1]][:, 0], False),

--- a/tests/tensor/test_blockwise.py
+++ b/tests/tensor/test_blockwise.py
@@ -31,6 +31,8 @@ from pytensor.tensor.blockwise import (
     vectorize_node_fallback,
 )
 from pytensor.tensor.nlinalg import MatrixInverse, eig
+from pytensor.tensor.random import normal
+from pytensor.tensor.random.op import default_rng
 from pytensor.tensor.rewriting.blas import specialize_matmul_to_batched_dot
 from pytensor.tensor.signal import convolve1d
 from pytensor.tensor.slinalg import (
@@ -114,16 +116,18 @@ def test_vectorize_blockwise():
 
 
 def test_vectorize_node_fallback_unsupported_type():
-    x = tensor("x", shape=(2, 6))
-    node = x[:, [0, 2, 4]].owner
+    rng = default_rng()
+    node = normal(rng=rng).owner
 
     with pytest.raises(
         NotImplementedError,
         match=re.escape(
-            "Cannot vectorize node AdvancedSubtensor(x, MakeSlice.0, [0 2 4]) with input MakeSlice.0 of type slice"
+            'Cannot vectorize node normal_rv{"(),()->()"}('
+            "DefaultGeneratorMakerOp.0, NoneConst{None}, 0.0, 1.0)"
+            " with input DefaultGeneratorMakerOp.0 of type RandomGeneratorType"
         ),
     ):
-        vectorize_node_fallback(node.op, node, node.inputs)
+        vectorize_node_fallback(node.op, node, *node.inputs)
 
 
 def check_blockwise_runtime_broadcasting(mode):

--- a/tests/tensor/test_variable.py
+++ b/tests/tensor/test_variable.py
@@ -35,7 +35,7 @@ from pytensor.tensor.type import (
     scalar,
     tensor3,
 )
-from pytensor.tensor.type_other import MakeSlice, NoneConst
+from pytensor.tensor.type_other import NoneConst
 from pytensor.tensor.variable import (
     DenseTensorConstant,
     DenseTensorVariable,
@@ -232,11 +232,11 @@ def test__getitem__AdvancedSubtensor():
 
     z = x[:, i]
     op_types = [type(node.op) for node in io_toposort([x, i], [z])]
-    assert op_types == [MakeSlice, AdvancedSubtensor]
+    assert op_types == [AdvancedSubtensor]
 
     z = x[..., i, None]
     op_types = [type(node.op) for node in io_toposort([x, i], [z])]
-    assert op_types == [MakeSlice, AdvancedSubtensor]
+    assert op_types == [DimShuffle, AdvancedSubtensor]
 
     z = x[i, None]
     op_types = [type(node.op) for node in io_toposort([x, i], [z])]


### PR DESCRIPTION
## Description
Allows vectorizing AdvancedSetSubtensor.

Gemini picks up where Copilot left off.

## Related Issue
- [x] Closes #541 
- [x] Directly follows from #1622 and related to [pymc-extras#577](https://github.com/pymc-devs/pymc-extras/issues/577)

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html) (ruff removed whitespace etc from copilot commits also I think)
- [x] Changed tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
