### PR TITLE
Fix unboxing of numpy boolean scalars in C-backend

### DIFF
--- a/pytensor/tensor/signal/conv.py
+++ b/pytensor/tensor/signal/conv.py
@@ -254,11 +254,6 @@ class Convolve2d(AbstractConvolveNd, Op):  # type: ignore[misc]
 
     def perform(self, node, inputs, outputs):
         in1, in2, full_mode = inputs
-
-        if isinstance(full_mode, np.bool):
-            # Patch for wrong unboxing of bool scalars in C backend
-            # Conditional, because numba will produce a bool, not np.bool_
-            full_mode = full_mode.item()
         mode = "full" if full_mode else "valid"
         outputs[0][0] = scipy_convolve(in1, in2, mode=mode, method=self.method)
 

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -2221,6 +2221,13 @@ def test_ScalarFromTensor(cast_policy):
             scalar_from_tensor(vector())
 
 
+def test_bool_scalar_from_tensor():
+    x = scalar("x", dtype="bool")
+    fn = function([x], scalar_from_tensor(x))
+    assert fn(np.array(True, dtype=bool))
+    assert not fn(np.array(False, dtype=bool))
+
+
 def test_op_cache():
     # TODO: What is this actually testing?
     # trigger bug in ticket #162


### PR DESCRIPTION
We were seeing weird things where an output of ScalarFromTensor for a np.array(True), would evaluate to False. See this old comment here:

https://github.com/pymc-devs/pytensor/blob/d8501d14bc5800fea46a2d6107066d4a790c6936/pytensor/tensor/signal/conv.py#L258-L260

And this snippet would fail:

```python
import numpy as np
import pytensor
import pytensor.tensor as pt

x = pt.scalar("x", dtype="bool")
y = pt.scalar_from_tensor(x)
fn = pytensor.function([x], y)
assert fn(np.array(True, dtype=bool))   # AssertionError :O
```

I tracked it down to the `c_sync` method for ScalarType, which is called when the C code has to generate a Python object as an output (or intermediate computation if going into python mode). Basically unboxing of the internal representation of scalars into numpy scalar arrays.