### PR TITLE
Better static shape inference in linalg.kron

### DIFF
--- a/pytensor/tensor/nlinalg.py
+++ b/pytensor/tensor/nlinalg.py
@@ -1176,7 +1176,7 @@ def kron(a, b):
         b = ptb.expand_dims(b, tuple(range(a.ndim - b.ndim)))
     a_reshaped = ptb.expand_dims(a, tuple(range(1, 2 * a.ndim, 2)))
     b_reshaped = ptb.expand_dims(b, tuple(range(0, 2 * b.ndim, 2)))
-    out_shape = tuple(a.shape * b.shape)
+    out_shape = tuple(a.shape[i] * b.shape[i] for i in range(a.ndim))
     output_out_of_shape = a_reshaped * b_reshaped
     output_reshaped = output_out_of_shape.reshape(out_shape)
 

--- a/tests/tensor/test_nlinalg.py
+++ b/tests/tensor/test_nlinalg.py
@@ -744,15 +744,23 @@ class TestKron(utt.InferShapeTester):
     def test_perform(self, shp0, shp1):
         if len(shp0) + len(shp1) == 2:
             pytest.skip("Sum of shp0 and shp1 must be more than 2")
-        x = tensor(dtype="floatX", shape=(None,) * len(shp0))
+
+        x = tensor(dtype="floatX", shape=shp0)
         a = np.asarray(self.rng.random(shp0)).astype(config.floatX)
-        y = tensor(dtype="floatX", shape=(None,) * len(shp1))
-        f = function([x, y], kron(x, y))
+
+        y = tensor(dtype="floatX", shape=shp1)
         b = self.rng.random(shp1).astype(config.floatX)
+
+        kron_xy = kron(x, y)
+        f = function([x, y], kron_xy)
         out = f(a, b)
-        # Using the np.kron to compare outputs
+
+        # Using np.kron to compare outputs
         np_val = np.kron(a, b)
         np.testing.assert_allclose(out, np_val)
+
+        # Regression test for issue #1867
+        assert kron_xy.type.shape == np_val.shape
 
     @pytest.mark.parametrize(
         "i, shp0, shp1",


### PR DESCRIPTION
## Description

This PR resolves the issue where `pt.linalg.kron` destroys static shape information, returning `(None, None)` even when input shapes are fully known. 

The previous implementation relied on a vector-wise symbolic multiplication of shapes:
`out_shape = tuple(a.shape * b.shape)`

This forced the underlying `Reshape` Op to treat the entire shape vector as a single symbolic entity, which prevented the **ShapeFeature** from constant-folding individual dimensions into their static values.

### The Fix
I implemented element-wise symbolic multiplication for the output shape:
`[a.shape[i] * b.shape[i] for i in range(a.ndim)]`

This provides the shape inference engine with enough granularity to resolve static constants (e.g., 4 * 3 = 12) at compile time while maintaining the symbolic integrity required for downstream operations like `clone_replace`.

## Related Issue
- [x] Closes #1867
- [ ] Related to #

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):