### PR TITLE
Allow freezing of FunctionGraph for hashing

### DIFF
--- a/pytensor/compile/builders.py
+++ b/pytensor/compile/builders.py
@@ -1,23 +1,26 @@
 """Define new Ops from existing Ops"""
 
+from __future__ import annotations
+
+import contextvars
 import warnings
 from collections.abc import Callable, Sequence
 from copy import copy
 from functools import partial
 from itertools import chain
-from typing import Union, cast
+from typing import cast
 
 from pytensor.compile.function import function
 from pytensor.compile.function.pfunc import rebuild_collect_shared
 from pytensor.compile.sharedvalue import SharedVariable
-from pytensor.gradient import DisconnectedType, Rop, grad
+from pytensor.gradient import DisconnectedType, Rop, disconnected_type, grad
 from pytensor.graph.basic import (
     Apply,
     Constant,
     NominalVariable,
     Variable,
 )
-from pytensor.graph.fg import FunctionGraph
+from pytensor.graph.fg import FrozenFunctionGraph, FunctionGraph
 from pytensor.graph.null_type import NullType
 from pytensor.graph.op import HasInnerGraph, Op, io_connection_pattern
 from pytensor.graph.replace import clone_replace
@@ -155,41 +158,37 @@ def construct_nominal_fgraph(
 
 
 class OpFromGraph(Op, HasInnerGraph):
-    r"""
-    This creates an `Op` from inputs and outputs lists of variables.
-    The signature is similar to :func:`pytensor.function <pytensor.function>`
-    and the resulting `Op`'s perform will do the same operation as::
+    r"""Create an Op from inputs and outputs lists of variables.
 
-        orig_function(inputs, outputs, **kwargs)
+    The signature is similar to :func:`pytensor.function` and the resulting Op's perform will do
+    the same operation as ``orig_function(inputs, outputs, **kwargs)``.
 
-    Currently does not support ``updates`` or ``givens`` argument.
+    Does not support ``updates`` or ``givens``.
 
-    .. TODO:
-        - Allow / test merging of OpFromGraph nodes
+    .. TODO::
         - Add support for NullType and DisconnectedType when R_op supports them
-        - Add support to pickle this Op.
         - Add optimization to removing unused inputs/outputs
         - Add optimization to work inplace on inputs when not inline
 
     Notes
     -----
-    - We support shared variables in the inner graph. This is automatic
-      and invisible to the user. They can be as input to the node or in
-      the inner graph.
-    - We support unused inputs. This is needed for the grad.
-    - We support nested OpFromGraph.
-    - ``inline=True`` will cause better runtime optimization at the cost
-      of compilation time. Currently only works with ``fast_compile`` or
-      ``fast_run`` mode.
-    - For overriding, it's recommended to provide pure functions (no side
-      effects like setting global variable) as callable(s). The callable(s)
-      supplied for overriding gradient/rop will be called only once at the
-      first call to L_op/R_op, and will be converted to OpFromGraph instances.
+    - Shared variables in the inner graph are supported. They are detected automatically and added
+      as implicit inputs.
+    - Unused inputs are supported (needed for gradient overrides).
+    - Nested OpFromGraph is supported.
+    - ``inline=True`` causes the Op's inner graph to be inlined during compilation, which gives
+      better runtime optimization at the cost of compilation time. Currently only works with
+      ``fast_compile`` or ``fast_run`` mode.
+    - Override callables should be pure functions (no side effects). They are called once at the
+      first call to L_op/R_op and converted to OpFromGraph instances. They are also called once at
+      construction time with dummy inputs to build a frozen representation for equality comparison.
+    - Two OpFromGraph instances with the same inner graph, overrides, shared variables, and settings
+      are considered equal. This allows the MergeOptimizer to deduplicate identical OpFromGraph
+      nodes.
 
     Examples
     --------
-
-    Example 1:
+    Basic usage:
 
     .. code-block:: python
 
@@ -203,7 +202,7 @@ class OpFromGraph(Op, HasInnerGraph):
         e2 = op(x, y, z) + op(z, y, x)
         fn = function([x, y, z], [e2])
 
-    Example 2 with shared variable:
+    With a shared variable:
 
     .. code-block:: python
 
@@ -216,11 +215,10 @@ class OpFromGraph(Op, HasInnerGraph):
         s = pytensor.shared(np.random.random((2, 2)).astype(config.floatX))
         e = x + y * z + s
         op = OpFromGraph([x, y, z], [e])
-        # op behaves like a normal pytensor op
         e2 = op(x, y, z) + op(z, y, x)
         fn = function([x, y, z], [e2])
 
-    Example 3 override second output of L_op
+    Per-input L_op override:
 
     .. code-block:: python
 
@@ -237,17 +235,12 @@ class OpFromGraph(Op, HasInnerGraph):
             return z * 2
 
 
-        op = OpFromGraph(
-            [x, y, z],
-            [e],
-            lop_overrides=[None, rescale_dy, None],
-        )
+        op = OpFromGraph([x, y, z], [e], lop_overrides=[None, rescale_dy, None])
         e2 = op(x, y, z)
         dx, dy, dz = grad(e2, [x, y, z])
         fn = function([x, y, z], [dx, dy, dz])
         # the gradient wrt y is now doubled
         fn(2.0, 3.0, 4.0)  # [1., 8., 3.]
-
     """
 
     def __init__(
@@ -256,9 +249,9 @@ class OpFromGraph(Op, HasInnerGraph):
         outputs: list[Variable],
         *,
         inline: bool = False,
-        lop_overrides: Union[Callable, "OpFromGraph", None] = None,
-        grad_overrides: Union[Callable, "OpFromGraph", None] = None,
-        rop_overrides: Union[Callable, "OpFromGraph", None] = None,
+        lop_overrides: Callable | list | OpFromGraph | None = None,
+        grad_overrides: Callable | list | OpFromGraph | None = None,
+        rop_overrides: Callable | list | OpFromGraph | None = None,
         connection_pattern: list[list[bool]] | None = None,
         strict: bool = False,
         name: str | None = None,
@@ -268,98 +261,54 @@ class OpFromGraph(Op, HasInnerGraph):
         """
         Parameters
         ----------
-        inputs
+        inputs : list of Variable
             The inputs to the graph.
-
-        outputs
+        outputs : list of Variable
             The outputs to the graph.
+        inline : bool, optional
+            If True, the Op's inner graph is inlined during compilation. If False (default), a
+            pre-compiled function is used instead.
+        lop_overrides : callable or OpFromGraph or list or None, optional
+            Override for the L_op method. Mutually exclusive with ``grad_overrides``.
 
-        inline
-            Defaults to ``False``
+            - None: use the default L_op result.
+            - OpFromGraph: should accept ``(inputs, outputs, output_grads)`` with the same types
+              as the inner graph.
+            - callable: should take three args ``(inputs, outputs, output_grads)``, each a list of
+              Variable, and return a list of Variable.
+            - list: one entry per input. Each entry is None (use default), a DisconnectedType or
+              NullType Variable, or a callable returning a single Variable.
+        grad_overrides : callable or OpFromGraph or list or None, optional
+            Deprecated in favor of ``lop_overrides``. Same as ``lop_overrides`` but the callable
+            signature is ``(inputs, output_grads)`` (no ``outputs`` argument). Mutually exclusive
+            with ``lop_overrides``.
+        rop_overrides : callable or OpFromGraph or list or None, optional
+            Override for the R_op method.
 
-            ``True`` : Cause the :class:`Op`'s original graph being used during
-            compilation, the :class:`Op` will not be visible in the compiled
-            graph but rather its internal graph.
+            - None: use the default R_op result.
+            - OpFromGraph: should accept ``(inputs, eval_points)`` with the same types as the
+              inner graph inputs.
+            - callable: should take two args ``(inputs, eval_points)``, each a list of Variable,
+              and return a list of Variable.
+            - list: one entry per output. Each entry is None (use default), a DisconnectedType or
+              NullType Variable, or a callable returning a single Variable.
 
-            ``False`` : will use a pre-compiled function inside.
+            .. warning::
 
-        grad_overrides
-            Defaults to ``None``.
-            This argument is mutually exclusive with ``lop_overrides``.
-
-            ``None`` : Do not override, use default grad() result
-
-            `OpFromGraph`: Override with another `OpFromGraph`, should
-            accept inputs as the same order and types of ``inputs`` and ``output_grads``
-            arguments as one would specify in :meth:`Op.grad`() method.
-
-            `callable`: Should take two args: ``inputs`` and ``output_grads``.
-            Each argument is expected to be a list of :class:`Variable `.
-            Must return list of :class:`Variable `.
-
-        lop_overrides
-            Defaults to ``None``.
-
-            This argument is mutually exclusive with ``grad_overrides``.
-
-            These options are similar to the ``grad_overrides`` above, but for
-            the :meth:`Op.L_op` method.
-
-            ``None``: Do not override, use the default :meth:`Op.L_op` result
-
-            `OpFromGraph`: Override with another `OpFromGraph`, should
-            accept inputs as the same order and types of ``inputs``,
-            ``outputs`` and ``output_grads`` arguments as one would specify in
-            :meth:`Op.grad` method.
-
-            `callable`: Should take three args: ``inputs``, ``outputs`` and ``output_grads``.
-            Each argument is expected to be a list of :class:`Variable`.
-            Must return list of :class:`Variable`.
-
-            ``list``: Each `OpFromGraph`/callable must return a single
-            :class:`Variable`. Each list element corresponds to gradient of
-            a specific input, length of list must be equal to number of inputs.
-
-        rop_overrides
-            One of ``{None, OpFromGraph, callable, Variable}``.
-
-            Defaults to ``None``.
-
-            ``None``: Do not override, use the default :meth:`Op.R_op` result
-
-            `OpFromGraph`: Override with another `OpFromGraph`, should
-            accept inputs as the same order and types of ``inputs`` and ``eval_points``
-            arguments as one would specify in :meth:`Op.R_op` method.
-
-            `callable`: Should take two args: ``inputs`` and ``eval_points``.
-            Each argument is expected to be a list of :class:`Variable`.  Must
-            return list of :class:`Variable`.
-
-            ``list``:
-            Each :class:`OpFromGraph`/callable must return a single
-            :class:`Variable <pytensor.graph.basic.Variable>`. Each list element
-            corresponds to a specific output of :meth:`Op.R_op`, length of list
-            must be equal to number of outputs.  connection_pattern If not
-            ``None``, this will be used as the connection_pattern for this
-            :class:`Op`.
-
-        .. warning::
-
-            rop overrides is ignored when `pytensor.gradient.Rop` is called with
-            `use_op_rop_implementation=False` (default). In this case the Lop
-            is used twice to obtain a mathematically equivalent Rop.
-
-        strict: bool, default False
-            If true, it raises when any variables needed to compute the inner graph
-            are not provided as explici inputs. This can only happen for graphs with
-            shared variables.
-
-        name
+                R_op overrides are ignored when ``pytensor.gradient.Rop`` is called with
+                ``use_op_rop_implementation=False`` (the default). In that case the L_op is used
+                twice to obtain a mathematically equivalent R_op.
+        connection_pattern : list of list of bool, optional
+            If provided, used as the connection pattern for this Op. Each inner list has one bool
+            per output, and the outer list has one entry per input.
+        strict : bool, optional
+            If True, raises when any variables needed to compute the inner graph are not provided
+            as explicit inputs. Only relevant for graphs with shared variables. Default False.
+        name : str, optional
             A name for debugging purposes.
