### PR TITLE
Python Scalar Pow: do not return complex values for fractional powers of negative floats

### DIFF
--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -2282,7 +2282,7 @@ class Pow(BinaryScalarOp):
     nfunc_spec = ("power", 2, 1)
 
     def impl(self, x, y):
-        return x**y
+        return np.power(x, y)
 
     def c_code(self, node, name, inputs, outputs, sub):
         (x, y) = inputs

--- a/tests/scalar/test_basic.py
+++ b/tests/scalar/test_basic.py
@@ -34,6 +34,7 @@ from pytensor.scalar.basic import (
     exp2,
     expm1,
     float32,
+    float64,
     floats,
     int8,
     int32,
@@ -47,6 +48,7 @@ from pytensor.scalar.basic import (
     mul,
     neg,
     neq,
+    pow,
     rad2deg,
     reciprocal,
     sin,
@@ -530,3 +532,25 @@ def test_cast_to_complex(inp_type):
     res_y = y.eval({x: np.array(1.0, dtype=inp_type.dtype)})
     assert res_y == 1
     assert res_y.dtype == "complex64"
+
+
+@pytest.mark.parametrize("mode", [Mode(linker="py"), None])
+def test_pow_negative_base_fractional_exponent(mode):
+    x = float64("x")
+    y = float64("y")
+    f = pytensor.function([x, y], pow(x, y), mode=mode)
+
+    # Positive base works normally
+    assert f(2.0, 3.0) == 8.0
+
+    # Negative base with integer exponent works
+    assert f(-2.0, 3.0) == -8.0
+
+    # Negative base with fractional exponent returns nan, not complex
+    result = f(-1.0, 0.01)
+    if not isinstance(f.maker.linker, NumbaLinker):
+        # Numba doesn't return numpy scalars
+        assert isinstance(result, np.floating), (
+            f"Expected numpy float, got {type(result)}: {result}"
+        )
+    assert np.isnan(result), f"Expected nan, got {result}"


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
`Pow.impl` in `pytensor/scalar/basic.py` uses Python's native `**` operator, which returns complex numbers for fractional powers of negative floats (e.g., `(-1.0) ** 0.01` returns `(0.999+0.031j)`). This is inconsistent with the tensor path, which already uses `np.power` via `nfunc_spec` and correctly returns `nan`.

The complex result then crashes `_cast_to_promised_scalar_dtype` when it tries to cast to `float64`.

**Fix:** Replace `x**y` with `np.power(x, y)` in `Pow.impl`, making the scalar path consistent with the tensor path.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1944 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
