### PR TITLE
Fix FillDiagonalOffset.grad for complex dtypes

### DIFF
--- a/pytensor/tensor/extra_ops.py
+++ b/pytensor/tensor/extra_ops.py
@@ -1069,7 +1069,7 @@ class FillDiagonalOffset(Op):
         height, width = grad.shape
 
         if a.dtype.startswith("complex"):
-            return [None, None]
+            return [None, None, None]
 
         # only valid for matrices
         wr_a = fill_diagonal_offset(grad, 0, offset)

--- a/tests/tensor/test_extra_ops.py
+++ b/tests/tensor/test_extra_ops.py
@@ -840,6 +840,23 @@ class TestFillDiagonalOffset(utt.InferShapeTester):
             self.op_class,
         )
 
+    def test_grad_complex_dtype(self):
+        """Regression test: FillDiagonalOffset.grad must return 3 gradient
+        entries (one per input: a, val, offset), even for complex dtypes."""
+        a = pt.zmatrix("a")
+        val = pt.zscalar("val")
+        offset = pt.iscalar("offset")
+        out = fill_diagonal_offset(a, val, offset)
+        # Directly call the Op's grad method to verify it returns
+        # the correct number of gradient entries for complex inputs
+        op_node = out.owner
+        cost_grad = [pt.ones_like(out)]
+        grads = op_node.op.grad(op_node.inputs, cost_grad)
+        assert len(grads) == 3, (
+            f"Expected 3 gradient entries for 3 inputs (a, val, offset), "
+            f"got {len(grads)}"
+        )
+
 
 def test_to_one_hot():
     v = ivector()


### PR DESCRIPTION
## Fix: Correct gradient length for `FillDiagonalOffset` with complex inputs

### Bug
`FillDiagonalOffset.grad` returned only 2 gradient entries in the complex-dtype early-exit path, even though the Op has 3 inputs (`a`, `val`, `offset`).  

This caused an opaque `AssertionError` inside the gradient machinery when users attempted to compute gradients with complex matrices.

### Fix
Updated the complex branch in `pytensor/tensor/extra_ops.py`:

```diff
- return [None, None]
+ return [None, None, None]