### PR TITLE
Add more sparse math Ops in numba

### DIFF
--- a/pytensor/link/numba/dispatch/sparse/math.py
+++ b/pytensor/link/numba/dispatch/sparse/math.py
@@ -1107,6 +1107,10 @@ def numba_funcify_Usmm(op, node, **kwargs):
 
             x_indices = x.indices.view(np.uint32)
             x_indptr = x.indptr.view(np.uint32)
+
+            x_data = x.data.astype(out_dtype)
+            y = y.astype(out_dtype)
+
             if x_format == "csr":
                 n_row = x.shape[0]
                 n_out_col = y.shape[1]
@@ -1114,7 +1118,7 @@ def numba_funcify_Usmm(op, node, **kwargs):
                 for i in range(n_row):
                     for x_idx in range(x_indptr[i], x_indptr[i + 1]):
                         k = x_indices[x_idx]
-                        x_val = alpha_val * x.data[x_idx]
+                        x_val = alpha_val * x_data[x_idx]
                         for j in range(n_out_col):
                             out[i, j] += x_val * y[k, j]
             else:
@@ -1124,7 +1128,7 @@ def numba_funcify_Usmm(op, node, **kwargs):
                 for k in range(n_col):
                     for x_idx in range(x_indptr[k], x_indptr[k + 1]):
                         i = x_indices[x_idx]
-                        x_val = alpha_val * x.data[x_idx]
+                        x_val = alpha_val * x_data[x_idx]
                         for j in range(n_out_col):
                             out[i, j] += x_val * y[k, j]
 
@@ -1151,27 +1155,27 @@ def numba_funcify_Usmm(op, node, **kwargs):
             assert x.shape[1] == y.shape[0]
             assert out.shape == (x.shape[0], y.shape[1])
 
+            y_indices = y.indices.view(np.uint32)
+            y_indptr = y.indptr.view(np.uint32)
+
+            x = x.astype(out_dtype)
+            y_data = y.data.astype(out_dtype)
+
             n_row = x.shape[0]
             if y_format == "csc":
-                y_indices = y.indices.view(np.uint32)
-                y_indptr = y.indptr.view(np.uint32)
                 n_col = y.shape[1]
-
                 for j in range(n_col):
                     for y_idx in range(y_indptr[j], y_indptr[j + 1]):
                         k = y_indices[y_idx]
-                        y_val = alpha_val * y.data[y_idx]
+                        y_val = alpha_val * y_data[y_idx]
                         for i in range(n_row):
                             out[i, j] += x[i, k] * y_val
             else:
-                y_indices = y.indices.view(np.uint32)
-                y_indptr = y.indptr.view(np.uint32)
                 k_dim = y.shape[0]
-
                 for k in range(k_dim):
                     for y_idx in range(y_indptr[k], y_indptr[k + 1]):
                         j = y_indices[y_idx]
-                        y_val = alpha_val * y.data[y_idx]
+                        y_val = alpha_val * y_data[y_idx]
                         for i in range(n_row):
                             out[i, j] += x[i, k] * y_val
 
@@ -1206,13 +1210,16 @@ def numba_funcify_Usmm(op, node, **kwargs):
         y_indices = y.indices.view(np.uint32)
         y_indptr = y.indptr.view(np.uint32)
 
+        x_data = x.data.astype(out_dtype)
+        y_data = y.data.astype(out_dtype)
+
         n_row = x.shape[0]
         for i in range(n_row):
             for x_idx in range(x_indptr[i], x_indptr[i + 1]):
                 k = x_indices[x_idx]
-                x_val = alpha_val * x.data[x_idx]
+                x_val = alpha_val * x_data[x_idx]
                 for y_idx in range(y_indptr[k], y_indptr[k + 1]):
-                    out[i, y_indices[y_idx]] += x_val * y.data[y_idx]
+                    out[i, y_indices[y_idx]] += x_val * y_data[y_idx]
 
         return out
 

--- a/tests/link/numba/sparse/test_math.py
+++ b/tests/link/numba/sparse/test_math.py
@@ -323,3 +323,21 @@ def test_usmm(alpha_shape, x_format, y_format):
     compare_numba_and_py_sparse(
         [alpha, x, y, z], out, [alpha_test, x_test, y_test, z_test]
     )
+
+
+@pytest.mark.parametrize("p_format", ["csr", "csc"])
+def test_sampling_dot(p_format):
+    x_shape = (11, 13)
+    y_shape = (17, 13)
+    p_shape = (x_shape[0], y_shape[0])
+
+    x = pt.matrix(name="x", shape=x_shape)
+    y = pt.matrix(name="y", shape=y_shape)
+    p = ps.matrix(format=p_format, name="p", shape=p_shape)
+    z = ps.sampling_dot(x, y, p)
+
+    x_test = np.random.normal(size=x_shape)
+    y_test = np.random.normal(size=y_shape)
+    p_test = scipy.sparse.random(*p_shape, density=0.27, format=p_format)
+
+    compare_numba_and_py_sparse([x, y, p], z, [x_test, y_test, p_test])

--- a/tests/sparse/test_math.py
+++ b/tests/sparse/test_math.py
@@ -783,15 +783,24 @@ class TestUsmm:
         a = scalar("a", dtype=dtype3)
         z = pytensor.shared(np.asarray(self.z, dtype=dtype4).copy())
 
+        out_dtype = np.result_type(dtype1, dtype2, dtype3, dtype4)
+
         def f_b(z, a, x, y):
+            # Make sure operations are done with the precision of the output dtype
+            x = x.astype(out_dtype)
+            y = y.astype(out_dtype)
+            z = z.astype(out_dtype)
+            a = a.astype(out_dtype)
             return z - a * (x * y)
 
         x_data = np.asarray(self.x, dtype=dtype1)
         if format1 != "dense":
             x_data = as_sparse_format(x_data, format1)
         y_data = np.asarray(self.y, dtype=dtype2)
+
         if format2 != "dense":
             y_data = as_sparse_format(y_data, format2)
+
         a_data = np.asarray(1.5, dtype=dtype3)
         z_data = np.asarray(self.z, dtype=dtype4)
 


### PR DESCRIPTION
## Description

This PR implements the following sparse ops in numba:

* `SparseSparseMultiply`
* `AddSS`
* `AddSD`
* `AddSSData`
* `StructuredAddSV`
* `Usmm`
* `SamplingDot`

Most of the initial implementations were done by Codex, I checked and adapted them as needed.

## Checklist

- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
