### PR TITLE
rewrite for solve and dot for diagonal matrices

### DIFF
--- a/pytensor/tensor/rewriting/linalg.py
+++ b/pytensor/tensor/rewriting/linalg.py
@@ -1164,14 +1164,18 @@ def rewrite_solve_diag(fgraph, node):
     d = None
 
     # Pattern 1: pt.diag(d)
-    if a.owner and isinstance(a.owner.op, AllocDiag) and AllocDiag.is_offset_zero(a.owner):
+    if (
+        a.owner
+        and isinstance(a.owner.op, AllocDiag)
+        and AllocDiag.is_offset_zero(a.owner)
+    ):
         d = a.owner.inputs[0]  # already 1D
 
     # Pattern 2: eye * x
     else:
         inputs_or_none = _find_diag_from_eye_mul(a)
         if inputs_or_none is not None:
-            eye_input, non_eye_inputs = inputs_or_none
+            _eye_input, non_eye_inputs = inputs_or_none
             if len(non_eye_inputs) == 1:
                 non_eye = non_eye_inputs[0]
                 if non_eye.type.broadcastable[-2:] == (True, True):
@@ -1191,17 +1195,11 @@ def rewrite_solve_diag(fgraph, node):
     # b_ndim tells us whether b's core case is a vector (1) or matrix (2)
     b_ndim = node.op.core_op.b_ndim
 
-    # Scalar d (0D): broadcasts over b directly, no reshape needed
-    if d.ndim == 0:
+    if d.ndim == 0 or b_ndim == 1:
         new_out = b / d
     else:
-        # d is 1D — broadcast it over rows of b:
-        #   b_ndim=1: b shape (N,)   -> result shape (N,)
-        #   b_ndim=2: b shape (N, K) -> result shape (N, K)
-        b_transposed = b[None, :] if b_ndim == 1 else b.mT
-        new_out = (b_transposed / pt.expand_dims(d, -2)).mT
-        if b_ndim == 1:
-            new_out = new_out.squeeze(-1)
+        # b_ndim=2: b.shape==(…,N,K), d.shape==(…,N) → d[...,None] broadcasts over K
+        new_out = b / d[..., None]
 
     copy_stack_trace(old_out, new_out)
     return [new_out]
@@ -1228,7 +1226,7 @@ def _extract_diagonal(x):
     if inputs_or_none is None:
         return None
 
-    eye_input, non_eye_inputs = inputs_or_none
+    _eye_input, non_eye_inputs = inputs_or_none
     if len(non_eye_inputs) != 1:
         return None
 
@@ -1287,6 +1285,6 @@ def rewrite_dot_diag(fgraph, node):
 
     else:
         return None
-    
+
     copy_stack_trace(old_out, new_out)
     return [new_out]

--- a/pytensor/tensor/rewriting/linalg.py
+++ b/pytensor/tensor/rewriting/linalg.py
@@ -1145,3 +1145,41 @@ def scalar_solve_to_division(fgraph, node):
     copy_stack_trace(old_out, new_out)
 
     return [new_out]
+
+
+@register_canonicalize
+@node_rewriter([blockwise_of(Solve)])
+def rewrite_solve_diag(fgraph, node):
+    """
+    Replace Blockwise(Solve)(diag(d), b) with elementwise b / d.
+
+    When the LHS matrix `a` is explicitly constructed as a diagonal matrix
+    via pt.diag(d) (i.e., AllocDiag), the general matrix solve Ax=b reduces
+    to simple elementwise division x_i = b_i / d_i.
+    """
+    a, b = node.inputs
+    old_out = node.outputs[0]
+
+    # Check that `a` was produced by AllocDiag (i.e. pt.diag(d)) on the main diagonal
+    if not (
+        a.owner
+        and isinstance(a.owner.op, AllocDiag)
+        and AllocDiag.is_offset_zero(a.owner)
+    ):
+        return None
+
+    # Grab d directly — no need to extract the diagonal from a full matrix
+    d = a.owner.inputs[0]
+
+    # b_ndim tells us whether b's core case is a vector (1) or matrix (2)
+    b_ndim = node.op.core_op.b_ndim
+
+    #   b_ndim=1: b shape (N,)    -> result shape (N,)
+    #   b_ndim=2: b shape (N, K)  -> result shape (N, K)
+    b_transposed = b[None, :] if b_ndim == 1 else b.mT
+    new_out = (b_transposed / pt.expand_dims(d, -2)).mT
+    if b_ndim == 1:
+        new_out = new_out.squeeze(-1)
+
+    copy_stack_trace(old_out, new_out)
+    return [new_out]

