### PR TITLE
Cache is_matrix_transpose in DimShuffle Op

### DIFF
--- a/pytensor/tensor/elemwise.py
+++ b/pytensor/tensor/elemwise.py
@@ -175,6 +175,12 @@ class DimShuffle(ExternalCOp):
         self.is_right_expand_dims = self.is_expand_dims and new_order[
             :input_ndim
         ] == list(range(input_ndim))
+        self.is_matrix_transpose = False
+        if dims_are_shuffled and (not drop) and input_ndim >= 2:
+            # We consider a matrix transpose if we only flip the last two dims
+            # Regardless of whethre there's an expand_dims or not
+            mt_pattern = [*range(input_ndim - 2), input_ndim - 1, input_ndim - 2]
+            self.is_matrix_transpose = list(new_order[len(augment) :]) == mt_pattern
 
     def __setstate__(self, state):
         self.__dict__.update(state)

--- a/pytensor/tensor/rewriting/linalg.py
+++ b/pytensor/tensor/rewriting/linalg.py
@@ -68,25 +68,11 @@ MATRIX_INVERSE_OPS = (MatrixInverse, MatrixPinv)
 def is_matrix_transpose(x: TensorVariable) -> bool:
     """Check if a variable corresponds to a transpose of the last two axes"""
     node = x.owner
-    if (
-        node
+    return (
+        node is not None
         and isinstance(node.op, DimShuffle)
-        and not (node.op.drop or node.op.augment)
-    ):
-        [inp] = node.inputs
-        ndims = inp.type.ndim
-        if ndims < 2:
-            return False
-        transpose_order = (*range(ndims - 2), ndims - 1, ndims - 2)
-
-        # Allow expand_dims on the left of the transpose
-        if (diff := len(transpose_order) - len(node.op.new_order)) > 0:
-            transpose_order = (
-                *(["x"] * diff),
-                *transpose_order,
-            )
-        return node.op.new_order == transpose_order
-    return False
+        and node.op.is_matrix_transpose
+    )
 
 
 @register_canonicalize


### PR DESCRIPTION
Add `is_matrix_transpose` attribute to `DimShuffle.__init__` to cache whether the operation represents a matrix transpose. This avoids repeated computation in the `is_matrix_transpose()` function in linalg.py.

Fix tuple/list comparison bug from original commit 07e50e2 by @ricardoV94 where `new_order` (a tuple) was compared directly to `mt_pattern` (a list). In Python, `(1, 0) == [1, 0]` returns `False`.

## Description
- Added `is_matrix_transpose` boolean attribute to `DimShuffle` Op during initialization
- Simplified `is_matrix_transpose()` function in `linalg.py` to use the cached attribute
- Fixed type mismatch: converted tuple slice to list for comparison

## Related Issue
- [x] Closes #1610
- [ ] Related to #

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):