### PR TITLE
Update node_rewriter typehint

### DIFF
--- a/pytensor/graph/rewriting/basic.py
+++ b/pytensor/graph/rewriting/basic.py
@@ -1010,7 +1010,7 @@ class FromFunctionNodeRewriter(NodeRewriter):
 
 
 def node_rewriter(
-    tracks: Sequence[Op | type, OpPattern] | None,
+    tracks: Sequence[Op | type | OpPattern] | None,
     inplace: bool = False,
     requirements: tuple[type, ...] | None = (),
 ):


### PR DESCRIPTION
The `tracks` argument of `node_rewriter` had a typehint of `Sequence[Op | type, OpPattern]`, which was triggering my code analyzer when we pass a single `OpPattern` (e.g. when tracking a single `blockwise_of`). I believe the correct typehint is `Sequence[Op | type | OpPattern]`. 