--- a/pytensor/tensor/rewriting/linalg.py
+++ b/pytensor/tensor/rewriting/linalg.py
@@ -1205,3 +1205,88 @@ def rewrite_solve_diag(fgraph, node):
 
     copy_stack_trace(old_out, new_out)
     return [new_out]
+
+
+def _extract_diagonal(x):
+    """
+    If x is provably a diagonal matrix, return its 1D diagonal vector.
+    Otherwise return None.
+
+    Handles two patterns:
+      - AllocDiag (pt.diag(d))
+      - eye * scalar/vector/matrix  (via _find_diag_from_eye_mul)
+    """
+    if not x.owner:
+        return None
+
+    # Pattern 1: pt.diag(d)
+    if isinstance(x.owner.op, AllocDiag) and AllocDiag.is_offset_zero(x.owner):
+        return x.owner.inputs[0]  # already 1D
+
+    # Pattern 2: eye * x
+    inputs_or_none = _find_diag_from_eye_mul(x)
+    if inputs_or_none is None:
+        return None
+
+    eye_input, non_eye_inputs = inputs_or_none
+    if len(non_eye_inputs) != 1:
+        return None
+
+    non_eye = non_eye_inputs[0]
+
+    if non_eye.type.broadcastable[-2:] == (True, True):
+        # scalar case — 0D
+        return non_eye.squeeze((-1, -2))
+    elif non_eye.type.broadcastable[-2:] == (False, False):
+        # matrix case — extract diagonal to 1D
+        return non_eye.diagonal(axis1=-1, axis2=-2)
+    else:
+        # vector case — already effectively 1D, squeeze the length-1 axis
+        return non_eye.squeeze(-2 if non_eye.type.broadcastable[-2] else -1)
+
+
+@register_canonicalize
+@node_rewriter([Dot])
+def rewrite_dot_diag(fgraph, node):
+    """
+    Replace Dot(l, r) with elementwise ops when one or both inputs are diagonal.
+
+    Cases:
+      diag(dl) . diag(dr)  ->  diag(dl * dr)
+      diag(dl) . r         ->  dl * r           (r is vector)
+                           ->  dl[:, None] * r  (r is matrix)
+      l . diag(dr)         ->  l * dr           (l is matrix or vector)
+    """
+    l, r = node.inputs
+    old_out = node.outputs[0]
+
+    dl = _extract_diagonal(l)
+    dr = _extract_diagonal(r)
+
+    if dl is not None and dr is not None:
+        # Both diagonal: diag(dl) . diag(dr) = diag(dl * dr)
+        # If both are 0D scalars, pt.diag needs a 1D input — use eye instead
+        if dl.ndim == 0 and dr.ndim == 0:
+            new_out = pt.eye(l.shape[-1]) * (dl * dr)
+        else:
+            new_out = pt.diag(dl * dr)
+
+    elif dl is not None:
+        # Left diagonal: diag(dl) . r
+        if dl.ndim == 0:
+            # scalar dl broadcasts trivially over any r
+            new_out = dl * r
+        elif r.ndim == 1:
+            new_out = dl * r
+        else:
+            new_out = dl[:, None] * r
+
+    elif dr is not None:
+        # Right diagonal: l . diag(dr)
+        new_out = pt.mul(l, dr)
+
+    else:
+        return None
+    
+    copy_stack_trace(old_out, new_out)
+    return [new_out]

--- a/pytensor/tensor/rewriting/linalg.py
+++ b/pytensor/tensor/rewriting/linalg.py
@@ -1160,26 +1160,48 @@ def rewrite_solve_diag(fgraph, node):
     a, b = node.inputs
     old_out = node.outputs[0]
 
