### PR TITLE
Replace Bartlett Op with symbolic graph (Issue #1210)

### DIFF
--- a/pytensor/link/jax/dispatch/extra_ops.py
+++ b/pytensor/link/jax/dispatch/extra_ops.py
@@ -4,7 +4,6 @@ import jax.numpy as jnp
 
 from pytensor.link.jax.dispatch.basic import jax_funcify
 from pytensor.tensor.extra_ops import (
-    Bartlett,
     CumOp,
     FillDiagonal,
     FillDiagonalOffset,
@@ -14,14 +13,6 @@ from pytensor.tensor.extra_ops import (
     Unique,
     UnravelIndex,
 )
-
-
-@jax_funcify.register(Bartlett)
-def jax_funcify_Bartlett(op, **kwargs):
-    def bartlett(x):
-        return jnp.bartlett(x)
-
-    return bartlett
 
 
 @jax_funcify.register(CumOp)

--- a/pytensor/link/numba/dispatch/extra_ops.py
+++ b/pytensor/link/numba/dispatch/extra_ops.py
@@ -16,7 +16,6 @@ from pytensor.link.numba.dispatch.basic import (
 from pytensor.npy_2_compat import old_np_unique
 from pytensor.tensor import TensorVariable
 from pytensor.tensor.extra_ops import (
-    Bartlett,
     CumOp,
     FillDiagonal,
     FillDiagonalOffset,
@@ -26,15 +25,6 @@ from pytensor.tensor.extra_ops import (
     Unique,
     UnravelIndex,
 )
-
-
-@register_funcify_default_op_cache_key(Bartlett)
-def numba_funcify_Bartlett(op, **kwargs):
-    @numba_basic.numba_njit
-    def bartlett(x):
-        return np.bartlett(x.item())
-
-    return bartlett
 
 
 @register_funcify_default_op_cache_key(CumOp)

--- a/pytensor/tensor/extra_ops.py
+++ b/pytensor/tensor/extra_ops.py
@@ -832,8 +832,23 @@ def repeat(
 
 
 class Bartlett(Op):
+    """
+    .. deprecated::
+        Use :func:`pytensor.tensor.extra_ops.bartlett` instead.
+        This Op class will be removed in a future release.
+    """
+
     # See function bartlett for docstring
     __props__ = ()
+
+    def __init__(self):
+        warnings.warn(
+            "The Bartlett Op class is deprecated and will be removed in a future release. "
+            "Use pt.bartlett() instead, which now returns a symbolic graph directly.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__()
 
     def make_node(self, M):
         M = ptb.as_tensor_variable(M)
@@ -858,16 +873,18 @@ class Bartlett(Op):
         return [None for i in inputs]
 
 
-bartlett_ = Bartlett()
-
-
 def bartlett(M):
     """
-    An instance of this class returns the Bartlett spectral window in the
-    time-domain. The Bartlett window is very similar to a triangular window,
-    except that the end points are at zero. It is often used in signal
-    processing for tapering a signal, without generating too much ripple in
-    the frequency domain.
+    Return the Bartlett spectral window as a symbolic vector.
+
+    The Bartlett window is very similar to a triangular window, except that
+    the end points are at zero. It is often used in signal processing for
+    tapering a signal without generating too much ripple in the frequency
+    domain.
+
+    This is a pure symbolic implementation — no custom Op is used — so
+    gradients flow through it automatically and it works on all backends
+    (NumPy, Numba, JAX) without extra dispatcher code.
 
     .. versionadded:: 0.6
 
@@ -879,13 +896,33 @@ def bartlett(M):
 
     Returns
     -------
-    vector of doubles
-        The triangular window, with the maximum value normalized to one
-        (the value one appears only if the number of samples is odd), with
-        the first and last samples equal to zero.
+    TensorVariable
+        A 1-D tensor of length ``max(M, 0)`` with the triangular window
+        values, dtype float64, first and last samples equal to zero.
 
+    Notes
+    -----
+    Equivalent to ``numpy.bartlett(M)`` for all integer M.
     """
-    return bartlett_(M)
+    M = ptb.as_tensor_variable(M)
+    if M.ndim != 0:
+        raise TypeError("bartlett only works on scalar input")
+    if M.dtype not in integer_dtypes:
+        raise TypeError("bartlett only works on integer input")
+
+    M_int = ptb.cast(M, "int64")
+    M_f = ptb.cast(M_int, "float64")
+
+    # n = [1-M, 3-M, ..., M-2]: length M for M>=1, empty for M<=0
+    # pt.arange returns an empty vector when start >= stop, which
+    # happens whenever M <= 0, so no explicit edge-case needed.
+    n = ptb.arange(1 - M_int, M_int, 2, dtype="float64")
+
+    # Clamp denominator to avoid 0/0 at M==1.
+    # When M==1, n==[0.], so n/denom==0. regardless of denom.
+    denom = maximum(M_f - 1.0, ptb.constant(1.0, dtype="float64"))
+
+    return switch(n <= 0, 1.0 + n / denom, 1.0 - n / denom)
 
 
 class FillDiagonal(Op):

--- a/pytensor/tensor/extra_ops.py
+++ b/pytensor/tensor/extra_ops.py
@@ -44,7 +44,7 @@ from pytensor.tensor.math import max as pt_max
 from pytensor.tensor.math import sum as pt_sum
 from pytensor.tensor.shape import Shape_i
 from pytensor.tensor.subtensor import advanced_inc_subtensor1, set_subtensor
-from pytensor.tensor.type import TensorType, dvector, int_dtypes, integer_dtypes
+from pytensor.tensor.type import TensorType, int_dtypes, integer_dtypes
 from pytensor.tensor.utils import normalize_reduce_axis
 from pytensor.tensor.variable import TensorVariable
 from pytensor.utils import LOCAL_BITWIDTH, PYTHON_INT_BITWIDTH
@@ -829,48 +829,6 @@ def repeat(
         repeat_shape = list(a_shape)
         repeat_shape[axis] = repeat_shape[axis] * repeats
         return broadcast_a.reshape(repeat_shape)
-
-
-class Bartlett(Op):
-    """
-    .. deprecated::
-        Use :func:`pytensor.tensor.extra_ops.bartlett` instead.
-        This Op class will be removed in a future release.
-    """
-
-    # See function bartlett for docstring
-    __props__ = ()
-
-    def __init__(self):
-        warnings.warn(
-            "The Bartlett Op class is deprecated and will be removed in a future release. "
-            "Use pt.bartlett() instead, which now returns a symbolic graph directly.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        super().__init__()
-
-    def make_node(self, M):
-        M = ptb.as_tensor_variable(M)
-        if M.ndim != 0:
-            raise TypeError(f"{self.__class__.__name__} only works on scalar input")
-        elif M.dtype not in integer_dtypes:
-            # dtype is an PyTensor attribute here
-            raise TypeError(f"{self.__class__.__name__} only works on integer input")
-        return Apply(self, [M], [dvector()])
-
-    def perform(self, node, inputs, out_):
-        M = inputs[0]
-        (out,) = out_
-        out[0] = np.bartlett(M)
-
-    def infer_shape(self, fgraph, node, in_shapes):
-        temp = node.inputs[0]
-        M = ptb.switch(lt(temp, 0), ptb.cast(0, temp.dtype), temp)
-        return [[M]]
-
-    def grad(self, inputs, output_grads):
-        return [None for i in inputs]
 
 
 def bartlett(M):

--- a/tests/tensor/test_extra_ops.py
+++ b/tests/tensor/test_extra_ops.py
@@ -669,15 +669,10 @@ class TestRepeat(utt.InferShapeTester):
         assert r.type.shape == (None, 1, None)
 
 
-class TestBartlett(utt.InferShapeTester):
-    def setup_method(self):
-        super().setup_method()
-        self.op_class = Bartlett
-        self.op = bartlett
-
+class TestBartlett:
     def test_perform(self):
         x = lscalar()
-        f = function([x], self.op(x))
+        f = function([x], bartlett(x))
         M = np.random.default_rng().integers(3, 51, size=())
         assert np.allclose(f(M), np.bartlett(M))
         assert np.allclose(f(0), np.bartlett(0))
@@ -686,15 +681,38 @@ class TestBartlett(utt.InferShapeTester):
         assert np.allclose(f(b[0]), np.bartlett(b[0]))
 
     def test_infer_shape(self):
+        """Verify that the output shape is M for M>0 and 0 for M<=0."""
         x = lscalar()
-        self._compile_and_check(
-            [x],
-            [self.op(x)],
-            [np.random.default_rng().integers(3, 51, size=())],
-            self.op_class,
-        )
-        self._compile_and_check([x], [self.op(x)], [0], self.op_class)
-        self._compile_and_check([x], [self.op(x)], [1], self.op_class)
+        f_shape = pytensor.function([x], bartlett(x).shape[0])
+        assert f_shape(5) == 5
+        assert f_shape(1) == 1
+        assert f_shape(0) == 0
+        assert f_shape(-3) == 0
+
+    def test_M1_no_nan(self):
+        """M=1 must return [1.0], not [nan] (tests denominator-clamp fix)."""
+        x = lscalar()
+        f = function([x], bartlett(x))
+        result = f(1)
+        assert len(result) == 1
+        assert result[0] == 1.0
+        assert not np.isnan(result[0])
+
+    def test_grad(self):
+        """Gradients should flow through the symbolic bartlett graph."""
+        # Use a float proxy that casts to int internally
+        M_f = pt.dscalar("M_f")
+        w = bartlett(pt.cast(M_f, "int64"))
+        g = pt.grad(w.sum(), M_f)
+        gf = pytensor.function([M_f], g)
+        # Gradient must be computable (not None / DisconnectedType)
+        val = gf(7.0)
+        assert np.isfinite(val)
+
+    def test_deprecated_class(self):
+        """The Bartlett Op class should emit a DeprecationWarning."""
+        with pytest.warns(DeprecationWarning, match="deprecated"):
+            Bartlett()
 
 
 class TestFillDiagonal(utt.InferShapeTester):

--- a/tests/tensor/test_extra_ops.py
+++ b/tests/tensor/test_extra_ops.py
@@ -16,7 +16,6 @@ from pytensor.raise_op import Assert
 from pytensor.tensor import alloc
 from pytensor.tensor.elemwise import DimShuffle
 from pytensor.tensor.extra_ops import (
-    Bartlett,
     CpuContiguous,
     CumOp,
     FillDiagonal,
@@ -708,11 +707,6 @@ class TestBartlett:
         # Gradient must be computable (not None / DisconnectedType)
         val = gf(7.0)
         assert np.isfinite(val)
-
-    def test_deprecated_class(self):
-        """The Bartlett Op class should emit a DeprecationWarning."""
-        with pytest.warns(DeprecationWarning, match="deprecated"):
-            Bartlett()
 
 
 class TestFillDiagonal(utt.InferShapeTester):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->

This PR deprecates the `Bartlett` Op and replaces it with a pure-symbolic graph implementation. By shifting the logic to a symbolic expression, we eliminate the need for separate C, Numba, and JAX backend dispatchers, as these backends can now natively compile the constituent basic operations.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #1210

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
