### PR TITLE
Replace PermuteRowElements Op with symbolic graph

### DIFF
--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -60,6 +60,7 @@ from pytensor.tensor.shape import (
     shape_tuple,
     specify_broadcastable,
 )
+from pytensor.tensor.sort import argsort
 from pytensor.tensor.type import (
     TensorType,
     discrete_dtypes,
@@ -3498,214 +3499,53 @@ mgrid = _nd_grid()
 ogrid = _nd_grid(sparse=True)
 
 
-class PermuteRowElements(Op):
-    """Permute the elements of each row (inner-most dim) of a tensor.
+def permute_row_elements(x, y, inverse=False):
+    """Permute the elements of each row (last axis) of a tensor.
 
     A permutation will be applied to every row (vector) of the input tensor x.
-    Depending on the dimensionality of x and the permutation tensor y,
-    different cases are possible.
-    If y.ndim = 1, y is a single permutation, that will be applied to every
-    vector of x. For instance, if x is a matrix, the same permutation will be
-    applied to each row of x.
-    If x.ndim = y.ndim, each row of x corresponds to a row of y, containing
-    a permutation that will be applied to that row. For instance, if x and y
-    are two matrices, a different permutation will be applied to each row of x.
-    If x.ndim > y.ndim, y will be broadcasted to fit x, then each row (vector)
-    of x will be reordered according to the corresponding row of y. (This is
-    a generalization of the first case).
-    If x.ndim = 1, every permutation in y will be applied to x, and the output
-    will contain all the results.
-    If x.ndim < y.ndim, x will be broadcasted to fit y, and different
-    permutations contained in y will be applied to each vector in x. (This is
-    a generalization of the previous case).
+    x and y are broadcast to the same number of dimensions by padding on the
+    left, then ``take_along_axis`` is used to gather elements along the last axis.
 
-    If the "inverse" argument is True, the Op will perform the inverse
-    permutation instead.
+    If ``inverse=True``, the inverse permutation is applied instead (equivalent
+    to ``argsort(y)`` applied along the last axis).
+
+    Parameters
+    ----------
+    x : TensorVariable
+        The input tensor, on which the permutation is applied.
+    y : TensorVariable
+        Tensor containing the permutations to apply (integer dtype).
+    inverse : bool, optional
+        If True, apply the inverse of the permutations in y. Default: False.
+
+    Returns
+    -------
+    TensorVariable
+        Permuted tensor with the same dtype as x.
     """
+    x = as_tensor_variable(x)
+    y = as_tensor_variable(y)
 
-    __props__ = ("inverse",)
+    # Broadcast x and y to the same number of dimensions (pad on the left)
+    if x.ndim > y.ndim:
+        y = shape_padleft(y, x.ndim - y.ndim)
+    elif x.ndim < y.ndim:
+        x = shape_padleft(x, y.ndim - x.ndim)
 
-    def __init__(self, inverse: bool):
-        super().__init__()
-        self.inverse = inverse
+    if inverse:
+        y = cast(argsort(y, axis=-1), y.dtype)
 
-    def make_node(self, x, y):
-        x = as_tensor_variable(x)
-        y = as_tensor_variable(y)
-
-        # y should contain integers
-        assert y.type.dtype in integer_dtypes
-
-        # Match shapes of x and y
-        x_dim = x.type.ndim
-        y_dim = y.type.ndim
-
-        if x_dim > y_dim:
-            y = shape_padleft(y, n_ones=(x_dim - y_dim))
-        elif x_dim < y_dim:
-            x = shape_padleft(x, n_ones=(y_dim - x_dim))
-
-        out_shape = [
-            1 if xb == 1 and yb == 1 else None
-            for xb, yb in zip(x.type.shape, y.type.shape, strict=True)
-        ]
-        out_type = tensor(dtype=x.type.dtype, shape=out_shape)
-
-        inputlist = [x, y]
-        outputlist = [out_type]
-        return Apply(self, inputlist, outputlist)
-
-    def _rec_perform(self, node, x, y, inverse, out, curdim):
-        """Perform the permutation by doing a recursion over the input
-        dimensions.
-
-        For every dimension, starting with the leftmost, the right set of
-        indices is determined (depending if broadcasting or not), then
-        the function is recursively called on the appropriate subtensors.
-
-        The terminal case is reached when the current tensors are vector,
-        then the permutation contained in y is applied to x.
-
-        Parameters
-        ----------
-        x: TensorVariable
-            The input tensor, on which the permutation is applied.
-        y: TensorVariable
-            Tensor containing the permutations to apply.
-        inverse: bool
-            Whether to apply permutations or their inverse.
-        out: TensorVariable
-            Tensor storing the output result.
-        curdim: int
-            Counter of the current depth of recursion.
-
-        """
-        if len(x.shape) == 1:
-            # Numpy advanced indexing works in this case
-            if inverse:
-                out[y] = x[:]
-            else:
-                out[:] = x[y]
-        else:
-            xs0 = x.shape[0]
-            ys0 = y.shape[0]
-            if xs0 == ys0:
-                for i in range(xs0):
-                    self._rec_perform(node, x[i], y[i], inverse, out[i], curdim + 1)
-            elif ys0 == 1 and node.inputs[1].type.shape[curdim] == 1:
-                # Broadcast y
-                for i in range(xs0):
-                    self._rec_perform(node, x[i], y[0], inverse, out[i], curdim + 1)
-            elif xs0 == 1 and node.inputs[0].type.shape[curdim] == 1:
-                # Broadcast x
-                for i in range(ys0):
-                    self._rec_perform(node, x[0], y[i], inverse, out[i], curdim + 1)
-            else:
-                raise ValueError(f"Dimension mismatch: {xs0}, {ys0}")
-
-    def perform(self, node, inp, out):
-        x, y = inp
-        (outs,) = out
-        x_s = x.shape
-        y_s = y.shape
-        assert len(x_s) == len(y_s)
-
-        # Make sure the output is big enough
-        out_s = []
-        # zip strict not specified because we are in a hot loop
-        for xdim, ydim in zip(x_s, y_s):
-            if xdim == ydim:
-                outdim = xdim
-            elif xdim == 1:
-                outdim = ydim
-            elif ydim == 1:
-                outdim = xdim
-            else:
-                raise ValueError(f"Dimension mismatch: {xdim}, {ydim}")
-            out_s.append(outdim)
-
-        if outs[0] is None or outs[0].shape != out_s:
-            outs[0] = np.empty(out_s, dtype=x.dtype)
-
-        self._rec_perform(node, x, y, self.inverse, outs[0], curdim=0)
-
-    def infer_shape(self, fgraph, node, in_shapes):
-        from pytensor.tensor.math import maximum
-
-        shp_x = in_shapes[0]
-        shp_y = in_shapes[1]
-        assert len(shp_x) == len(shp_y)
-        out_shape = [maximum(sx, sy) for sx, sy in zip(shp_x, shp_y, strict=True)]
-        return [out_shape]
-
-    def grad(self, inp, grads):
-        from pytensor.tensor.math import Sum
-
-        x, y = inp
-        (gz,) = grads
-        # First, compute the gradient wrt the broadcasted x.
-        # If 'inverse' is False (0), apply the inverse of y on gz.
-        # Else, apply y on gz.
-        gx = permute_row_elements(gz, y, not self.inverse)
-
-        # If x has been broadcasted along some axes, we need to sum
-        # the gradient over these axes, but keep the dimension (as
-        # broadcastable)
-        broadcasted_dims = [
-            dim
-            for dim in range(gz.type.ndim)
-            if x.type.shape[dim] == 1 and gz.type.shape[dim] != 1
-        ]
-        gx = Sum(axis=broadcasted_dims)(gx)
-
-        # Sum(...) removed the dimensions in broadcasted_dims,
-        # so we need to put them back.
-        newdims = []
-        i = 0
-        for dim in range(gz.type.ndim):
-            if dim in broadcasted_dims:
-                newdims.append("x")
-            else:
-                newdims.append(i)
-                i += 1
-
-        gx = gx.dimshuffle(newdims)
-        assert gx.type.ndim == x.type.ndim
-        assert all(
-            s1 == s2
-            for s1, s2 in zip(gx.type.shape, x.type.shape, strict=True)
-            if s1 == 1 or s2 == 1
-        )
-
-        # if x is an integer type, then so is the output.
-        # this means f(x+eps) = f(x) so the gradient with respect
-        # to x is zero
-        if x.type.dtype in discrete_dtypes:
-            gx = x.zeros_like()
-
-        # The elements of y affect the output,
-        # so they are connected to the output,
-        # and the transformation isn't defined if their values
-        # are non-integer, so the gradient with respect to them is
-        # undefined
-
-        return [gx, grad_undefined(self, 1, y)]
-
-
-def permute_row_elements(x, y, inverse=False):
-    return PermuteRowElements(inverse=inverse)(x, y)
+    return take_along_axis(x, y, axis=-1)
 
 
 def inverse_permutation(perm):
-    """Computes the inverse of permutations.
+    """Compute the inverse of permutations along the last axis.
 
     Each row of input should contain a permutation of the first integers.
-
+    Returns the argsort of each row, which is the inverse permutation.
     """
     _perm = as_tensor_variable(perm)
-    return permute_row_elements(
-        arange(_perm.shape[-1], dtype=_perm.dtype), _perm, inverse=True
-    )
+    return cast(argsort(_perm, axis=-1), _perm.dtype)
 
 
 class ExtractDiag(COp):

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -3498,47 +3498,6 @@ mgrid = _nd_grid()
 ogrid = _nd_grid(sparse=True)
 
 
-def permute_row_elements(x, y, inverse=False):
-    """Permute the elements of each row (last axis) of a tensor.
-
-    A permutation will be applied to every row (vector) of the input tensor x.
-    x and y are broadcast to the same number of dimensions by padding on the
-    left, then ``take_along_axis`` is used to gather elements along the last axis.
-
-    If ``inverse=True``, the inverse permutation is applied instead (equivalent
-    to ``argsort(y)`` applied along the last axis).
-
-    Parameters
-    ----------
-    x : TensorVariable
-        The input tensor, on which the permutation is applied.
-    y : TensorVariable
-        Tensor containing the permutations to apply (integer dtype).
-    inverse : bool, optional
-        If True, apply the inverse of the permutations in y. Default: False.
-
-    Returns
-    -------
-    TensorVariable
-        Permuted tensor with the same dtype as x.
-    """
-    from pytensor.tensor.sort import argsort
-
-    x = as_tensor_variable(x)
-    y = as_tensor_variable(y)
-
-    # Broadcast x and y to the same number of dimensions (pad on the left)
-    if x.ndim > y.ndim:
-        y = shape_padleft(y, x.ndim - y.ndim)
-    elif x.ndim < y.ndim:
-        x = shape_padleft(x, y.ndim - x.ndim)
-
-    if inverse:
-        y = cast(argsort(y, axis=-1), y.dtype)
-
-    return take_along_axis(x, y, axis=-1)
-
-
 def inverse_permutation(perm):
     """Compute the inverse of permutations along the last axis.
 
@@ -4435,7 +4394,6 @@ __all__ = [
     "ogrid",
     "ones",
     "ones_like",
-    "permute_row_elements",
     "roll",
     "scalar_from_tensor",
     "second",

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -3498,18 +3498,6 @@ mgrid = _nd_grid()
 ogrid = _nd_grid(sparse=True)
 
 
-def inverse_permutation(perm):
-    """Compute the inverse of permutations along the last axis.
-
-    Each row of input should contain a permutation of the first integers.
-    Returns the argsort of each row, which is the inverse permutation.
-    """
-    from pytensor.tensor.sort import argsort
-
-    _perm = as_tensor_variable(perm)
-    return cast(argsort(_perm, axis=-1), _perm.dtype)
-
-
 class ExtractDiag(COp):
     """
     Return specified diagonals.
@@ -4383,7 +4371,6 @@ __all__ = [
     "horizontal_stack",
     "identity",
     "identity_like",
-    "inverse_permutation",
     "is_flat",
     "join",
     "matrix_transpose",

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -60,7 +60,6 @@ from pytensor.tensor.shape import (
     shape_tuple,
     specify_broadcastable,
 )
-from pytensor.tensor.sort import argsort
 from pytensor.tensor.type import (
     TensorType,
     discrete_dtypes,
@@ -3523,6 +3522,8 @@ def permute_row_elements(x, y, inverse=False):
     TensorVariable
         Permuted tensor with the same dtype as x.
     """
+    from pytensor.tensor.sort import argsort
+
     x = as_tensor_variable(x)
     y = as_tensor_variable(y)
 
@@ -3544,6 +3545,8 @@ def inverse_permutation(perm):
     Each row of input should contain a permutation of the first integers.
     Returns the argsort of each row, which is the inverse permutation.
     """
+    from pytensor.tensor.sort import argsort
+
     _perm = as_tensor_variable(perm)
     return cast(argsort(_perm, axis=-1), _perm.dtype)
 

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -31,7 +31,6 @@ from pytensor.tensor.basic import (
     Eye,
     Join,
     MakeVector,
-    PermuteRowElements,
     ScalarFromTensor,
     Split,
     TensorFromScalar,
@@ -3948,64 +3947,47 @@ class TestInferShape(utt.InferShapeTester):
             )
 
     def test_PermuteRowElements(self):
-        admat = dmatrix()
+        """Verify output shapes of the symbolic permute_row_elements."""
         advec = dvector()
         aivec = ivector()
+        admat = dmatrix()
+        adtens3 = dtensor3()
 
         rng = np.random.default_rng(utt.fetch_seed())
         advec_val = random(5)
         aivec_val = rng.permutation(5).astype("int32")
-        self._compile_and_check(
-            [advec, aivec],
-            [PermuteRowElements(inverse=True)(advec, aivec)],
-            [advec_val, aivec_val],
-            PermuteRowElements,
-        )
 
+        # vector x vector: shape must be (5,)
+        f = pytensor.function([advec, aivec], permute_row_elements(advec, aivec))
+        assert f(advec_val, aivec_val).shape == (5,)
+
+        # matrix x vector (broadcast y): shape must be (3, 5)
         admat_val = random(3, 5)
-        self._compile_and_check(
-            [admat, aivec],
-            [PermuteRowElements(inverse=False)(admat, aivec)],
-            [admat_val, aivec_val],
-            PermuteRowElements,
-        )
+        f = pytensor.function([admat, aivec], permute_row_elements(admat, aivec))
+        assert f(admat_val, aivec_val).shape == (3, 5)
 
-        adtens3 = dtensor3()
+        # 3d tensor x vector (broadcast y): shape must be (3, 2, 5)
         adtens3_val = random(3, 2, 5)
-        self._compile_and_check(
-            [adtens3, aivec],
-            [PermuteRowElements(inverse=True)(adtens3, aivec)],
-            [adtens3_val, aivec_val],
-            PermuteRowElements,
-        )
+        f = pytensor.function([adtens3, aivec], permute_row_elements(adtens3, aivec))
+        assert f(adtens3_val, aivec_val).shape == (3, 2, 5)
 
+        # matrix x matrix (one perm per row): shape must be (3, 5)
         aimat = imatrix()
         perma = rng.permutation(5).astype("int32")
         permb = rng.permutation(5).astype("int32")
         permc = rng.permutation(5).astype("int32")
         aimat_val = np.vstack((perma, permb, permc))
-        admat_val = random(3, 5)
-        self._compile_and_check(
-            [admat, aimat],
-            [PermuteRowElements(inverse=False)(admat, aimat)],
-            [admat_val, aimat_val],
-            PermuteRowElements,
-        )
+        f = pytensor.function([admat, aimat], permute_row_elements(admat, aimat))
+        assert f(admat_val, aimat_val).shape == (3, 5)
 
+        # matrix x 3d perm (broadcast x): shape must be (2, 3, 5)
         aitens3 = itensor3()
-        perma = rng.permutation(5).astype("int32")
-        permb = rng.permutation(5).astype("int32")
-        permc = rng.permutation(5).astype("int32")
         bimat_val = np.vstack((perma, permb, permc))
         aitens3_val = np.empty((2, 3, 5), "int32")
-        aitens3_val[0, ::, ::] = aimat_val
-        aitens3_val[1, ::, ::] = bimat_val
-        self._compile_and_check(
-            [admat, aitens3],
-            [PermuteRowElements(inverse=True)(admat, aitens3)],
-            [admat_val, aitens3_val],
-            PermuteRowElements,
-        )
+        aitens3_val[0] = aimat_val
+        aitens3_val[1] = bimat_val
+        f = pytensor.function([admat, aitens3], permute_row_elements(admat, aitens3))
+        assert f(admat_val, aitens3_val).shape == (2, 3, 5)
 
     def test_ScalarFromTensor(self):
         aiscal = iscalar()

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -65,7 +65,6 @@ from pytensor.tensor.basic import (
     nonzero_values,
     ogrid,
     ones_like,
-    permute_row_elements,
     roll,
     scalar_from_tensor,
     second,
@@ -112,7 +111,6 @@ from pytensor.tensor.type import (
     int_dtypes,
     iscalar,
     iscalars,
-    itensor3,
     ivector,
     lscalar,
     lvector,
@@ -2981,133 +2979,6 @@ class TestInversePermutation:
             assert np.all(i_row[p_row] == np.arange(10))
 
 
-class TestPermuteRowElements:
-    def test_1_1(self):
-        # Test PermuteRowElements(vector, vector)
-        input = dvector()
-        p = ivector()
-        out = permute_row_elements(input, p)
-        permute = function([input, p], out)
-
-        rng = np.random.default_rng(utt.fetch_seed())
-        input_val = rng.uniform(size=(5,))
-        p_val = rng.permutation(5).astype("int32")
-        out_val = permute(input_val, p_val)
-
-        # Should be equivalent to advanced indexing
-        out_bis = input_val[p_val]
-        assert np.all(out_val == out_bis)
-
-        # Verify gradient
-        def permute_fixed(s_input):
-            # Auxiliary op defined to get rid of gradient wrt p_val
-            return permute_row_elements(s_input, p_val)
-
-        utt.verify_grad(permute_fixed, [input_val])
-
-    def test_2_1(self):
-        # Test broadcasting in PermuteRowElements(matrix, vector)
-        input = matrix()
-        p = ivector()
-        out = permute_row_elements(input, p)
-        permute = function([input, p], out)
-
-        rng = np.random.default_rng(utt.fetch_seed())
-        input_val = rng.uniform(size=(3, 5)).astype(config.floatX)
-        p_val = rng.permutation(5).astype("int32")
-        out_val = permute(input_val, p_val)
-
-        # The same permutation should be applied to every row of the input matrix.
-        out_bis = np.asarray([r[p_val] for r in input_val])
-        assert np.all(out_val == out_bis)
-
-        # Verify gradient
-        def permute_fixed(s_input):
-            # Auxiliary op defined to get rid of gradient wrt p_val
-            return permute_row_elements(s_input, p_val)
-
-        utt.verify_grad(permute_fixed, [input_val])
-
-    def test_2_2(self):
-        # Test PermuteRowElements(matrix, matrix)
-        input = matrix()
-        p = imatrix()
-        out = permute_row_elements(input, p)
-        permute = function([input, p], out)
-
-        rng = np.random.default_rng(utt.fetch_seed())
-        input_val = rng.uniform(size=(3, 5)).astype(config.floatX)
-        p_val = np.asarray([rng.permutation(5) for i in range(3)], dtype="int32")
-        out_val = permute(input_val, p_val)
-
-        # Each row of p contains a permutation to apply to the corresponding
-        # row of input
-        out_bis = np.asarray(
-            [i_row[p_row] for i_row, p_row in zip(input_val, p_val, strict=True)]
-        )
-        assert np.all(out_val == out_bis)
-
-        # Verify gradient
-        def permute_fixed(s_input):
-            # Auxiliary op defined to get rid of gradient wrt p_val
-            return permute_row_elements(s_input, p_val)
-
-        utt.verify_grad(permute_fixed, [input_val])
-
-    def test_1_2(self):
-        # Test PermuteRowElements(vector, matrix)
-        # Different permutations will be applied to the same input vector
-        input = vector()
-        p = imatrix()
-        out = permute_row_elements(input, p)
-        permute = function([input, p], out)
-
-        rng = np.random.default_rng(utt.fetch_seed())
-        input_val = rng.uniform(size=(5,)).astype(config.floatX)
-        p_val = np.asarray([rng.permutation(5) for i in range(3)], dtype="int32")
-        out_val = permute(input_val, p_val)
-
-        # Each row of p contains a permutation to apply to the input vector
-        out_bis = np.asarray([input_val[p_row] for p_row in p_val])
-        assert np.all(out_val == out_bis)
-
-        # Verify gradient
-        def permute_fixed(s_input):
-            # Auxiliary op defined to get rid of gradient wrt p_val
-            return permute_row_elements(s_input, p_val)
-
-        utt.verify_grad(permute_fixed, [input_val])
-
-    def test_3b_2(self):
-        # Test permute_row_elements on a more complex broadcasting pattern:
-        # input.type.shape = (None, 1, None),
-        # p.type.shape = (None, None).
-
-        input = TensorType("floatX", shape=(None, 1, None))()
-        p = imatrix()
-        out = permute_row_elements(input, p)
-        permute = function([input, p], out)
-
-        rng = np.random.default_rng(utt.fetch_seed())
-        input_val = rng.uniform(size=(4, 1, 5)).astype(config.floatX)
-        p_val = np.asarray([rng.permutation(5) for i in range(3)], dtype="int32")
-        out_val = permute(input_val, p_val)
-
-        # Each row of p contains a permutation to apply to each row
-        # of the input tensor
-        out_bis = np.asarray(
-            [[in_mat[0, p_row] for p_row in p_val] for in_mat in input_val]
-        )
-        assert np.all(out_val == out_bis)
-
-        # Verify gradient
-        def permute_fixed(s_input):
-            # Auxiliary op defined to get rid of gradient wrt p_val
-            return permute_row_elements(s_input, p_val)
-
-        utt.verify_grad(permute_fixed, [input_val])
-
-
 def test_stack():
     sx, sy = dscalar(), dscalar()
 
@@ -3945,49 +3816,6 @@ class TestInferShape(utt.InferShapeTester):
                 [aiscal_val, admat_val, bdmat_val, cdmat_val],
                 Join,
             )
-
-    def test_PermuteRowElements(self):
-        """Verify output shapes of the symbolic permute_row_elements."""
-        advec = dvector()
-        aivec = ivector()
-        admat = dmatrix()
-        adtens3 = dtensor3()
-
-        rng = np.random.default_rng(utt.fetch_seed())
-        advec_val = random(5)
-        aivec_val = rng.permutation(5).astype("int32")
-
-        # vector x vector: shape must be (5,)
-        f = pytensor.function([advec, aivec], permute_row_elements(advec, aivec))
-        assert f(advec_val, aivec_val).shape == (5,)
-
-        # matrix x vector (broadcast y): shape must be (3, 5)
-        admat_val = random(3, 5)
-        f = pytensor.function([admat, aivec], permute_row_elements(admat, aivec))
-        assert f(admat_val, aivec_val).shape == (3, 5)
-
-        # 3d tensor x vector (broadcast y): shape must be (3, 2, 5)
-        adtens3_val = random(3, 2, 5)
-        f = pytensor.function([adtens3, aivec], permute_row_elements(adtens3, aivec))
-        assert f(adtens3_val, aivec_val).shape == (3, 2, 5)
-
-        # matrix x matrix (one perm per row): shape must be (3, 5)
-        aimat = imatrix()
-        perma = rng.permutation(5).astype("int32")
-        permb = rng.permutation(5).astype("int32")
-        permc = rng.permutation(5).astype("int32")
-        aimat_val = np.vstack((perma, permb, permc))
-        f = pytensor.function([admat, aimat], permute_row_elements(admat, aimat))
-        assert f(admat_val, aimat_val).shape == (3, 5)
-
-        # matrix x 3d perm (broadcast x): shape must be (2, 3, 5)
-        aitens3 = itensor3()
-        bimat_val = np.vstack((perma, permb, permc))
-        aitens3_val = np.empty((2, 3, 5), "int32")
-        aitens3_val[0] = aimat_val
-        aitens3_val[1] = bimat_val
-        f = pytensor.function([admat, aitens3], permute_row_elements(admat, aitens3))
-        assert f(admat_val, aitens3_val).shape == (2, 3, 5)
 
     def test_ScalarFromTensor(self):
         aiscal = iscalar()

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -56,7 +56,6 @@ from pytensor.tensor.basic import (
     horizontal_stack,
     identity_like,
     infer_static_shape,
-    inverse_permutation,
     join,
     make_vector,
     mgrid,
@@ -2931,52 +2930,6 @@ class TestNdGrid:
         ):
             for ng, tg in zip(n, t, strict=True):
                 utt.assert_allclose(ng, tg)
-
-
-class TestInversePermutation:
-    def test_dim1(self):
-        # Test the inversion of one permutation (int vector)
-        p = ivector()
-        inv = inverse_permutation(p)
-        assert inv.dtype == p.dtype
-        f_inverse = function([p], inv)
-
-        # Generate a random permutation
-        rng = np.random.default_rng(utt.fetch_seed())
-        p_val = rng.permutation(10).astype("int32")
-        inv_val = f_inverse(p_val)
-
-        # Check that the inverse of the inverse is the original permutation
-        assert np.all(f_inverse(inv_val) == p_val)
-        # Check that permutation(inverse) == inverse(permutation) = identity
-        assert np.all(p_val[inv_val] == np.arange(10))
-        assert np.all(inv_val[p_val] == np.arange(10))
-
-        # Test passing a list
-        p = [2, 4, 3, 0, 1]
-        inv = ptb.inverse_permutation(p)
-        f = pytensor.function([], inv)
-        assert np.array_equal(f(), np.array([3, 4, 0, 2, 1]))
-
-    def test_dim2(self):
-        # Test the inversion of several permutations at a time
-        # Each row of p is a different permutation to inverse
-        p = imatrix()
-        inv = inverse_permutation(p)
-        f_inverse = function([p], inv)
-
-        rng = np.random.default_rng(utt.fetch_seed())
-        # Generate 10 random permutations
-        p_val = np.asarray([rng.permutation(10) for i in range(7)], dtype="int32")
-        inv_val = f_inverse(p_val)
-
-        # Check that the inverse of the inverse is the original permutation list
-        assert np.all(f_inverse(inv_val) == p_val)
-        # Check that, for each permutation,
-        # permutation(inverse) == inverse(permutation) = identity
-        for p_row, i_row in zip(p_val, inv_val, strict=True):
-            assert np.all(p_row[i_row] == np.arange(10))
-            assert np.all(i_row[p_row] == np.arange(10))
 
 
 def test_stack():


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
- permute_row_elements() now uses take_along_axis + argsort
- inverse_permutation() simplified to cast(argsort(perm), perm.dtype)
- class PermuteRowElements deleted entirely"

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #1210 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
