### PR TITLE
Rewrite log1mexp(log1mexp(x)) to x

### DIFF
--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -625,6 +625,13 @@ def local_exp_log_nan_switch(fgraph, node):
         new_out = switch(ge(x, 0), log1p(-x), np.asarray(np.nan, old_out.dtype))
         return [new_out]
 
+    # Case for log1mexp(log1mexp(x)) -> x
+    if isinstance(prev_op, ps_math.Log1mexp) and isinstance(node_op, ps_math.Log1mexp):
+        x = x.owner.inputs[0]
+        old_out = node.outputs[0]
+        new_out = switch(le(x, 0), x, np.asarray(np.nan, old_out.dtype))
+        return [new_out]
+
 
 @register_canonicalize
 @register_specialize


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description

$$ \log(1-\exp(\log(1-\exp(x)))) = x$$

at least when $x<0$. When $x=0$ and we accept both $\log(0)=-\infty$ and $\exp(-\infty)=0$, then it also works. For $x>0$ it's NaN.

**WHY???** The `log1mexp` function arises naturally when converting from log-CDFs to complimentary log-CDFs, The "geometric distribution" has log-CDF equal to $\log\left(1-(1-p)^k\right) = \textrm{log1mexp}(k \\, \log(1-p))$, so the natural complimentary CDF looks like 

$$ \textrm{log1mexp}(\textrm{log1mexp}(k \\, \log(1-p))), $$

which we would like to simplify to just $k \\, \log(1-p)$.

Assisted with claude-4.5-opus-high cloud agent in Cursor.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #471, closes #474
- [ ] Related to #535

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
