### PR TITLE
Make Numba the default linker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # default-mode: "CVM" is actually a no-op, to make sure we're testing default config settings
+        # default-mode: "NUMBA" is actually a no-op, to make sure we're testing default config settings
         default-mode: ["CVM", "NUMBA", "FAST_COMPILE"]
         python-version: ["3.11", "3.14"]
         os: ["ubuntu-latest"]
@@ -192,7 +192,7 @@ jobs:
         shell: micromamba-shell {0}
         run: |
           if [[ $DEFAULT_MODE == "FAST_COMPILE" ]]; then export PYTENSOR_FLAGS=$PYTENSOR_FLAGS,mode=FAST_COMPILE; fi
-          if [[ $DEFAULT_MODE == "NUMBA" ]]; then export PYTENSOR_FLAGS=$PYTENSOR_FLAGS,linker=numba; fi
+          if [[ $DEFAULT_MODE == "CVM" ]]; then export PYTENSOR_FLAGS=$PYTENSOR_FLAGS,linker=cvm; fi
           export PYTENSOR_FLAGS=$PYTENSOR_FLAGS,warn__ignore_bug_before=all,on_opt_error=raise,on_shape_error=raise,gcc__cxxflags=-pipe
           python -m pytest -r A --verbose --runslow --durations=50 --cov=pytensor/ --cov-report=xml:coverage/coverage-${MATRIX_ID}.xml --no-cov-on-fail $PART --benchmark-skip
         env:

--- a/pytensor/compile/mode.py
+++ b/pytensor/compile/mode.py
@@ -512,7 +512,7 @@ def get_mode(orig_string):
     if upper_string == "FAST_RUN":
         linker = config.linker
         if linker == "auto":
-            return CVM if config.cxx else VM
+            return NUMBA
         return fast_run_linkers_to_mode[linker]
 
     global _CACHED_RUNTIME_MODES


### PR DESCRIPTION
This will be the default from version 3.0 onwards.

We have successfully tested compatibility with :
* pymc: https://github.com/pymc-devs/pymc/pull/7993
* pymc-extras: https://github.com/pymc-devs/pymc-extras/pull/615
* pymc-bart: https://github.com/pymc-devs/pymc-bart/pull/257
* pymc-marketing: https://github.com/pymc-labs/pymc-marketing/pull/2135
* bambi: https://github.com/bambinos/bambi/pull/955

Numba is currently our most advanced backend. It supports Sparse, Random, Linalg, Blockwise, and many forms of Advanced indexing natively, and has robust caching on pair with the C/CVM backends.

Also even if still "too slow", Scan is leagues ahead of the python/cython laggards.