-    # Check that `a` was produced by AllocDiag (i.e. pt.diag(d)) on the main diagonal
-    if not (
-        a.owner
-        and isinstance(a.owner.op, AllocDiag)
-        and AllocDiag.is_offset_zero(a.owner)
-    ):
+    # Step 1: try to get d (the effective diagonal) from either pattern
+    d = None
+
+    # Pattern 1: pt.diag(d)
+    if a.owner and isinstance(a.owner.op, AllocDiag) and AllocDiag.is_offset_zero(a.owner):
+        d = a.owner.inputs[0]  # already 1D
+
+    # Pattern 2: eye * x
+    else:
+        inputs_or_none = _find_diag_from_eye_mul(a)
+        if inputs_or_none is not None:
+            eye_input, non_eye_inputs = inputs_or_none
+            if len(non_eye_inputs) == 1:
+                non_eye = non_eye_inputs[0]
+                if non_eye.type.broadcastable[-2:] == (True, True):
+                    # scalar case — squeeze to 0D
+                    d = non_eye.squeeze((-1, -2))
+                elif non_eye.type.broadcastable[-2:] == (False, False):
+                    # matrix case — extract diagonal to get 1D
+                    d = non_eye.diagonal(axis1=-1, axis2=-2)
+                else:
+                    # vector case — squeeze the length-1 axis to get 1D
+                    d = non_eye.squeeze(-2 if non_eye.type.broadcastable[-2] else -1)
+
+    if d is None:
         return None
 
-    # Grab d directly — no need to extract the diagonal from a full matrix
-    d = a.owner.inputs[0]
-
+    # Step 2: apply b / d
     # b_ndim tells us whether b's core case is a vector (1) or matrix (2)
     b_ndim = node.op.core_op.b_ndim
 
-    #   b_ndim=1: b shape (N,)    -> result shape (N,)
-    #   b_ndim=2: b shape (N, K)  -> result shape (N, K)
-    b_transposed = b[None, :] if b_ndim == 1 else b.mT
-    new_out = (b_transposed / pt.expand_dims(d, -2)).mT
-    if b_ndim == 1:
-        new_out = new_out.squeeze(-1)
+    # Scalar d (0D): broadcasts over b directly, no reshape needed
+    if d.ndim == 0:
+        new_out = b / d
+    else:
+        # d is 1D — broadcast it over rows of b:
+        #   b_ndim=1: b shape (N,)   -> result shape (N,)
+        #   b_ndim=2: b shape (N, K) -> result shape (N, K)
+        b_transposed = b[None, :] if b_ndim == 1 else b.mT
+        new_out = (b_transposed / pt.expand_dims(d, -2)).mT
+        if b_ndim == 1:
+            new_out = new_out.squeeze(-1)
 
     copy_stack_trace(old_out, new_out)
     return [new_out]

--- a/tests/tensor/rewriting/test_linalg.py
+++ b/tests/tensor/rewriting/test_linalg.py
@@ -15,7 +15,7 @@ from pytensor.graph.rewriting.utils import rewrite_graph
 from pytensor.tensor import swapaxes
 from pytensor.tensor.blockwise import Blockwise, BlockwiseWithCoreShape
 from pytensor.tensor.elemwise import DimShuffle
