### PR TITLE
Cache tridiagonal solve in numba mode

### DIFF
--- a/pytensor/link/numba/dispatch/linalg/solve/tridiagonal.py
+++ b/pytensor/link/numba/dispatch/linalg/solve/tridiagonal.py
@@ -9,8 +9,10 @@ from scipy import linalg
 
 from pytensor import config
 from pytensor.link.numba.dispatch import basic as numba_basic
-from pytensor.link.numba.dispatch import numba_funcify
-from pytensor.link.numba.dispatch.basic import generate_fallback_impl
+from pytensor.link.numba.dispatch.basic import (
+    generate_fallback_impl,
+    register_funcify_default_op_cache_key,
+)
 from pytensor.link.numba.dispatch.linalg._LAPACK import (
     _LAPACK,
     int_ptr_to_val,
@@ -346,7 +348,7 @@ def _tridiagonal_solve_impl(
     return impl
 
 
-@numba_funcify.register(LUFactorTridiagonal)
+@register_funcify_default_op_cache_key(LUFactorTridiagonal)
 def numba_funcify_LUFactorTridiagonal(op: LUFactorTridiagonal, node, **kwargs):
     if any(i.type.numpy_dtype.kind == "c" for i in node.inputs):
         return generate_fallback_impl(op, node=node)
@@ -389,10 +391,11 @@ def numba_funcify_LUFactorTridiagonal(op: LUFactorTridiagonal, node, **kwargs):
         )
         return dl, d, du, du2, ipiv
 
-    return lu_factor_tridiagonal
+    cache_key = 1
+    return lu_factor_tridiagonal, cache_key
 
 
-@numba_funcify.register(SolveLUFactorTridiagonal)
+@register_funcify_default_op_cache_key(SolveLUFactorTridiagonal)
 def numba_funcify_SolveLUFactorTridiagonal(
     op: SolveLUFactorTridiagonal, node, **kwargs
 ):
@@ -443,4 +446,5 @@ def numba_funcify_SolveLUFactorTridiagonal(
         )
         return x
 
-    return solve_lu_factor_tridiagonal
+    cache_key = 1
+    return solve_lu_factor_tridiagonal, cache_key


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
I missed these dispatches in https://github.com/pymc-devs/pytensor/pull/1807. All required lapack functions were already handled, so it's just changing the decorator.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
