### PR TITLE
Add tests for cumprod gradient with zero inputs

### DIFF
--- a/tests/tensor/test_extra_ops.py
+++ b/tests/tensor/test_extra_ops.py
@@ -321,10 +321,12 @@ class TestCumprodGradZeros:
 
     def test_cumprod_grad_2d_with_zeros(self):
         """2D cumprod along axis=1 with zeros in each row."""
-        x_val = np.array([
-            [3.0, 0.0, 5.0],
-            [0.0, 7.0, 3.0],
-        ])
+        x_val = np.array(
+            [
+                [3.0, 0.0, 5.0],
+                [0.0, 7.0, 3.0],
+            ]
+        )
         x = pt.matrix("x", dtype="float64")
         y = cumprod(x, axis=1)
         loss = y.sum()
@@ -339,10 +341,12 @@ class TestCumprodGradZeros:
         #   dloss/dx[0] = 1 + x[1] + x[1]*x[2] = 1+7+21 = 29
         #   dloss/dx[1] = x[0] + x[0]*x[2] = 0+0 = 0
         #   dloss/dx[2] = x[0]*x[1] = 0
-        expected = np.array([
-            [1.0, 18.0, 0.0],
-            [29.0, 0.0, 0.0],
-        ])
+        expected = np.array(
+            [
+                [1.0, 18.0, 0.0],
+                [29.0, 0.0, 0.0],
+            ]
+        )
 
         assert not np.any(np.isnan(result)), f"NaN in gradient: {result}"
         np.testing.assert_allclose(result, expected)

--- a/tests/tensor/test_extra_ops.py
+++ b/tests/tensor/test_extra_ops.py
@@ -244,6 +244,110 @@ class TestCumOp(utt.InferShapeTester):
             utt.verify_grad(self.op_class(axis=axis, mode="mul"), [a], eps=4e-4)
 
 