-from pytensor.tensor.math import dot, matmul
+from pytensor.tensor.math import dot, matmul, Dot
 from pytensor.tensor.nlinalg import (
     SVD,
     Det,
@@ -1189,3 +1189,79 @@ def test_solve_diag_from_eye_mul(b_ndim, x_shape):
     )
     atol = rtol = 1e-3 if config.floatX == "float32" else 1e-8
     assert_allclose(f(x_val, b_val), f_ref(x_val, b_val), atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize(
+    "case_id",
+    [
+        "both_0d_diag",
+        "both_1d_diag",
+        "left_0d_diag",
+        "left_1d_diag_vector_r",
+        "left_1d_diag_matrix_r",
+        "right_diag",
+    ],
+)
+def test_rewrite_dot_diag(case_id):
+    rng = np.random.default_rng(sum(map(ord, "test_rewrite_dot_diag" + case_id)))
+
+    if case_id == "both_0d_diag":
+        # dl.ndim == 0 and dr.ndim == 0: (eye*scalar) · (eye*scalar)
+        s1, s2 = pt.scalar("s1"), pt.scalar("s2")
+        inputs = [s1, s2]
+        out = pt.dot(pt.eye(3) * s1, pt.eye(3) * s2)
+        vals = [
+            rng.uniform(1, 5, size=()).astype(config.floatX),
+            rng.uniform(1, 5, size=()).astype(config.floatX),
+        ]
+    elif case_id == "both_1d_diag":
+        # both diagonal 1D: diag(d1) · diag(d2)
+        d1, d2 = pt.vector("d1"), pt.vector("d2")
+        inputs = [d1, d2]
+        out = pt.dot(pt.diag(d1), pt.diag(d2))
+        vals = [
+            rng.uniform(1, 5, size=(3,)).astype(config.floatX),
+            rng.uniform(1, 5, size=(3,)).astype(config.floatX),
+        ]
+    elif case_id == "left_0d_diag":
+        # dl.ndim == 0: (eye*scalar) · matrix
+        s, M = pt.scalar("s"), pt.matrix("M")
+        inputs = [s, M]
+        out = pt.dot(pt.eye(3) * s, M)
+        vals = [
+            rng.uniform(1, 5, size=()).astype(config.floatX),
+            rng.uniform(size=(3, 4)).astype(config.floatX),
+        ]
+    elif case_id == "left_1d_diag_vector_r":
+        # r.ndim == 1: diag(d) · vector
+        d, v = pt.vector("d"), pt.vector("v")
+        inputs = [d, v]
+        out = pt.dot(pt.diag(d), v)
+        vals = [
+            rng.uniform(1, 5, size=(3,)).astype(config.floatX),
+            rng.uniform(size=(3,)).astype(config.floatX),
+        ]
+    elif case_id == "left_1d_diag_matrix_r":
+        # left diagonal, matrix r: diag(d) · M
+        d, M = pt.vector("d"), pt.matrix("M")
+        inputs = [d, M]
+        out = pt.dot(pt.diag(d), M)
+        vals = [
+            rng.uniform(1, 5, size=(3,)).astype(config.floatX),
+            rng.uniform(size=(3, 4)).astype(config.floatX),
+        ]
+    elif case_id == "right_diag":
+        # right diagonal: M · diag(d)
+        M, d = pt.matrix("M"), pt.vector("d")
+        inputs = [M, d]
+        out = pt.dot(M, pt.diag(d))
+        vals = [
+            rng.uniform(size=(3, 3)).astype(config.floatX),
+            rng.uniform(1, 5, size=(3,)).astype(config.floatX),
+        ]
+    f = function(inputs, out, mode="FAST_RUN")
+    assert not any(isinstance(node.op, Dot) for node in f.maker.fgraph.apply_nodes)
+
+    f_ref = function(inputs, out, mode=get_default_mode().excluding("rewrite_dot_diag"))
+    atol = rtol = 1e-3 if config.floatX == "float32" else 1e-8
+    assert_allclose(f(*vals), f_ref(*vals), atol=atol, rtol=rtol)

--- a/tests/tensor/rewriting/test_linalg.py
+++ b/tests/tensor/rewriting/test_linalg.py
@@ -1130,47 +1130,62 @@ def test_scalar_solve_to_division_rewrite(
     )
 
 
-def test_solve_diag_vector_b():
+@pytest.mark.parametrize("b_ndim", [1, 2], ids=["vector_b", "matrix_b"])
+def test_solve_diag_from_diag(b_ndim):
+    rng = np.random.default_rng(sum(map(ord, "test_solve_diag_from_diag")) + b_ndim)
     d = pt.vector("d")
-    b = pt.vector("b")
-    x = solve(pt.diag(d), b)
+    b = pt.vector("b") if b_ndim == 1 else pt.matrix("b")
+    x = solve(pt.diag(d), b, b_ndim=b_ndim)
 
     f = function([d, b], x, mode="FAST_RUN")
-    nodes = f.maker.fgraph.apply_nodes
     assert not any(
         isinstance(node.op, Blockwise) and isinstance(node.op.core_op, Solve)
-        for node in nodes
+        for node in f.maker.fgraph.apply_nodes
     )
+    f_ref = function([d, b], x, mode=get_default_mode().excluding("rewrite_solve_diag"))
 
-    f_ref = function(
-        [d, b], x, mode=get_default_mode().excluding("rewrite_solve_diag")
+    d_val = rng.uniform(1, 5, size=(5,)).astype(config.floatX)
+    b_val = (
+        rng.standard_normal(size=(5,)).astype(config.floatX)
+        if b_ndim == 1
+        else rng.standard_normal(size=(5, 3)).astype(config.floatX)
     )
-
-    d_val = np.random.rand(5).astype(config.floatX)
-    b_val = np.random.rand(5).astype(config.floatX)
+    expected = b_val / d_val if b_ndim == 1 else b_val / d_val[:, None]
     atol = rtol = 1e-3 if config.floatX == "float32" else 1e-8
-    assert_allclose(f(d_val, b_val), b_val / d_val, atol=atol, rtol=rtol)
+    assert_allclose(f(d_val, b_val), expected, atol=atol, rtol=rtol)
     assert_allclose(f(d_val, b_val), f_ref(d_val, b_val), atol=atol, rtol=rtol)
 
 
-def test_solve_diag_matrix_b():
-    d = pt.vector("d")
-    b = pt.matrix("b")
-    x = solve(pt.diag(d), b, b_ndim=2)
+@pytest.mark.parametrize("b_ndim", [1, 2], ids=["vector_b", "matrix_b"])
+@pytest.mark.parametrize(
+    "x_shape",
+    [(), (5,), (5, 5)],
+    ids=["scalar", "vector", "matrix"],
+)
+def test_solve_diag_from_eye_mul(b_ndim, x_shape):
+    rng = np.random.default_rng(
+        sum(map(ord, "test_solve_diag_from_eye_mul")) + b_ndim + sum(x_shape)
+    )
+    n = 5
+    x = pt.tensor("x", shape=x_shape)
+    a = pt.eye(n) * x
+    b = pt.vector("b") if b_ndim == 1 else pt.matrix("b")
+    sol = solve(a, b, b_ndim=b_ndim)
 
-    f = function([d, b], x, mode="FAST_RUN")
-    nodes = f.maker.fgraph.apply_nodes
+    f = function([x, b], sol, mode="FAST_RUN")
     assert not any(
         isinstance(node.op, Blockwise) and isinstance(node.op.core_op, Solve)
-        for node in nodes
+        for node in f.maker.fgraph.apply_nodes
     )
-
     f_ref = function(
-        [d, b], x, mode=get_default_mode().excluding("rewrite_solve_diag")
+        [x, b], sol, mode=get_default_mode().excluding("rewrite_solve_diag")
     )
 
-    d_val = np.random.rand(5).astype(config.floatX)
-    b_val = np.random.rand(5, 3).astype(config.floatX)
+    x_val = rng.uniform(1, 5, size=x_shape).astype(config.floatX)
+    b_val = (
+        rng.standard_normal(size=(n,)).astype(config.floatX)
+        if b_ndim == 1
+        else rng.standard_normal(size=(n, 3)).astype(config.floatX)
+    )
     atol = rtol = 1e-3 if config.floatX == "float32" else 1e-8
-    assert_allclose(f(d_val, b_val), b_val / d_val[:, None], atol=atol, rtol=rtol)
-    assert_allclose(f(d_val, b_val), f_ref(d_val, b_val), atol=atol, rtol=rtol)
+    assert_allclose(f(x_val, b_val), f_ref(x_val, b_val), atol=atol, rtol=rtol)

--- a/tests/tensor/rewriting/test_linalg.py
+++ b/tests/tensor/rewriting/test_linalg.py
@@ -15,7 +15,7 @@ from pytensor.graph.rewriting.utils import rewrite_graph
 from pytensor.tensor import swapaxes
 from pytensor.tensor.blockwise import Blockwise, BlockwiseWithCoreShape
 from pytensor.tensor.elemwise import DimShuffle
-from pytensor.tensor.math import dot, matmul, Dot
+from pytensor.tensor.math import Dot, dot, matmul
 from pytensor.tensor.nlinalg import (
     SVD,
     Det,
@@ -1153,6 +1153,33 @@ def test_solve_diag_from_diag(b_ndim):
     expected = b_val / d_val if b_ndim == 1 else b_val / d_val[:, None]
     atol = rtol = 1e-3 if config.floatX == "float32" else 1e-8
     assert_allclose(f(d_val, b_val), expected, atol=atol, rtol=rtol)
+    assert_allclose(f(d_val, b_val), f_ref(d_val, b_val), atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize("b_ndim", [1, 2], ids=["vector_b", "matrix_b"])
+def test_solve_diag_from_diag_batched(b_ndim):
+    rng = np.random.default_rng(
+        sum(map(ord, "test_solve_diag_from_diag_batched")) + b_ndim
+    )
+    d = pt.vector("d")  # shape (N,) — the diagonal; batch dim lives in b
+    b = pt.matrix("b") if b_ndim == 1 else pt.tensor("b", shape=(None, None, None))
+    x = solve(pt.diag(d), b, b_ndim=b_ndim)
+
+    f = function([d, b], x, mode="FAST_RUN")
+    assert not any(
+        isinstance(node.op, Blockwise) and isinstance(node.op.core_op, Solve)
+        for node in f.maker.fgraph.apply_nodes
+    )
+    f_ref = function([d, b], x, mode=get_default_mode().excluding("rewrite_solve_diag"))
+
+    B, N = 4, 5
+    d_val = rng.uniform(1, 5, size=(N,)).astype(config.floatX)
+    b_val = (
+        rng.standard_normal(size=(B, N)).astype(config.floatX)
+        if b_ndim == 1
+        else rng.standard_normal(size=(B, N, 3)).astype(config.floatX)
+    )
+    atol = rtol = 1e-3 if config.floatX == "float32" else 1e-8
     assert_allclose(f(d_val, b_val), f_ref(d_val, b_val), atol=atol, rtol=rtol)
 
 

--- a/tests/tensor/rewriting/test_linalg.py
+++ b/tests/tensor/rewriting/test_linalg.py
@@ -1128,3 +1128,49 @@ def test_scalar_solve_to_division_rewrite(
     np.testing.assert_allclose(
         f(a_val, b_val), c_val, rtol=1e-7 if config.floatX == "float64" else 1e-5
     )
+
+
+def test_solve_diag_vector_b():
+    d = pt.vector("d")
+    b = pt.vector("b")
+    x = solve(pt.diag(d), b)
+
+    f = function([d, b], x, mode="FAST_RUN")
+    nodes = f.maker.fgraph.apply_nodes
+    assert not any(
+        isinstance(node.op, Blockwise) and isinstance(node.op.core_op, Solve)
+        for node in nodes
+    )
+
+    f_ref = function(
+        [d, b], x, mode=get_default_mode().excluding("rewrite_solve_diag")
+    )
+
+    d_val = np.random.rand(5).astype(config.floatX)
+    b_val = np.random.rand(5).astype(config.floatX)
+    atol = rtol = 1e-3 if config.floatX == "float32" else 1e-8
+    assert_allclose(f(d_val, b_val), b_val / d_val, atol=atol, rtol=rtol)
+    assert_allclose(f(d_val, b_val), f_ref(d_val, b_val), atol=atol, rtol=rtol)
+
+
+def test_solve_diag_matrix_b():
+    d = pt.vector("d")
+    b = pt.matrix("b")
+    x = solve(pt.diag(d), b, b_ndim=2)
+
+    f = function([d, b], x, mode="FAST_RUN")
+    nodes = f.maker.fgraph.apply_nodes
+    assert not any(
+        isinstance(node.op, Blockwise) and isinstance(node.op.core_op, Solve)
+        for node in nodes
+    )
+
+    f_ref = function(
+        [d, b], x, mode=get_default_mode().excluding("rewrite_solve_diag")
+    )
+
+    d_val = np.random.rand(5).astype(config.floatX)
+    b_val = np.random.rand(5, 3).astype(config.floatX)
+    atol = rtol = 1e-3 if config.floatX == "float32" else 1e-8
+    assert_allclose(f(d_val, b_val), b_val / d_val[:, None], atol=atol, rtol=rtol)
+    assert_allclose(f(d_val, b_val), f_ref(d_val, b_val), atol=atol, rtol=rtol)


### PR DESCRIPTION
# Rewrite `solve` and `dot` with diagonal matrices

implementation of [#1791](https://github.com/pymc-devs/pytensor/issues/1791).

## What was done

### 1. `rewrite_solve_diag`

Added a graph rewrite `rewrite_solve_diag` in `pytensor/tensor/rewriting/linalg.py` that detects when the first argument to `solve` is a diagonal matrix and replaces the expensive `Blockwise(Solve(...))` node with elementwise division.

For a diagonal matrix `A` with diagonal entries `d`, the linear system `A @ x = b` has the closed-form solution `x = b / d`, which avoids the full LU factorisation performed by `scipy.linalg.solve`.

The rewrite handles both `b_ndim=1` (vector `b`) and `b_ndim=2` (matrix `b`), and detects diagonal matrices from two structural patterns:

#### Pattern 1: `pt.diag(d)` (`AllocDiag`)

`d` is extracted directly as the 1D diagonal vector and `b / d` is computed with appropriate broadcasting.

- `solve(pt.diag(d), b)` → `b / d`
- `solve(pt.diag(d), b, b_ndim=2)` → `b / d[:, None]`

#### Pattern 2: `pt.eye(n) * x`

Uses the existing `_find_diag_from_eye_mul` helper (shared with `rewrite_inv_diag_to_diag_reciprocal`, `rewrite_det_diag_from_eye_mul`, etc.) to detect elementwise multiplication with an identity matrix. The effective diagonal `d` is extracted depending on the shape of `x`:

- **Scalar** `x` (0D): `d = x` (scalar), `b / d` broadcasts trivially
- **Vector** `x` (1D): `d = x`, equivalent to `pt.diag(x)`
- **Matrix** `x` (2D): `d = x.diagonal()`, zeros off the diagonal are ignored

Tests in `tests/tensor/rewriting/test_linalg.py`:
- `test_solve_diag_from_diag` — parametrized over `b_ndim ∈ {1, 2}`, verifies `Blockwise(Solve)` is eliminated and the result matches both `b / d` and the unoptimised reference.
- `test_solve_diag_from_eye_mul` — parametrized over `x_shape ∈ {(), (5,), (5,5)}` × `b_ndim ∈ {1, 2}` (6 cases), verifies the rewrite fires and matches the unoptimised reference for all shape combinations.

---

### 2. `rewrite_dot_diag`

Added a graph rewrite `rewrite_dot_diag` in `pytensor/tensor/rewriting/linalg.py` that detects when either argument to `dot` is a diagonal matrix and replaces the `Dot` node with elementwise operations.

A shared helper `_extract_diagonal` is introduced (alongside the existing `_find_diag_from_eye_mul`) to detect both `AllocDiag` and `eye * x` diagonal patterns and return the effective 1D diagonal (or 0D scalar for the `eye * scalar` case).

The rewrite covers all structural combinations:

| Pattern | Rewrite |
|---|---|
| `dot(diag(dl), diag(dr))` | `diag(dl * dr)` |
| `dot(eye*s1, eye*s2)` (both 0D) | `eye(n) * (s1 * s2)` |
| `dot(eye*s, r)` (0D left) | `s * r` |
| `dot(diag(d), v)` (vector `r`) | `d * v` |
| `dot(diag(d), M)` (matrix `r`) | `d[:, None] * M` |
| `dot(l, diag(d))` | `l * d` |

Both `AllocDiag` (`pt.diag(d)`) and `eye * x` patterns are handled for either operand, consistent with `rewrite_solve_diag`.

Tests in `tests/tensor/rewriting/test_linalg.py`:
- `test_rewrite_dot_diag` — parametrized over 6 case IDs covering every rewrite branch, verifies the `Dot` node is eliminated and the result matches the unoptimised reference.

## What remains to be done

### Rewrite `matmul` with diagonal matrices

Issue [#1791](https://github.com/pymc-devs/pytensor/issues/1791) also asks for rewrites for `matmul` and the batched `Blockwise` variants:

- Same `AllocDiag` and `eye * x` detection, applied to the `Blockwise(Dot)` node used by `pt.matmul`.