-
-        kwargs
-            Check :func:`pytensor.function` for more arguments, only works when not
-            inline.
+        **kwargs
+            Additional arguments passed to :func:`pytensor.function`. Only used when
+            ``inline=False``.
         """
         ignore_unused_inputs = kwargs.get("on_unused_input", False) == "ignore"
         if not ignore_unused_inputs and len(inputs) != len(set(inputs)):
@@ -388,6 +337,7 @@ class OpFromGraph(Op, HasInnerGraph):
         self.fgraph, self.shared_inputs, _, _ = construct_nominal_fgraph(
             inputs, outputs
         )
+        self._frozen_fgraph = self.fgraph.freeze()
 
         if strict and self.shared_inputs:
             raise ValueError(
@@ -437,13 +387,127 @@ class OpFromGraph(Op, HasInnerGraph):
         self.name = name
         self.destroy_map = destroy_map if destroy_map is not None else {}
 
+        self._frozen_lop = None
+        self._frozen_rop = None
+
+    # Thread-safe guard against infinite recursion when freezing overrides.
+    # When True, __eq__ skips override comparison entirely.
+    _freezing_overrides = contextvars.ContextVar(
+        "OpFromGraph._freezing_overrides", default=False
+    )
+
+    @staticmethod
+    def _freeze_override_to_fgraph(
+        all_inputs: list[Variable], results: list[Variable]
+    ) -> tuple[tuple[bool, ...], FrozenFunctionGraph | None]:
+        """Build a FrozenFunctionGraph from override results, filtering out disconnected/null types."""
+        pattern = tuple(
+            isinstance(r.type, DisconnectedType | NullType) for r in results
+        )
+        connected = [
+            r for r, is_disc in zip(results, pattern, strict=True) if not is_disc
+        ]
+        if not connected:
+            return pattern, None
+        return pattern, FunctionGraph(all_inputs, connected).freeze()
+
+    def _freeze_override(self, override, make_dummy_args):
+        """Freeze one override (lop/grad/rop) into a FrozenFunctionGraph."""
+        if override is None:
+            return None
+        if isinstance(override, OpFromGraph):
+            return override._frozen_fgraph
+
+        all_inputs, callable_args = make_dummy_args()
+
+        if isinstance(override, list):
+            results = []
+            for entry in override:
+                if entry is None:
+                    results.append(disconnected_type())
+                elif isinstance(entry, Variable):
+                    results.append(entry)
+                elif callable(entry):
+                    results.append(entry(*callable_args))
+            return self._freeze_override_to_fgraph(all_inputs, results)
+
+        return self._freeze_override_to_fgraph(all_inputs, override(*callable_args))
+
+    def _ensure_frozen_overrides(self):
+        if self._frozen_lop is not None or self._frozen_rop is not None:
+            return
+
+        lop = self.lop_overrides if self._lop_op_interface else self.grad_overrides
+        rop = self.rop_overrides
+        if lop is None and rop is None:
+            return
+
+        token = self._freezing_overrides.set(True)
+        try:
+            if lop is not None:
+
+                def make_lop_args():
+                    dummy_inputs = [t() for t in self.input_types]
+                    dummy_outputs = [t() for t in self.output_types]
+                    dummy_output_grads = [t() for t in self.output_types]
+                    if self._lop_op_interface:
+                        return dummy_inputs + dummy_outputs + dummy_output_grads, (
+                            dummy_inputs,
+                            dummy_outputs,
+                            dummy_output_grads,
+                        )
+                    return dummy_inputs + dummy_output_grads, (
+                        dummy_inputs,
+                        dummy_output_grads,
+                    )
+
+                self._frozen_lop = self._freeze_override(lop, make_lop_args)
+
+            if rop is not None:
+
+                def make_rop_args():
+                    dummy_inputs = [t() for t in self.input_types]
+                    dummy_eval_points = [t() for t in self.input_types]
+                    return dummy_inputs + dummy_eval_points, (
+                        dummy_inputs,
+                        dummy_eval_points,
+                    )
+
+                self._frozen_rop = self._freeze_override(rop, make_rop_args)
+        finally:
+            self._freezing_overrides.reset(token)
+
     def __eq__(self, other):
-        # TODO: recognize a copy
-        return self is other
+        if self is other:
+            return True
+        if type(self) is not type(other):
+            return False
+        if (
+            self._frozen_fgraph != other._frozen_fgraph
+            or self.is_inline != other.is_inline
+            or self.destroy_map != other.destroy_map
+            or len(self.shared_inputs) != len(other.shared_inputs)
+            or any(
+                a is not b
+                for a, b in zip(self.shared_inputs, other.shared_inputs, strict=True)
+            )
+        ):
+            return False
+        # When freezing overrides, skip override comparison to break infinite
+        # recursion for self-referential overrides (e.g. Sylvester L_op).
+        # The fgraph comparison above is sufficient for cache correctness
+        # since overrides only affect gradient computation, not forward output.
+        if self._freezing_overrides.get():
+            return True
+        self._ensure_frozen_overrides()
+        other._ensure_frozen_overrides()
+        return (
+            self._frozen_lop == other._frozen_lop
+            and self._frozen_rop == other._frozen_rop
+        )
 
     def __hash__(self):
-        # TODO: use internal variables in hash
-        return hash(type(self))
+        return hash((type(self), self._frozen_fgraph, self.is_inline))
 
     def __str__(self):
         name = self.__class__.__name__ if self.name is None else self.name

--- a/pytensor/graph/basic.py
+++ b/pytensor/graph/basic.py
@@ -2,6 +2,7 @@
 
 import abc
 import warnings
+import weakref
 from collections.abc import (
     Hashable,
     Iterable,
@@ -14,6 +15,7 @@ from typing import (
     Any,
     Generic,
     Optional,
+    Self,
     TypeVar,
     Union,
     cast,
@@ -788,6 +790,93 @@ class Constant(AtomicVariable[_TypeType]):
         return self.data
 
 
+def _get_frozen_output(apply_node: "FrozenApply", index: int) -> Variable:
+    """Resolve a FrozenApply output by index. Used by pickle."""
+    return apply_node.outputs[index]
+
+
+def _make_frozen_output_reduce(out: Variable):
+    """Create a __reduce_ex__ override for a FrozenApply output Variable."""
+    owner = out.owner
+    index = out.index
+
+    def __reduce_ex__(protocol):
+        return (_get_frozen_output, (owner, index))
+
+    return __reduce_ex__
+
+
+class FrozenApply(Apply):
+    """An immutable, globally-interned Apply node for frozen graphs.
+
+    Uses tuples for ``inputs`` and ``outputs`` so mutation raises ``TypeError``
+    at the language level.  Interned by ``(op, cache_key(inputs))`` —
+    constructing a ``FrozenApply`` with the same op and input variables returns
+    the cached instance.
+
+    Constants are keyed by ``(type, data_bytes)`` so that two independently
+    created Constants with the same value resolve to the same cached node.
+    """
+
+    _cache: weakref.WeakValueDictionary = weakref.WeakValueDictionary()
+
+    @staticmethod
+    def _input_to_key(inp: Variable):
+        """Convert an input Variable to a hashable, value-based cache key element.
+
+        Non-Constants (NominalVariables, FrozenApply outputs) are already
+        globally interned, so identity works.  Constants use their byte
+        representation so that independently-created equal constants
+        (including NaN) produce the same key.  Object-dtype constants
+        (e.g. slices) fall back to ``signature()`` since their byte
+        representation stores pointers, not values.
+        """
+        if isinstance(inp, Constant):
+            a = np.asarray(inp.data)
+            if a.dtype.kind != "O":
+                return (inp.type, a.tobytes(), a.dtype.str, a.shape)
+            return inp.signature()
+        return inp
+
+    def __new__(
+        cls,
+        op: "Op",
+        inputs: tuple[Variable, ...],
+        output_types: tuple["Type", ...],
+    ):
+        cache_key = (op, tuple(cls._input_to_key(i) for i in inputs))
+        cached = cls._cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        instance = object.__new__(cls)
+        instance.op = op
+        instance.inputs = inputs  # type: ignore[assignment]
+        instance.outputs = tuple(  # type: ignore[assignment]
+            t.variable_type(type=t, owner=instance, index=i)
+            for i, t in enumerate(output_types)
+        )
+        # Give each output Variable a __reduce__ that resolves to the
+        # canonical output on unpickle, avoiding fresh Variable objects.
+        for out in instance.outputs:
+            out.__reduce_ex__ = _make_frozen_output_reduce(out)  # type: ignore[method-assign]
+        instance.tag = Scratchpad()
+        cls._cache[cache_key] = instance
+        return instance
+
+    def __init__(self, op, inputs, output_types):
+        # All initialization is done in __new__
+        pass
+
+    def clone(self, clone_inner_graph: bool = False) -> Self:
+        """Frozen nodes are immutable — cloning returns self."""
+        return self
+
+    def __reduce__(self):
+        output_types = tuple(o.type for o in self.outputs)
+        return (type(self), (self.op, self.inputs, output_types))
+
+
 def clone(
     inputs: Sequence[Variable],
     outputs: Sequence[Variable],
@@ -1104,14 +1193,14 @@ def equal_computations(
 
     for x, y in zip(xs, ys, strict=True):
         if not isinstance(x, Variable) and not isinstance(y, Variable):
-            return np.array_equal(x, y)
+            return np.array_equal(x, y, equal_nan=True)
         if not isinstance(x, Variable):
             if isinstance(y, Constant):
-                return np.array_equal(y.data, x)
+                return np.array_equal(y.data, x, equal_nan=True)
             return False
         if not isinstance(y, Variable):
             if isinstance(x, Constant):
-                return np.array_equal(x.data, y)
+                return np.array_equal(x.data, y, equal_nan=True)
             return False
         x_is_owned, y_is_owned = (x.owner is not None, y.owner is not None)
         if x_is_owned != y_is_owned:

--- a/pytensor/graph/basic.py
+++ b/pytensor/graph/basic.py
@@ -695,7 +695,7 @@ class NominalVariable(Generic[_TypeType, _IdType], AtomicVariable[_TypeType]):
                 return cls, (self.id, self.type)
 
             def _str(self):
-                return f"*{self.id}-{var_type.__str__(self)}"
+                return f"i{self.id}"
 
             new_type = type(
                 type_name, (cls, var_type), {"__reduce__": _reduce, "__str__": _str}

--- a/pytensor/graph/basic.py
+++ b/pytensor/graph/basic.py
@@ -877,8 +877,7 @@ class FrozenApply(Apply):
         return self
 
     def __reduce__(self):
-        output_types = tuple(o.type for o in self.outputs)
-        return (type(self), (self.op, self.inputs, output_types))
+        return (type(self), (self.op, self.inputs, tuple(o.type for o in self.outputs)))
 
 
 def clone(

--- a/pytensor/graph/basic.py
+++ b/pytensor/graph/basic.py
@@ -825,10 +825,14 @@ class FrozenApply(Apply):
         """Convert an input Variable to a hashable, value-based cache key element.
 
         Non-Constants (NominalVariables, FrozenApply outputs) are already
-        globally interned, so identity works.  Constants use their byte
-        representation so that independently-created equal constants
-        (including NaN) produce the same key.  Object-dtype constants
-        (e.g. slices) fall back to ``signature()`` since their byte
+        globally interned, so ``id()`` is a correct identity key.  Using
+        ``id()`` instead of the object itself avoids strong references in
+        cache keys that would prevent GC from collecting chains of
+        FrozenApply nodes in a single pass.
+
+        Constants use their byte representation so that independently-created
+        equal constants (including NaN) produce the same key.  Object-dtype
+        constants (e.g. slices) fall back to ``signature()`` since their byte
         representation stores pointers, not values.
         """
         if isinstance(inp, Constant):
@@ -836,7 +840,7 @@ class FrozenApply(Apply):
             if a.dtype.kind != "O":
                 return (inp.type, a.tobytes(), a.dtype.str, a.shape)
             return inp.signature()
-        return inp
+        return id(inp)
 
     def __new__(
         cls,

--- a/pytensor/graph/fg.py
+++ b/pytensor/graph/fg.py
@@ -1014,10 +1014,10 @@ class FrozenFunctionGraph(AbstractFunctionGraph):
 
         self.inputs: tuple[Variable, ...] = nominal_inputs
         self.outputs: tuple[Variable, ...] = frozen_outputs
-        self._variables: frozenset[Variable] | None = None
         self.apply_nodes: frozenset[Apply] = frozenset(sorted_apply_nodes)
-        self._clients: dict[Variable, list[ClientType]] | None = None
         self._toposort: tuple[Apply, ...] = tuple(sorted_apply_nodes)
+        self._variables: frozenset[Variable] | None = None
+        self._clients: dict[Variable, list[ClientType]] | None = None
 
     def __reduce__(self):
         return FrozenFunctionGraph, (self.inputs, self.outputs)

--- a/pytensor/graph/fg.py
+++ b/pytensor/graph/fg.py
@@ -970,28 +970,26 @@ class FrozenFunctionGraph(AbstractFunctionGraph):
         memo: dict[Variable, Variable] = dict(zip(inputs, nominal_inputs, strict=True))
         sorted_apply_nodes: list[Apply] = []
 
-        for node in toposort(outputs, blockers=inputs):
-            for inp in node.inputs:
-                if inp not in memo:
-                    if isinstance(inp, Constant):
-                        memo[inp] = inp
-                    else:
-                        raise ValueError(
-                            f"Orphan {inp} found in the graph. "
-                            "All variables must be graph inputs, "
-                            "Constants, or produced by Apply nodes "
-                            "reachable from the inputs."
-                        )
+        def _resolve_input(inp, memo=memo):
+            mapped = memo.get(inp)
+            if mapped is not None:
+                return mapped
+            if isinstance(inp, Constant):
+                memo[inp] = inp
+                return inp
+            raise ValueError(
+                f"Orphan {inp} found in the graph. "
+                "All variables must be graph inputs, "
+                "Constants, or produced by Apply nodes "
+                "reachable from the inputs."
+            )
 
-            new_inputs = tuple(memo[i] for i in node.inputs)
+        for node in toposort(outputs, blockers=inputs):
+            new_inputs = tuple(_resolve_input(inp) for inp in node.inputs)
             output_types = tuple(out.type for out in node.outputs)
             new_node = FrozenApply(node.op, new_inputs, output_types)
             sorted_apply_nodes.append(new_node)
 
-            # FrozenApply interning may return a cached node whose inputs
-            # reference different (interned) constant objects.
-            # Update memo so that variables tracks the actual interned objects.
-            memo.update(zip(node.inputs, new_node.inputs))
             memo.update(zip(node.outputs, new_node.outputs, strict=True))
 
         # Handle outputs that are Constants or AtomicVariables not
@@ -1016,7 +1014,7 @@ class FrozenFunctionGraph(AbstractFunctionGraph):
 
         self.inputs: tuple[Variable, ...] = nominal_inputs
         self.outputs: tuple[Variable, ...] = frozen_outputs
-        self.variables: frozenset[Variable] = frozenset(memo.values())
+        self._variables: frozenset[Variable] | None = None
         self.apply_nodes: frozenset[Apply] = frozenset(sorted_apply_nodes)
         self._clients: dict[Variable, list[ClientType]] | None = None
         self._toposort: tuple[Apply, ...] = tuple(sorted_apply_nodes)
@@ -1045,6 +1043,12 @@ class FrozenFunctionGraph(AbstractFunctionGraph):
 
     def toposort(self) -> tuple[Apply, ...]:
         return self._toposort
+
+    @property
+    def variables(self) -> frozenset[Variable]:  # type: ignore[override]
+        if self._variables is None:
+            self._variables = frozenset(vars_between(self.inputs, self.outputs))
+        return self._variables
 
     @property
     def clients(self) -> dict[Variable, list[ClientType]]:  # type: ignore[override]

--- a/pytensor/graph/fg.py
+++ b/pytensor/graph/fg.py
@@ -1,6 +1,7 @@
 """A container for specifying and manipulating a graph with distinct inputs and outputs."""
 
 import time
+from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Iterable, Sequence
 from typing import Any, Union, cast
@@ -9,6 +10,8 @@ from pytensor.configdefaults import config
 from pytensor.graph.basic import (
     Apply,
     AtomicVariable,
+    Constant,
+    NominalVariable,
     Variable,
     clone_get_equiv,
 )
@@ -22,10 +25,23 @@ from pytensor.graph.traversal import (
     toposort_with_orderings,
     vars_between,
 )
-from pytensor.graph.utils import MetaObject, MissingInputError
+from pytensor.graph.utils import MissingInputError
 
 
 ClientType = tuple[Apply, int]
+
+
+class AbstractFunctionGraph(ABC):
+    """Read-only interface shared by FunctionGraph and FrozenFunctionGraph."""
+
+    inputs: Sequence[Variable]
+    outputs: Sequence[Variable]
+    apply_nodes: set[Apply]
+    variables: set[Variable]
+    clients: dict[Variable, list[ClientType]]
+
+    @abstractmethod
+    def toposort(self) -> list[Apply]: ...
 
 
 class Output(Op):
@@ -46,7 +62,7 @@ class Output(Op):
         return f"output[{self.idx}]"
 
 
-class FunctionGraph(MetaObject):
+class FunctionGraph(AbstractFunctionGraph):
     r"""
     A `FunctionGraph` represents a subgraph bound by a set of input variables and
     a set of output variables, ie a subgraph that specifies an PyTensor function.
@@ -911,3 +927,167 @@ class FunctionGraph(MetaObject):
         from pytensor.printing import debugprint
 
         return debugprint(self, **kwargs)
