### PR TITLE
Fix FillDiagonalOffset.grad for complex

### DIFF
--- a/pytensor/tensor/extra_ops.py
+++ b/pytensor/tensor/extra_ops.py
@@ -1069,7 +1069,7 @@ class FillDiagonalOffset(Op):
         height, width = grad.shape
 
         if a.dtype.startswith("complex"):
-            return [None, None]
+            return [None, None, None]
 
         # only valid for matrices
         wr_a = fill_diagonal_offset(grad, 0, offset)


### PR DESCRIPTION
## Fix incorrect gradient return count in FillDiagonalOffset.grad

### Problem

`FillDiagonalOffset.grad` in `pytensor/tensor/extra_ops.py` returns an incorrect
number of gradient values when the input dtype is complex.

The op has three inputs:

- `a`
- `val`
- `offset`

However the complex branch of `grad()` currently returns:

This produces only two gradient values and causes an `AssertionError`
inside the gradient infrastructure because the number of returned
gradients must match the number of inputs.

### Example

```python
import pytensor.tensor as pt

a = pt.zmatrix("a")
val = pt.zscalar("val")
offset = pt.iscalar("offset")

out = pt.extra_ops.fill_diagonal_offset(a, val, offset)

pt.grad(out.sum(), wrt=a)