### PR TITLE
BUGFix: Wrap roll as OpFromGraph with custom JAX dispatch to jnp.roll

### DIFF
--- a/pytensor/link/jax/dispatch/subtensor.py
+++ b/pytensor/link/jax/dispatch/subtensor.py
@@ -1,4 +1,7 @@
+import jax.numpy as jnp
+
 from pytensor.link.jax.dispatch.basic import jax_funcify
+from pytensor.tensor.basic import Roll
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
     AdvancedIncSubtensor1,
@@ -99,3 +102,13 @@ def jax_funcify_MakeSlice(op, **kwargs):
         return slice(*x)
 
     return makeslice
+
+
+@jax_funcify.register(Roll)
+def jax_funcify_Roll(op, **kwargs):
+    axis = op.axis
+
+    def roll(x, shift):
+        return jnp.roll(x, shift, axis=axis)
+
+    return roll

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -2865,9 +2865,21 @@ def roll(x, shift, axis=None):
     # List of slices describing the back half [:, :, :shift, :]
     end_slice = slice(0, -shift)
     end_list = [allslice] * axis + [end_slice] + [allslice] * (_x.ndim - axis - 1)
-    return join(
-        axis, _x.__getitem__(tuple(front_list)), _x.__getitem__(tuple(end_list))
-    )
+    out = join(axis, _x.__getitem__(tuple(front_list)), _x.__getitem__(tuple(end_list)))
+    return Roll(inputs=[_x, shift], outputs=[out], axis=axis)(_x, shift)
+
+
+class Roll(OpFromGraph):
+    """
+    Wrapper Op for roll graphs, enabling custom dispatch in JAX/Numba backends.
+    """
+
+    def __init__(self, *args, axis, **kwargs):
+        self.axis = axis
+        super().__init__(*args, **kwargs, strict=True)
+
+    def __str__(self):
+        return f"Roll{{axis={self.axis}}}"
 
 
 def stack(tensors: Sequence["TensorLike"], axis: int = 0):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description

`pt.roll` is currently implemented as a pure macro that decomposes into 
two `Subtensor` slice operations and a `Join`. When `shift` is a symbolic 
scalar, the slice boundaries become dynamic JAX tracers at compile time, 
causing JIT compilation to fail:

IndexError: Slice entries must be static integers.
Got slice(None, JitTracer(int32[]), None) at position 0
Apply node: Join(0, Subtensor{start:}.0, Subtensor{:stop}.0)

This is a fundamental incompatibility between PyTensor's macro-based roll 
expansion and JAX's strict static indexing requirements under `jax.jit`.

**Fix:**

Introduced `Roll(OpFromGraph)` — a thin wrapper that encapsulates the 
existing roll graph while exposing a registration point for backend-specific 
dispatch. All existing backends (C, Python) continue to execute the original 
graph transparently via `OpFromGraph` inlining, preserving full correctness 
and gradient flow through the existing graph structure.

For the JAX backend, a dedicated `jax_funcify` dispatch is registered that 
maps `Roll` directly to `jnp.roll`, which internally uses `lax.dynamic_slice` 
and handles symbolic shift values correctly under JIT.

This approach follows the established pattern used by `Pad`, `AllocDiag`, 
and `KroneckerProduct` in the codebase — minimizing Op count while still 
enabling backend-specific lowering where necessary.

**Changes:**
- `pytensor/tensor/basic.py`: Introduced `Roll(OpFromGraph)` and updated 
  `roll()` to wrap its output graph in the new Op
- `pytensor/link/jax/dispatch/subtensor.py`: Registered JAX dispatch for 
  `Roll` mapping to `jnp.roll`
- `tests/link/jax/test_tensor_basic.py`: Added `test_jax_roll` covering 
  dynamic shift, negative shift, axis=None, and shift > axis size

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1899
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