+
+    def freeze(self) -> "FrozenFunctionGraph":
+        """Return a frozen, hashable version of this FunctionGraph."""
+        return FrozenFunctionGraph(self.inputs, self.outputs)
+
+
+class FrozenFunctionGraph(AbstractFunctionGraph):
+    """Immutable, hashable function graph for inner graphs of Ops.
+
+    All internal nodes are globally interned via ``FrozenApply``.  Two
+    ``FrozenFunctionGraph`` instances built from structurally identical source
+    graphs share the same interned output objects, so equality reduces to
+    identity comparison on the outputs tuple.
+
+    Use ``FunctionGraph.freeze()`` or ``FrozenFunctionGraph(inputs, outputs)``
+    to create instances.
+
+    .. code-block:: python
+
+        from pytensor.scalar.basic import float64, add
+        from pytensor.graph.fg import FunctionGraph
+
+        x, y = float64("x"), float64("y")
+        frozen = FunctionGraph([x, y], [add(x, y)]).freeze()
+        frozen2 = FunctionGraph([x, y], [add(x, y)]).freeze()
+
+        assert frozen == frozen2
+        assert {frozen: "value"}[frozen2] == "value"
+    """
+
+    def __init__(
+        self,
+        inputs: Sequence[Variable],
+        outputs: Sequence[Variable],
+    ):
+        from pytensor.graph.basic import FrozenApply
+
+        nominal_inputs = tuple(
+            NominalVariable(i, inp.type, name=inp.name) for i, inp in enumerate(inputs)
+        )
+
+        memo: dict[Variable, Variable] = dict(zip(inputs, nominal_inputs, strict=True))
+
+        for node in toposort(outputs, blockers=inputs):
+            for inp in node.inputs:
+                if inp not in memo:
+                    if isinstance(inp, Constant):
+                        memo[inp] = inp
+                    elif isinstance(inp, AtomicVariable):
+                        memo[inp] = inp
+                    else:
+                        raise ValueError(
+                            f"Non-Constant, non-AtomicVariable orphan {inp} found "
+                            "in the graph. All variables must be graph inputs, "
+                            "Constants, AtomicVariables, or produced by Apply "
+                            "nodes reachable from the inputs."
+                        )
+
+            new_inputs = tuple(memo[i] for i in node.inputs)
+            output_types = tuple(out.type for out in node.outputs)
+            new_node = FrozenApply(node.op, new_inputs, output_types)
+
+            memo.update(zip(node.outputs, new_node.outputs, strict=True))
+
+        # Handle outputs that are Constants or AtomicVariables not
+        # encountered during toposort (e.g. a graph with no Apply nodes)
+        for o in outputs:
+            if o not in memo:
+                if isinstance(o, Constant):
+                    memo[o] = o
+                elif isinstance(o, AtomicVariable):
+                    memo[o] = o
+
+        try:
+            frozen_outputs = tuple(memo[o] for o in outputs)
+        except KeyError:
+            unmapped = [o for o in outputs if o not in memo]
+            raise ValueError(
+                f"Output variable {unmapped[0]} could not be mapped to a frozen "
+                "graph variable. All outputs must be graph inputs, "
+                "constants, or produced by Apply nodes reachable from "
+                "the inputs."
+            )
+
+        self.inputs: tuple[Variable, ...] = nominal_inputs
+        self.outputs: tuple[Variable, ...] = frozen_outputs
+        self._variables: set[Variable] | None = None
+        self._apply_nodes: set[Apply] | None = None
+        self._clients: dict[Variable, list[ClientType]] | None = None
+        self._toposort: list[Apply] | None = None
+
+    def __reduce__(self):
+        return FrozenFunctionGraph, (self.inputs, self.outputs)
+
+    def __hash__(self):
+        return hash(self.outputs)
+
+    def __eq__(self, other):
+        if self is other:
+            return True
+        if not isinstance(other, FrozenFunctionGraph):
+            return False
+        return self.inputs == other.inputs and self.outputs == other.outputs
+
+    def __repr__(self):
+        return f"FrozenFunctionGraph(inputs={list(self.inputs)}, outputs={list(self.outputs)})"
+
+    def __copy__(self):
+        return self
+
+    def __deepcopy__(self, memo):
+        return self
+
+    @property
+    def apply_nodes(self) -> set[Apply]:  # type: ignore[override]
+        if self._apply_nodes is None:
+            self._apply_nodes = set(applys_between(self.inputs, self.outputs))
+        return self._apply_nodes
+
+    def toposort(self) -> list[Apply]:
+        if self._toposort is None:
+            self._toposort = list(toposort(self.outputs, blockers=self.inputs))
+        return self._toposort
+
+    @property
+    def variables(self) -> set[Variable]:  # type: ignore[override]
+        if self._variables is None:
+            self._variables = set(vars_between(self.inputs, self.outputs))
+        return self._variables
+
+    @property
+    def clients(self) -> dict[Variable, list[ClientType]]:  # type: ignore[override]
+        if self._clients is None:
+            clients: dict[Variable, list[ClientType]] = {v: [] for v in self.inputs}
+            for node in self.toposort():
+                for i, inp in enumerate(node.inputs):
+                    clients.setdefault(inp, []).append((node, i))
+                for out in node.outputs:
+                    clients.setdefault(out, [])
+            self._clients = clients
+        return self._clients
+
+    def unfreeze(self) -> "FunctionGraph":
+        """Return a mutable FunctionGraph with fresh mutable Apply nodes."""
+        memo: dict[Variable, Variable] = {inp: inp.type() for inp in self.inputs}
+
+        for node in self.toposort():
+            for i in node.inputs:
+                if i not in memo:
+                    if isinstance(i, AtomicVariable):
+                        memo[i] = i
+                    else:
+                        memo[i] = i.clone()
+            new_inputs = [memo[i] for i in node.inputs]
+            new_node = Apply(
+                node.op,
+                new_inputs,
+                [o.type() for o in node.outputs],
+            )
+            memo.update(zip(node.outputs, new_node.outputs))
+
+        new_inputs = [memo[i] for i in self.inputs]
+        new_outputs = [memo[o] for o in self.outputs]
+        return FunctionGraph(new_inputs, new_outputs, clone=False)

--- a/pytensor/graph/fg.py
+++ b/pytensor/graph/fg.py
@@ -1029,7 +1029,7 @@ class FrozenFunctionGraph(AbstractFunctionGraph):
             return True
         if not isinstance(other, FrozenFunctionGraph):
             return False
-        return self.inputs == other.inputs and self.outputs == other.outputs
+        return self.outputs == other.outputs and self.inputs == other.inputs
 
     def __repr__(self):
         return f"FrozenFunctionGraph(inputs={list(self.inputs)}, outputs={list(self.outputs)})"

--- a/pytensor/graph/fg.py
+++ b/pytensor/graph/fg.py
@@ -965,7 +965,7 @@ class FrozenFunctionGraph(AbstractFunctionGraph):
         from pytensor.graph.basic import FrozenApply
 
         nominal_inputs = tuple(
-            NominalVariable(i, inp.type, name=inp.name) for i, inp in enumerate(inputs)
+            NominalVariable(i, inp.type) for i, inp in enumerate(inputs)
         )
 
         memo: dict[Variable, Variable] = dict(zip(inputs, nominal_inputs, strict=True))
@@ -1013,6 +1013,8 @@ class FrozenFunctionGraph(AbstractFunctionGraph):
 
         self.inputs: tuple[Variable, ...] = nominal_inputs
         self.outputs: tuple[Variable, ...] = frozen_outputs
+        for i, out in enumerate(frozen_outputs):
+            out.name = f"o{i}"
         self._variables: set[Variable] | None = None
         self._apply_nodes: set[Apply] | None = None
         self._clients: dict[Variable, list[ClientType]] | None = None

--- a/pytensor/graph/fg.py
+++ b/pytensor/graph/fg.py
@@ -975,14 +975,12 @@ class FrozenFunctionGraph(AbstractFunctionGraph):
                 if inp not in memo:
                     if isinstance(inp, Constant):
                         memo[inp] = inp
-                    elif isinstance(inp, AtomicVariable):
-                        memo[inp] = inp
                     else:
                         raise ValueError(
-                            f"Non-Constant, non-AtomicVariable orphan {inp} found "
-                            "in the graph. All variables must be graph inputs, "
-                            "Constants, AtomicVariables, or produced by Apply "
-                            "nodes reachable from the inputs."
+                            f"Orphan {inp} found in the graph. "
+                            "All variables must be graph inputs, "
+                            "Constants, or produced by Apply nodes "
+                            "reachable from the inputs."
                         )
 
             new_inputs = tuple(memo[i] for i in node.inputs)
@@ -990,20 +988,24 @@ class FrozenFunctionGraph(AbstractFunctionGraph):
             new_node = FrozenApply(node.op, new_inputs, output_types)
             sorted_apply_nodes.append(new_node)
 
+            # FrozenApply interning may return a cached node whose inputs
+            # reference different (interned) constant objects.
+            # Update memo so that variables tracks the actual interned objects.
+            memo.update(zip(node.inputs, new_node.inputs))
             memo.update(zip(node.outputs, new_node.outputs, strict=True))
 
         # Handle outputs that are Constants or AtomicVariables not
         # encountered during toposort (e.g. a graph with no Apply nodes)
         for o in outputs:
             if o not in memo:
+                # TODO: We could create those dummy ApplyOutput here and get the interned constant
                 if isinstance(o, Constant):
-                    memo[o] = o
-                elif isinstance(o, AtomicVariable):
                     memo[o] = o
 
         try:
             frozen_outputs = tuple(memo[o] for o in outputs)
         except KeyError:
