### PR TITLE
fix incorrect comment in StructuredDot.grad

### DIFF
--- a/pytensor/sparse/math.py
+++ b/pytensor/sparse/math.py
@@ -1394,11 +1394,10 @@ class StructuredDot(Op):
         out[0] = np.asarray(variable, str(variable.dtype))
 
     def grad(self, inputs, gout):
-        # NOTE: a is sparse; b and g_out may be dense or sparse.
-        # Sparse b and g_out are supported in Python and Numba,
-        # but the C backend does not yet support them.
-        #
-        # ga = structured_dot_grad(a, b, g_out)
+        # NOTE: a is sparse; b and g_out are both dense or sparse.
+        # Python and Numba backends support sparse b and g_out.
+        # C backend only supports dense b and g_out.
+        # ga = g_out x b.T
         # gb = a.T x g_out
         (a, b) = inputs
         (g_out,) = gout


### PR DESCRIPTION
## Description
This PR resolves #1871 by correcting outdated and misleading comments in the `StructuredDot.grad` method.

### Changes:
- Fixed the comment for `ga`. It previously described a standard dense dot product ($g_{out} \times B^T$), but the implementation uses `structured_dot_grad` to maintain the sparsity pattern of `a`.
- Removed the incorrect claim that `b` and `g_out` must be dense. 
- Added a note specifying that sparse inputs are supported in the Python and Numba backends (referencing the work in #1860) but are not yet supported by the C backend.

## Related Issue
- [x] Closes #1871
- [ ] Related to #

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):