### PR TITLE
Improve string representation of Advanced(Inc)Subtensor

### DIFF
--- a/pytensor/tensor/subtensor.py
+++ b/pytensor/tensor/subtensor.py
@@ -787,6 +787,37 @@ class BaseSubtensor:
         )
         return hash((type(self), props_values))
 
+    @staticmethod
+    def str_from_slice(entry):
+        if entry.step is not None:
+            return ":".join(
+                (
+                    "start" if entry.start is not None else "",
+                    "stop" if entry.stop is not None else "",
+                    "step",
+                )
+            )
+        if entry.stop is not None:
+            return f"{'start' if entry.start is not None else ''}:stop"
+        if entry.start is not None:
+            return "start:"
+        return ":"
+
+    @staticmethod
+    def str_from_indices(idx_list):
+        indices = []
+        letter_indexes = 0
+        for entry in idx_list:
+            if isinstance(entry, slice):
+                indices.append(BaseSubtensor.str_from_slice(entry))
+            else:
+                indices.append("ijk"[letter_indexes % 3] * (letter_indexes // 3 + 1))
+                letter_indexes += 1
+        return ", ".join(indices)
+
+    def __str__(self):
+        return f"{self.__class__.__name__}{{{self.str_from_indices(self.idx_list)}}}"
+
 
 class Subtensor(BaseSubtensor, COp):
     """Basic NumPy indexing operator."""
@@ -906,37 +937,6 @@ class Subtensor(BaseSubtensor, COp):
         rval = [[True], *([False] for _ in index_variables)]
 
         return rval
-
-    @staticmethod
-    def str_from_slice(entry):
-        if entry.step is not None:
-            return ":".join(
-                (
-                    "start" if entry.start is not None else "",
-                    "stop" if entry.stop is not None else "",
-                    "step",
-                )
-            )
-        if entry.stop is not None:
-            return f"{'start' if entry.start is not None else ''}:stop"
-        if entry.start is not None:
-            return "start:"
-        return ":"
-
-    @staticmethod
-    def str_from_indices(idx_list):
-        indices = []
-        letter_indexes = 0
-        for entry in idx_list:
-            if isinstance(entry, slice):
-                indices.append(Subtensor.str_from_slice(entry))
-            else:
-                indices.append("ijk"[letter_indexes % 3] * (letter_indexes // 3 + 1))
-                letter_indexes += 1
-        return ", ".join(indices)
-
-    def __str__(self):
-        return f"{self.__class__.__name__}{{{self.str_from_indices(self.idx_list)}}}"
 
     @staticmethod
     def default_helper_c_code_args():
@@ -1407,7 +1407,7 @@ class IncSubtensor(BaseSubtensor, COp):
 
     def __str__(self):
         name = "SetSubtensor" if self.set_instead_of_inc else "IncSubtensor"
-        return f"{name}{{{Subtensor.str_from_indices(self.idx_list)}}}"
+        return f"{name}{{{super().str_from_indices(self.idx_list)}}}"
 
     def make_node(self, x, y, *inputs):
         """
@@ -2578,11 +2578,12 @@ class AdvancedIncSubtensor(BaseSubtensor, Op):
         self.ignore_duplicates = ignore_duplicates
 
     def __str__(self):
-        return (
+        name = (
             "AdvancedSetSubtensor"
             if self.set_instead_of_inc
             else "AdvancedIncSubtensor"
         )
+        return f"{name}{{{super().str_from_indices(self.idx_list)}}}"
 
     def make_node(self, x, y, *index_variables):
         if len(index_variables) != self.n_index_vars:


### PR DESCRIPTION
Moves str_from_slice and str_from_indices from Subtensor to BaseSubtensor and adds a shared __str__ method. AdvancedIncSubtensor and IncSubtensor now use super() to call these methods. AdvancedSubtensor inherits __str__ directly from BaseSubtensor.

## Related Issue
- [x] Closes #1906 
- [ ] Related to #

## Checklist
- [x] Checked that the pre-commit linting/style checks pass
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a relevant logical change

## Type of change
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):