### PR TITLE
Canonicalize JoinDims and SplitDims to simpler operations than reshape 

### DIFF
--- a/pytensor/tensor/rewriting/reshape.py
+++ b/pytensor/tensor/rewriting/reshape.py
@@ -1,19 +1,38 @@
 from pytensor.graph import node_rewriter
 from pytensor.graph.rewriting.basic import copy_stack_trace
+from pytensor.tensor.basic import expand_dims
+from pytensor.tensor.extra_ops import squeeze
 from pytensor.tensor.reshape import JoinDims, SplitDims
 from pytensor.tensor.rewriting.basic import register_canonicalize
+from pytensor.tensor.shape import specify_shape
 
 
 @register_canonicalize
 @node_rewriter([SplitDims])
-def local_split_dims_to_reshape(fgraph, node):
+def local_split_dims(fgraph, node):
     """
     Canonicalize SplitDims Ops to Reshape Ops for further graph reasoning (and dispatch to other backends).
+    Special case: if shape is (0,), converts to squeeze instead.
     """
 
     x, shape = node.inputs
     axis = node.op.axis
 
+    # Special case: empty shape -> squeeze
+    if shape.type.shape == (0,):
+        squeezed_x = squeeze(x, axis=axis)
+        copy_stack_trace(x, squeezed_x)
+        return [squeezed_x]
+
+    # Special case: size 1 shape -> SpecifyShape
+    if shape.type.shape == (1,):
+        specified_shape = [None] * x.type.ndim
+        specified_shape[axis] = shape
+        specified_x = specify_shape(x, specified_shape)
+        copy_stack_trace(x, specified_x)
+        return [specified_x]
+
+    # General case: rewrite to reshape
     output_shape = [
         *x.shape[:axis],
         *shape,
@@ -28,7 +47,7 @@ def local_split_dims_to_reshape(fgraph, node):
 
 @register_canonicalize
 @node_rewriter([JoinDims])
-def local_join_dims_to_reshape(fgraph, node):
+def local_join_dims(fgraph, node):
     """
     Canonicalize JoinDims Ops to Reshape Ops for further graph reasoning (and dispatch to other backends).
     """
@@ -37,6 +56,15 @@ def local_join_dims_to_reshape(fgraph, node):
     op = node.op
     start_axis = op.start_axis
     n_axes = op.n_axes
+
+    if n_axes == 0:
+        expanded_x = expand_dims(x, axis=node.op.start_axis)
+        copy_stack_trace(x, expanded_x)
+        return [expanded_x]
+
+    if n_axes == 1:
+        copy_stack_trace(x, x)
+        return [x]
 
     output_shape = [
         *x.shape[:start_axis],

--- a/tests/tensor/rewriting/test_reshape.py
+++ b/tests/tensor/rewriting/test_reshape.py
@@ -1,7 +1,11 @@
 from pytensor.graph import FunctionGraph, rewrite_graph
+from pytensor.graph.traversal import apply_ancestors
+from pytensor.tensor.basic import expand_dims
+from pytensor.tensor.extra_ops import squeeze
 from pytensor.tensor.reshape import JoinDims, SplitDims, join_dims, split_dims
-from pytensor.tensor.shape import Reshape
+from pytensor.tensor.shape import Reshape, specify_shape
 from pytensor.tensor.type import tensor
+from tests.unittest_tools import assert_equal_computations
 
 
 def test_local_split_dims_to_reshape():
@@ -32,3 +36,59 @@ def test_local_join_dims_to_reshape():
     assert sum([1 for node in fg.toposort() if isinstance(node.op, JoinDims)]) == 0
     assert sum([1 for node in fg.toposort() if isinstance(node.op, Reshape)]) == 1
     assert fg.outputs[0].type.shape == (2, 10, 3)
+
+
+def test_local_join_dims_noop():
+    """Test that join_dims with n_axes=1 becomes identity (no-op)."""
+    x = tensor("x", shape=(2, 3, 4))
+    x_join = join_dims(x, start_axis=1, n_axes=1)
+
+    assert (
+        sum([isinstance(node.op, JoinDims) for node in apply_ancestors([x_join])]) == 1
+    )
+    rewritten = rewrite_graph(x_join, include=("canonicalize",))
+    assert_equal_computations([rewritten], [x])
+
+
+def test_local_join_dims_to_expand_dims():
+    """Test that join_dims with n_axes=0 becomes expand_dims."""
+    x = tensor("x", shape=(2, 3, 4))
+    x_join = join_dims(x, start_axis=1, n_axes=0)
+
+    assert (
+        sum([isinstance(node.op, JoinDims) for node in apply_ancestors([x_join])]) == 1
+    )
+    rewritten = rewrite_graph(x_join, include=("canonicalize",))
+    # Output shape should be (2, 1, 3, 4) - new dimension of size 1 inserted at axis 1
+    expected = expand_dims(x, axis=1)
+    assert_equal_computations([rewritten], [expected])
+
+
+def test_local_split_dims_to_squeeze():
+    """Test that split_dims with shape tensor of static shape (0,) becomes squeeze via merged rewrite."""
+    x = tensor("x", shape=(2, 1, 3, 4))
+    x_split = split_dims(x, axis=1, shape=())
+
+    assert (
+        sum([isinstance(node.op, SplitDims) for node in apply_ancestors([x_split])])
+        == 1
+    )
+    rewritten = rewrite_graph(x_split, include=("canonicalize",))
+    # Output shape should be (2, 3, 4) - dimension 1 removed
+    expected = squeeze(x, axis=1)
+    assert_equal_computations([rewritten], [expected])
+
+
+def test_local_split_dims_to_specify_shape():
+    """Test that split_dims with shape tensor of static shape (0,) becomes squeeze via merged rewrite."""
+    x = tensor("x", shape=(2, None, 4))
+    x_split = split_dims(x, axis=1, shape=(5,))
+
+    assert (
+        sum([isinstance(node.op, SplitDims) for node in apply_ancestors([x_split])])
+        == 1
+    )
+    rewritten = rewrite_graph(x_split, include=("canonicalize",))
+    # Output shape should be (2, 3, 4) - dimension 1 removed
+    expected = specify_shape(x, (None, 5, None))
+    assert_equal_computations([rewritten], [expected], strict_dtype=False)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

### Description

closes 1843:
- [x] `join_dims(x, axis=axis, n_axes=1)` → identity (no-op)
- [x] `join_dims(x, axis=axis, n_axes=0)` → `expand_dims(x, axis)`
- [x] `split_dims(x, axis=axis, shape=())` → `squeeze(x, axis)`
- [x] `split_dims(x, axis=axis, shape=(dim,))` → `specify_shape(...)` (see Block section)

### Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1843


### Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

### Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->