### PR TITLE
Add isfinite function for element-wise finite value detection

### DIFF
--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -1610,7 +1610,34 @@ class IsInf(FixedLogicalComparison):
         return (*scalarop_version, 3)
 
 
+
 isinf = IsInf()
+
+
+class IsFinite(FixedLogicalComparison):
+    nfunc_spec = ("isfinite", 1, 1)
+
+    def impl(self, x):
+        return np.isfinite(x)
+
+    def c_code(self, node, name, inputs, outputs, sub):
+        (x,) = inputs
+        (z,) = outputs
+        if node.inputs[0].type in complex_types:
+            # For complex: finite if both real and imaginary parts are finite
+            return f"{z} = isfinite(real({x})) && isfinite(imag({x}));"
+        # Discrete types are always finite
+        if node.inputs[0].type in discrete_types:
+            return f"{z} = true;"
+
+        return f"{z} = abs(isfinite({x}));"
+
+    def c_code_cache_version(self):
+        scalarop_version = super().c_code_cache_version()
+        return (*scalarop_version, 1)
+
+
+isfinite = IsFinite()
 
 
 class Switch(ScalarOp):

--- a/pytensor/tensor/math.py
+++ b/pytensor/tensor/math.py
@@ -881,6 +881,56 @@ def isinf(a):
     return isinf_(a)
 
 
+@scalar_elemwise
+def isfinite(a):
+    """isfinite(a)
+
+    Computes element-wise detection of finite values.
+
+    A value is finite if it is neither NaN nor infinite.
+
+    Parameters
+    ----------
+    a : TensorLike
+        Input tensor
+
+    Returns
+    -------
+    TensorVariable
+        Output tensor of type bool, with 1 (True) where elements are finite
+        (not NaN or infinite), and 0 (False) elsewhere.
+
+    Examples
+    --------
+    >>> import pytensor
+    >>> import pytensor.tensor as pt
+    >>> import numpy as np
+    >>> x = pt.vector("x")
+    >>> f = pytensor.function([x], pt.isfinite(x))
+    >>> f([1.0, np.nan, np.inf, -np.inf, 3.0])
+    array([ True, False, False, False,  True])
+
+    Notes
+    -----
+    For discrete dtypes (int, uint, bool), all values are finite by definition.
+    """
+
+
+# Rename isfinite to isfinite_ to allow bypassing when not needed
+isfinite_ = isfinite
+
+
+def isfinite(a):
+    """isfinite(a)"""
+    a = as_tensor_variable(a)
+    if a.dtype in discrete_dtypes:
+        # All discrete values are finite
+        return alloc(
+            np.asarray(True, dtype="bool"), *[a.shape[i] for i in range(a.ndim)]
+        )
+    return isfinite_(a)
+
+
 def allclose(a, b, rtol=1.0e-5, atol=1.0e-8, equal_nan=False):
     """
     Implement Numpy's ``allclose`` on tensors.


### PR DESCRIPTION
- Add IsFinite scalar op in pytensor.scalar.basic
  - Implements np.isfinite with proper C code generation
  - Handles discrete types (always finite), complex types, and floats
  - Uses abs() for cross-platform consistency

- Add isfinite() tensor function in pytensor.tensor.math
  - Uses @scalar_elemwise decorator pattern
  - Bypasses scalar op for discrete dtypes (returns all True)
  - Includes comprehensive docstring with examples

- Add test_isfinite() in tests.tensor.test_math
  - Tests float32, float64, int, and bool dtypes
  - Comprehensive edge case testing (NaN, Inf, -Inf, mixed)
  - Validates empty arrays and isfinite_ usage

Fixes #1870

<