+            # TODO: Can this ever happen if we didn't fail in the previous look?
             unmapped = [o for o in outputs if o not in memo]
             raise ValueError(
                 f"Output variable {unmapped[0]} could not be mapped to a frozen "

--- a/pytensor/graph/fg.py
+++ b/pytensor/graph/fg.py
@@ -3,7 +3,7 @@
 import time
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Sequence, Set
 from typing import Any, Union, cast
 
 from pytensor.configdefaults import config
@@ -11,6 +11,7 @@ from pytensor.graph.basic import (
     Apply,
     AtomicVariable,
     Constant,
+    FrozenApply,
     NominalVariable,
     Variable,
     clone_get_equiv,
@@ -36,12 +37,12 @@ class AbstractFunctionGraph(ABC):
 
     inputs: Sequence[Variable]
     outputs: Sequence[Variable]
-    apply_nodes: set[Apply]
-    variables: set[Variable]
+    apply_nodes: Set[Apply]  # abc.Set covers both set and frozenset
+    variables: Set[Variable]
     clients: dict[Variable, list[ClientType]]
 
     @abstractmethod
-    def toposort(self) -> list[Apply]: ...
+    def toposort(self) -> Sequence[Apply]: ...
 
 
 class Output(Op):
@@ -962,13 +963,12 @@ class FrozenFunctionGraph(AbstractFunctionGraph):
         inputs: Sequence[Variable],
         outputs: Sequence[Variable],
     ):
-        from pytensor.graph.basic import FrozenApply
-
         nominal_inputs = tuple(
             NominalVariable(i, inp.type) for i, inp in enumerate(inputs)
         )
 
         memo: dict[Variable, Variable] = dict(zip(inputs, nominal_inputs, strict=True))
+        sorted_apply_nodes: list[Apply] = []
 
         for node in toposort(outputs, blockers=inputs):
             for inp in node.inputs:
@@ -988,6 +988,7 @@ class FrozenFunctionGraph(AbstractFunctionGraph):
             new_inputs = tuple(memo[i] for i in node.inputs)
             output_types = tuple(out.type for out in node.outputs)
             new_node = FrozenApply(node.op, new_inputs, output_types)
+            sorted_apply_nodes.append(new_node)
 
             memo.update(zip(node.outputs, new_node.outputs, strict=True))
 
@@ -1013,12 +1014,10 @@ class FrozenFunctionGraph(AbstractFunctionGraph):
 
         self.inputs: tuple[Variable, ...] = nominal_inputs
         self.outputs: tuple[Variable, ...] = frozen_outputs
-        for i, out in enumerate(frozen_outputs):
-            out.name = f"o{i}"
-        self._variables: set[Variable] | None = None
-        self._apply_nodes: set[Apply] | None = None
+        self.variables: frozenset[Variable] = frozenset(memo.values())
+        self.apply_nodes: frozenset[Apply] = frozenset(sorted_apply_nodes)
         self._clients: dict[Variable, list[ClientType]] | None = None
-        self._toposort: list[Apply] | None = None
+        self._toposort: tuple[Apply, ...] = tuple(sorted_apply_nodes)
 
     def __reduce__(self):
         return FrozenFunctionGraph, (self.inputs, self.outputs)
@@ -1042,32 +1041,16 @@ class FrozenFunctionGraph(AbstractFunctionGraph):
     def __deepcopy__(self, memo):
         return self
 
-    @property
-    def apply_nodes(self) -> set[Apply]:  # type: ignore[override]
-        if self._apply_nodes is None:
-            self._apply_nodes = set(applys_between(self.inputs, self.outputs))
-        return self._apply_nodes
-
-    def toposort(self) -> list[Apply]:
-        if self._toposort is None:
-            self._toposort = list(toposort(self.outputs, blockers=self.inputs))
+    def toposort(self) -> tuple[Apply, ...]:
         return self._toposort
-
-    @property
-    def variables(self) -> set[Variable]:  # type: ignore[override]
-        if self._variables is None:
-            self._variables = set(vars_between(self.inputs, self.outputs))
-        return self._variables
 
     @property
     def clients(self) -> dict[Variable, list[ClientType]]:  # type: ignore[override]
         if self._clients is None:
-            clients: dict[Variable, list[ClientType]] = {v: [] for v in self.inputs}
+            clients: dict[Variable, list[ClientType]] = {v: [] for v in self.variables}
             for node in self.toposort():
                 for i, inp in enumerate(node.inputs):
-                    clients.setdefault(inp, []).append((node, i))
-                for out in node.outputs:
-                    clients.setdefault(out, [])
+                    clients[inp].append((node, i))
             self._clients = clients
         return self._clients
 
@@ -1082,14 +1065,16 @@ class FrozenFunctionGraph(AbstractFunctionGraph):
                         memo[i] = i
                     else:
                         memo[i] = i.clone()
-            new_inputs = [memo[i] for i in node.inputs]
+
             new_node = Apply(
                 node.op,
-                new_inputs,
+                [memo[i] for i in node.inputs],
                 [o.type() for o in node.outputs],
             )
             memo.update(zip(node.outputs, new_node.outputs))
 
-        new_inputs = [memo[i] for i in self.inputs]
-        new_outputs = [memo[o] for o in self.outputs]
-        return FunctionGraph(new_inputs, new_outputs, clone=False)
+        return FunctionGraph(
+            [memo[i] for i in self.inputs],
+            [memo[o] for o in self.outputs],
+            clone=False,
+        )

--- a/pytensor/graph/op.py
+++ b/pytensor/graph/op.py
@@ -18,7 +18,7 @@ from pytensor.graph.utils import (
 
 if TYPE_CHECKING:
     from pytensor.compile.function.types import Function
-    from pytensor.graph.fg import FunctionGraph
+    from pytensor.graph.fg import AbstractFunctionGraph, FunctionGraph
     from pytensor.graph.type import Type
 
 StorageCellType = list[Any | None]
@@ -370,16 +370,18 @@ class Op(MetaObject):
         """
 
     def do_constant_folding(self, fgraph: "FunctionGraph", node: Apply) -> bool:
-        """Determine whether or not constant folding should be performed for the given node.
+        """Determine whether constant folding should be performed for the given node.
 
         This allows each `Op` to determine if it wants to be constant
         folded when all its inputs are constant. This allows it to choose where
         it puts its memory/speed trade-off. Also, it could make things faster
-        as constants can't be used for in-place operations (see
-        ``*IncSubtensor``).
+        as constants can't be used for in-place operations (see ``*IncSubtensor``).
 
         Parameters
         ----------
+        fgraph : FunctionGraph
+            Function graph to which `node` belongs. This is passed in case the `Op` needs to inspect the graph to make
+            its decision.
         node : Apply
             The node for which the constant folding determination is made.
 
@@ -544,8 +546,8 @@ class _NoPythonOp(Op):
 class HasInnerGraph(ABC):
     r"""A mixin for an `Op` that contain an inner graph."""
 
-    fgraph: "FunctionGraph"
-    """A `FunctionGraph` of the inner function."""
+    fgraph: "AbstractFunctionGraph"
+    """The inner function graph (FunctionGraph or FrozenFunctionGraph)."""
 
     @property
     @abstractmethod

--- a/pytensor/link/jax/dispatch/basic.py
+++ b/pytensor/link/jax/dispatch/basic.py
@@ -11,7 +11,7 @@ from pytensor.compile.builders import OpFromGraph
 from pytensor.compile.ops import DeepCopyOp, TypeCastingOp
 from pytensor.configdefaults import config
 from pytensor.graph import Constant
-from pytensor.graph.fg import FunctionGraph
+from pytensor.graph.fg import AbstractFunctionGraph
 from pytensor.ifelse import IfElse
 from pytensor.link.jax.ops import JAXOp
 from pytensor.link.utils import fgraph_to_python
@@ -46,7 +46,7 @@ def jax_funcify(op, node=None, storage_map=None, **kwargs):
     raise NotImplementedError(f"No JAX conversion for the given `Op`: {op}")
 
 
-@jax_funcify.register(FunctionGraph)
+@jax_funcify.register(AbstractFunctionGraph)
 def jax_funcify_FunctionGraph(
     fgraph,
     node=None,

--- a/pytensor/link/mlx/dispatch/basic.py
+++ b/pytensor/link/mlx/dispatch/basic.py
@@ -10,7 +10,7 @@ from pytensor.compile.builders import OpFromGraph
 from pytensor.compile.mode import MLX
 from pytensor.compile.ops import DeepCopyOp, TypeCastingOp
 from pytensor.graph import Constant
-from pytensor.graph.fg import FunctionGraph
+from pytensor.graph.fg import AbstractFunctionGraph
 from pytensor.ifelse import IfElse
 from pytensor.link.utils import fgraph_to_python
 from pytensor.raise_op import Assert, CheckAndRaise
@@ -136,7 +136,7 @@ def mlx_funcify(op, node=None, storage_map=None, **kwargs):
     )
 
 
-@mlx_funcify.register(FunctionGraph)
+@mlx_funcify.register(AbstractFunctionGraph)
 def mlx_funcify_FunctionGraph(
     fgraph,
     node=None,

--- a/pytensor/link/numba/dispatch/basic.py
+++ b/pytensor/link/numba/dispatch/basic.py
@@ -12,7 +12,7 @@ from numba.cpython.unsafe.tuple import tuple_setitem  # noqa: F401
 
 from pytensor import config
 from pytensor.graph.basic import Apply, Constant, Variable
-from pytensor.graph.fg import FunctionGraph
+from pytensor.graph.fg import AbstractFunctionGraph
 from pytensor.graph.type import Type
 from pytensor.link.numba.cache import (
     compile_numba_function_src,
@@ -151,7 +151,7 @@ def get_numba_type(
 
 
 def create_numba_signature(
-    node_or_fgraph: FunctionGraph | Apply,
+    node_or_fgraph: AbstractFunctionGraph | Apply,
     force_scalar: bool = False,
     reduce_to_scalar: bool = False,
 ) -> numba.types.Type:
@@ -484,9 +484,9 @@ def cache_key_for_constant(data):
         return hash_from_pickle_dump(data)
 
 
-@register_funcify_and_cache_key(FunctionGraph)
+@register_funcify_and_cache_key(AbstractFunctionGraph)
 def numba_funcify_FunctionGraph(
-    fgraph: FunctionGraph,
+    fgraph: AbstractFunctionGraph,
     node=None,
     fgraph_name="numba_funcified_fgraph",
     **kwargs,

--- a/pytensor/link/numba/dispatch/random.py
+++ b/pytensor/link/numba/dispatch/random.py
@@ -424,7 +424,7 @@ def numba_funcify_RandomVariable(op: RandomVariableWithCoreShape, node, **kwargs
 
     match core_rv_fn_and_cache_key:
         case (core_rv_fn, (int() | None) as core_cache_key):
-            pass  # type: ignore[unreachable]
+            pass
         case (_core_rv_fn, invalid_core_cache_key):
             raise ValueError(
                 f"Invalid core_cache_key returned from numba_core_rv_funcify: {invalid_core_cache_key}. Must be int or None."

--- a/pytensor/link/pytorch/dispatch/basic.py
+++ b/pytensor/link/pytorch/dispatch/basic.py
@@ -10,7 +10,7 @@ from pytensor.compile.builders import OpFromGraph
 from pytensor.compile.function.types import add_supervisor_to_fgraph
 from pytensor.compile.ops import DeepCopyOp, TypeCastingOp
 from pytensor.graph.basic import Constant
-from pytensor.graph.fg import FunctionGraph
+from pytensor.graph.fg import AbstractFunctionGraph
 from pytensor.ifelse import IfElse
 from pytensor.link.utils import fgraph_to_python
 from pytensor.raise_op import CheckAndRaise
@@ -53,7 +53,7 @@ def pytorch_funcify(op, node=None, storage_map=None, **kwargs):
     )
 
 
-@pytorch_funcify.register(FunctionGraph)
+@pytorch_funcify.register(AbstractFunctionGraph)
 def pytorch_funcify_FunctionGraph(
     fgraph,
     node=None,

--- a/pytensor/link/utils.py
+++ b/pytensor/link/utils.py
@@ -24,7 +24,7 @@ import numpy as np
 
 from pytensor import config, utils
 from pytensor.graph.basic import Apply, Constant, Variable
-from pytensor.graph.fg import FunctionGraph
+from pytensor.graph.fg import AbstractFunctionGraph, FunctionGraph
 
 
 if TYPE_CHECKING:
@@ -664,7 +664,7 @@ def unique_name_generator(
 
 
 def fgraph_to_python(
-    fgraph: FunctionGraph,
+    fgraph: AbstractFunctionGraph,
     op_conversion_fn: Callable,
     *,
     type_conversion_fn: Callable = lambda x, **kwargs: x,

--- a/pytensor/link/utils.py
+++ b/pytensor/link/utils.py
@@ -668,7 +668,7 @@ def fgraph_to_python(
     op_conversion_fn: Callable,
     *,
     type_conversion_fn: Callable = lambda x, **kwargs: x,
-    order: list[Apply] | None = None,
+    order: Sequence[Apply] | None = None,
     storage_map: Optional["StorageMapType"] = None,
     fgraph_name: str = "fgraph_to_python",
     global_env: dict[Any, Any] | None = None,
@@ -741,11 +741,7 @@ def fgraph_to_python(
             is_constant = isinstance(inp, Constant)
             input_storage = storage_map.setdefault(
                 inp,
-                [
-                    inp.data  # type: ignore[attr-defined]
-                    if is_constant
-                    else None
-                ],
+                [inp.data if isinstance(inp, Constant) else None],
             )
             if (
                 is_constant or input_storage[0] is not None

--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -974,17 +974,17 @@ def constant(x, name=None, dtype=None) -> ScalarConstant:
 
 
 def as_scalar(x: Any, name: str | None = None) -> ScalarVariable:
-    if isinstance(x, ScalarVariable):
-        return x
-
     if isinstance(x, Variable):
+        if isinstance(x.type, ScalarType):
+            # NOTE: We may have a Variable with ScalarType that is not ScalarVariable/ScalarConstant/ScalarSharedVariable
+            # if it bypasses those constructs (same issue with TensorVariables). We should make that impossible to happen!
+            return x  # type: ignore[return-value]
+
         from pytensor.tensor.basic import scalar_from_tensor
         from pytensor.tensor.type import TensorType
 
         if isinstance(x.type, TensorType) and x.type.ndim == 0:
             return scalar_from_tensor(x)
-        elif isinstance(x, Constant) and isinstance(x.type, ScalarType):
-            return ScalarConstant(x.type, x.data, name=x.name)
         else:
             raise TypeError(f"Cannot convert {x} to a scalar type")
 

--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -4001,6 +4001,8 @@ complex_from_polar = ComplexFromPolar(name="complex_from_polar")
 class ScalarInnerGraphOp(ScalarOp, HasInnerGraph):
     """Includes boilerplate code for Python and C-implementation of Scalar Ops with inner graph."""
 
+    __props__ = ("fgraph",)
+
     def __init__(self, *args, **kwargs):
         self.prepare_node_called = set()
         super().__init__(*args, **kwargs)
@@ -4112,16 +4114,6 @@ class ScalarInnerGraphOp(ScalarOp, HasInnerGraph):
             for n in applys_between(self.inputs, self.outputs):
                 n.op.prepare_node(n, None, None, impl)
             self.prepare_node_called.add(impl)
-
-    def __eq__(self, other):
-        if self is other:
-            return True
-        if type(self) is not type(other):
-            return False
-        return self.fgraph == other.fgraph
-
-    def __hash__(self):
-        return hash((type(self), self.fgraph))
 
     def __getstate__(self):
         rval = dict(self.__dict__)

--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -23,10 +23,9 @@ import pytensor
 from pytensor import printing
 from pytensor.configdefaults import config
 from pytensor.gradient import disconnected_type, grad_undefined
-from pytensor.graph.basic import Apply, Constant, Variable, clone
-from pytensor.graph.fg import FunctionGraph
+from pytensor.graph.basic import Apply, Constant, Variable
+from pytensor.graph.fg import FrozenFunctionGraph
 from pytensor.graph.op import HasInnerGraph
-from pytensor.graph.rewriting.basic import MergeOptimizer
 from pytensor.graph.traversal import applys_between
 from pytensor.graph.type import HasDataType, HasShape
 from pytensor.graph.utils import MetaObject, MethodNotDefined
@@ -984,6 +983,8 @@ def as_scalar(x: Any, name: str | None = None) -> ScalarVariable:
 
         if isinstance(x.type, TensorType) and x.type.ndim == 0:
             return scalar_from_tensor(x)
+        elif isinstance(x, Constant) and isinstance(x.type, ScalarType):
+            return ScalarConstant(x.type, x.data, name=x.name)
         else:
             raise TypeError(f"Cannot convert {x} to a scalar type")
 
@@ -4004,41 +4005,14 @@ class ScalarInnerGraphOp(ScalarOp, HasInnerGraph):
         self.prepare_node_called = set()
         super().__init__(*args, **kwargs)
 
-    def _cleanup_graph(self, inputs, outputs, clone: builtins.bool = True):
-        # TODO: We could convert to TensorVariable, optimize graph,
-        # and then convert back to ScalarVariable.
-        # This would introduce rewrites like `log(1 + x) -> log1p`.
-
-        fgraph = FunctionGraph(inputs, outputs, clone=clone)
-
-        # Validate node types
+    def _validate_inner_graph(self, fgraph):
+        """Validate that all ops in the inner graph are ScalarOps."""
         for node in fgraph.apply_nodes:
             if not isinstance(node.op, ScalarOp):
                 raise TypeError(
                     f"The fgraph of {self.__class__.__name__} must be exclusively "
                     "composed of scalar operations."
                 )
-
-        # Run MergeOptimization to avoid duplicated nodes
-        MergeOptimizer().rewrite(fgraph)
-
-        inputs, outputs = fgraph.inputs, fgraph.outputs
-
-        # Clone identical outputs that may have been merged
-        # If fgraph.outputs = [out_A, out_B, out_A], then final outputs = [out_A, out_B, clone(out_A)]
-        if len(set(fgraph.outputs)) != len(outputs):
-            old_outputs = outputs
-            outputs = []
-            for old_output in old_outputs:
-                if old_output not in outputs:
-                    outputs.append(old_output)
-                else:
-                    node = old_output.owner
-                    output_idx = node.outputs.index(old_output)
-                    output = node.clone().outputs[output_idx]
-                    outputs.append(output)
-
-        return inputs, outputs
 
     @property
     def fn(self):
@@ -4116,6 +4090,8 @@ class ScalarInnerGraphOp(ScalarOp, HasInnerGraph):
         return "\n".join(sorted(rval))
 
     def c_support_code_apply(self, node, name):
+        # Ensure nodenames is populated (side effect of c_code_template)
+        _ = self.c_code_template
         rval = []
         for subnode, subnodename in zip(
             self.fgraph.toposort(), self.nodenames, strict=True
@@ -4140,38 +4116,17 @@ class ScalarInnerGraphOp(ScalarOp, HasInnerGraph):
     def __eq__(self, other):
         if self is other:
             return True
-        if (
-            type(self) is not type(other)
-            or self.nin != other.nin
-            or self.nout != other.nout
-        ):
+        if type(self) is not type(other):
             return False
-
-        # TODO FIXME: Why this?  Shouldn't we expect equivalent inputs to this
-        # object to generate the same `_c_code`?
-        return self.c_code_template == other.c_code_template
+        return self.fgraph == other.fgraph
 
     def __hash__(self):
-        # Note that in general, the configparser settings at the time
-        # of code generation (__init__) affect the semantics of this Op.
-        # This function assumes that all relevant info about the configparser
-        # is embodied in _c_code.  So the _c_code, rather than self.fgraph,
-        # is the signature of the semantics of this Op.
-        # _c_code is preserved through unpickling, so the Op will not change
-        # semantics when it is reloaded with different configparser
-        # settings.
-        #
-        # TODO FIXME: Doesn't the above just mean that we should be including
-        # the relevant "configparser settings" here?  Also, why should we even
-        # care about the exact form of the generated C code when comparing
-        # `Op`s?  All this smells of leaky concerns and interfaces.
-        return hash((type(self), self.nin, self.nout, self.c_code_template))
+        return hash((type(self), self.fgraph))
 
     def __getstate__(self):
         rval = dict(self.__dict__)
         rval.pop("_c_code", None)
         rval.pop("_py_perform_fn", None)
-        rval.pop("_fgraph", None)
         rval.pop("prepare_node_called", None)
         return rval
 
@@ -4190,78 +4145,51 @@ class Composite(ScalarInnerGraphOp):
 
     """
 
-    init_param: tuple[str, ...] = ("inputs", "outputs")
-
     def __init__(
-        self, inputs, outputs, name="Composite", clone_graph: builtins.bool = True
+        self,
+        inputs,
+        outputs,
+        name="Composite",
     ):
         self.name = name
         self._name = None
-        # We need to clone the graph as sometimes its nodes already
-        # contain a reference to an fgraph. As we want the Composite
-        # to be pickable, we can't have reference to fgraph.
 
-        # Also, if there is Composite in the inner graph, we want to
-        # remove them. In that case, we do a more complicated clone
-        # that will flatten Composite. We don't need to do this
-        # recursively, as the way the fusion optimizer work, we have
-        # only 1 new Composite each time at the output.
         for i in inputs:
             assert i not in outputs  # This isn't supported, use identity
 
-        if len(outputs) > 1 or not any(
-            isinstance(var.owner.op, Composite) for var in outputs
+        # Flatten nested Composites in single-output case
+        if len(outputs) == 1 and any(
+            var.owner is not None and isinstance(var.owner.op, Composite)
+            for var in outputs
         ):
-            if clone_graph:
-                inputs, outputs = clone(inputs, outputs)
-
-        else:
-            # Inner Composite that we need to flatten
-            # FIXME: There could be a composite in the middle of the graph, why is this here?
-            #  If anything it should be an optimization, but I suspect lower-level compilation can handle this anyway.
-            assert len(outputs) == 1
-            # 1. Create a new graph from inputs up to the
-            # Composite
+            inner_op = outputs[0].owner.op
+            inner_fgraph = inner_op.fgraph.unfreeze()
             res = pytensor.compile.rebuild_collect_shared(
                 inputs=inputs, outputs=outputs[0].owner.inputs, copy_inputs_over=False
-            )  # Clone also the inputs
-            # 2. We continue this partial clone with the graph in
-            # the inner Composite
+            )
             res2 = pytensor.compile.rebuild_collect_shared(
-                inputs=outputs[0].owner.op.inputs,
-                outputs=outputs[0].owner.op.outputs,
-                replace=dict(zip(outputs[0].owner.op.inputs, res[1], strict=True)),
+                inputs=inner_fgraph.inputs,
+                outputs=inner_fgraph.outputs,
+                replace=dict(zip(inner_fgraph.inputs, res[1], strict=True)),
             )
             assert len(res2[1]) == len(outputs)
             assert len(res[0]) == len(inputs)
-            assert res[0] != inputs
             inputs, outputs = res[0], res2[1]
 
-        # We already cloned the graph, or the user told us there was no need for it
-        self.inputs, self.outputs = self._cleanup_graph(inputs, outputs, clone=False)
-        self.inputs_type = tuple(input.type for input in self.inputs)
-        self.outputs_type = tuple(output.type for output in self.outputs)
-        self.nin = len(inputs)
-        self.nout = len(outputs)
+        self.fgraph = FrozenFunctionGraph(inputs, outputs)
+        self._validate_inner_graph(self.fgraph)
+
+        self.inputs = self.fgraph.inputs
+        self.outputs = self.fgraph.outputs
+        self.inputs_type = tuple(inp.type for inp in self.inputs)
+        self.outputs_type = tuple(out.type for out in self.outputs)
+        self.nin = len(self.inputs)
+        self.nout = len(self.outputs)
         super().__init__()
 
     def __str__(self):
         if self._name is not None:
             return self._name
-
-        # Rename internal variables
-        for i, r in enumerate(self.fgraph.inputs):
-            r.name = f"i{i}"
-        for i, r in enumerate(self.fgraph.outputs):
-            r.name = f"o{i}"
-        io = set(self.fgraph.inputs + self.fgraph.outputs)
-        for i, r in enumerate(self.fgraph.variables):
-            if (
-                not isinstance(r, Constant)
-                and r not in io
-                and len(self.fgraph.clients[r]) > 1
-            ):
-                r.name = f"t{i}"
 
         if len(self.fgraph.outputs) > 1 or len(self.fgraph.apply_nodes) > 10:
             self._name = "Composite{...}"
@@ -4271,18 +4199,9 @@ class Composite(ScalarInnerGraphOp):
 
         return self._name
 
-    @property
-    def fgraph(self):
-        if hasattr(self, "_fgraph"):
-            return self._fgraph
-        # fgraph cannot be a property of the base class because it messes up with C caching.
-        # We also need a `FunctionGraph(clone=True)` (default) according to an old comment
-        fgraph = FunctionGraph(self.inputs, self.outputs)
-        self._fgraph = fgraph
-        return self._fgraph
-
     def clone(self):
-        return self.__class__(self.fgraph.inputs, self.fgraph.outputs)
+        mutable_fg = self.fgraph.unfreeze()
+        return self.__class__(mutable_fg.inputs, mutable_fg.outputs)
 
     def output_types(self, input_types):
         if tuple(input_types) != self.inputs_type:
@@ -4292,14 +4211,16 @@ class Composite(ScalarInnerGraphOp):
         return self.outputs_type
 
     def make_node(self, *inputs):
-        if tuple(i.type for i in self.inputs) == tuple(i.type for i in inputs):
+        if self.inputs_type == tuple(i.type for i in inputs):
             return super().make_node(*inputs)
         else:
-            # Make a new op with the right input type.
+            # Make a new op with the right input types.
+            # Unfreeze the frozen inner graph for rebuild_collect_shared.
             assert len(inputs) == self.nin
+            mutable_fg = self.fgraph.unfreeze()
             res = pytensor.compile.rebuild_collect_shared(
-                self.outputs,
-                replace=dict(zip(self.inputs, inputs, strict=True)),
+                mutable_fg.outputs,
+                replace=dict(zip(mutable_fg.inputs, inputs, strict=True)),
                 rebuild_strict=False,
             )
             # After rebuild_collect_shared, the Variable in inputs

--- a/pytensor/scalar/loop.py
+++ b/pytensor/scalar/loop.py
@@ -3,7 +3,7 @@ from itertools import chain
 
 from pytensor.compile import rebuild_collect_shared
 from pytensor.graph.basic import Constant, Variable, clone
-from pytensor.graph.fg import FunctionGraph
+from pytensor.graph.fg import FrozenFunctionGraph
 from pytensor.scalar.basic import ScalarInnerGraphOp, as_scalar
 
 
@@ -41,13 +41,6 @@ class ScalarLoop(ScalarInnerGraphOp):
 
     """
 
-    init_param: tuple[str, ...] = (
-        "init",
-        "update",
-        "constant",
-        "until",
-    )
-
     def __init__(
         self,
         init: Sequence[Variable],
@@ -67,11 +60,15 @@ class ScalarLoop(ScalarInnerGraphOp):
             inputs, outputs = clone([*init, *constant], update)
 
         self.is_while = until is not None
-        self.inputs, self.outputs = self._cleanup_graph(inputs, outputs)
+
+        self.fgraph = FrozenFunctionGraph(inputs, outputs)
+        self._validate_inner_graph(self.fgraph)
+        self.inputs = self.fgraph.inputs
+        self.outputs = self.fgraph.outputs
         self._validate_updates(self.inputs, self.outputs)
 
-        self.inputs_type = tuple(input.type for input in self.inputs)
-        self.outputs_type = tuple(output.type for output in self.outputs)
+        self.inputs_type = tuple(inp.type for inp in self.inputs)
+        self.outputs_type = tuple(out.type for out in self.outputs)
         self.nin = len(self.inputs) + 1  # n_steps is not part of the inner graph
         self.nout = len(self.outputs)
         self.name = name
@@ -106,23 +103,16 @@ class ScalarLoop(ScalarInnerGraphOp):
                 "If you want to return an output as a lagged input, wrap it in an identity Op."
             )
 
-    @property
-    def fgraph(self):
-        if hasattr(self, "_fgraph"):
-            return self._fgraph
-        # fgraph cannot be a property of the base class because it messes up with C caching.
-        # We also need a `FunctionGraph(clone=True)` (default) according to an old comment
-        fgraph = FunctionGraph(self.inputs, self.outputs)
-        self._fgraph = fgraph
-        return self._fgraph
-
     def clone(self, name=None, **kwargs):
+        mutable_fg = self.fgraph.unfreeze()
+        inputs = mutable_fg.inputs
+        outputs = mutable_fg.outputs
         if self.is_while:
-            *update, until = self.outputs
+            *update, until = outputs
         else:
-            update, until = self.outputs, None
-        init = self.inputs[: len(update)]
-        constant = self.inputs[len(update) :]
+            update, until = outputs, None
+        init = inputs[: len(update)]
+        constant = inputs[len(update) :]
         return self.__class__(
             init=init,
             update=update,
@@ -150,9 +140,10 @@ class ScalarLoop(ScalarInnerGraphOp):
             return super().make_node(n_steps, *inputs)
         else:
             # Make a new op with the right input types.
+            mutable_fg = self.fgraph.unfreeze()
             res = rebuild_collect_shared(
-                self.outputs,
-                replace=dict(zip(self.inputs, inputs, strict=True)),
+                mutable_fg.outputs,
+                replace=dict(zip(mutable_fg.inputs, inputs, strict=True)),
                 rebuild_strict=False,
             )
             if self.is_while:

--- a/pytensor/scan/op.py
+++ b/pytensor/scan/op.py
@@ -74,7 +74,6 @@ from pytensor.gradient import (
 from pytensor.graph.basic import (
     Apply,
     Variable,
-    equal_computations,
 )
 from pytensor.graph.features import NoOutputFromInplace
 from pytensor.graph.op import HasInnerGraph, Op, io_connection_pattern
@@ -82,7 +81,6 @@ from pytensor.graph.replace import clone_replace
 from pytensor.graph.traversal import graph_inputs
 from pytensor.graph.type import HasShape
 from pytensor.graph.utils import InconsistencyError, MissingInputError
-from pytensor.link.c.basic import CLinker
 from pytensor.link.vm import VMLinker
 from pytensor.printing import op_debug_information
 from pytensor.scan.utils import ScanProfileStats, Validator, forced_replace, safe_new
@@ -930,13 +928,12 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
                 "Inner-graphs must not contain in-place operations."
             )
 
-        self._cmodule_key = CLinker().cmodule_key_variables(
-            self.inner_inputs, self.inner_outputs, []
-        )
-        self._hash_inner_graph = hash(self._cmodule_key)
+        self._frozen_fgraph = self.fgraph.freeze()
 
     def __setstate__(self, d):
         self.__dict__.update(d)
+        if not hasattr(self, "_frozen_fgraph"):
+            self._frozen_fgraph = self.fgraph.freeze()
         # Ensure that the graph associated with the inner function is valid.
         self.validate_inner_graph()
 
@@ -1315,27 +1312,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         if self.allow_gc != other.allow_gc:
             return False
 
-        # Compare inner graphs
-        # TODO: Use `self.inner_fgraph == other.inner_fgraph`
-        if len(self.inner_inputs) != len(other.inner_inputs):
-            return False
-
-        if len(self.inner_outputs) != len(other.inner_outputs):
-            return False
-
-        # strict=False because length already compared above
-        for self_in, other_in in zip(
-            self.inner_inputs, other.inner_inputs, strict=False
-        ):
-            if self_in.type != other_in.type:
-                return False
-
-        return equal_computations(
-            self.inner_outputs,
-            other.inner_outputs,
-            self.inner_inputs,
-            other.inner_inputs,
-        )
+        return self._frozen_fgraph == other._frozen_fgraph
 
     def __str__(self):
         inplace = "none"
@@ -1355,7 +1332,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         return hash(
             (
                 type(self),
-                self._hash_inner_graph,
+                self._frozen_fgraph,
                 self.info,
                 self.profile,
                 self.truncate_gradient,
@@ -1546,7 +1523,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
 
     def clone(self) -> "Scan":
         res = copy(self)
-        res.fgraph = res.fgraph.clone(clone_inner_graphs=True)
+        res.fgraph = res.fgraph.clone(clone_inner_graphs=True)  # type: ignore[attr-defined]
         return res
 
     def make_thunk(self, node, storage_map, compute_map, no_recycling, impl=None):

--- a/pytensor/tensor/_linalg/solve/rewriting.py
+++ b/pytensor/tensor/_linalg/solve/rewriting.py
@@ -187,9 +187,9 @@ def _scan_split_non_sequence_decomposition_and_solve(
                 ):
                     if new_scan_fgraph is scan_op.fgraph:
                         # Clone the first time to avoid mutating the original fgraph
-                        new_scan_fgraph, equiv = new_scan_fgraph.clone_get_equiv()
+                        new_scan_fgraph, equiv = new_scan_fgraph.clone_get_equiv()  # type: ignore[attr-defined]
                         non_sequences = {equiv[non_seq] for non_seq in non_sequences}
-                        inner_node = equiv[inner_node]  # type: ignore
+                        inner_node = equiv[inner_node]
 
                     replace_dict = _split_decomp_and_solve_steps(
                         new_scan_fgraph,
@@ -200,7 +200,7 @@ def _scan_split_non_sequence_decomposition_and_solve(
                     assert isinstance(replace_dict, dict) and len(replace_dict) > 0, (
                         "Rewrite failed"
                     )
-                    new_scan_fgraph.replace_all(replace_dict.items())
+                    new_scan_fgraph.replace_all(replace_dict.items())  # type: ignore[attr-defined]
                     changed = True
                     break  # Break to start over with a fresh toposort
         else:  # no_break

--- a/pytensor/tensor/einsum.py
+++ b/pytensor/tensor/einsum.py
@@ -3,7 +3,7 @@ import warnings
 from collections.abc import Sequence
 from functools import partial, reduce
 from itertools import pairwise
-from typing import cast
+from typing import Any, cast
 
 import numpy as np
 from numpy._core.einsumfunc import (  # type: ignore[attr-defined]
@@ -588,14 +588,19 @@ def einsum(subscripts: str, *operands: "TensorLike", optimize=None) -> TensorVar
     else:
         # Case 2: All operands have known shapes. In this case, we can use opt_einsum to compute the optimal
         # contraction order.
-        _, contraction_list_raw = np.einsum_path(
-            subscripts,
-            # Numpy einsum_path requires arrays even though only the shapes matter
-            # It's not trivial to duck-type our way around because of internal call to `asanyarray`
-            *[np.empty(shape) for shape in shapes],
-            # einsum_call is not part of public API
-            einsum_call=True,  # type: ignore[arg-type]
-            optimize="optimal",
+        # Numpy einsum_path requires arrays even though only the shapes matter. It's not trivial to duck-type our way
+        # around because of internal call to `asanyarray`
+        _, contraction_list_raw = cast(
+            tuple[Any, list],
+            cast(
+                object,
+                np.einsum_path(
+                    subscripts,
+                    *[np.empty(shape) for shape in shapes],
+                    einsum_call=True,  # type: ignore[arg-type]
+                    optimize="optimal",
+                ),
+            ),
         )
         # Numpy API changed in v2.4.2, and now returns only 3 values instead of 5
         # We never needed the last two but we need the code to work with both cases
@@ -604,15 +609,15 @@ def einsum(subscripts: str, *operands: "TensorLike", optimize=None) -> TensorVar
             match len(contraction_list_raw[0]):
                 case 5:
                     # Old API, the first 3 entries have what we need
-                    contraction_list = [c[:3] for c in contraction_list_raw]  # type: ignore[misc]
+                    contraction_list = [c[:3] for c in contraction_list_raw]
                 case 3:
                     # New API doesn't have index removed
                     contraction_list = []
-                    for pos, step_ein_str, _ in contraction_list_raw:  # type: ignore[str-unpack]
+                    for pos, step_ein_str, _ in contraction_list_raw:
                         # e.g., 'ijp,oij->op' -> removed_str = {'i', 'j'}
                         inp_str, out_str = step_ein_str.replace(",", "").split("->")
                         removed_idx = set(inp_str) - set(out_str)
-                        contraction_list.append((pos, removed_idx, step_ein_str))  # type: ignore[arg-type]
+                        contraction_list.append((pos, removed_idx, step_ein_str))
                 case _:
                     raise ValueError("Unexpected contraction list template")
         del contraction_list_raw

--- a/pytensor/tensor/rewriting/elemwise.py
+++ b/pytensor/tensor/rewriting/elemwise.py
@@ -883,10 +883,9 @@ class FusionOptimizer(GraphRewriter):
                 continue
 
             scalar_inputs, scalar_outputs = self.elemwise_to_scalar(inputs, outputs)
-            composite_outputs = Elemwise(
-                # No need to clone Composite graph, because `self.elemwise_to_scalar` creates fresh variables
-                Composite(scalar_inputs, scalar_outputs, clone_graph=False)
-            )(*inputs, return_list=True)
+            composite_outputs = Elemwise(Composite(scalar_inputs, scalar_outputs))(
+                *inputs, return_list=True
+            )
             assert len(outputs) == len(composite_outputs)
             for old_out, composite_out in zip(outputs, composite_outputs):
                 # Preserve any names on the original outputs
@@ -1061,31 +1060,35 @@ def local_careduce_fusion(fgraph, node):
 def local_inline_composite_constants(fgraph, node):
     """Inline scalar constants in Composite graphs."""
     composite_op = node.op.scalar_op
+
+    # Check if any outer inputs are inlineable constants before unfreezing
+    inlineable = [
+        (i, outer_inp)
+        for i, outer_inp in enumerate(node.inputs)
+        if isinstance(outer_inp, TensorConstant)
+        and "complex" not in outer_inp.type.dtype
+        and outer_inp.unique_value is not None
+    ]
+    if not inlineable:
+        return None
+
+    mutable_fg = composite_op.fgraph.unfreeze()
+    inlineable_indices = {i for i, _ in inlineable}
     new_outer_inputs = []
     new_inner_inputs = []
     inner_replacements = {}
-    for outer_inp, inner_inp in zip(
-        node.inputs, composite_op.fgraph.inputs, strict=True
+    for i, (outer_inp, inner_inp) in enumerate(
+        zip(node.inputs, mutable_fg.inputs, strict=True)
     ):
-        # Complex variables don't have a `c_literal` that can be inlined
-        if (
-            isinstance(outer_inp, TensorConstant)
-            and "complex" not in outer_inp.type.dtype
-        ):
-            if outer_inp.unique_value is not None:
-                inner_replacements[inner_inp] = scalar_constant(
-                    outer_inp.unique_value, dtype=inner_inp.dtype
-                )
-                continue
-        new_outer_inputs.append(outer_inp)
-        new_inner_inputs.append(inner_inp)
+        if i in inlineable_indices:
+            inner_replacements[inner_inp] = scalar_constant(
+                outer_inp.unique_value, dtype=inner_inp.dtype
+            )
+        else:
+            new_outer_inputs.append(outer_inp)
+            new_inner_inputs.append(inner_inp)
 
-    if not inner_replacements:
-        return None
-
-    new_inner_outs = clone_replace(
-        composite_op.fgraph.outputs, replace=inner_replacements
-    )
+    new_inner_outs = clone_replace(mutable_fg.outputs, replace=inner_replacements)
     new_composite_op = Composite(new_inner_inputs, new_inner_outs)
     new_outputs = Elemwise(new_composite_op).make_node(*new_outer_inputs).outputs
 

--- a/tests/compile/test_builders.py
+++ b/tests/compile/test_builders.py
@@ -904,10 +904,10 @@ Inner graphs:
 
 OpFromGraph{inline=False} [id A]
  ← Add [id E]
-    ├─ *0-<Matrix(float64, shape=(?, ?))> [id F]
+    ├─ i0 [id F]
     └─ Mul [id G]
-       ├─ *1-<Matrix(float64, shape=(?, ?))> [id H]
-       └─ *2-<Matrix(float64, shape=(?, ?))> [id I]
+       ├─ i1 [id H]
+       └─ i2 [id I]
 """
 
     for truth, out in zip(exp_res.split("\n"), lines, strict=True):

--- a/tests/compile/test_builders.py
+++ b/tests/compile/test_builders.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import pytensor.tensor as pt
+from pytensor import Mode
 from pytensor.compile import shared
 from pytensor.compile.builders import OpFromGraph
 from pytensor.compile.function import function
@@ -18,6 +19,7 @@ from pytensor.gradient import (
 from pytensor.graph.basic import equal_computations
 from pytensor.graph.fg import FunctionGraph
 from pytensor.graph.null_type import NullType, null_type
+from pytensor.graph.rewriting.basic import MergeOptimizer
 from pytensor.graph.rewriting.utils import rewrite_graph
 from pytensor.graph.utils import MissingInputError
 from pytensor.printing import debugprint
@@ -700,6 +702,187 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         g = OpFromGraph([x, x, y], [x + y], on_unused_input="ignore")
         f = g(x, x, y)
         assert f.eval({x: 5, y: 5}) == 10
+
+    def test_equality_and_hashing(self):
+        x, y = dscalars("x", "y")
+        e = x + y * x
+
+        op1 = OpFromGraph([x, y], [e])
+        op2 = OpFromGraph([x, y], [e])
+
+        # Same output with same inputs are equal with consistent hash
+        assert op1 == op2
+        assert hash(op1) == hash(op2)
+        assert {op1: "v"}[op2] == "v"
+
+        # Distinct variables with the same graph structure are equal
+        a, b = dscalars("a", "b")
+        op3 = OpFromGraph([a, b], [a + b * a])
+        assert op1 == op3
+        assert hash(op1) == hash(op3)
+
+        # Different graphs are not equal
+        op_different = OpFromGraph([x, y], [x * y + x])
+        assert op1 != op_different
+
+        # inline flag participates in equality
+        op_inline = OpFromGraph([x, y], [e], inline=True)
+        assert op1 != op_inline
+
+        # destroy_map participates in equality
+        op_destroy = OpFromGraph([x, y], [e], destroy_map={0: (0,)})
+        assert op1 != op_destroy
+
+        # Multi-output OFGs are also hashed and compared based on their inner graph structure
+        op_multi1 = OpFromGraph([x, y], [x + y, x * y])
+        op_multi2 = OpFromGraph([a, b], [a + b, a * b])
+        assert op_multi1 == op_multi2
+
+        # OFG is hashable, and different OFGs have different hashes
+        assert hash(op1) != hash(op_inline)
+
+    def test_equality_shared_variables(self):
+        x = scalar("x")
+        s = shared(np.array(1.0, dtype=config.floatX))
+
+        op1 = OpFromGraph([x], [x + s])
+        op2 = OpFromGraph([x], [x + s])
+        assert op1 == op2
+
+        # Same value, different shared object -> not equal
+        s2 = shared(np.array(1.0, dtype=config.floatX))
+        op3 = OpFromGraph([x], [x + s2])
+        assert op1 != op3
+
+    def test_equality_callable_overrides(self):
+        x, y = dscalars("x", "y")
+        e = x + y
+
+        op_plain = OpFromGraph([x, y], [e])
+
+        # lop override present vs absent
+        op_with_lop = OpFromGraph(
+            [x, y],
+            [e],
+            lop_overrides=lambda inps, outs, grads: [grads[0], grads[0]],
+        )
+        assert op_plain != op_with_lop
+
+        # Structurally identical callable overrides are equal
+        op_with_lop2 = OpFromGraph(
+            [x, y],
+            [e],
+            lop_overrides=lambda inps, outs, grads: [grads[0], grads[0]],
+        )
+        assert op_with_lop == op_with_lop2
+
+        # Structurally different callable override are not equal
+        op_with_lop3 = OpFromGraph(
+            [x, y],
+            [e],
+            lop_overrides=lambda inps, outs, grads: [grads[0] * 2, grads[0]],
+        )
+        assert op_with_lop != op_with_lop3
+
+        # Overrides returning disconnected_type for different inputs are not equal
+        op_disc_y = OpFromGraph(
+            [x, y],
+            [e],
+            lop_overrides=lambda inps, outs, grads: [grads[0], disconnected_type()],
+        )
+        op_disc_x = OpFromGraph(
+            [x, y],
+            [e],
+            lop_overrides=lambda inps, outs, grads: [disconnected_type(), grads[0]],
+        )
+        assert op_disc_y != op_disc_x
+
+        # Same disconnected pattern is equal
+        op_disc_y2 = OpFromGraph(
+            [x, y],
+            [e],
+            lop_overrides=lambda inps, outs, grads: [grads[0], disconnected_type()],
+        )
+        assert op_disc_y == op_disc_y2
+
+        # All disconnected is still an override — not equal to no override
+        op_all_disc = OpFromGraph(
+            [x, y],
+            [e],
+            lop_overrides=lambda inps, outs, grads: [
+                disconnected_type(),
+                disconnected_type(),
+            ],
+        )
+        assert op_all_disc != op_plain
+        assert op_all_disc != op_disc_y
+
+        # rop override follows the same logic
+        op_with_rop = OpFromGraph(
+            [x, y],
+            [e],
+            rop_overrides=lambda inps, epts: [epts[0] + epts[1]],
+        )
+        op_with_rop2 = OpFromGraph(
+            [x, y],
+            [e],
+            rop_overrides=lambda inps, epts: [epts[0] + epts[1]],
+        )
+        assert op_with_rop == op_with_rop2
+        assert op_with_rop != op_plain
+
+    def test_equality_list_overrides(self):
+        x, y = dscalars("x", "y")
+        e = x + y
+
+        def scale_grad(inps, outs, grads):
+            return grads[0] * 2
+
+        op1 = OpFromGraph([x, y], [e], lop_overrides=[scale_grad, None])
+        op2 = OpFromGraph([x, y], [e], lop_overrides=[scale_grad, None])
+        assert op1 == op2
+
+        def scale_grad_3x(inps, outs, grads):
+            return grads[0] * 3
+
+        op3 = OpFromGraph([x, y], [e], lop_overrides=[scale_grad_3x, None])
+        assert op1 != op3
+
+        # Position of None vs callable matters
+        op4 = OpFromGraph([x, y], [e], lop_overrides=[None, scale_grad])
+        assert op1 != op4
+
+    def test_merge_identical_ofgs(self):
+        x, y = dscalars("x", "y")
+        e = x + y * x
+
+        op1 = OpFromGraph([x, y], [e])
+        op2 = OpFromGraph([x, y], [e])
+
+        a, b = dscalars("a", "b")
+
+        # Two OFG with the same inputs are collapsed to one node by MergeOptimizer
+        fg = FunctionGraph([a, b], [op1(a, b), op2(a, b)])
+        MergeOptimizer().rewrite(fg)
+        ofg_nodes = [n for n in fg.toposort() if isinstance(n.op, OpFromGraph)]
+        assert len(ofg_nodes) == 1
+
+        # Different inputs are different graphs, so both nodes survive
+        c, d = dscalars("c", "d")
+        fg = FunctionGraph([a, b, c, d], [op1(a, b), op2(c, d)])
+        MergeOptimizer().rewrite(fg)
+        ofg_nodes = [n for n in fg.toposort() if isinstance(n.op, OpFromGraph)]
+        assert len(ofg_nodes) == 2
+
+        # Check numerics to make sure the merged OFG is correct
+        fn = function(
+            [a, b, c, d],
+            [op1(a, b), op2(c, d)],
+            mode=Mode(optimizer="merge", linker="py"),
+        )
+        r1, r2 = fn(2.0, 3.0, 4.0, 5.0)
+        np.testing.assert_allclose(r1, 2.0 + 3.0 * 2.0)
+        np.testing.assert_allclose(r2, 4.0 + 5.0 * 4.0)
 
 
 @config.change_flags(floatX="float64")

--- a/tests/graph/test_basic.py
+++ b/tests/graph/test_basic.py
@@ -524,6 +524,6 @@ class TestFrozenApply:
         out1 = add(x, ScalarConstant(float64, 3.14))
         out2 = add(x, ScalarConstant(float64, 3.14))
 
-        ffg1 = FrozenFunctionGraph.from_graph([x], [out1])
-        ffg2 = FrozenFunctionGraph.from_graph([x], [out2])
+        ffg1 = FrozenFunctionGraph([x], [out1])
+        ffg2 = FrozenFunctionGraph([x], [out2])
         assert ffg1 == ffg2

--- a/tests/graph/test_basic.py
+++ b/tests/graph/test_basic.py
@@ -471,3 +471,59 @@ def test_dprint():
     o1 = MyOp(r1, r2)
     assert o1.dprint(file="str") == debugprint(o1, file="str")
     assert o1.owner.dprint(file="str") == debugprint(o1.owner, file="str")
+
+
+class TestFrozenApply:
+    def test_interning_and_immutability(self):
+        from pytensor.graph.basic import FrozenApply
+        from pytensor.scalar.basic import add, float64, mul
+
+        x = NominalVariable(0, float64)
+        y = NominalVariable(1, float64)
+
+        fa1 = FrozenApply(add, (x, y), (float64,))
+        fa2 = FrozenApply(add, (x, y), (float64,))
+        fa_diff_op = FrozenApply(mul, (x, y), (float64,))
+        fa_diff_order = FrozenApply(add, (y, x), (float64,))
+
+        # Same (op, inputs) implies the same object
+        assert fa1 is fa2
+
+        # Different op or input order implies a different object
+        assert fa1 is not fa_diff_op
+        assert fa1 is not fa_diff_order
+
+        assert isinstance(fa1, Apply)
+
+        assert fa1.outputs[0].owner is fa1
+        assert fa1.outputs[0].index == 0
+
+    def test_cross_graph_identity(self):
+        """Two independently-built identical graphs share all FrozenApply nodes."""
+        from pytensor.graph.basic import FrozenApply
+        from pytensor.scalar.basic import float64, mul, sin, sqr
+
+        def build_graph():
+            a = NominalVariable(0, float64)
+            b = NominalVariable(1, float64)
+            n_sin = FrozenApply(sin, (a,), (float64,))
+            n_sqr = FrozenApply(sqr, (b,), (float64,))
+            n_mul = FrozenApply(mul, (n_sin.outputs[0], n_sqr.outputs[0]), (float64,))
+            return n_mul.outputs[0]
+
+        out1 = build_graph()
+        out2 = build_graph()
+        assert out1 is out2
+
+    def test_constant_deduplication_via_frozen_fgraph(self):
+        """Constants with the same value are deduplicated via FrozenFunctionGraph's cache_key."""
+        from pytensor.graph.fg import FrozenFunctionGraph
+        from pytensor.scalar.basic import ScalarConstant, add, float64
+
+        x = float64("x")
+        out1 = add(x, ScalarConstant(float64, 3.14))
+        out2 = add(x, ScalarConstant(float64, 3.14))
+
+        ffg1 = FrozenFunctionGraph.from_graph([x], [out1])
+        ffg2 = FrozenFunctionGraph.from_graph([x], [out2])
+        assert ffg1 == ffg2

--- a/tests/graph/test_fg.py
+++ b/tests/graph/test_fg.py
@@ -883,7 +883,7 @@ class TestFrozenFunctionGraph:
         var1 = MyVariable("x")
         orphan = MyVariable("orphan")
         out = op1(var1, orphan)
-        with pytest.raises(ValueError, match=r"Non-Constant.*orphan"):
+        with pytest.raises(ValueError, match=r"Orphan.*orphan"):
             FrozenFunctionGraph([var1], [out])
 
     def test_unmapped_output_raises(self):

--- a/tests/graph/test_fg.py
+++ b/tests/graph/test_fg.py
@@ -8,6 +8,7 @@ from pytensor.graph.basic import NominalVariable
 from pytensor.graph.fg import FunctionGraph, Output
 from pytensor.graph.utils import MissingInputError
 from pytensor.printing import debugprint
+from pytensor.scalar.basic import add, float64, mul
 from tests.graph.utils import (
     MyConstant,
     MyOp,
@@ -17,6 +18,8 @@ from tests.graph.utils import (
     op1,
     op2,
     op3,
+    op_y,
+    op_z,
 )
 
 
@@ -750,3 +753,152 @@ class TestFunctionGraph:
         cap_out = capsys.readouterr().out
         assert "y->z" not in cap_out
         assert "z->y" not in cap_out
+
+
+class TestFrozenFunctionGraph:
+    def test_hashability_and_comparison(self):
+        var1, var2 = MyVariable("x"), MyVariable("y")
+
+        # op_y and op_z are both MyOp(x=1), so they are structurally equal
+        ffg1 = FunctionGraph([var1, var2], [op_y(var1, var2)]).freeze()
+        ffg2 = FunctionGraph([var1, var2], [op_z(var1, var2)]).freeze()
+        # Structurally different op (different x value)
+        op_different = MyOp("Different", x=2)
+        ffg_different = FunctionGraph([var1, var2], [op_different(var1, var2)]).freeze()
+
+        assert ffg1 == ffg2
+        assert hash(ffg1) == hash(ffg2)
+        assert ffg1 != ffg_different
+
+        assert {ffg1: "value"}[ffg2] == "value"
+        assert len({ffg1, ffg2}) == 1
+
+    def test_nominal_inputs_renumbered(self):
+        """Inputs are always renumbered 0..n regardless of original ids."""
+        t = MyType()
+        nm5, nm10 = NominalVariable(5, t), NominalVariable(10, t)
+
+        ffg = FunctionGraph([nm5, nm10], [op1(nm5, nm10)]).freeze()
+        assert [inp.id for inp in ffg.inputs] == [0, 1]
+
+    def test_deduplication(self):
+        var1 = MyVariable("x")
+
+        dup1, dup2 = op1(var1), op1(var1)
+        frozen = FunctionGraph([var1], [op2(dup1, dup2)]).freeze()
+        assert {n.op for n in frozen.apply_nodes} == {op1, op2}
+
+        c1 = MyConstant("c", data=42)
+        c2 = MyConstant("c", data=42)
+        frozen_const = FunctionGraph(
+            [var1], [op2(op1(var1, c1), op1(var1, c2))]
+        ).freeze()
+        assert {n.op for n in frozen_const.apply_nodes} == {op1, op2}
+
+    def test_input_passed_directly_to_output(self):
+        var1 = MyVariable("x")
+        frozen = FunctionGraph([var1], [var1]).freeze()
+
+        assert frozen.apply_nodes == set()
+        assert isinstance(frozen.outputs[0], NominalVariable)
+
+    def test_cross_graph_output_identity(self):
+        var1, var2 = MyVariable("x"), MyVariable("y")
+        ffg1 = FunctionGraph([var1, var2], [op1(var1, var2)]).freeze()
+        ffg2 = FunctionGraph([var1, var2], [op1(var1, var2)]).freeze()
+
+        assert all(a is b for a, b in zip(ffg1.outputs, ffg2.outputs))
+
+    def test_pickle_round_trip(self):
+        from pytensor.scalar.basic import add, float64, mul
+
+        x, y = float64("x"), float64("y")
+        ffg = FunctionGraph([x, y], [mul(add(x, y), y)]).freeze()
+
+        ffg2 = pickle.loads(pickle.dumps(ffg))
+        assert ffg == ffg2
+        assert hash(ffg) == hash(ffg2)
+        # Interned objects survive pickle
+        assert all(o1 is o2 for o1, o2 in zip(ffg.outputs, ffg2.outputs))
+
+    def test_pickle_with_constants(self):
+        from pytensor.scalar.basic import ScalarConstant, add, float64
+
+        x = float64("x")
+        c = ScalarConstant(float64, 3.14)
+        ffg = FunctionGraph([x], [add(x, c)]).freeze()
+
+        ffg2 = pickle.loads(pickle.dumps(ffg))
+        assert ffg == ffg2
+        assert hash(ffg) == hash(ffg2)
+
+    def test_pickle_identity_output(self):
+        """Pickle round-trip when an input is passed directly to the output."""
+        var1 = MyVariable("x")
+        ffg = FunctionGraph([var1], [var1]).freeze()
+
+        ffg2 = pickle.loads(pickle.dumps(ffg))
+        assert ffg == ffg2
+        assert hash(ffg) == hash(ffg2)
+
+    def test_pickle_multi_output_shared_subexpr(self):
+        """Pickle round-trip with multiple outputs sharing subexpressions."""
+        from pytensor.scalar.basic import add, float64, mul
+
+        x, y = float64("x"), float64("y")
+        shared = add(x, y)
+        out1 = mul(shared, x)
+        out2 = add(shared, y)
+        ffg = FunctionGraph([x, y], [out1, out2]).freeze()
+
+        ffg2 = pickle.loads(pickle.dumps(ffg))
+        assert ffg == ffg2
+        assert hash(ffg) == hash(ffg2)
+
+    def test_pickle_hash_stability(self):
+        """Hash is the same before and after pickle, and across independent constructions."""
+        from pytensor.scalar.basic import add, float64, mul
+
+        x, y = float64("x"), float64("y")
+        ffg = FunctionGraph([x, y], [mul(add(x, y), y)]).freeze()
+        h_before = hash(ffg)
+
+        ffg2 = pickle.loads(pickle.dumps(ffg))
+        assert hash(ffg2) == h_before
+
+        ffg3 = FunctionGraph([x, y], [mul(add(x, y), y)]).freeze()
+        assert hash(ffg3) == h_before
+
+    def test_different_arity_not_equal(self):
+        """Graphs with different numbers of inputs must not be equal, even if outputs match."""
+        var1, var2 = MyVariable("x"), MyVariable("y")
+        # op1(var1) uses only var1
+        ffg1 = FunctionGraph([var1], [op1(var1)]).freeze()
+        ffg2 = FunctionGraph([var1, var2], [op1(var1)]).freeze()
+        assert ffg1 != ffg2
+
+    def test_orphan_non_constant_raises(self):
+        from pytensor.graph.fg import FrozenFunctionGraph
+
+        var1 = MyVariable("x")
+        orphan = MyVariable("orphan")
+        out = op1(var1, orphan)
+        with pytest.raises(ValueError, match=r"Non-Constant.*orphan"):
+            FrozenFunctionGraph([var1], [out])
+
+    def test_unmapped_output_raises(self):
+        from pytensor.graph.fg import FrozenFunctionGraph
+
+        var1 = MyVariable("x")
+        disconnected = MyVariable("disconnected")
+        with pytest.raises(ValueError, match="could not be mapped"):
+            FrozenFunctionGraph([var1], [disconnected])
+
+    def test_freeze_unfreeze_round_trip(self):
+        x, y = float64("x"), float64("y")
+        ffg = FunctionGraph([x, y], [mul(add(x, y), y)]).freeze()
+
+        refrozen = ffg.unfreeze().freeze()
+
+        assert ffg == refrozen
+        assert hash(ffg) == hash(refrozen)

--- a/tests/graph/test_fg.py
+++ b/tests/graph/test_fg.py
@@ -894,6 +894,37 @@ class TestFrozenFunctionGraph:
         with pytest.raises(ValueError, match="could not be mapped"):
             FrozenFunctionGraph([var1], [disconnected])
 
+    def test_interned_constant_in_variables(self):
+        """Regression test: all node inputs must appear in variables.
+
+        FrozenApply interns whole nodes, not individual constants. A cache
+        miss stores the current constant (c2), while a cache hit for a
+        different node returns a previously interned constant (c1). If the
+        cache hit overwrites memo[c2]=c1, c2 is evicted from variables
+        while the cache-miss node still references it.
+        """
+        from pytensor.graph.fg import FrozenFunctionGraph
+
+        op_shared = MyOp("shared")
+        op_unique = MyOp("unique")
+
+        # Populate FrozenApply cache: op_shared(NomVar_0, c1)
+        x1 = MyVariable("x")
+        c1 = MyConstant("c", data=42)
+        FrozenFunctionGraph([x1], [op_shared(x1, c1)])
+
+        # New graph with a fresh constant c2 (same value, different object).
+        # op_unique: cache miss → FrozenApply stores c2
+        # op_shared: cache hit from above → FrozenApply has c1
+        # Both c1 and c2 must be in variables.
+        x2 = MyVariable("x")
+        c2 = MyConstant("c", data=42)
+        fg = FrozenFunctionGraph([x2], [op_shared(x2, c2), op_unique(x2, c2)])
+
+        for node in fg.toposort():
+            for inp in node.inputs:
+                assert inp in fg.variables
+
     def test_freeze_unfreeze_round_trip(self):
         x, y = float64("x"), float64("y")
         ffg = FunctionGraph([x, y], [mul(add(x, y), y)]).freeze()

--- a/tests/scalar/test_basic.py
+++ b/tests/scalar/test_basic.py
@@ -1,3 +1,5 @@
+import pickle
+
 import numpy as np
 import pytest
 
@@ -93,6 +95,24 @@ class TestComposite:
         CC = Composite([x, y, z], [C(x * y, y), C(x * z, y)])
         # We don't flatten that case.
         assert isinstance(CC.outputs[0].owner.op, Composite)
+
+    def test_shared_identity(self):
+        x, y = floats("xy")
+        c1 = Composite([x, y], [x + y])
+        c2 = Composite([x, y], [x + y])
+        assert c1 == c2
+        assert hash(c1) == hash(c2)
+        assert {c1: 1}[c2] == 1
+
+        c3 = Composite([x, y], [x * y])
+        assert c1 != c3
+
+    def test_pickle_roundtrip(self):
+        x, y = floats("xy")
+        c = Composite([x, y], [x + y])
+        c2 = pickle.loads(pickle.dumps(c))
+        assert c == c2
+        assert hash(c) == hash(c2)
 
     @pytest.mark.parametrize("literal_value", (70.0, -np.inf, np.float32("nan")))
     def test_with_constants(self, literal_value):

--- a/tests/scan/test_printing.py
+++ b/tests/scan/test_printing.py
@@ -663,7 +663,7 @@ Scan{scan_fn, while_loop=False, inplace=all} [id B]
        └─ 0 [id R]
 
 Composite{switch(lt(0, i0), 1, 0)} [id K]
- ← Switch [id S] 'o0'
+ ← Switch [id S]
     ├─ LT [id T]
     │  ├─ 0 [id U]
     │  └─ i0 [id V]

--- a/tests/scan/test_printing.py
+++ b/tests/scan/test_printing.py
@@ -59,8 +59,8 @@ def test_debugprint_sitsot():
 
     Scan{scan_fn, while_loop=False, inplace=none} [id C]
      ← Mul [id U] (inner_out_sit_sot-0)
-        ├─ *0-<Vector(float64, shape=(?,))> [id V] -> [id E] (inner_in_sit_sot-0)
-        └─ *1-<Vector(float64, shape=(?,))> [id W] -> [id L] (inner_in_non_seqs-0)
+        ├─ i0 [id V] -> [id E] (inner_in_sit_sot-0)
+        └─ i1 [id W] -> [id L] (inner_in_non_seqs-0)
     """
 
     for truth, out in zip(expected_output.split("\n"), lines, strict=True):
@@ -116,8 +116,8 @@ def test_debugprint_sitsot_no_extra_info():
 
     Scan{scan_fn, while_loop=False, inplace=none} [id C]
      ← Mul [id U]
-        ├─ *0-<Vector(float64, shape=(?,))> [id V] -> [id E]
-        └─ *1-<Vector(float64, shape=(?,))> [id W] -> [id L]
+        ├─ i0 [id V] -> [id E]
+        └─ i1 [id W] -> [id L]
     """
 
     for truth, out in zip(expected_output.split("\n"), lines, strict=True):
@@ -183,10 +183,10 @@ def test_debugprint_nitsot():
 
     Scan{scan_fn, while_loop=False, inplace=none} [id B]
      ← Mul [id X] (inner_out_nit_sot-0)
-        ├─ *0-<Scalar(float64, shape=())> [id Y] -> [id S] (inner_in_seqs-0)
+        ├─ i0 [id Y] -> [id S] (inner_in_seqs-0)
         └─ Pow [id Z]
-           ├─ *2-<Scalar(float64, shape=())> [id BA] -> [id W] (inner_in_non_seqs-0)
-           └─ *1-<Scalar(int64, shape=())> [id BB] -> [id U] (inner_in_seqs-1)
+           ├─ i2 [id BA] -> [id W] (inner_in_non_seqs-0)
+           └─ i1 [id BB] -> [id U] (inner_in_seqs-1)
    """
 
     for truth, out in zip(expected_output.split("\n"), lines, strict=True):
@@ -264,21 +264,21 @@ def test_debugprint_nested_scans():
     Scan{scan_fn, while_loop=False, inplace=none} [id B]
      ← Mul [id Y] (inner_out_nit_sot-0)
         ├─ ExpandDims{axis=0} [id Z]
-        │  └─ *0-<Scalar(float64, shape=())> [id BA] -> [id S] (inner_in_seqs-0)
+        │  └─ i0 [id BA] -> [id S] (inner_in_seqs-0)
         └─ Pow [id BB]
            ├─ Subtensor{i} [id BC]
            │  ├─ Subtensor{start:} [id BD]
            │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id BE] (outer_out_sit_sot-0)
-           │  │  │  ├─ *3-<Scalar(int32, shape=())> [id BF] -> [id X] (inner_in_non_seqs-1) (n_steps)
+           │  │  │  ├─ i3 [id BF] -> [id X] (inner_in_non_seqs-1) (n_steps)
            │  │  │  ├─ SetSubtensor{:stop} [id BG] (outer_in_sit_sot-0)
            │  │  │  │  ├─ AllocEmpty{dtype='float64'} [id BH]
            │  │  │  │  │  ├─ Add [id BI]
-           │  │  │  │  │  │  ├─ *3-<Scalar(int32, shape=())> [id BF] -> [id X] (inner_in_non_seqs-1)
+           │  │  │  │  │  │  ├─ i3 [id BF] -> [id X] (inner_in_non_seqs-1)
            │  │  │  │  │  │  └─ Subtensor{i} [id BJ]
            │  │  │  │  │  │     ├─ Shape [id BK]
            │  │  │  │  │  │     │  └─ ExpandDims{axis=0} [id BL]
            │  │  │  │  │  │     │     └─ Second [id BM]
-           │  │  │  │  │  │     │        ├─ *2-<Vector(float64, shape=(?,))> [id BN] -> [id W] (inner_in_non_seqs-0)
+           │  │  │  │  │  │     │        ├─ i2 [id BN] -> [id W] (inner_in_non_seqs-0)
            │  │  │  │  │  │     │        └─ ExpandDims{axis=0} [id BO]
            │  │  │  │  │  │     │           └─ 1.0 [id BP]
            │  │  │  │  │  │     └─ 0 [id BQ]
@@ -291,16 +291,16 @@ def test_debugprint_nested_scans():
            │  │  │  │  └─ ScalarFromTensor [id BT]
            │  │  │  │     └─ Subtensor{i} [id BJ]
            │  │  │  │        └─ ···
-           │  │  │  └─ *2-<Vector(float64, shape=(?,))> [id BN] -> [id W] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
+           │  │  │  └─ i2 [id BN] -> [id W] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
            │  │  └─ 1 [id BU]
            │  └─ -1 [id BV]
            └─ ExpandDims{axis=0} [id BW]
-              └─ *1-<Scalar(int64, shape=())> [id BX] -> [id U] (inner_in_seqs-1)
+              └─ i1 [id BX] -> [id U] (inner_in_seqs-1)
 
     Scan{scan_fn, while_loop=False, inplace=none} [id BE]
      ← Mul [id BY] (inner_out_sit_sot-0)
-        ├─ *0-<Vector(float64, shape=(?,))> [id BZ] -> [id BG] (inner_in_sit_sot-0)
-        └─ *1-<Vector(float64, shape=(?,))> [id CA] -> [id BN] (inner_in_non_seqs-0)
+        ├─ i0 [id BZ] -> [id BG] (inner_in_sit_sot-0)
+        └─ i1 [id CA] -> [id BN] (inner_in_non_seqs-0)
     """
 
     for truth, out in zip(expected_output.split("\n"), lines, strict=True):
@@ -354,27 +354,27 @@ def test_debugprint_nested_scans():
     Inner graphs:
 
     Scan{scan_fn, while_loop=False, inplace=none} [id E]
-     → *0-<Scalar(float64, shape=())> [id Y] -> [id U] (inner_in_seqs-0)
-     → *1-<Scalar(int64, shape=())> [id Z] -> [id W] (inner_in_seqs-1)
-     → *2-<Vector(float64, shape=(?,))> [id BA] -> [id C] (inner_in_non_seqs-0)
-     → *3-<Scalar(int32, shape=())> [id BB] -> [id B] (inner_in_non_seqs-1)
+     → i0 [id Y] -> [id U] (inner_in_seqs-0)
+     → i1 [id Z] -> [id W] (inner_in_seqs-1)
+     → i2 [id BA] -> [id C] (inner_in_non_seqs-0)
+     → i3 [id BB] -> [id B] (inner_in_non_seqs-1)
      ← Mul [id BC] (inner_out_nit_sot-0)
         ├─ ExpandDims{axis=0} [id BD]
-        │  └─ *0-<Scalar(float64, shape=())> [id Y] (inner_in_seqs-0)
+        │  └─ i0 [id Y] (inner_in_seqs-0)
         └─ Pow [id BE]
            ├─ Subtensor{i} [id BF]
            │  ├─ Subtensor{start:} [id BG]
            │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id BH] (outer_out_sit_sot-0)
-           │  │  │  ├─ *3-<Scalar(int32, shape=())> [id BB] (inner_in_non_seqs-1) (n_steps)
+           │  │  │  ├─ i3 [id BB] (inner_in_non_seqs-1) (n_steps)
            │  │  │  ├─ SetSubtensor{:stop} [id BI] (outer_in_sit_sot-0)
            │  │  │  │  ├─ AllocEmpty{dtype='float64'} [id BJ]
            │  │  │  │  │  ├─ Add [id BK]
-           │  │  │  │  │  │  ├─ *3-<Scalar(int32, shape=())> [id BB] (inner_in_non_seqs-1)
+           │  │  │  │  │  │  ├─ i3 [id BB] (inner_in_non_seqs-1)
            │  │  │  │  │  │  └─ Subtensor{i} [id BL]
            │  │  │  │  │  │     ├─ Shape [id BM]
            │  │  │  │  │  │     │  └─ ExpandDims{axis=0} [id BN]
            │  │  │  │  │  │     │     └─ Second [id BO]
-           │  │  │  │  │  │     │        ├─ *2-<Vector(float64, shape=(?,))> [id BA] (inner_in_non_seqs-0)
+           │  │  │  │  │  │     │        ├─ i2 [id BA] (inner_in_non_seqs-0)
            │  │  │  │  │  │     │        └─ ExpandDims{axis=0} [id BP]
            │  │  │  │  │  │     │           └─ 1.0 [id BQ]
            │  │  │  │  │  │     └─ 0 [id BR]
@@ -387,18 +387,18 @@ def test_debugprint_nested_scans():
            │  │  │  │  └─ ScalarFromTensor [id BU]
            │  │  │  │     └─ Subtensor{i} [id BL]
            │  │  │  │        └─ ···
-           │  │  │  └─ *2-<Vector(float64, shape=(?,))> [id BA] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
+           │  │  │  └─ i2 [id BA] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
            │  │  └─ 1 [id BV]
            │  └─ -1 [id BW]
            └─ ExpandDims{axis=0} [id BX]
-              └─ *1-<Scalar(int64, shape=())> [id Z] (inner_in_seqs-1)
+              └─ i1 [id Z] (inner_in_seqs-1)
 
     Scan{scan_fn, while_loop=False, inplace=none} [id BH]
-     → *0-<Vector(float64, shape=(?,))> [id BY] -> [id BI] (inner_in_sit_sot-0)
-     → *1-<Vector(float64, shape=(?,))> [id BZ] -> [id BA] (inner_in_non_seqs-0)
+     → i0 [id BY] -> [id BI] (inner_in_sit_sot-0)
+     → i1 [id BZ] -> [id BA] (inner_in_non_seqs-0)
      ← Mul [id CA] (inner_out_sit_sot-0)
-        ├─ *0-<Vector(float64, shape=(?,))> [id BY] (inner_in_sit_sot-0)
-        └─ *1-<Vector(float64, shape=(?,))> [id BZ] (inner_in_non_seqs-0)
+        ├─ i0 [id BY] (inner_in_sit_sot-0)
+        └─ i1 [id BZ] (inner_in_non_seqs-0)
     """
 
     for truth, out in zip(expected_output.split("\n"), lines, strict=True):
@@ -470,11 +470,11 @@ def test_debugprint_mitsot():
 
     Scan{scan_fn, while_loop=False, inplace=none} [id C]
      ← Add [id BB] (inner_out_mit_sot-0)
-        ├─ *1-<Scalar(int64, shape=())> [id BC] -> [id E] (inner_in_mit_sot-0-1)
-        └─ *0-<Scalar(int64, shape=())> [id BD] -> [id E] (inner_in_mit_sot-0-0)
+        ├─ i1 [id BC] -> [id E] (inner_in_mit_sot-0-1)
+        └─ i0 [id BD] -> [id E] (inner_in_mit_sot-0-0)
      ← Add [id BE] (inner_out_mit_sot-1)
-        ├─ *3-<Scalar(int64, shape=())> [id BF] -> [id O] (inner_in_mit_sot-1-1)
-        └─ *2-<Scalar(int64, shape=())> [id BG] -> [id O] (inner_in_mit_sot-1-0)
+        ├─ i3 [id BF] -> [id O] (inner_in_mit_sot-1-1)
+        └─ i2 [id BG] -> [id O] (inner_in_mit_sot-1-0)
     """
 
     for truth, out in zip(expected_output.split("\n"), lines, strict=True):
@@ -597,19 +597,19 @@ def test_debugprint_mitmot():
     Scan{grad_of_scan_fn, while_loop=False, inplace=none} [id B]
      ← Add [id CK] (inner_out_mit_mot-0-0)
         ├─ Mul [id CL]
-        │  ├─ *2-<Vector(float64, shape=(?,))> [id CM] -> [id BJ] (inner_in_mit_mot-0-0)
-        │  └─ *5-<Vector(float64, shape=(?,))> [id CN] -> [id O] (inner_in_non_seqs-0)
-        └─ *3-<Vector(float64, shape=(?,))> [id CO] -> [id BJ] (inner_in_mit_mot-0-1)
+        │  ├─ i2 [id CM] -> [id BJ] (inner_in_mit_mot-0-0)
+        │  └─ i5 [id CN] -> [id O] (inner_in_non_seqs-0)
+        └─ i3 [id CO] -> [id BJ] (inner_in_mit_mot-0-1)
      ← Add [id CP] (inner_out_sit_sot-0)
         ├─ Mul [id CQ]
-        │  ├─ *2-<Vector(float64, shape=(?,))> [id CM] -> [id BJ] (inner_in_mit_mot-0-0)
-        │  └─ *0-<Vector(float64, shape=(?,))> [id CR] -> [id X] (inner_in_seqs-0)
-        └─ *4-<Vector(float64, shape=(?,))> [id CS] -> [id CC] (inner_in_sit_sot-0)
+        │  ├─ i2 [id CM] -> [id BJ] (inner_in_mit_mot-0-0)
+        │  └─ i0 [id CR] -> [id X] (inner_in_seqs-0)
+        └─ i4 [id CS] -> [id CC] (inner_in_sit_sot-0)
 
     Scan{scan_fn, while_loop=False, inplace=none} [id F]
      ← Mul [id CT] (inner_out_sit_sot-0)
-        ├─ *0-<Vector(float64, shape=(?,))> [id CR] -> [id H] (inner_in_sit_sot-0)
-        └─ *1-<Vector(float64, shape=(?,))> [id CU] -> [id O] (inner_in_non_seqs-0)
+        ├─ i0 [id CR] -> [id H] (inner_in_sit_sot-0)
+        └─ i1 [id CU] -> [id O] (inner_in_non_seqs-0)
     """
 
     for truth, out in zip(expected_output.split("\n"), lines, strict=True):
@@ -655,11 +655,11 @@ Inner graphs:
 Scan{scan_fn, while_loop=False, inplace=all} [id B]
  ← Composite{switch(lt(0, i0), 1, 0)} [id K] (inner_out_sit_sot-0)
     └─ Subtensor{i, j, k} [id L]
-       ├─ *2-<Tensor3(float64, shape=(20000, 2, 2))> [id M] -> [id J] (inner_in_non_seqs-0)
+       ├─ i2 [id M] -> [id J] (inner_in_non_seqs-0)
        ├─ ScalarFromTensor [id N]
-       │  └─ *0-<Scalar(int64, shape=())> [id O] -> [id D] (inner_in_seqs-0)
+       │  └─ i0 [id O] -> [id D] (inner_in_seqs-0)
        ├─ ScalarFromTensor [id P]
-       │  └─ *1-<Scalar(int64, shape=())> [id Q] -> [id E] (inner_in_sit_sot-0)
+       │  └─ i1 [id Q] -> [id E] (inner_in_sit_sot-0)
        └─ 0 [id R]
 
 Composite{switch(lt(0, i0), 1, 0)} [id K]

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -318,7 +318,7 @@ def test_debugprint():
         Inner graphs:
 
         Composite{(i0 + (i1 - i2))}
-        ← add 'o0'
+        ← add
             ├─ i0
             └─ sub
             ├─ i1

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -387,8 +387,8 @@ Inner graphs:
 
 MyInnerGraphOp [id A]
  ← op2 [id D] 'igo1'
-    ├─ *0-<MyType()> [id E]
-    └─ *1-<MyType()> [id F]
+    ├─ i0 [id E]
+    └─ i1 [id F]
     """
 
     for exp_line, res_line in zip(exp_res.split("\n"), lines, strict=True):
@@ -410,13 +410,13 @@ Inner graphs:
 
 MyInnerGraphOp [id A]
  ← MyInnerGraphOp [id C]
-    ├─ *0-<MyType()> [id D]
-    └─ *1-<MyType()> [id E]
+    ├─ i0 [id D]
+    └─ i1 [id E]
 
 MyInnerGraphOp [id C]
  ← op2 [id F] 'igo1'
-    ├─ *0-<MyType()> [id D]
-    └─ *1-<MyType()> [id E]
+    ├─ i0 [id D]
+    └─ i1 [id E]
     """
 
     for exp_line, res_line in zip(exp_res.split("\n"), lines, strict=True):


### PR DESCRIPTION
Closes #1606 

LLM disclosure: this PR made heavy use of Claude in the planning and first cut stages, though I was heavily involved. Still, the code should be subject to extra scrutiny as a result.

The purpose of the PR is to refactor Ops with inner graphs to allow comparison. The linked issue has an exhaustive discussion of the factors at play. There was an attempt in the aesara days to attack this, but it was perhaps too aggressive: it cons-hashed *all* Apply nodes, which necessitated changes across the codebase. @ricardoV94 suggested a weakref dict approach for subgraphs. This is implemented at the Op level. The plan is for Ops that have inner graphs (`Composite`, `ScalarLoop`, `Scan`, `OpFromGraph`, etc) to have a `_cache` class attribute, and implement the op-specific logic for caching, pickling, unpickling, etc. It didn't look super generalizable to me at first blush, but we can argue about it maybe. 

Changes to `FunctionGraph`:

- `FunctionGraph` now has a method `freeze` that returns a `FrozenFunctionGraph`. 
- The `FrozenFunctionGraph` does cons-hashing of Apply nodes within its scope only
- It generates a hash based on its inner graph
- Two `FrozenFunctionGraphs` with the same inner graph with evaluate to equal, but their `Apply` nodes won't be references to the same objects (this is the "conservatism" of my approach)

Specific implementation details:

- The `structural_hash` of a `FrozenFunctionGraph` is built from a list of 3-tuples: `(name, type, inputs)`, plus the outputs. For constants, `inputs` is replaced with the hash of the input data.
- Equality between `FrozenFunctionGraphs` is done by comparing hashes, then falling back to `equal_computation` if the hash misses.

A consequence of the cons-hashing in this approach is that the inner graph is de-duplicated when we call` fg.freeze()`. So a `MergeOptimizer` pass is no longer required. Usage is demonstrated on the `Composite` Op. If we like the approach I can move forward with refactoring other Ops, but I wanted to stop here and discuss the approach. 

Code example:

```py
import pytensor.tensor as pt
import pytensor

a, b, c, d = pt.dscalars('a', 'b', 'c', 'd')
eq1 = pt.sin(a) * b ** 2
eq2 = pt.sin(c) * d ** 2

with pytensor.config.change_flags(optimizer_verbose=True):
    f = pytensor.function([a, b, c, d], [eq1, eq2])

f.dprint()
```

Result:

```
Composite{(sin(*0-<float64>) * sqr(*1-<float64>))} [id A] 1
 ├─ a [id B]
 └─ b [id C]
Composite{(sin(*0-<float64>) * sqr(*1-<float64>))} [id D] 0
 ├─ c [id E]
 └─ d [id F]

Inner graphs:

Composite{(sin(*0-<float64>) * sqr(*1-<float64>))} [id A]
 ← mul [id G]
    ├─ sin [id H]
    │  └─ *0-<float64> [id I]
    └─ sqr [id J]
       └─ *1-<float64> [id K]

Composite{(sin(*0-<float64>) * sqr(*1-<float64>))} [id D]
 ← mul [id G]
    └─ ···
```