### PR TITLE
Fix incorrect attribute access in DestroyHandler.on_detach

### DIFF
--- a/pytensor/graph/destroyhandler.py
+++ b/pytensor/graph/destroyhandler.py
@@ -466,7 +466,7 @@ class DestroyHandler(Bookkeeper):
         del self.view_o
         del self.clients
         del self.stale_droot
-        assert self.fgraph.destroyer_handler is self
+        assert self.fgraph.destroy_handler is self
         delattr(self.fgraph, "destroyers")
         delattr(self.fgraph, "has_destroyers")
         delattr(self.fgraph, "destroy_handler")

--- a/tests/graph/test_destroyhandler.py
+++ b/tests/graph/test_destroyhandler.py
@@ -459,3 +459,16 @@ def test_multiple_inplace():
     ).rewrite(g)
     assert g.consistent()
     assert fail.failures == 1
+
+
+def test_destroy_handler_detach():
+    x, _y, _z = inputs()
+    g = FunctionGraph([x], [x], clone=False)
+
+    dh = DestroyHandler()
+    dh.on_attach(g)
+
+    dh.on_detach(g)
+
+    assert not hasattr(g, "destroy_handler")
+    


### PR DESCRIPTION
DestroyHandler.on_detach references fgraph.destroyer_handler, but the attribute set during on_attach is fgraph.destroy_handler. This mismatch causes an AttributeError when on_detach is called.

This change corrects the attribute reference so that the handler detaches cleanly from the FunctionGraph.

A small test is added to ensure DestroyHandler can attach and detach without errors and that the destroy_handler attribute is removed from the FunctionGraph.