### PR TITLE
Fix Eigvalsh.grad for standard eigenvalue problem

### DIFF
--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -1167,9 +1167,16 @@ class Eigvalsh(Op):
             w[0] = scipy_linalg.eigvalsh(a=inputs[0], b=None, lower=self.lower)
 
     def grad(self, inputs, g_outputs):
-        a, b = inputs
         (gw,) = g_outputs
-        return EigvalshGrad(self.lower)(a, b, gw)
+        if len(inputs) == 1:
+            (a,) = inputs
+            import pytensor.tensor as pt
+            b = pt.zeros_like(a)
+            out = EigvalshGrad(self.lower)(a, b, gw)
+            return [out[0]]
+        else:
+            a, b = inputs
+            return list(EigvalshGrad(self.lower)(a, b, gw))
 
     def infer_shape(self, fgraph, node, shapes):
         n = shapes[0][0]
@@ -1218,9 +1225,15 @@ class EigvalshGrad(Op):
 
     def perform(self, node, inputs, outputs):
         (a, b, gw) = inputs
-        w, v = scipy_linalg.eigh(a, b, lower=self.lower)
-        gA = v.dot(np.diag(gw).dot(v.T))
-        gB = -v.dot(np.diag(gw * w).dot(v.T))
+        # Support zero-like placeholder for the standard eigenvalue problem
+        if np.all(b == 0):
+            w, v = scipy_linalg.eigh(a, None, lower=self.lower)
+            gA = v.dot(np.diag(gw).dot(v.T))
+            gB = np.zeros_like(b)
+        else:
+            w, v = scipy_linalg.eigh(a, b, lower=self.lower)
+            gA = v.dot(np.diag(gw).dot(v.T))
+            gB = -v.dot(np.diag(gw * w).dot(v.T))
 
         # See EighGrad comments for an explanation of these lines
         out1 = self.tri0(gA) + self.tri1(gA).T

--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -1171,6 +1171,7 @@ class Eigvalsh(Op):
         if len(inputs) == 1:
             (a,) = inputs
             import pytensor.tensor as pt
+
             b = pt.zeros_like(a)
             out = EigvalshGrad(self.lower)(a, b, gw)
             return [out[0]]

--- a/test_eigvalsh_grad.py
+++ b/test_eigvalsh_grad.py
@@ -1,0 +1,24 @@
+import numpy as np
+import pytensor
+from pytensor.tensor import slinalg
+
+from tests import unittest_tools as utt
+
+def test_eigvalsh_grad_no_b():
+    rng = np.random.default_rng(utt.fetch_seed())
+    a = rng.standard_normal((5,5))
+    a = a + a.T
+    
+    def func(x):
+        return slinalg.eigvalsh(x, pytensor.tensor.type_other.NoneConst)
+    
+    utt.verify_grad(func, [a])
+
+def test_eigvalsh_grad_with_b():
+    rng = np.random.default_rng(utt.fetch_seed())
+    a = rng.standard_normal((5,5))
+    a = a + a.T
+    b = rng.standard_normal((5,5))
+    b = b.dot(b.T) + np.eye(5)
+    
+    utt.verify_grad(lambda x, y: slinalg.eigvalsh(x, y), [a, b])

--- a/test_eigvalsh_grad.py
+++ b/test_eigvalsh_grad.py
@@ -1,24 +1,26 @@
 import numpy as np
+
 import pytensor
 from pytensor.tensor import slinalg
-
 from tests import unittest_tools as utt
+
 
 def test_eigvalsh_grad_no_b():
     rng = np.random.default_rng(utt.fetch_seed())
-    a = rng.standard_normal((5,5))
+    a = rng.standard_normal((5, 5))
     a = a + a.T
-    
+
     def func(x):
         return slinalg.eigvalsh(x, pytensor.tensor.type_other.NoneConst)
-    
+
     utt.verify_grad(func, [a])
+
 
 def test_eigvalsh_grad_with_b():
     rng = np.random.default_rng(utt.fetch_seed())
-    a = rng.standard_normal((5,5))
+    a = rng.standard_normal((5, 5))
     a = a + a.T
-    b = rng.standard_normal((5,5))
+    b = rng.standard_normal((5, 5))
     b = b.dot(b.T) + np.eye(5)
-    
+
     utt.verify_grad(lambda x, y: slinalg.eigvalsh(x, y), [a, b])


### PR DESCRIPTION
## Fix Eigvalsh.grad crash for standard eigenvalue problem (b=NoneConst)

### Summary
Fixes a crash in `Eigvalsh.grad` when computing gradients for the standard symmetric eigenvalue problem where `b=NoneConst`.

### Problem
`Eigvalsh.make_node` stores only one input when `b == NoneConst`, but `Eigvalsh.grad` always assumes two inputs:

```python
a, b = inputs