+class TestCumprodGradZeros:
+    """Tests for cumprod gradient correctness when inputs contain zeros.
+
+    The gradient of sum(cumprod(x)) w.r.t. x[k] is:
+        dloss/dx[k] = sum_{i>=k} product(x[j] for j in 0..i, j != k)
+    """
+
+    def _compute_cumprod_grad(self, x_val):
+        """Compile and evaluate cumprod gradient via pytensor."""
+        x = pt.vector("x", dtype="float64")
+        y = cumprod(x)
+        loss = y.sum()
+        (grad,) = pytensor.gradient.grad(loss, [x])
+        f = pytensor.function([x], grad)
+        return f(x_val)
+
+    def test_cumprod_grad_single_zero_middle(self):
+        """x = [3, 0, 5]: single zero in the middle."""
+        x_val = np.array([3.0, 0.0, 5.0])
+        result = self._compute_cumprod_grad(x_val)
+
+        # y = [3, 0, 0]
+        # dloss/dx[0] = 1 + x[1] + x[1]*x[2] = 1 + 0 + 0 = 1
+        # dloss/dx[1] = x[0] + x[0]*x[2] = 3 + 15 = 18
+        # dloss/dx[2] = x[0]*x[1] = 0
+        expected = np.array([1.0, 18.0, 0.0])
+
+        assert not np.any(np.isnan(result)), f"NaN in gradient: {result}"
+        np.testing.assert_allclose(result, expected)
+
+    def test_cumprod_grad_zero_at_beginning(self):
+        """x = [0, 3, 5]: zero at position 0."""
+        x_val = np.array([0.0, 3.0, 5.0])
+        result = self._compute_cumprod_grad(x_val)
+
+        # y = [0, 0, 0]
+        # dloss/dx[0] = 1 + x[1] + x[1]*x[2] = 1 + 3 + 15 = 19
+        # dloss/dx[1] = x[0] + x[0]*x[2] = 0 + 0 = 0
+        # dloss/dx[2] = x[0]*x[1] = 0
+        expected = np.array([19.0, 0.0, 0.0])
+
+        assert not np.any(np.isnan(result)), f"NaN in gradient: {result}"
+        np.testing.assert_allclose(result, expected)
+
+    def test_cumprod_grad_multiple_zeros(self):
+        """x = [3, 0, 0, 5]: two adjacent zeros."""
+        x_val = np.array([3.0, 0.0, 0.0, 5.0])
+        result = self._compute_cumprod_grad(x_val)
+
+        # y = [3, 0, 0, 0]
+        # dloss/dx[0] = 1 + x[1] + x[1]*x[2] + x[1]*x[2]*x[3] = 1+0+0+0 = 1
+        # dloss/dx[1] = x[0] + x[0]*x[2] + x[0]*x[2]*x[3] = 3+0+0 = 3
+        # dloss/dx[2] = x[0]*x[1] + x[0]*x[1]*x[3] = 0+0 = 0
+        #   (two zeros in prefix => gradient contribution is zero)
+        # dloss/dx[3] = x[0]*x[1]*x[2] = 0
+        expected = np.array([1.0, 3.0, 0.0, 0.0])
+
+        assert not np.any(np.isnan(result)), f"NaN in gradient: {result}"
+        np.testing.assert_allclose(result, expected)
+
+    def test_cumprod_grad_all_zeros(self):
+        """x = [0, 0, 0]: all zeros, gradients must not produce NaN."""
+        x_val = np.array([0.0, 0.0, 0.0])
+        result = self._compute_cumprod_grad(x_val)
+
+        # y = [0, 0, 0]
+        # dloss/dx[0] = 1 + x[1] + x[1]*x[2] = 1+0+0 = 1
+        # dloss/dx[1] = x[0] + x[0]*x[2] = 0+0 = 0
+        #   (x[0] is zero, so all terms involving x[0] are zero)
+        # dloss/dx[2] = x[0]*x[1] = 0
+        expected = np.array([1.0, 0.0, 0.0])
+
+        assert not np.any(np.isnan(result)), f"NaN in gradient: {result}"
+        np.testing.assert_allclose(result, expected)
+
+    def test_cumprod_grad_2d_with_zeros(self):
+        """2D cumprod along axis=1 with zeros in each row."""
+        x_val = np.array([
+            [3.0, 0.0, 5.0],
+            [0.0, 7.0, 3.0],
+        ])
+        x = pt.matrix("x", dtype="float64")
+        y = cumprod(x, axis=1)
+        loss = y.sum()
+        (grad,) = pytensor.gradient.grad(loss, [x])
+        f = pytensor.function([x], grad)
+        result = f(x_val)
+
+        # Row 0: [3, 0, 5] — same as test_cumprod_grad_single_zero_middle
+        #   expected: [1, 18, 0]
+        # Row 1: [0, 7, 3]
+        #   y = [0, 0, 0]
+        #   dloss/dx[0] = 1 + x[1] + x[1]*x[2] = 1+7+21 = 29
+        #   dloss/dx[1] = x[0] + x[0]*x[2] = 0+0 = 0
+        #   dloss/dx[2] = x[0]*x[1] = 0
+        expected = np.array([
+            [1.0, 18.0, 0.0],
+            [29.0, 0.0, 0.0],
+        ])
+
+        assert not np.any(np.isnan(result)), f"NaN in gradient: {result}"
+        np.testing.assert_allclose(result, expected)
+
+
 class TestBinCount(utt.InferShapeTester):
     @pytest.mark.parametrize(
         "dtype",


### PR DESCRIPTION
## Problem

`CumOp.L_op` computed the gradient of `cumprod` using a division-based formula:

    cumsum((cumprod(x, axis) * g_out)[reverse], axis)[reverse] / x

When `x[i] == 0`, this produced `0 / 0 = NaN`, silently corrupting the gradient.  
This NaN propagates through the computation graph and can break optimization or MCMC without any clear indication that `cumprod` is the source.

This is a real-world issue since zeros commonly appear in probability masks, indicator variables, ReLU outputs, and sparse data.  
The existing tests did not catch this because they only used random inputs in `(0, 1)`, which never include zeros.

---

## Root Cause

The gradient formula relied on dividing by `x`, which is only valid when all elements are nonzero.

Unlike `Prod.L_op`, which implements explicit zero-handling logic, `CumOp.L_op` did not account for zero values.

---

## Fix

Replaced the division-based implementation with a mathematically equivalent **division-free formulation**.

For each position `i`:

    grad[i] = L[i] * R[i]

Where:

- `L[i]` = exclusive prefix product (`prod(x[0:i])`)
- `R[i]` = reverse linear recurrence  
      R[i] = g[i] + x[i+1] * R[i+1]

This approach:

- Avoids division entirely
- Correctly handles zero values
- Preserves the computation graph
- Passes finite-difference gradient checks

---

## Changes

- Updated `CumOp.L_op` in:
      pytensor/tensor/extra_ops.py

- Added regression tests in:
      tests/tensor/test_extra_ops.py

---

## Tests Added

New tests cover:

- Single zero in the middle
- Zero at the beginning
- Multiple zeros
- 2D inputs with zeros along an axis

All existing tests pass, and gradients are now correct for inputs containing zeros.

---

## Impact

- Eliminates silent NaN corruption in `cumprod` gradients
- Prevents hard-to-debug failures in downstream models (e.g., PyMC)
- Adds regression protection against future breakage
- Maintains backward compatibility

This PR fixes a clear correctness bug in `cumprod` gradient computation.
---