### PR TITLE
Exclude `numba` rewrites from JAX Scan rewrites

### DIFF
--- a/pytensor/link/jax/dispatch/scan.py
+++ b/pytensor/link/jax/dispatch/scan.py
@@ -29,7 +29,10 @@ def jax_funcify_Scan(op: Scan, **kwargs):
 
     # Optimize inner graph (exclude any defalut rewrites that are incompatible with JAX mode)
     rewriter = (
-        get_mode(op.mode).including("jax").excluding(*JAX._optimizer.exclude).optimizer
+        get_mode(op.mode)
+        .including("jax")
+        .excluding("numba", *JAX._optimizer.exclude)
+        .optimizer
     )
     rewriter(op.fgraph)
     scan_inner_func = jax_funcify(op.fgraph, **kwargs)


### PR DESCRIPTION
Now that the default mode can be Numba, we could get numba-specific rewrites (which are never the default otherwise) in the JAX scan optimization.

This is a symptom of Scan having the mode concept, which we should move away from. For now the band-aid is simple enough.

Led to failures in  https://github.com/pymc-devs/pymc-extras/pull/615

