### PR TITLE
Allow `infer_shape` to work with xtensor lowering

### DIFF
--- a/pytensor/xtensor/rewriting/utils.py
+++ b/pytensor/xtensor/rewriting/utils.py
@@ -4,12 +4,19 @@ from collections.abc import Sequence
 from pytensor.compile import optdb
 from pytensor.graph.rewriting.basic import NodeRewriter, dfs_rewriter
 from pytensor.graph.rewriting.db import EquilibriumDB, RewriteDatabase
+from pytensor.tensor.basic import infer_shape_db
 from pytensor.tensor.rewriting.ofg import inline_ofg_expansion
 from pytensor.tensor.variable import TensorVariable
 from pytensor.xtensor.type import XTensorVariable
 
 
 lower_xtensor_db = EquilibriumDB(ignore_newtrees=False)
+
+infer_shape_db.register(
+    "lower_xtensor",
+    lower_xtensor_db,
+    "infer_shape",
+)
 
 optdb.register(
     "lower_xtensor",
@@ -50,6 +57,7 @@ def register_lower_xtensor(
             "fast_run",
             "fast_compile",
             "minimum_compile",
+            "infer_shape",
             *tags,
             **kwargs,
         )

--- a/tests/xtensor/test_rewriting.py
+++ b/tests/xtensor/test_rewriting.py
@@ -1,0 +1,24 @@
+from pytensor.graph import FunctionGraph
+from pytensor.tensor.basic import infer_shape_db
+from pytensor.tensor.rewriting.shape import ShapeFeature
+from pytensor.tensor.shape import Shape_i
+from pytensor.xtensor import xtensor
+from tests.unittest_tools import assert_equal_computations
+
+
+def test_infer_shape_db_handles_xtensor_lowering():
+    x = xtensor("x", dims=("a", "b"))
+    y = x.sum(dim="a")
+    shape_y = y.shape[0]
+
+    # Without ShapeFeature
+    fgraph = FunctionGraph([x], [shape_y], features=[], copy_inputs=False)
+    infer_shape_db.default_query.rewrite(fgraph)
+    [rewritten_shape_y] = fgraph.outputs
+    assert_equal_computations([rewritten_shape_y], [(x.values.sum(0)).shape[0]])
+
+    # With ShapeFeature
+    fgraph = FunctionGraph([x], [shape_y], features=[ShapeFeature()], copy_inputs=False)
+    infer_shape_db.default_query.rewrite(fgraph)
+    [rewritten_shape_y] = fgraph.outputs
+    assert_equal_computations([rewritten_shape_y], [Shape_i(1)(x)])


### PR DESCRIPTION
I've expanded `infer_shape` to work with xtensor. It wasn't working at first, because I was missing a critical rewrite originally: `local_track_shape_i`. I had no idea this existed or what it was about.

I have no convincing opinion on the current design, but decided to at least document it a bit better.

This functionality is being used/planned to be used directly elsewhere: https://github.com/pymc-devs/pymc/pull/8092 so it's important it works robustly :)