### PR TITLE
ENH: Support dynamic slice indexing in JAX backend via lax.dynamic_slice

### DIFF
--- a/pytensor/link/jax/dispatch/subtensor.py
+++ b/pytensor/link/jax/dispatch/subtensor.py
@@ -1,4 +1,10 @@
+import jax
+import jax.numpy as jnp
+from jax import lax
+
+from pytensor.graph.basic import Constant
 from pytensor.link.jax.dispatch.basic import jax_funcify
+from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
     AdvancedIncSubtensor1,
@@ -6,6 +12,7 @@ from pytensor.tensor.subtensor import (
     AdvancedSubtensor1,
     IncSubtensor,
     Subtensor,
+    get_idx_list,
     indices_from_subtensor,
 )
 from pytensor.tensor.type_other import MakeSlice
@@ -31,15 +38,142 @@ slice length.
 """
 
 
+def _get_static_length(start_var, stop_var):
+    """
+    Analyzes the PyTensor graph to prove that (stop_var - start_var) is a constant.
+    This bypasses PyTensor's (None,) static shape inference.
+    """
+
+    def extract_offset(var):
+        # Unwrap ScalarFromTensor to get to the actual math operations
+        if (
+            hasattr(var, "owner")
+            and var.owner
+            and var.owner.op.__class__.__name__ == "ScalarFromTensor"
+        ):
+            var = var.owner.inputs[0]
+
+        # Check if the variable is a pure constant
+        if isinstance(var, Constant):
+            try:
+                return None, int(var.data.item())
+            except Exception:
+                pass
+
+        # Check if the variable is an operation  like (base + offset) or (base - offset)
+        if hasattr(var, "owner") and var.owner and isinstance(var.owner.op, Elemwise):
+            scalar_op = getattr(var.owner.op, "scalar_op", None)
+            if scalar_op:
+                op_name = getattr(scalar_op, "name", "")
+
+                if op_name == "add":
+                    c_in = [i for i in var.owner.inputs if isinstance(i, Constant)]
+                    v_in = [i for i in var.owner.inputs if not isinstance(i, Constant)]
+                    if len(c_in) == 1 and len(v_in) == 1:
+                        return v_in[0], int(c_in[0].data.item())
+
+                elif op_name == "sub":
+                    if isinstance(var.owner.inputs[1], Constant) and not isinstance(
+                        var.owner.inputs[0], Constant
+                    ):
+                        return var.owner.inputs[0], -int(
+                            var.owner.inputs[1].data.item()
+                        )
+
+        return var, 0
+
+    if start_var is None or stop_var is None:
+        return None
+
+    start_base, start_off = extract_offset(start_var)
+    stop_base, stop_off = extract_offset(stop_var)
+
+    # If both variables  share the same dynamic base  , the size is static
+    if start_base is not None and stop_base is not None and start_base == stop_base:
+        return stop_off - start_off
+
+    return None
+
+
 @jax_funcify.register(Subtensor)
 @jax_funcify.register(AdvancedSubtensor)
 @jax_funcify.register(AdvancedSubtensor1)
 def jax_funcify_Subtensor(op, node, **kwargs):
     idx_list = getattr(op, "idx_list", None)
+    out_shape = list(node.outputs[0].type.shape)
+    is_basic_subtensor = isinstance(op, Subtensor)
+
+    # Extract original PyTensor symbolic variables to deduce static slice lengths
+    pt_idx_list = list(get_idx_list(node.inputs, idx_list))
 
     def subtensor(x, *ilists):
         indices = indices_from_subtensor(ilists, idx_list)
-        if len(indices) == 1:
+        idx_iter = indices if isinstance(indices, tuple) else (indices,)
+
+        has_tracer = False
+        for idx in idx_iter:
+            if isinstance(idx, jax.core.Tracer):
+                has_tracer = True
+            elif isinstance(idx, slice):
+                if isinstance(idx.start, jax.core.Tracer) or isinstance(
+                    idx.stop, jax.core.Tracer
+                ):
+                    has_tracer = True
+
+        if has_tracer and is_basic_subtensor:
+            try:
+                start_indices = []
+                slice_sizes = []
+                squeeze_dims = []
+
+                out_dim_idx = 0
+                for i, (idx, pt_idx) in enumerate(zip(idx_iter, pt_idx_list)):
+                    if isinstance(idx, slice):
+                        if idx.step not in (None, 1):
+                            raise ValueError(
+                                "Dynamic slicing with step != 1 is not supported by JAX."
+                            )
+
+                        start = 0 if idx.start is None else idx.start
+
+                        # Determine slice size
+                        size = out_shape[out_dim_idx]
+                        if size is None:
+                            # Mathematical Prover
+                            size = _get_static_length(pt_idx.start, pt_idx.stop)
+                            if size is None:
+                                raise ValueError(
+                                    "Could not prove static slice size for JAX lowering."
+                                )
+
+                        start_indices.append(start)
+                        slice_sizes.append(size)
+                        out_dim_idx += 1
+                    else:
+                        start_indices.append(idx)
+                        slice_sizes.append(1)
+                        squeeze_dims.append(i)
+
+                for i in range(len(start_indices), x.ndim):
+                    start_indices.append(0)
+                    size = out_shape[out_dim_idx]
+                    if size is None:
+                        # unlikely to hit but unless the trailing dimension is genuinely dynamic
+                        size = x.shape[i]
+                    slice_sizes.append(size)
+                    out_dim_idx += 1
+
+                sliced = lax.dynamic_slice(x, start_indices, slice_sizes)
+
+                if squeeze_dims:
+                    sliced = jnp.squeeze(sliced, axis=tuple(squeeze_dims))
+
+                return sliced
+            except Exception:
+                # If prover fails or assumptions break, fall back to standard indexing crash
+                pass
+
+        if len(indices) == 1 and isinstance(indices, tuple):
             indices = indices[0]
 
         return x.__getitem__(indices)

--- a/tests/link/jax/test_tensor_basic.py
+++ b/tests/link/jax/test_tensor_basic.py
@@ -68,6 +68,30 @@ def test_arange_of_shape():
     compare_jax_and_py([x], [out], [np.zeros((5,))], jax_mode="JAX")
 
 
+def test_jax_dynamic_subtensor_slice():
+    import numpy as np
+
+    import pytensor
+    import pytensor.tensor as pt
+
+    x = pt.dvector("x")
+    i = pt.iscalar("i")
+
+    # Test a dynamic start index with a statically provable length of 3
+    out = x[i : i + 3]
+
+    # If the JAX dispatcher fails to prove the static length, this will raise a JitTracer IndexError
+    f_jax = pytensor.function([x, i], out, mode="JAX")
+
+    x_val = np.arange(10, dtype=np.float64)
+    i_val = 2
+
+    result = f_jax(x_val, i_val)
+    expected = x_val[i_val : i_val + 3]
+
+    assert np.array_equal(result, expected)
+
+
 def test_arange_nonconcrete():
     """JAX cannot JIT-compile `jax.numpy.arange` when arguments are not concrete values."""
 


### PR DESCRIPTION
## Description
This PR addresses the fundamental incompatibility between PyTensor's dynamic graph indexing and XLA's strict static compilation requirements, specifically unblocking time-series sliding windows and sequential loops (like those required for the Scalable Online SSM project in `pymc-extras`).

**The Problem:**
When compiling a dynamic slice like `x[i : i+3]` where `i` is a runtime variable, PyTensor's static shape inference evaluates the sliced dimension as `(None,)`. Because JAX's `lax.dynamic_slice` strictly requires a static integer for the slice size, the JAX dispatcher falls back to standard `__getitem__` indexing, which immediately crashes with a `JitTracer` error.

**The Solution:**
Instead of adding new Ops or modifying core PyTensor shape inference, I implemented a static length prover (`_get_static_length`) directly inside `jax_funcify_Subtensor`:
1. It detects if the `idx_list` contains JAX Tracers.
2. It traverses the symbolic PyTensor graph, unwrapping `ScalarFromTensor` and `Elemwise` operations to algebraically deduce the constant difference between `start` and `stop` (e.g., proving `(i+3) - i == 3`).
3. If a static size is successfully proven, it feeds that integer directly to `jax.lax.dynamic_slice`, preserving XLA compatibility.
4. It squeezes out any integer-indexed dimensions to maintain exact PyTensor dimensionality semantics.

**Addressing the Semantic Trade-off (@ricardoV94):**
Regarding the out-of-bounds semantics (e.g., `pt.zeros(5)[10:13]`): In pure NumPy semantics, out-of-bounds slices shrink the array size. However, XLA mathematically cannot JIT-compile a function that returns dynamically sized arrays based on runtime variables. 

Because of this, `jax.lax.dynamic_slice` intentionally deviates from NumPy by clipping out-of-bounds indices so the returned slice always strictly matches the requested static size. We face a binary choice for the JAX backend here:
1. We strictly enforce NumPy shrinking semantics, which means dynamic slicing with Tracers will *never* compile in JAX.
2. We accept JAX's clipping semantics for out-of-bounds dynamic slices. This safely unlocks compilation for dynamic time-series algorithms where indices are structurally guaranteed to be in-bounds anyway.

Given the constraints of XLA, I believe adopting the clipping semantics specifically for the JAX dispatcher when Tracers are present is the necessary path forward.

## Related Issue
- [ ] Closes #
- [x] Related to #1899 

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
## Type of change
- [x] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):