### PR TITLE
Determinant of factorized matrices

### DIFF
--- a/tests/tensor/rewriting/test_linalg.py
+++ b/tests/tensor/rewriting/test_linalg.py
@@ -309,14 +309,15 @@ def test_local_det_chol():
     det_X = pt.linalg.det(X)
 
     f = function([X], [L, det_X])
-
-    nodes = f.maker.fgraph.toposort()
-    assert not any(isinstance(node, Det) for node in nodes)
+    assert not any(isinstance(node, Det) for node in f.maker.fgraph.apply_nodes)
 
     # This previously raised an error (issue #392)
     f = function([X], [L, det_X, X])
-    nodes = f.maker.fgraph.toposort()
-    assert not any(isinstance(node, Det) for node in nodes)
+    assert not any(isinstance(node, Det) for node in f.maker.fgraph.apply_nodes)
+
+    # Test graph that only has det_X
+    f = function([X], [det_X])
+    assert not any(isinstance(node, Det) for node in f.maker.fgraph.apply_nodes)
 
 
 def test_psd_solve_with_chol():


### PR DESCRIPTION
The old `local_det_chol` rewrite is extended to cover more cases of a matrix that is factorized elsewhere, not just with Cholesky, but also LU, LUFactor, or SVD, QR (the latter two only if the sign isn't needed)

A new rewrite is added for the determinant of a factorization itself. The logic is slightly different, for instance det(LUFactor) is non-sensical, and the determinant for some outputs of SVD/ QR can always be computed even if the determinant of the whole factorization cannot.

Also extended the rewrite of log(prod(x)) to sum(log(x)), which should increase the stability of many of these when we want the log determinant (or log(abs(determintant))).

Still missing tests

Closes #1679 
Related to #573 