### PR TITLE
Tweaks to reshape Ops

### DIFF
--- a/pytensor/tensor/rewriting/reshape.py
+++ b/pytensor/tensor/rewriting/reshape.py
@@ -34,8 +34,9 @@ def local_join_dims_to_reshape(fgraph, node):
     """
 
     (x,) = node.inputs
-    start_axis = node.op.start_axis
-    n_axes = node.op.n_axes
+    op = node.op
+    start_axis = op.start_axis
+    n_axes = op.n_axes
 
     output_shape = [
         *x.shape[:start_axis],

--- a/tests/tensor/rewriting/test_reshape.py
+++ b/tests/tensor/rewriting/test_reshape.py
@@ -21,7 +21,7 @@ def test_local_split_dims_to_reshape():
 
 def test_local_join_dims_to_reshape():
     x = tensor("x", shape=(2, 2, 5, 1, 3))
-    x_join = join_dims(x, axis=(1, 2, 3))
+    x_join = join_dims(x, start_axis=1, n_axes=3)
 
     fg = FunctionGraph(inputs=[x], outputs=[x_join])
 


### PR DESCRIPTION
## (join|split)_dims
I've changed `join_dims`, to be a true mirror of `split_dims`. The `JoinDims` Op itself already was, and if we make the helper also behave like the `Op` we can simplify logic elsewhere.

The signature is now `join(x, axis: int=0, n_axes: int | None = None)`.

The main change is that:
1. join_dims(x, n_axes=0), implies an `expand_dims`. This is the mirror of `split_dims(x, split_shape=())` implying a `squeeze`.
2. join_dims treats scalar (0d) inputs as if they had one dimension, when reasoning about axis. Otherwise axis=0/-1 doesn't make sense. This is analogous to expand_dims.
Also:
1. `split_dims` axis no longer accepts None, the default is 0.

It also has the pleasant side-effect that you can't specify non-consecutive axis, which the other syntax would suggest is possible (before erroring out). You can only fail with axis or n_axes too large.

## (un)pack
Rename (un)pack axes argument to `keep_axes`.
Also:
* Allow default `None` on unpack
* ~~Allow default of `None` to work even with >1d inputs~~ Reverted
* Fix case with single input

Cherry picked from #1806 
Closes #1835 
