### PR TITLE
tests: allow TypeError in test_tri_nonconcrete for JAX compatibility

### DIFF
--- a/tests/link/jax/test_tensor_basic.py
+++ b/tests/link/jax/test_tensor_basic.py
@@ -230,5 +230,5 @@ def test_tri_nonconcrete():
 
     # The actual error the user will see should be jax.errors.ConcretizationTypeError, but
     # the error handler raises an Attribute error first, so that's what this test needs to pass
-    with pytest.raises(AttributeError):
+    with pytest.raises((AttributeError, TypeError)):
         compare_jax_and_py([m, n, k], [out], [m_test_value, n_test_value, k_test_value])


### PR DESCRIPTION
JAX 0.8.2 raises ConcretizationTypeError (a subclass of TypeError) directly instead of the AttributeError that was previously observed (and caught) in this test case. This change allows both exceptions to be caught, ensuring the test passes on both older and newer JAX versions.