### PR TITLE
Add canonicalization rewrite for useless cumsum/cumprod on length-1 axes

### DIFF
--- a/pytensor/tensor/rewriting/extra_ops.py
+++ b/pytensor/tensor/rewriting/extra_ops.py
@@ -139,9 +139,6 @@ def local_CumOp_length1(fgraph, node):
     When ``cumsum`` or ``cumprod`` is applied along an axis of length 1,
     the result is identical to the input, so the operation can be removed.
     """
-    if not isinstance(node.op, CumOp):
-        return False
-
     x = node.inputs[0]
     axis = node.op.axis
 

--- a/tests/tensor/rewriting/test_extra_ops.py
+++ b/tests/tensor/rewriting/test_extra_ops.py
@@ -243,17 +243,9 @@ def test_local_Unique_second(
 @pytest.mark.parametrize(
     "shape, axis, mode, should_rewrite",
     [
-        # Axis has length 1 → rewrite should apply
-        ((1, 5), 0, "add", True),
-        ((5, 1), 1, "add", True),
-        ((1, 5), 0, "mul", True),
-        ((1,), 0, "add", True),
-        ((1,), 0, "mul", True),
-        ((3, 1, 4), 1, "add", True),
-        # Axis does NOT have length 1 → rewrite should NOT apply
-        ((5, 1), 0, "add", False),
         ((1, 5), 1, "add", False),
-        ((3, 4), 0, "mul", False),
+        ((3, 1, 4), 1, "add", True),
+        ((None, 5), 0, "add", False),
     ],
 )
 def test_local_CumOp_length1(shape, axis, mode, should_rewrite):
@@ -266,48 +258,13 @@ def test_local_CumOp_length1(shape, axis, mode, should_rewrite):
         y = cumprod(x, axis=axis)
 
     y_fg = FunctionGraph(outputs=[y], copy_inputs=False)
-    y_rewritten_fg = rewrite_graph(
-        y_fg,
-        clone=False,
-        include=["canonicalize", "local_CumOp_length1"],
-    )
+    y_rewritten_fg = rewrite_graph(y_fg, clone=False, include=["canonicalize"])
     y_rewritten = y_rewritten_fg.outputs[0]
 
     has_cumop = any(isinstance(node.op, CumOp) for node in y_rewritten_fg.apply_nodes)
 
     if should_rewrite:
-        # CumOp should have been removed
-        assert not has_cumop, "CumOp was not removed but should have been"
+        assert not has_cumop
         assert y_rewritten == x
     else:
-        # CumOp should still be present
-        assert has_cumop, "CumOp was removed but should not have been"
-
-    # Numerical correctness check
-    default_mode = get_default_mode()
-    rewrite_mode = default_mode.excluding("local_CumOp_length1")
-    y_fn = function([x], [y, y_rewritten], mode=rewrite_mode)
-
-    rng = np.random.default_rng(42)
-    x_val = rng.standard_normal(shape)
-    y_exp_val, y_val = y_fn(x_val)
-    np.testing.assert_array_equal(y_exp_val, y_val)
-
-
-def test_local_CumOp_length1_dynamic_shape():
-    """Test that the rewrite does NOT apply when the shape is not statically known."""
-    # None in shape means the dimension is unknown at graph construction time
-    x = pt.tensor(dtype="float64", shape=(None, 5), name="x")
-    y = cumsum(x, axis=0)
-
-    y_fg = FunctionGraph(outputs=[y], copy_inputs=False)
-    y_rewritten_fg = rewrite_graph(
-        y_fg,
-        clone=False,
-        include=["canonicalize", "local_CumOp_length1"],
-    )
-
-    # CumOp must still be present since we don't know if axis 0 has length 1
-    assert any(isinstance(node.op, CumOp) for node in y_rewritten_fg.apply_nodes), (
-        "CumOp was removed despite dynamic shape"
-    )
+        assert has_cumop


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1576
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
