### PR TITLE
Remove need for explicit left expand_dims in inputs of Elemwise

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,36 +57,35 @@ Getting started
     d = a/a + (M + a).dot(v)
 
     pytensor.dprint(d)
-    #  Add [id A]
-    #  ├─ ExpandDims{axis=0} [id B]
-    #  │  └─ True_div [id C]
-    #  │     ├─ a [id D]
-    #  │     └─ a [id D]
-    #  └─ dot [id E]
-    #     ├─ Add [id F]
-    #     │  ├─ M [id G]
-    #     │  └─ ExpandDims{axes=[0, 1]} [id H]
-    #     │     └─ a [id D]
-    #     └─ v [id I]
+    # Add [id A]
+    #  ├─ True_div [id B]
+    #  │  ├─ a [id C]
+    #  │  └─ a [id C]
+    #  └─ Squeeze{axis=1} [id D]
+    #     └─ Dot [id E]
+    #        ├─ Add [id F]
+    #        │  ├─ M [id G]
+    #        │  └─ a [id C]
+    #        └─ ExpandDims{axis=1} [id H]
+    #           └─ v [id I]
 
     f_d = pytensor.function([a, v, M], d)
 
     # `a/a` -> `1` and the dot product is replaced with a BLAS function
     # (i.e. CGemv)
     pytensor.dprint(f_d)
-    # Add [id A] 5
-    #  ├─ [1.] [id B]
-    #  └─ CGemv{inplace} [id C] 4
-    #     ├─ AllocEmpty{dtype='float64'} [id D] 3
-    #     │  └─ Shape_i{0} [id E] 2
+    # Add [id A] 4
+    #  ├─ 1.0 [id B]
+    #  └─ CGemv{inplace} [id C] 3
+    #     ├─ AllocEmpty{dtype='float64'} [id D] 2
+    #     │  └─ Shape_i{0} [id E] 1
     #     │     └─ M [id F]
-    #     ├─ 1.0 [id G]
-    #     ├─ Add [id H] 1
+    #     ├─ 1.0 [id B]
+    #     ├─ Add [id G] 0
     #     │  ├─ M [id F]
-    #     │  └─ ExpandDims{axes=[0, 1]} [id I] 0
-    #     │     └─ a [id J]
-    #     ├─ v [id K]
-    #     └─ 0.0 [id L]
+    #     │  └─ a [id H]
+    #     ├─ v [id I]
+    #     └─ 0.0 [id J]
 
 See `the PyTensor documentation <https://pytensor.readthedocs.io/en/latest/>`__ for in-depth tutorials.
 

--- a/pytensor/link/numba/dispatch/elemwise.py
+++ b/pytensor/link/numba/dispatch/elemwise.py
@@ -383,7 +383,9 @@ def numba_funcify_Elemwise(op, node, **kwargs):
                 type(op),
                 tuple(op.inplace_pattern.items()),
                 input_bc_patterns,
+                output_bc_patterns,
                 scalar_cache_key,
+                2,  # cache version
             )
         )
         elemwise_key = sha256(elemwise_key.encode()).hexdigest()

--- a/pytensor/link/numba/dispatch/vectorize_codegen.py
+++ b/pytensor/link/numba/dispatch/vectorize_codegen.py
@@ -125,7 +125,7 @@ def _vectorized(
         raise TypeError("allow_core_scalar must be literal.")
     allow_core_scalar = allow_core_scalar.literal_value
 
-    batch_ndim = len(input_bc_patterns[0])
+    batch_ndim = len(output_bc_patterns[0])
     nin = len(constant_inputs_types) + len(input_types)
     nout = len(output_bc_patterns)
 
@@ -137,13 +137,6 @@ def _vectorized(
 
     if not all(isinstance(input, types.Array) for input in input_types):
         raise TypingError("Vectorized inputs must be arrays.")
-
-    if not all(
-        len(pattern) == batch_ndim for pattern in input_bc_patterns + output_bc_patterns
-    ):
-        raise TypingError(
-            "Vectorized broadcastable patterns must have the same length."
-        )
 
     core_input_types = []
     for input_type, bc_pattern in zip(input_types, input_bc_patterns, strict=True):
@@ -291,7 +284,7 @@ def compute_itershape(
     size: list[ir.Instruction] | None,
 ):
     one = ir.IntType(64)(1)
-    batch_ndim = len(broadcast_pattern[0])
+    batch_ndim = max((len(p) for p in broadcast_pattern), default=0)
     shape = [None] * batch_ndim
     if size is not None:
         shape = size
@@ -299,8 +292,13 @@ def compute_itershape(
             for j, (bc, in_shape) in enumerate(
                 zip(broadcast_pattern, in_shapes, strict=True)
             ):
-                length = in_shape[i]
-                if bc[i]:
+                # Offset for inputs with fewer dims than batch_ndim
+                offset = batch_ndim - len(bc)
+                if i < offset:
+                    # Implicit broadcast dim — no array dim to check
+                    continue
+                length = in_shape[i - offset]
+                if bc[i - offset]:
                     with builder.if_then(
                         builder.icmp_unsigned("!=", length, one), likely=False
                     ):
@@ -336,8 +334,11 @@ def compute_itershape(
             for j, (bc, in_shape) in enumerate(
                 zip(broadcast_pattern, in_shapes, strict=True)
             ):
-                length = in_shape[i]
-                if bc[i]:
+                offset = batch_ndim - len(bc)
+                if i < offset:
+                    continue
+                length = in_shape[i - offset]
+                if bc[i - offset]:
                     with builder.if_then(
                         builder.icmp_unsigned("!=", length, one), likely=False
                     ):
@@ -452,6 +453,7 @@ def make_loop_call(
     # output_scope_set = mod.add_metadata([input_scope, output_scope])
 
     zero = ir.Constant(ir.IntType(64), 0)
+    batch_ndim = len(iter_shape)
 
     # Setup loops and initialize accumulators for outputs
     # This part corresponds to opening the loops
@@ -480,9 +482,12 @@ def make_loop_call(
     for input, input_type, bc in zip(inputs, input_types, input_bc, strict=True):
         core_ndim = input_type.ndim - len(bc)
 
-        idxs_bc = [zero if bc else idx for idx, bc in zip(idxs, bc, strict=True)] + [
-            zero
-        ] * core_ndim
+        # For inputs with fewer batch dims than the loop, skip leading loop indices
+        offset = batch_ndim - len(bc)
+        idxs_bc = [
+            zero if bc_dim else idx
+            for idx, bc_dim in zip(idxs[offset:], bc, strict=True)
+        ] + [zero] * core_ndim
         ptr = cgutils.get_item_pointer2(
             context,
             builder,

--- a/pytensor/scan/rewriting.py
+++ b/pytensor/scan/rewriting.py
@@ -56,6 +56,7 @@ from pytensor.tensor.basic import (
     Alloc,
     AllocEmpty,
     atleast_Nd,
+    expand_dims,
     get_scalar_constant_value,
 )
 from pytensor.tensor.elemwise import DimShuffle, Elemwise
@@ -503,6 +504,21 @@ def scan_push_out_seq(fgraph, node):
                 continue
 
             to_remove_set.add(nd)
+
+            # When inner Elemwise inputs have different ndims, lower-ndim
+            # inputs are implicitly left-padded. Outer equivalents of inputs
+            # with a time dimension need broadcast dims inserted right after
+            # the time dim (position 0) to match that implicit padding.
+            # E.g., inner (v,) broadcasting with (a, v) → outer (t, v)
+            # must become (t, 1, v) so it broadcasts with (a, v) to (t, a, v).
+            inner_max_ndim = max(x.type.ndim for x in nd.inputs)
+            for i, x in enumerate(nd.inputs):
+                has_time = x in inner_seqs_set or x in to_replace_set
+                n_pad = inner_max_ndim - x.type.ndim
+                if has_time and n_pad > 0:
+                    outside_ins[i] = expand_dims(
+                        outside_ins[i], axis=tuple(range(1, 1 + n_pad))
+                    )
 
             # Do not call make_node for test_value
             nw_outer_node = nd.op.make_node(*outside_ins)

--- a/pytensor/sparse/rewriting.py
+++ b/pytensor/sparse/rewriting.py
@@ -16,7 +16,7 @@ from pytensor.link.c.op import COp, _NoPythonCOp
 from pytensor.sparse.basic import csm_properties
 from pytensor.sparse.math import usmm
 from pytensor.tensor import blas
-from pytensor.tensor.basic import as_tensor_variable, cast
+from pytensor.tensor.basic import as_tensor_variable, atleast_Nd, cast
 from pytensor.tensor.math import mul, neg, sub
 from pytensor.tensor.rewriting.basic import register_canonicalize, register_specialize
 from pytensor.tensor.shape import shape, specify_shape
@@ -957,6 +957,9 @@ def local_usmm_csx(fgraph, node):
                 if y.type.dtype != dtype_out:
                     return False
 
+                # UsmmCscDense requires alpha to be 2-d with shape (1, 1)
+                if alpha.ndim < 2:
+                    alpha = atleast_Nd(alpha, n=2)
                 return [usmm_csc_dense(alpha, x_val, x_ind, x_ptr, x_nsparse, y, z)]
     return False
 

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -379,7 +379,7 @@ def _get_underlying_scalar_constant_value(
                     ret = [[None]]
                     v.owner.op.perform(v.owner, const, ret)
                     return np.asarray(ret[0][0].copy())
-            # In fast_compile, we don't enable local_fill_to_alloc, so
+            # In fast_compile, we don't enable local_second_to_alloc, so
             # we need to investigate Second as Alloc. So elemwise
             # don't disable the check for Second.
             elif isinstance(op, Elemwise):

--- a/pytensor/tensor/elemwise.py
+++ b/pytensor/tensor/elemwise.py
@@ -11,7 +11,7 @@ from pytensor.configdefaults import config
 from pytensor.gradient import DisconnectedType
 from pytensor.graph.basic import Apply
 from pytensor.graph.null_type import NullType
-from pytensor.graph.replace import _vectorize_node, _vectorize_not_needed
+from pytensor.graph.replace import _vectorize_node
 from pytensor.graph.utils import MethodNotDefined
 from pytensor.link.c.basic import failure_code
 from pytensor.link.c.op import COp, ExternalCOp, OpenMPOp
@@ -38,6 +38,32 @@ from pytensor.tensor.utils import (
 )
 from pytensor.tensor.variable import TensorVariable
 from pytensor.utils import uniq, unzip
+
+
+def aligned_broadcastable_of(inp, out_ndim):
+    """Return broadcastable left-padded with True to out_ndim.
+
+    When Elemwise inputs have different ndims, the shorter ones are implicitly
+    left-padded with broadcastable (size-1) dimensions. This helper makes that
+    padding explicit, so callers can reason about aligned dimensions without
+    ad-hoc offset arithmetic.
+    """
+    inp_bc = inp.type.broadcastable
+    return (True,) * (out_ndim - len(inp_bc)) + inp_bc
+
+
+def aligned_shape_of(inp, out_ndim):
+    """Return shape left-padded with 1 to out_ndim.
+
+    Counterpart of :func:`aligned_broadcastable_of` for static shapes.
+    """
+    inp_shape = inp.type.shape
+    return (1,) * (out_ndim - len(inp_shape)) + inp_shape
+
+
+def input_offset(inp, out_ndim):
+    """Return number of implicit leading dims for *inp* in an Elemwise with *out_ndim* output dims."""
+    return out_ndim - inp.type.ndim
 
 
 class DimShuffle(ExternalCOp):
@@ -383,7 +409,7 @@ class Elemwise(OpenMPOp):
 
     def get_output_info(self, *inputs):
         """Return the outputs dtype and broadcastable pattern and the
-        dimshuffled inputs.
+        (unchanged) inputs.
 
         """
         shadow = self.scalar_op.make_node(
@@ -392,29 +418,13 @@ class Elemwise(OpenMPOp):
 
         target_length = max(input.type.ndim for input in inputs)
 
-        args = []
-        for input in inputs:
-            length = input.type.ndim
-            difference = target_length - length
-            if not difference:
-                args.append(input)
-            else:
-                args.append(input.dimshuffle(["x"] * difference + list(range(length))))
-        inputs = args
+        padded_shapes = [aligned_shape_of(inp, target_length) for inp in inputs]
 
-        # HERE: all the broadcast dims have the same length now
-
-        # cleverness: we iterate over the first, second, third broadcast flag
-        # of all inputs in parallel... the all() gives us each output
-        # broadcastable bit in turn.
-
-        # it is multiplied by nout because Elemwise supports multiple outputs
-        # (nout of them)
         try:
             out_shapes = [
                 [
-                    broadcast_static_dim_lengths(shape)
-                    for shape in zip(*[inp.type.shape for inp in inputs], strict=True)
+                    broadcast_static_dim_lengths(dims)
+                    for dims in zip(*padded_shapes, strict=True)
                 ]
             ] * shadow.nout
         except ValueError:
@@ -426,8 +436,10 @@ class Elemwise(OpenMPOp):
         inplace_pattern = self.inplace_pattern
         if inplace_pattern:
             for overwriter, overwritten in inplace_pattern.items():
+                # Left-pad the overwritten input's shape before comparing
+                padded_in_shape = padded_shapes[overwritten]
                 for out_s, in_s in zip(
-                    out_shapes[overwriter], inputs[overwritten].type.shape, strict=True
+                    out_shapes[overwriter], padded_in_shape, strict=True
                 ):
                     if in_s == 1 and out_s != 1:
                         raise ValueError(
@@ -450,9 +462,9 @@ class Elemwise(OpenMPOp):
 
     def make_node(self, *inputs):
         """
-        If the inputs have different number of dimensions, their shape
-        is left-completed to the greatest number of dimensions with 1s
-        using DimShuffle.
+        If the inputs have different number of dimensions, broadcasting
+        is handled implicitly by left-padding shorter shapes with 1s.
+        No DimShuffle nodes are inserted.
         """
         inputs = [as_tensor_variable(i) for i in inputs]
         out_dtypes, out_shapes, inputs = self.get_output_info(*inputs)
@@ -516,22 +528,29 @@ class Elemwise(OpenMPOp):
         rval = self._bgrad(inputs, outs, ograds)
 
         # sum out the broadcasted dimensions
+        out_ndim = outs[0].type.ndim
         for i, ipt in enumerate(inputs):
             if isinstance(rval[i].type, NullType | DisconnectedType):
                 continue
 
+            padded_shape = aligned_shape_of(ipt, out_ndim)
+            ipt_offset = input_offset(ipt, out_ndim)
+
             # List of all the dimensions that are broadcastable for input[i] so
-            # we can sum over them
-            # TODO: only count dimensions that were effectively broadcasted
+            # we can sum over them (including implicit leading dims)
             to_sum = [
                 j
-                for j, in_s in enumerate(ipt.type.shape)
+                for j, in_s in enumerate(padded_shape)
                 if in_s == 1 and outs[0].type.shape[j] != 1
             ]
 
             if to_sum:
                 sr = pt_sum(rval[i], axis=to_sum, keepdims=True)
                 rval[i] = sr
+
+            # Squeeze out the implicit leading dimensions
+            if ipt_offset > 0:
+                rval[i] = rval[i].squeeze(axis=tuple(range(ipt_offset)))
 
         return rval
 
@@ -561,7 +580,7 @@ class Elemwise(OpenMPOp):
                 f"{self.scalar_op!s}.grad returned {type(scalar_igrads)!s} instead of list or tuple"
             )
 
-        nd = inputs[0].type.ndim  # this is the same for everyone
+        nd = outputs[0].type.ndim  # this is the same for everyone
 
         def transform(r):
             # From a graph of ScalarOps, make a graph of Broadcast ops.
@@ -730,14 +749,13 @@ class Elemwise(OpenMPOp):
 
     @staticmethod
     def _check_runtime_broadcast(node, inputs):
-        # zip strict not specified because we are in a hot loop
-        for dims_and_bcast in zip(
-            *[
-                zip(input.shape, sinput.type.broadcastable)
-                for input, sinput in zip(inputs, node.inputs)
-            ],
-            strict=False,
-        ):
+        out_ndim = node.outputs[0].type.ndim
+        padded = []
+        for input, sinput in zip(inputs, node.inputs):
+            ipt_offset = input_offset(sinput, out_ndim)
+            shape_bcast = tuple(zip(input.shape, sinput.type.broadcastable))
+            padded.append(((1, True),) * ipt_offset + shape_bcast)
+        for dims_and_bcast in zip(*padded):
             if any(d != 1 for d, _ in dims_and_bcast) and (1, False) in dims_and_bcast:
                 raise ValueError(
                     "Runtime broadcasting not allowed. "
@@ -748,7 +766,10 @@ class Elemwise(OpenMPOp):
     def infer_shape(self, fgraph, node, i_shapes) -> list[tuple[TensorVariable, ...]]:
         from pytensor.tensor.extra_ops import broadcast_shape
 
-        out_shape = broadcast_shape(*i_shapes, arrays_are_shapes=True)
+        max_ndim = max((len(s) for s in i_shapes), default=0)
+        _one = as_tensor_variable(1, dtype="int64")
+        padded = [(_one,) * (max_ndim - len(s)) + s for s in i_shapes]
+        out_shape = broadcast_shape(*padded, arrays_are_shapes=True)
         return [tuple(as_tensor_variable(s) for s in out_shape)] * len(node.outputs)
 
     def _c_all(self, node, nodename, inames, onames, sub):
@@ -821,14 +842,17 @@ class Elemwise(OpenMPOp):
 
         # for each input:
         # same as range(ndim), but with 'x' at all broadcastable positions
-        orders = [
-            [(s == 1 and "x") or i for i, s in enumerate(input.type.shape)]
-            for input in inputs
-        ]
+        target_ndim = node.outputs[0].type.ndim
+        orders = []
+        for input in inputs:
+            ipt_offset = input_offset(input, target_ndim)
+            order = ["x"] * ipt_offset + [
+                ("x" if s == 1 else i) for i, s in enumerate(input.type.shape)
+            ]
+            orders.append(order)
 
-        # number of nested loops we will need (all inputs have same
-        # dimensionality)
-        nnested = len(orders[0])
+        # number of nested loops we will need
+        nnested = target_ndim
         sub = dict(sub)
         for i, (input, iname) in enumerate(zip(inputs, inames, strict=True)):
             # the c generators will substitute the input names for
@@ -1017,7 +1041,11 @@ class Elemwise(OpenMPOp):
                     or all(
                         len(set(inp_shape)) == 1 and None not in inp_shape
                         for inp_shape in zip(
-                            *(inp.type.shape for inp in node.inputs), strict=True
+                            *[
+                                aligned_shape_of(inp, target_ndim)
+                                for inp in node.inputs
+                            ],
+                            strict=True,
                         )
                     )
                 ):
@@ -1099,7 +1127,7 @@ class Elemwise(OpenMPOp):
         return support_code
 
     def c_code_cache_version_apply(self, node):
-        version = [17]  # the version corresponding to the c code in this Op
+        version = [18]  # the version corresponding to the c code in this Op
 
         # now we insert versions for the ops on which we depend...
         scalar_node = Apply(
@@ -1668,7 +1696,30 @@ def _get_vector_length_Elemwise(op, var):
     raise ValueError(f"Length of {var} cannot be determined")
 
 
-_vectorize_node.register(Elemwise, _vectorize_not_needed)
+def _vectorize_elemwise(op, node, *batched_inputs):
+    """Vectorize an Elemwise node with mixed-ndim inputs.
+
+    When inputs have different ndims, right-pad shorter inputs with
+    trailing broadcastable dims so that batch dims (added at the left
+    by vectorize_graph) remain aligned across all inputs.
+    """
+    max_core_ndim = max((inp.type.ndim for inp in node.inputs), default=0)
+
+    if all(inp.type.ndim == max_core_ndim for inp in node.inputs):
+        return op.make_node(*batched_inputs).outputs
+
+    new_inputs = []
+    for old_inp, new_inp in zip(node.inputs, batched_inputs, strict=True):
+        n_trailing = input_offset(old_inp, max_core_ndim)
+        if n_trailing > 0 and new_inp.type.ndim > old_inp.type.ndim:
+            order = list(range(new_inp.type.ndim)) + ["x"] * n_trailing
+            new_inputs.append(new_inp.dimshuffle(order))
+        else:
+            new_inputs.append(new_inp)
+    return op.make_node(*new_inputs).outputs
+
+
+_vectorize_node.register(Elemwise, _vectorize_elemwise)
 
 
 @_vectorize_node.register(DimShuffle)

--- a/pytensor/tensor/rewriting/basic.py
+++ b/pytensor/tensor/rewriting/basic.py
@@ -18,11 +18,12 @@ alloc(x, broadcast_shapes(x.shape, y.shape)) + alloc(y, broadcast_shapes(x.shape
 second(y, x) + second(x, y) -> x + y
 
 Theano developers (mostly) preferred to use the first form during canonicalization and introduce the second form later,
-via rewrites like `local_fill_to_alloc`, and using the `alloc_like` helper inside rewrites.
+via rewrites like `local_second_to_alloc`, and using the `broadcast_like_elemwise` helper inside rewrites.
 Many stabilize and stabilization rewrites refuse to be applied when a variable has multiple clients, so this is important.
 """
 
 import logging
+from collections.abc import Sequence
 
 import numpy as np
 from numpy.lib.array_utils import normalize_axis_index
@@ -30,7 +31,7 @@ from numpy.lib.array_utils import normalize_axis_index
 from pytensor import compile, config
 from pytensor.compile.ops import ViewOp
 from pytensor.graph import FunctionGraph, Op
-from pytensor.graph.basic import Constant
+from pytensor.graph.basic import Apply, Constant
 from pytensor.graph.rewriting.basic import (
     NodeProcessingGraphRewriter,
     NodeRewriter,
@@ -58,6 +59,7 @@ from pytensor.scalar import (
     Second,
     Switch,
 )
+from pytensor.tensor import TensorLike
 from pytensor.tensor.basic import (
     Alloc,
     AllocEmpty,
@@ -70,22 +72,25 @@ from pytensor.tensor.basic import (
     as_tensor_variable,
     atleast_Nd,
     cast,
+    constant,
     fill,
     get_scalar_constant_value,
     join,
-    ones_like,
     register_infer_shape,
+    second,
     switch,
     tensor_copy,
     tile,
     zeros,
-    zeros_like,
 )
-from pytensor.tensor.elemwise import DimShuffle, Elemwise
+from pytensor.tensor.elemwise import (
+    DimShuffle,
+    Elemwise,
+)
 from pytensor.tensor.exceptions import NotScalarConstantError
 from pytensor.tensor.extra_ops import broadcast_arrays
 from pytensor.tensor.math import Sum, add, eq, variadic_add
-from pytensor.tensor.shape import Shape_i, shape_padleft
+from pytensor.tensor.shape import Shape_i
 from pytensor.tensor.type import DenseTensorType, TensorType
 from pytensor.tensor.variable import TensorConstant, TensorVariable
 from pytensor.utils import NoDuplicateOptWarningFilter
@@ -93,6 +98,29 @@ from pytensor.utils import NoDuplicateOptWarningFilter
 
 _logger = logging.getLogger("pytensor.tensor.rewriting.basic")
 _logger.addFilter(NoDuplicateOptWarningFilter())
+
+
+def broadcasted_by_axes(
+    x: TensorVariable, y: TensorVariable, negative_indices: bool = False
+) -> tuple[int, ...]:
+    bx = x.type.broadcastable
+    by = y.type.broadcastable
+    missing_x_dims = len(by) - len(bx)
+    indices = (
+        *range(missing_x_dims),
+        *(
+            i
+            for i, (bx_dim, by_dim) in enumerate(
+                zip(bx, by[missing_x_dims:]), start=missing_x_dims
+            )
+            if bx_dim and not by_dim
+        ),
+    )
+    if negative_indices:
+        ndim = len(by)
+        return tuple(i - ndim for i in reversed(indices))
+    else:
+        return indices
 
 
 def broadcasted_by(x: TensorVariable, y: TensorVariable) -> bool:
@@ -119,38 +147,126 @@ def broadcasted_by(x: TensorVariable, y: TensorVariable) -> bool:
     return any(bx_dim and not by_dim for bx_dim, by_dim in zip(bx, by, strict=True))
 
 
-def merge_broadcastables(broadcastables):
-    return [all(bcast) for bcast in zip(*broadcastables, strict=True)]
+def get_simplified_shape(x: TensorVariable, *, fgraph) -> tuple:
+    try:
+        return fgraph.shape_feature.shape_of[x]
+    except Exception:
+        pass
+
+    static_shape = x.type.shape
+    if not any(d is None for d in static_shape):
+        return static_shape
+
+    return tuple(x.shape)
 
 
-def alloc_like(
-    value: TensorVariable,
-    template: TensorVariable,
+def get_simplified_broadcast_shape(first, *others, fgraph):
+    broadcast_ndim = max(x.type.ndim for x in (first, *others))
+    first_broadcastable = first.type.broadcastable
+    first_shape = get_simplified_shape(first, fgraph=fgraph)
+    missing_dims = broadcast_ndim - len(first_shape)
+
+    if not (missing_dims or any(first_broadcastable)):
+        return first_shape
+
+    broadcastable_dims = [*([True] * missing_dims), *first_broadcastable]
+    broadcast_shape = [*([1] * missing_dims), *first_shape]
+    for other in others:
+        other_shape = get_simplified_shape(other, fgraph=fgraph)
+        for i, (other_broadcastable, other_dim_length) in enumerate(
+            reversed(tuple(zip(other.type.broadcastable, other_shape))), start=1
+        ):
+            i = -i
+            if other_broadcastable or not broadcastable_dims[i]:
+                # Doesn't provide any new info
+                continue
+            broadcast_shape[i] = other_dim_length
+            broadcastable_dims[i] = False  # Don't override again
+    return broadcast_shape
+
+
+def broadcast_like_elemwise(
+    value: TensorVariable | TensorLike | Sequence[TensorVariable | TensorLike],
+    node: Apply[Elemwise],
+    *,
     fgraph: FunctionGraph,
-    dtype=None,
-) -> TensorVariable:
-    """Fill value to the same shape and dtype as the template via alloc."""
-    value = as_tensor_variable(value)
-    if value.type.is_super(template.type):
-        return value
-    if template not in fgraph.variables:
-        raise NotImplementedError(
-            "broadcast_like currently requires the "
-            "template Variable to be in the fgraph already"
-        )
-    if dtype is None:
-        dtype = template.dtype
-    value = cast(value, dtype)
-    if value.type.is_super(template.type):
-        return value
-    if hasattr(fgraph, "shape_feature"):
-        new_shape = fgraph.shape_feature.shape_of[template]
-    else:
-        new_shape = template.shape
-    rval = alloc(value, *new_shape)
-    assert rval.type.dtype == dtype
+    ref_input_idx: int | None = None,
+    stack_trace: bool = False,
+) -> TensorVariable | list[TensorVariable]:
+    """Broadcast value(s) to match the output shape and dtype(s) of an elemwise node.
 
-    return rval
+    Each value is cast to match its corresponding ``node.outputs[i]`` dtype,
+    then expanded to the correct number of dimensions and, if necessary,
+    broadcast via `Alloc` to the full output shape.
+
+    When only dimension padding is needed (no size-1 axes must be broadcast),
+    a lightweight ``DimShuffle`` is used instead of ``Alloc``.
+
+    The broadcast shape is derived from ``node.inputs`` rather than
+    ``node.outputs``, so the result does not depend on the node's outputs.
+    This eagerness may mask shape errors present in the original graph
+    ("shape_unsafe").
+
+    Parameters
+    ----------
+    value
+        A single variable (or constant), or a list of variables.
+        When a list is given each entry corresponds to an output of ``node``.
+    node
+        The elemwise node whose output shape the values should match.
+    fgraph
+        The function graph containing the node (used to simplify shapes).
+    ref_input_idx
+        If given, ``node.inputs[ref_input_idx]`` is passed as the first
+        argument to ``get_simplified_broadcast_shape``, giving its shape
+        priority for non-broadcastable dims. This is useful when the value
+        originates from that input, so the Alloc reuses the value's own
+        shape for dims that don't need broadcasting. By default
+        (``None``), ``node.inputs[0]`` already has priority by virtue of
+        being first.
+    stack_trace
+        If ``True``, copy the stack trace from ``node.outputs[0]`` onto every
+        returned variable.
+    """
+    is_seq = isinstance(value, list | tuple)
+    values = value if is_seq else (value,)
+
+    ref_out = node.outputs[0]
+    out_ndim = ref_out.type.ndim
+
+    # Convert and cast to match each output's dtype
+    casted = []
+    for v, out in zip(values, node.outputs):
+        # Shortcut for the common cases
+        if isinstance(v, TensorVariable):
+            pass
+        elif isinstance(v, np.ndarray):
+            v = constant(v)
+        else:
+            v = as_tensor_variable(v)
+        if v.type.dtype != out.type.dtype:
+            v = cast(v, out.type.dtype)
+        casted.append(v)
+
+    # Pad dims and check if broadcasting is needed
+    padded = [atleast_Nd(v, n=out_ndim) for v in casted]
+    if broadcasted_by_axes(padded[0], ref_out, negative_indices=True):
+        # Alloc can expand dims itself, so use the un-padded values
+        if ref_input_idx is not None:
+            inputs = list(node.inputs)
+            ref = inputs.pop(ref_input_idx)
+            inputs.insert(0, ref)
+        else:
+            inputs = node.inputs
+        bcast_shape = get_simplified_broadcast_shape(*inputs, fgraph=fgraph)
+        results = [alloc(v, *bcast_shape) for v in casted]
+    else:
+        results = padded
+
+    if stack_trace:
+        copy_stack_trace(ref_out, results)
+
+    return results if is_seq else results[0]
 
 
 def register_useless(
@@ -292,65 +408,34 @@ def local_elemwise_alloc(fgraph, node):
     if len(node.inputs) == 1:
         return None
 
-    def dimshuffled_alloc(i):
-        return (
-            isinstance(i.owner.op, DimShuffle)
-            and i.owner.inputs[0].owner
-            and isinstance(i.owner.inputs[0].owner.op, Alloc)
-        )
-
     # At least one input must have an owner that is either a `Alloc` or a
     # `DimShuffle` with an owner that is a `Alloc` -- otherwise there is
     # nothing to optimize.
     alloc_idxs = [
         idx
         for idx, i in enumerate(node.inputs)
-        if i.owner and (isinstance(i.owner.op, Alloc) or dimshuffled_alloc(i))
+        if i.owner is not None and isinstance(i.owner.op, Alloc)
     ]
-    if len(alloc_idxs) == 0:
+    if not alloc_idxs:
         return False
 
     new_inputs = list(node.inputs)
     for idx in alloc_idxs:
-        i = node.inputs[idx]
-
-        # Remove simple `Alloc`
-        if isinstance(i.owner.op, Alloc):
-            new_inp = i.owner.inputs[0]
-
-        # Remove `Dimshuffle(Alloc)`
-        elif isinstance(i.owner.op, DimShuffle):
-            old_alloc = i.owner.inputs[0]
-            old_alloc_inp = old_alloc.owner.inputs[0]
-            missing_ndims = old_alloc.type.ndim - old_alloc_inp.type.ndim
-            if missing_ndims > 0:
-                # The `Alloc` added new dimensions to the left.
-                # We replace those cases with a `DimShuffle` here.
-                # Nested dimshuffles will be merged later by other rewrites.
-                old_alloc_inp = shape_padleft(old_alloc_inp, missing_ndims)
-            # We need to keep the old `DimShuffle`. It could swap axes or
-            # add dimensions anywhere.
-            new_inp = i.owner.op(old_alloc_inp)
-
-        copy_stack_trace(i, new_inp)
+        alloc_inp = node.inputs[idx]
+        new_inp = alloc_inp.owner.inputs[0]
+        copy_stack_trace(alloc_inp, new_inp)
         new_inputs[idx] = new_inp
 
     new_outs = node.op(*new_inputs, return_list=True)
-
-    if new_outs[0].type.broadcastable != node.outputs[0].type.broadcastable:
-        new_outs = [
-            alloc_like(new_out, node.outputs[0], fgraph) for new_out in new_outs
-        ]
-
-    copy_stack_trace(node.outputs, new_outs)
+    new_outs = broadcast_like_elemwise(new_outs, node, fgraph=fgraph, stack_trace=True)
     return new_outs
 
 
 @node_rewriter([Elemwise])
-def local_fill_sink(fgraph, node):
+def local_second_sink(fgraph, node):
     """
-    f(fill(a, b), fill(c, d), e) -> fill(c, fill(a, f(b, d, e)))
-    f need to be an elemwise that isn't a fill.
+    f(second(a, b), second(c, d), e) -> second(c, second(a, f(b, d, e)))
+    f need to be an elemwise that isn't a second.
     """
     if isinstance(node.op.scalar_op, Second):
         return False
@@ -358,10 +443,10 @@ def local_fill_sink(fgraph, node):
     models = []
     inputs = []
     for inp in node.inputs:
-        if inp.owner and inp.owner.op == fill:
+        if inp.owner and inp.owner.op == second:
             a, b = inp.owner.inputs
             if b.type.dtype != inp.dtype:
-                # The input was implicitly casted by the fill operation
+                # The input was implicitly casted by the second operation
                 b = b.cast(inp.dtype)
             models.append(a)
             inputs.append(b)
@@ -373,65 +458,55 @@ def local_fill_sink(fgraph, node):
 
     outputs = node.op.make_node(*inputs).outputs
 
-    # Check if we need to propagate the fill to the new outputs
+    # Check if we need to propagate the second to the new outputs
     # It's enough to check the first output, as Elemwise outputs must all have the same shapes
-    # Note: There are orderings that may require fewer fills.
+    # Note: There are orderings that may require fewer seconds.
     for model in models:
         # Only apply this model if it would actually do anything
         if broadcasted_by(outputs[0], model):
-            outputs = [fill(model, output) for output in outputs]
+            outputs = [second(model, output) for output in outputs]
 
     return outputs
 
 
 # The rewrite is wrapped in an in2out GraphRewriter
-# so that fill can be sinked until the terminal nodes in a single pass through the graph
+# so that second can be sinked until the terminal nodes in a single pass through the graph
 # without triggering other rewrites after each local substitution
-topological_fill_sink = in2out(local_fill_sink)
-register_canonicalize(topological_fill_sink, "shape_unsafe")
+topological_second_sink = in2out(local_second_sink)
+register_canonicalize(topological_second_sink, "shape_unsafe")
 
 
 @register_specialize("shape_unsafe")
 @register_stabilize("shape_unsafe")
-@node_rewriter([fill])
-def local_fill_to_alloc(fgraph, node):
-    r"""Remove `fill`\s or replace them with `Alloc`\s.
+@node_rewriter([second])
+def local_second_to_alloc(fgraph, node):
+    r"""Remove `second`\s or replace them with `Alloc`\s.
 
     `Alloc`\s are preferable because they replace explicit tensor dependencies
     with their dependencies on those tensors' shapes, and sometimes those
     shapes can be computed without needing to compute the tensors themselves.
 
-    Like `local_fill_sink` this rewrites assumes non-broadcastable shapes are equivalent,
+    Like `local_second_sink` this rewrites assumes non-broadcastable shapes are equivalent,
     which could mask shape errors.
     """
-    shape_ref, values_ref = node.inputs
-    out_type = node.outputs[0].type
+    _first, second = node.inputs
 
-    if values_ref.type.broadcastable == out_type.broadcastable:
-        # The assumption here is that `values_ref` already has the same shape
-        # as `shape_ref`, so a `fill`/`Alloc` is unnecessary.
-        return [values_ref]
-
-    if shape_ref.type.broadcastable == out_type.broadcastable:
-        # In this case, we assume that some broadcasting is needed (otherwise
-        # the condition above would've been true), so we replace the `fill`
-        # with an `Alloc`.
-        o = alloc_like(values_ref, shape_ref, fgraph, dtype=values_ref.dtype)
-        copy_stack_trace(node.outputs[0], o)
-        return [o]
-
-    # The case that is not covered is when `shape_ref` is broadcasted by `values_ref`
-    # TODO: Return broadcast_to(values_ref, broadcast_shapes(values_ref.shape, shape_ref.shape))
-
-    return
+    new_out = broadcast_like_elemwise(
+        second, node, fgraph=fgraph, ref_input_idx=1, stack_trace=True
+    )
+    return [new_out]
 
 
 # Register this after stabilize at 1.5 to make sure stabilize don't
 # get affected by less canonicalized graph due to alloc.
 compile.optdb.register(
-    "local_fill_to_alloc", in2out(local_fill_to_alloc), "fast_run", position=1.51
+    "local_second_to_alloc",
+    in2out(local_second_to_alloc),
+    "fast_run",
+    "shape_unsafe",
+    position=1.51,
 )
-# Needed to clean some extra alloc added by local_fill_to_alloc
+# Needed to clean some extra alloc added by local_second_to_alloc
 compile.optdb.register(
     "local_elemwise_alloc", in2out(local_elemwise_alloc), "fast_run", position=1.52
 )
@@ -445,7 +520,7 @@ def local_useless_fill(fgraph, node):
     """fill(s,v) -> v
 
     This rewrite is only needed in FAST_COMPILE mode to make the code
-    more readable. Normally, it is done by the `local_fill_to_alloc`
+    more readable. Normally, it is done by the `local_second_to_alloc`
     rewrite.
 
     """
@@ -566,87 +641,88 @@ def local_useless_elemwise(fgraph, node):
         xor(x, x) -> zeros_like(x)
 
     TODO: This implementation is painfully redundant.
-    TODO: Allow rewrite when useless input broadcasts output
-
     """
-    out_bcast = node.outputs[0].type.broadcastable
     dtype = node.outputs[0].type.dtype
     scalar_op = node.op.scalar_op
 
-    if isinstance(scalar_op, EQ) and len(node.inputs) == 2:
-        if node.inputs[0] is node.inputs[1]:
-            # it is the same var in the graph. That will always be true
-            ret = ones_like(node.inputs[0], dtype=dtype, opt=True)
-
-            # Copy stack trace from input to constant output
-            copy_stack_trace(node.outputs[0], ret)
-            return [ret]
-    elif isinstance(scalar_op, NEQ | XOR) and len(node.inputs) == 2:
-        if node.inputs[0] is node.inputs[1]:
-            # it is the same var in the graph. That will always be false
-            ret = zeros_like(node.inputs[0], dtype=dtype, opt=True)
-
-            # Copy stack trace from input to constant output
-            copy_stack_trace(node.outputs[0], ret)
-            return [ret]
-
-    elif isinstance(node.op.scalar_op, Mul | Add | Identity) and len(node.inputs) == 1:
+    if isinstance(node.op.scalar_op, Mul | Add | Identity) and len(node.inputs) == 1:
         # No need to copy over any stack trace
         return [node.inputs[0]]
 
-    elif isinstance(node.op.scalar_op, AND) and len(node.inputs) == 2:
-        if (
-            isinstance(node.inputs[0], TensorConstant)
-            and node.inputs[1].type.broadcastable == out_bcast
-        ):
-            const_val = node.inputs[0].unique_value
-            if const_val is not None:
-                if const_val == 0:
-                    return [zeros_like(node.inputs[1], dtype=dtype, opt=True)]
-                elif node.outputs[0].dtype == "bool":
-                    # If the output is not Boolean, it is the bitwise AND,
-                    # and this rewrite would be wrong
-                    return [node.inputs[1].astype(node.outputs[0].dtype)]
+    if len(node.inputs) != 2:
+        # All other rewrites except 2 inputs
+        return None
 
-        if (
-            isinstance(node.inputs[1], TensorConstant)
-            and node.inputs[0].type.broadcastable == out_bcast
-        ):
-            const_val = node.inputs[1].unique_value
-            if const_val is not None:
-                if const_val == 0:
-                    return [zeros_like(node.inputs[0], dtype=dtype, opt=True)]
-                elif node.outputs[0].dtype == "bool":
-                    # If the output is not Boolean, it is the bitwise AND,
-                    # and this rewrite would be wrong
-                    return [node.inputs[0].astype(node.outputs[0].dtype)]
+    if isinstance(scalar_op, EQ) and node.inputs[0] is node.inputs[1]:
+        return [
+            broadcast_like_elemwise(
+                np.array(1, dtype=dtype),
+                node,
+                fgraph=fgraph,
+                stack_trace=True,
+            )
+        ]
+    elif isinstance(scalar_op, NEQ | XOR) and node.inputs[0] is node.inputs[1]:
+        return [
+            broadcast_like_elemwise(
+                np.array(0, dtype=dtype),
+                node,
+                fgraph=fgraph,
+                stack_trace=True,
+            )
+        ]
 
-    elif isinstance(node.op.scalar_op, OR) and len(node.inputs) == 2:
-        if (
-            isinstance(node.inputs[0], TensorConstant)
-            and node.inputs[1].type.broadcastable == out_bcast
-        ):
-            const_val = node.inputs[0].unique_value
-            if const_val is not None:
-                if const_val == 0:
-                    return [node.inputs[1].astype(node.outputs[0].dtype)]
-                elif node.outputs[0].dtype == "bool":
-                    # If the output is not Boolean, it is the bitwise OR,
-                    # and this rewrite would be wrong
-                    return [ones_like(node.inputs[1], dtype=dtype, opt=True)]
+    elif isinstance(node.op.scalar_op, AND | OR):
+        for const_idx in (0, 1):
+            other_idx = 1 - const_idx
+            if not (
+                isinstance((const_inp := node.inputs[const_idx]), TensorConstant)
+                and (const_val := const_inp.unique_value) is not None
+            ):
+                continue
+            other = node.inputs[other_idx]
+            if (not all(const_inp.type.broadcastable)) and any(
+                d is None for d in other.type.shape
+            ):
+                # Get out if there's any risk the constant may broadcast explicit dimensions of other
+                # (otherwise this rewrite would be `shape_unsafe`, and wouldn't belong in `infer_static_shape`)
+                return None
 
-        if (
-            isinstance(node.inputs[1], TensorConstant)
-            and node.inputs[0].type.broadcastable == out_bcast
-        ):
-            const_val = node.inputs[1].unique_value
-            if const_val is not None:
-                if const_val == 0:
-                    return [node.inputs[0].astype(node.outputs[0].dtype)]
-                elif node.outputs[0].dtype == "bool":
-                    # If the output is not Boolean, it is the bitwise OR,
-                    # and this rewrite would be wrong
-                    return [ones_like(node.inputs[0], dtype=dtype, opt=True)]
+            old_out_dtype = node.outputs[0].type.dtype
+
+            if const_val == 0:
+                if isinstance(node.op.scalar_op, AND):
+                    # x & 0 = 0
+                    return [
+                        broadcast_like_elemwise(
+                            np.array(0, dtype=old_out_dtype), node, fgraph=fgraph
+                        )
+                    ]
+                else:
+                    # x | 0 = x
+                    return [
+                        broadcast_like_elemwise(
+                            other, node, fgraph=fgraph, ref_input_idx=other_idx
+                        )
+                    ]
+
+            elif old_out_dtype == "bool":
+                # If the output is not Boolean, it is the bitwise AND,
+                # and this rewrite would be wrong
+                if isinstance(node.op.scalar_op, AND):
+                    # x & 1 = x
+                    return [
+                        broadcast_like_elemwise(
+                            other, node, fgraph=fgraph, ref_input_idx=other_idx
+                        )
+                    ]
+                else:
+                    # x | 1 = 1
+                    return [
+                        broadcast_like_elemwise(
+                            np.array(1, dtype=old_out_dtype), node, fgraph=fgraph
+                        )
+                    ]
 
 
 @register_specialize
@@ -659,12 +735,12 @@ def local_alloc_unary(fgraph, node):
             x = a.owner.inputs[0]
             shp = a.owner.inputs[1:]
             v = node.op(x)
-            # at.alloc does not preserve the stacktrace of v,
+            # alloc does not preserve the stacktrace of v,
             # so we need to copy it over from x.
             copy_stack_trace(node.outputs[0], v)
             ret = alloc(cast(v, node.outputs[0].dtype), *shp)
 
-            # at.cast does not preserve the stacktrace of x,
+            # cast does not preserve the stacktrace of x,
             # so we need to copy it over to the output.
             copy_stack_trace([node.outputs[0], a], ret)
             return [ret]

--- a/pytensor/tensor/rewriting/blas.py
+++ b/pytensor/tensor/rewriting/blas.py
@@ -272,8 +272,7 @@ def _gemm_canonicalize(fgraph, r, scale, rval, maxclients):
                 # just put the original arguments as in the base case
                 rval.append((scale, r))
                 return rval
-        if len(matrices) == 1:
-            assert len(vectors) == 0
+        if len(matrices) == 1 and len(vectors) == 0:
             m = matrices[0]
             if len(scalars) == 0:
                 _gemm_canonicalize(fgraph, m, scale, rval, 1)
@@ -283,8 +282,7 @@ def _gemm_canonicalize(fgraph, r, scale, rval, maxclients):
                 _gemm_canonicalize(
                     fgraph, m, mul(scaled(scalars[0]), *scalars[1:]), rval, 1
                 )
-        elif len(vectors) == 1:
-            assert len(matrices) == 0
+        elif len(vectors) == 1 and len(matrices) == 0:
             v = vectors[0]
             if len(scalars) == 0:
                 _gemm_canonicalize(fgraph, v, scale, rval, 1)
@@ -358,6 +356,9 @@ def _gemm_from_factored_list(fgraph, lst):
             sm0 = ptb.as_tensor_variable(sm0)
             if pytensor.scalar.upcast(sm0.dtype, sm1.dtype) == sm1.dtype:
                 lst2.append((ptb.cast(sm0, sm1.dtype), sM[1]))
+        else:
+            # Preserve non-decomposable terms (e.g. scalars with ndim not in (1, 2))
+            lst2.append(sM)
 
     lst = lst2
 
@@ -374,9 +375,13 @@ def _gemm_from_factored_list(fgraph, lst):
 
     # Try every pair in the sM_list, trying to turn it into a gemm operation
     for i in range(len(lst) - 1):
+        if not isinstance(lst[i], tuple):
+            continue
         s_i, M_i = lst[i]
 
         for j in range(i + 1, len(lst)):
+            if not isinstance(lst[j], tuple):
+                continue
             s_j, M_j = lst[j]
 
             if not M_j.type.in_same_class(M_i.type):

--- a/pytensor/tensor/rewriting/elemwise.py
+++ b/pytensor/tensor/rewriting/elemwise.py
@@ -43,10 +43,15 @@ from pytensor.scalar import constant as scalar_constant
 from pytensor.scalar.math import Grad2F1Loop, _grad_2f1_loop
 from pytensor.tensor.basic import MakeVector
 from pytensor.tensor.basic import constant as tensor_constant
-from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
+from pytensor.tensor.elemwise import (
+    CAReduce,
+    DimShuffle,
+    Elemwise,
+    input_offset,
+)
 from pytensor.tensor.math import add, exp, mul
 from pytensor.tensor.rewriting.basic import (
-    alloc_like,
+    broadcast_like_elemwise,
     broadcasted_by,
     elemwise_of,
     register_canonicalize,
@@ -378,9 +383,24 @@ def local_dimshuffle_lift(fgraph, node):
         and (len(fgraph.clients[inp]) == 1)
     ):
         # Don't use make_node to have tag.test_value set.
+        out_ndim = inode.outputs[0].type.ndim
         new_inputs = []
         for inp in inode.inputs:
-            new_inp = inp.dimshuffle(op.new_order)
+            ipt_offset = input_offset(inp, out_ndim)
+            if ipt_offset == 0:
+                inp_new_order = op.new_order
+            else:
+                # Strip leading entries that correspond to the implicit padding
+                inp_new_order = []
+                for entry in op.new_order:
+                    if entry == "x":
+                        inp_new_order.append("x")
+                    elif entry < ipt_offset:
+                        inp_new_order.append("x")
+                    else:
+                        inp_new_order.append(entry - ipt_offset)
+                inp_new_order = tuple(inp_new_order)
+            new_inp = inp.dimshuffle(inp_new_order)
             new_inputs.append(apply_local_dimshuffle_lift(fgraph, new_inp))
         copy_stack_trace(node.outputs[0], new_inputs)
         ret = inode.op(*new_inputs, return_list=True)
@@ -1088,17 +1108,11 @@ def local_inline_composite_constants(fgraph, node):
         composite_op.fgraph.outputs, replace=inner_replacements
     )
     new_composite_op = Composite(new_inner_inputs, new_inner_outs)
+
     new_outputs = Elemwise(new_composite_op).make_node(*new_outer_inputs).outputs
-
-    # Some of the inlined constants were broadcasting the output shape
-    if node.outputs[0].type.broadcastable != new_outputs[0].type.broadcastable:
-        new_outputs = [
-            alloc_like(new_out, template=node.outputs[0], fgraph=fgraph)
-            for new_out in new_outputs
-        ]
-
-    copy_stack_trace(node.outputs, new_outputs)
-    return new_outputs
+    return broadcast_like_elemwise(
+        list(new_outputs), node, fgraph=fgraph, stack_trace=True
+    )
 
 
 @node_rewriter(tracks=[add, mul])
@@ -1123,6 +1137,7 @@ def constant_fold_branches_of_add_mul(fgraph, node):
                 if i == j:
                     continue
                 other_inp = new_constants[j]
+                # TODO: Adding dummy dims should be fine
                 if not broadcasted_by(reference_inp, other_inp):
                     other_inps.append(other_inp)
             if other_inps:

--- a/pytensor/tensor/rewriting/linalg.py
+++ b/pytensor/tensor/rewriting/linalg.py
@@ -640,14 +640,21 @@ def rewrite_det_diag_to_prod_diag(fgraph, node):
     eye_input, non_eye_input = eye_input[0], non_eye_inputs[0]
 
     # Checking if original x was scalar/vector/matrix
-    if non_eye_input.type.broadcastable[-2:] == (True, True):
-        # For scalar
+    non_eye_ndim = non_eye_input.type.ndim
+    if non_eye_ndim == 0:
+        # Scalar
+        det_val = non_eye_input ** (eye_input.shape[0])
+    elif non_eye_ndim == 1:
+        # Vector
+        det_val = non_eye_input.prod(axis=-1)
+    elif non_eye_input.type.broadcastable[-2:] == (True, True):
+        # Scalar-like (broadcastable in last 2 dims)
         det_val = non_eye_input.squeeze(axis=(-1, -2)) ** (eye_input.shape[0])
     elif non_eye_input.type.broadcastable[-2:] == (False, False):
-        # For Matrix
+        # Matrix
         det_val = non_eye_input.diagonal(axis1=-1, axis2=-2).prod(axis=-1)
     else:
-        # For vector
+        # Vector-like (broadcastable in one of last 2 dims)
         det_val = non_eye_input.prod(axis=(-1, -2))
     det_val = det_val.astype(node.outputs[0].type.dtype)
     return [det_val]
@@ -1033,9 +1040,13 @@ def rewrite_cholesky_diag_to_sqrt_diag(fgraph, node):
 
     # Now, we can simply return the matrix consisting of sqrt values of the original diagonal elements
     # For a matrix, we have to first extract the diagonal (non-zero values) and then only use those
-    if non_eye_input.type.broadcastable[-2:] == (False, False):
+    if non_eye_input.type.ndim >= 2 and non_eye_input.type.broadcastable[-2:] == (
+        False,
+        False,
+    ):
         non_eye_input = non_eye_input.diagonal(axis1=-1, axis2=-2)
-        if eye_input.type.ndim > 2:
+        # If the original mul was batched (output ndim > 2), pad so shapes align
+        if input.type.ndim > 2:
             non_eye_input = pt.shape_padaxis(non_eye_input, -2)
 
     return [eye_input * (non_eye_input**0.5)]

--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -25,6 +25,7 @@ from pytensor.tensor.basic import (
     MakeVector,
     alloc,
     as_tensor_variable,
+    atleast_Nd,
     cast,
     constant,
     expand_dims,
@@ -37,7 +38,13 @@ from pytensor.tensor.basic import (
     zeros,
     zeros_like,
 )
-from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
+from pytensor.tensor.elemwise import (
+    CAReduce,
+    DimShuffle,
+    Elemwise,
+    aligned_broadcastable_of,
+    input_offset,
+)
 from pytensor.tensor.exceptions import NotScalarConstantError
 from pytensor.tensor.extra_ops import broadcast_arrays, concat_with_broadcast
 from pytensor.tensor.math import (
@@ -96,9 +103,8 @@ from pytensor.tensor.math import max as pt_max
 from pytensor.tensor.math import pow as pt_pow
 from pytensor.tensor.math import sum as pt_sum
 from pytensor.tensor.rewriting.basic import (
-    alloc_like,
-    broadcasted_by,
-    local_fill_sink,
+    broadcast_like_elemwise,
+    local_second_sink,
     register_canonicalize,
     register_specialize,
     register_stabilize,
@@ -824,21 +830,9 @@ def local_expm1(fgraph, node):
         else:  # no break
             return None
 
-    [old_out] = node.outputs
-
     [x] = exp_x.owner.inputs
-    if x.type.broadcastable != old_out.type.broadcastable:
-        x = broadcast_arrays(x, other_inp)[0]
-
     new_out = expm1(x)
-
-    if new_out.dtype != old_out.dtype:
-        new_out = cast(new_out, dtype=old_out.dtype)
-
-    if not old_out.type.is_super(new_out.type):
-        return None
-
-    return [new_out]
+    return [broadcast_like_elemwise(new_out, node, fgraph=fgraph, stack_trace=True)]
 
 
 @register_specialize
@@ -1409,8 +1403,10 @@ class AlgebraicCanonizer(NodeRewriter):
         if new.type.dtype != out.type.dtype:
             new = cast(new, out.type.dtype)
 
-        if new.type.broadcastable != out.type.broadcastable:
-            new = broadcast_arrays(new, *node.inputs)[0]
+        aligned = atleast_Nd(new, n=out.type.ndim)
+        if aligned.type.broadcastable != out.type.broadcastable:
+            aligned = broadcast_arrays(new, *node.inputs)[0]
+        new = aligned
 
         if (new.type.dtype == out.type.dtype) and (
             new.type.broadcastable == out.type.broadcastable
@@ -1500,10 +1496,16 @@ def local_sum_prod_of_mul_or_div(fgraph, node):
         # Mul accepts arbitrary inputs, so we need to separate into two groups
         outer_terms = []
         inner_terms = []
+        out_ndim = node_inps.type.ndim
         for term in node_inps.owner.inputs:
-            term_bcast = term.type.broadcastable
-            if all(term_bcast[i] for i in reduced_axes):
-                outer_terms.append(term.squeeze(reduced_axes))
+            aligned_bc = aligned_broadcastable_of(term, out_ndim)
+            if all(aligned_bc[i] for i in reduced_axes):
+                # Squeeze reduced axis (if they exist in the input)
+                term_offset = input_offset(term, out_ndim)
+                term_axes = tuple(
+                    i - term_offset for i in reduced_axes if i >= term_offset
+                )
+                outer_terms.append(term.squeeze(term_axes))
             else:
                 inner_terms.append(term)
 
@@ -1520,9 +1522,14 @@ def local_sum_prod_of_mul_or_div(fgraph, node):
     else:  # true_div
         # We only care about removing the denominator out of the reduction
         numerator, denominator = node_inps.owner.inputs
-        denominator_bcast = denominator.type.broadcastable
-        if all(denominator_bcast[i] for i in reduced_axes):
-            outer_term = denominator.squeeze(reduced_axes)
+        out_ndim = node_inps.type.ndim
+        aligned_bc = aligned_broadcastable_of(denominator, out_ndim)
+        if all(aligned_bc[i] for i in reduced_axes):
+            denom_offset = input_offset(denominator, out_ndim)
+            denom_axes = tuple(
+                i - denom_offset for i in reduced_axes if i >= denom_offset
+            )
+            outer_term = denominator.squeeze(denom_axes)
             inner_term = numerator
         else:
             return None
@@ -1623,7 +1630,6 @@ def local_useless_elemwise_comparison(fgraph, node):
         return
 
     dtype = node.outputs[0].type.dtype
-    out_bcast = node.outputs[0].type.broadcastable
 
     # Elemwise[{LT,GT}](X, X) -> Elemwise[zeros](X)
     if (
@@ -1666,12 +1672,14 @@ def local_useless_elemwise_comparison(fgraph, node):
         )
         == 0
     ):
-        res = zeros_like(node.inputs[0], dtype=dtype, opt=True)
-        if res.type.broadcastable != out_bcast:
-            res = broadcast_arrays(res, node.inputs[1])[0]
-        # Copy over stacktrace from previous output.
-        copy_stack_trace(node.outputs, res)
-        return [res]
+        return [
+            broadcast_like_elemwise(
+                np.array(0, dtype=dtype),
+                node,
+                fgraph=fgraph,
+                stack_trace=True,
+            )
+        ]
 
     # Elemwise[GE](X.shape[i], 0) -> Elemwise[ones](X)
     if (
@@ -1683,12 +1691,14 @@ def local_useless_elemwise_comparison(fgraph, node):
         )
         == 0
     ):
-        res = ones_like(node.inputs[0], dtype=dtype, opt=True)
-        if res.type.broadcastable != out_bcast:
-            res = broadcast_arrays(res, node.inputs[1])[0]
-        # Copy over stacktrace from previous output.
-        copy_stack_trace(node.outputs, res)
-        return [res]
+        return [
+            broadcast_like_elemwise(
+                np.array(1, dtype=dtype),
+                node,
+                fgraph=fgraph,
+                stack_trace=True,
+            )
+        ]
 
     # Elemwise[maximum](X.shape[i], 0) -> X.shape[i]
     if isinstance(node.op.scalar_op, ps.ScalarMaximum):
@@ -1703,11 +1713,11 @@ def local_useless_elemwise_comparison(fgraph, node):
                 )
                 == 0
             ):
-                res = node.inputs[idx]
-                if res.type.broadcastable != out_bcast:
-                    res = broadcast_arrays(res, node.inputs[1 - idx])[0]
-                # No need to copy over stacktrace.
-                return [res]
+                return [
+                    broadcast_like_elemwise(
+                        node.inputs[idx], node, fgraph=fgraph, ref_input_idx=idx
+                    )
+                ]
 
     # Elemwise[minimum](X.shape[i], 0) -> 0
     if isinstance(node.op.scalar_op, ps.ScalarMinimum):
@@ -1722,11 +1732,11 @@ def local_useless_elemwise_comparison(fgraph, node):
                 )
                 == 0
             ):
-                res = zeros_like(node.inputs[idx], dtype=dtype, opt=True)
-                if res.type.broadcastable != out_bcast:
-                    res = broadcast_arrays(res, node.inputs[1 - idx])[0]
-                # No need to copy over stacktrace.
-                return [res]
+                return [
+                    broadcast_like_elemwise(
+                        np.array(0, dtype=dtype), node, fgraph=fgraph
+                    )
+                ]
 
     # Elemwise[LT](add([anything that is shapes]), 0) -> Elemwise[zeros](X)
     if (
@@ -1743,12 +1753,14 @@ def local_useless_elemwise_comparison(fgraph, node):
         )
         == 0
     ):
-        res = zeros_like(node.inputs[0], dtype=dtype, opt=True)
-        if res.type.broadcastable != out_bcast:
-            res = broadcast_arrays(res, node.inputs[1])[0]
-        # Copy over stacktrace from previous output.
-        copy_stack_trace(node.outputs, res)
-        return [res]
+        return [
+            broadcast_like_elemwise(
+                np.array(0, dtype=dtype),
+                node,
+                fgraph=fgraph,
+                stack_trace=True,
+            )
+        ]
 
     # Elemwise[GE](add([anything that is shapes]), 0) -> Elemwise[ones](X)
     if (
@@ -1765,12 +1777,14 @@ def local_useless_elemwise_comparison(fgraph, node):
         )
         == 0
     ):
-        res = ones_like(node.inputs[0], dtype=dtype, opt=True)
-        if res.type.broadcastable != out_bcast:
-            res = broadcast_arrays(res, node.inputs[1])[0]
-        # Copy over stacktrace from previous output.
-        copy_stack_trace(node.outputs, res)
-        return [res]
+        return [
+            broadcast_like_elemwise(
+                np.array(1, dtype=dtype),
+                node,
+                fgraph=fgraph,
+                stack_trace=True,
+            )
+        ]
 
     # Elemwise[EQ](Subtensor(Shape(x)), -N)
     # Elemwise[EQ](somegraph that only depend of shape, -N)
@@ -1808,12 +1822,14 @@ def local_useless_elemwise_comparison(fgraph, node):
             and node.inputs[1].unique_value < 0
         )
     ):
-        res = zeros_like(node.inputs[0], dtype=dtype, opt=True)
-        if res.type.broadcastable != out_bcast:
-            res = broadcast_arrays(res, node.inputs[1])[0]
-        # Copy over stacktrace from previous output.
-        copy_stack_trace(node.outputs, res)
-        return [res]
+        return [
+            broadcast_like_elemwise(
+                np.array(0, dtype=dtype),
+                node,
+                fgraph=fgraph,
+                stack_trace=True,
+            )
+        ]
 
     return
 
@@ -2137,21 +2153,18 @@ def local_mul_zero(fgraph, node):
 @register_specialize
 @node_rewriter([true_div])
 def local_div_to_reciprocal(fgraph, node):
-    if (
-        get_underlying_scalar_constant_value(
-            node.inputs[0], only_process_constants=True, raise_not_constant=False
-        )
-        == 1.0
-    ):
-        out = node.outputs[0]
-        new_out = reciprocal(local_mul_canonizer.merge_num_denum(node.inputs[1:], []))
-        # The ones could have forced upcasting
-        if new_out.dtype != out.dtype:
-            new_out = cast(new_out, dtype=out.dtype)
-        # The ones could have forced a specific length
-        if not out.type.is_super(new_out.type):
-            new_out = alloc_like(new_out, out, fgraph)
-        return [new_out]
+    numerator, denominator = node.inputs
+    if isinstance(numerator, TensorConstant) and numerator.unique_value == 1.0:
+        new_out = reciprocal(denominator)
+        return [
+            broadcast_like_elemwise(
+                new_out,
+                node,
+                fgraph=fgraph,
+                ref_input_idx=1,
+                stack_trace=True,
+            )
+        ]
 
 
 @register_canonicalize
@@ -2211,64 +2224,57 @@ def local_mul_to_sqr(fgraph, node):
 
 
 @register_canonicalize
-@node_rewriter([int_div])
-def local_intdiv_by_one(fgraph, node):
-    """x // 1 -> x"""
-    if isinstance(node.inputs[1], TensorConstant) and np.all(node.inputs[1].value == 1):
-        return [node.inputs[0].astype(node.outputs[0].dtype)]
+@node_rewriter([true_div, int_div])
+def local_div_by_one(fgraph, node):
+    """x / 1 -> x"""
+    numerator, denominator = node.inputs
+    if isinstance(denominator, TensorConstant) and denominator.unique_value == 1:
+        new_out = numerator
+        new_out = broadcast_like_elemwise(
+            new_out, node, fgraph=fgraph, stack_trace=True
+        )
+        return [new_out]
 
 
 @register_canonicalize
 @register_specialize
-@node_rewriter([int_div, true_div])
+@node_rewriter([true_div, int_div])
 def local_zero_div(fgraph, node):
     """0 / x -> 0"""
-    if (
-        get_underlying_scalar_constant_value(
-            node.inputs[0], only_process_constants=True, raise_not_constant=False
+    numerator, _denominator = node.inputs
+    if isinstance(numerator, TensorConstant) and numerator.unique_value == 0:
+        new_out = broadcast_like_elemwise(
+            np.array(0, dtype=node.outputs[0].dtype), node, fgraph=fgraph
         )
-        == 0
-    ):
-        ret = alloc_like(0, node.outputs[0], fgraph)
-        ret.tag.values_eq_approx = values_eq_approx_remove_nan
-        return [ret]
+        new_out.tag.values_eq_approx = values_eq_approx_remove_nan
+        return [new_out]
 
 
 @register_specialize
 @node_rewriter([pt_pow])
 def local_pow_specialize(fgraph, node):
-    # the idea here is that we have pow(x, y)
-    odtype = node.outputs[0].dtype
-    xsym = node.inputs[0]
-    ysym = node.inputs[1]
-    try:
-        y = get_underlying_scalar_constant_value(ysym, only_process_constants=True)
-    except NotScalarConstantError:
-        return
-
-    if not broadcasted_by(xsym, ysym):
-        rval = None
-
-        if np.all(y == 2):
-            rval = [sqr(xsym)]
-        if np.all(y == 1):
-            rval = [xsym]
-        if np.all(y == 0):
-            rval = [alloc_like(1, xsym, fgraph)]
-        if np.all(y == 0.5):
-            rval = [sqrt(xsym)]
-        if np.all(y == -0.5):
-            rval = [reciprocal(sqrt(xsym))]
-        if np.all(y == -1):
-            rval = [reciprocal(xsym)]
-        if np.all(y == -2):
-            rval = [reciprocal(sqr(xsym))]
-        if rval:
-            if not rval[0].type.broadcastable == node.outputs[0].type.broadcastable:
+    xsym, ysym = node.inputs
+    if isinstance(ysym, TensorConstant) and (y := ysym.unique_value) is not None:
+        old_out = node.outputs[0]
+        match y:
+            case 2:
+                rval = sqr(xsym)
+            case 1:
+                rval = xsym
+            case 0:
+                rval = np.array(1.0, dtype=old_out.dtype)
+            case 0.5:
+                rval = sqrt(xsym)
+            case -0.5:
+                rval = reciprocal(sqrt(xsym))
+            case -1:
+                rval = reciprocal(xsym)
+            case -2:
+                rval = reciprocal(sqr(xsym))
+            case _:
                 return None
-            rval[0] = cast(rval[0], odtype)
-            assert rval[0].type.dtype == node.outputs[0].type.dtype
-            return rval
+
+        return [broadcast_like_elemwise(rval, node, fgraph=fgraph, stack_trace=True)]
 
 
 @register_specialize
@@ -2287,8 +2293,6 @@ def local_pow_to_nested_squaring(fgraph, node):
     except NotScalarConstantError:
         return
 
-    odtype = node.outputs[0].dtype
-
     # the next line is needed to fix a strange case that I don't
     # know how to make a separate test.
     # That happen in the `test_log_erfc` test.
@@ -2303,41 +2307,43 @@ def local_pow_to_nested_squaring(fgraph, node):
             y = y[0]
         except IndexError:
             pass
-    if not broadcasted_by(xsym, ysym):
-        rval = None
-        # 512 is too small for the cpu and too big for some gpu!
-        if abs(y) == int(abs(y)) and abs(y) <= 512:
-            pow2 = [xsym]
-            pow2_scal = [ps.get_scalar_type(xsym.dtype)()]
-            y_to_do = abs(y)
-            for i in range(int(np.log2(y_to_do))):
-                pow2.append(sqr(pow2[i]))
-                pow2_scal.append(ps.sqr(pow2_scal[i]))
-            rval1 = None
-            rval1_scal = None
-            while y_to_do > 0:
-                log_to_do = int(np.log2(y_to_do))
-                if rval1 is not None:
-                    rval1 *= pow2[log_to_do]
-                    rval1_scal *= pow2_scal[log_to_do]
-                else:
-                    rval1 = pow2[log_to_do]
-                    rval1_scal = pow2_scal[log_to_do]
-                y_to_do -= 2**log_to_do
 
-            if abs(y) > 2:
-                # We fuse all the pow together here to make
-                # compilation faster
-                rval1 = Elemwise(ps.Composite([pow2_scal[0]], [rval1_scal])).make_node(
-                    xsym
-                )
-            if y < 0:
-                rval = [reciprocal(rval1)]
+    rval = None
+    # 512 is too small for the cpu and too big for some gpu!
+    if abs(y) == int(abs(y)) and abs(y) <= 512:
+        pow2 = [xsym]
+        pow2_scal = [ps.get_scalar_type(xsym.dtype)()]
+        y_to_do = abs(y)
+        for i in range(int(np.log2(y_to_do))):
+            pow2.append(sqr(pow2[i]))
+            pow2_scal.append(ps.sqr(pow2_scal[i]))
+        rval1 = None
+        rval1_scal = None
+        while y_to_do > 0:
+            log_to_do = int(np.log2(y_to_do))
+            if rval1 is not None:
+                rval1 *= pow2[log_to_do]
+                rval1_scal *= pow2_scal[log_to_do]
             else:
-                rval = [rval1]
-        if rval is not None:
-            rval[0] = cast(rval[0], odtype)
-            return rval
+                rval1 = pow2[log_to_do]
+                rval1_scal = pow2_scal[log_to_do]
+            y_to_do -= 2**log_to_do
+
+        if abs(y) > 2:
+            # We fuse all the pow together here to make
+            # compilation faster
+            rval1 = (
+                Elemwise(ps.Composite([pow2_scal[0]], [rval1_scal]))
+                .make_node(xsym)
+                .outputs[0]
+            )
+        if y < 0:
+            rval = reciprocal(rval1)
+        else:
+            rval = rval1
+
+    if rval is not None:
+        return [broadcast_like_elemwise(rval, node, fgraph=fgraph)]
 
 
 @register_specialize
@@ -2355,64 +2361,59 @@ def local_mul_specialize(fgraph, node):
     mul(-1, x, y) -/-> neg(mul(x, y))
 
     """
-
-    # at this point [post canonicalize], mul() may have many inputs.
-    # the idea here is that we have pow(x, y)
     has_neg = False
     new_inputs = []
     nb_neg_node = 0
     nb_cst = 0
+    has_zero = False
     for inp in node.inputs:
         # remove any neg arguments
-        while inp.owner and inp.owner.op == neg:
+        while inp.owner is not None and inp.owner.op == neg:
             has_neg ^= True
-            inp = inp.owner.inputs[0]
+            [inp] = inp.owner.inputs
             nb_neg_node += 1
 
         # remove special case arguments of 1, -1 or 0
-        y = get_underlying_scalar_constant_value(
+        match get_underlying_scalar_constant_value(
             inp, only_process_constants=True, raise_not_constant=False
-        )
-        if y == 1.0:
-            nb_cst += 1
-        elif y == -1.0:
-            nb_cst += 1
-            has_neg ^= True  # toggles
-        elif y == 0.0:
-            # if we find any zero, we just return right away
-            return [alloc_like(0, node.outputs[0], fgraph)]
-        else:
-            new_inputs.append(inp)
+        ):
+            case 1.0:
+                nb_cst += 1
+            case -1.0:
+                nb_cst += 1
+                has_neg ^= True  # toggles
+            case 0.0:
+                # if we find any zero, there's nothing else to do
+                has_zero = True
+                break
+            case _:
+                new_inputs.append(inp)
 
     if new_inputs != node.inputs:
-        if new_inputs:
+        [old_out] = node.outputs
+        if has_zero:
+            new_out = np.array(0, dtype=old_out.type.dtype)
+        elif len(new_inputs) == 0:
+            new_out = np.array(-1 if has_neg else 1, dtype=old_out.type.dtype)
+        else:
             if len(new_inputs) == 1:
                 if has_neg:
-                    if new_inputs[0].dtype in ([*uint_dtypes, "bool"]):
-                        return
-                    else:
-                        rval = -new_inputs[0]
+                    if new_inputs[0].dtype in (*uint_dtypes, "bool"):
+                        return None
+                    new_out = -new_inputs[0]
                 else:
-                    rval = new_inputs[0]
+                    new_out = new_inputs[0]
             else:
                 # The next case would cause a replace by an equivalent case.
                 if has_neg and nb_neg_node == 0 and nb_cst == 1:
-                    return
+                    return None
                 elif has_neg:
-                    # Don't add an extra neg node as we can't
-                    # fully replace this mul by a neg.
-                    m1 = np.asarray(-1, dtype=node.outputs[0].dtype)
+                    # Don't add an extra neg node as we can't fully replace this mul by a neg.
+                    m1 = np.array(-1, dtype=old_out.type.dtype)
                     new_inputs = [m1, *new_inputs]
-                rval = mul(*new_inputs)
+                new_out = mul(*new_inputs)
 
-            return [alloc_like(rval, node.outputs[0], fgraph)]
-        else:
-            # there are no variable inputs to mul
-            # N.B. this could have been constant-folded...
-            if has_neg:
-                return [alloc_like(-1, node.outputs[0], fgraph)]
-            else:
-                return [alloc_like(1, node.outputs[0], fgraph)]
+        return [broadcast_like_elemwise(new_out, node, fgraph=fgraph, stack_trace=True)]
 
 
 @register_specialize
@@ -2421,40 +2422,22 @@ def local_add_remove_zeros(fgraph, node):
     new_inputs = []
     for inp in node.inputs:
         try:
-            y = get_underlying_scalar_constant_value(inp)
+            not_zero = get_underlying_scalar_constant_value(inp) != 0.0
         except NotScalarConstantError:
-            y = inp
-        if y == 0.0:
-            continue
-        new_inputs.append(inp)
+            not_zero = True
+        if not_zero:
+            new_inputs.append(inp)
 
     if len(new_inputs) == len(node.inputs):
-        return False
+        return None
 
-    node_output = node.outputs[0]
-    dtype = node_output.type.dtype
-
-    if len(new_inputs) == 0:
-        # we got rid of the entire expression!
-        ndim = node_output.type.ndim
-        # Reuse call to constant for cache()
-        cst = constant(np.zeros((1,) * ndim, dtype=dtype))
-        assert cst.type.broadcastable == (True,) * ndim
-        return [alloc_like(cst, node_output, fgraph)]
-
-    ret = [alloc_like(variadic_add(*new_inputs), node_output, fgraph)]
-
-    # The dtype should not be changed. It can happen if the input
-    # that was forcing upcasting was equal to 0.
-    if ret[0].dtype != dtype:
-        ret = [cast(ret[0], dtype)]
-
-    return ret
+    new_out = variadic_add(*new_inputs)
+    return [broadcast_like_elemwise(new_out, node, fgraph=fgraph, stack_trace=True)]
 
 
 mul_canonizer = in2out(
     SequentialNodeRewriter(
-        local_mul_canonizer, local_fill_sink, apply_all_rewrites=True
+        local_mul_canonizer, local_second_sink, apply_all_rewrites=True
     ),
     name="mul_canonizer_groups",
 )
@@ -2553,10 +2536,12 @@ def local_log1p(fgraph, node):
         # scalar_inputs are potentially dimshuffled and fill'd scalars
         if scalars and isclose(np.sum(scalars), 1):
             if nonconsts:
-                ninp = variadic_add(*nonconsts)
-                if ninp.dtype != log_arg.type.dtype:
-                    ninp = ninp.astype(node.outputs[0].dtype)
-                return [alloc_like(log1p(ninp), node.outputs[0], fgraph)]
+                new_out = log1p(variadic_add(*nonconsts))
+                return [
+                    broadcast_like_elemwise(
+                        new_out, node, fgraph=fgraph, stack_trace=True
+                    )
+                ]
 
     elif log_arg.owner and log_arg.owner.op == sub:
         one, other = log_arg.owner.inputs
@@ -2568,13 +2553,8 @@ def local_log1p(fgraph, node):
         if one != 1:
             return
 
-        if other.type.broadcastable != log_arg.type.broadcastable:
-            other = broadcast_arrays(other, one)[0]
-
-        if other.type.dtype != log_arg.type.dtype:
-            other = other.astype(log_arg.dtype)
-
-        return [log1p(neg(other))]
+        new_out = log1p(neg(other))
+        return [broadcast_like_elemwise(new_out, node, fgraph=fgraph, stack_trace=True)]
 
 
 @register_stabilize
@@ -2688,7 +2668,7 @@ def add_calculate(num, denum, aslist=False, out_type=None):
 local_add_canonizer = AlgebraicCanonizer(add, sub, neg, add_calculate)
 add_canonizer = in2out(
     SequentialNodeRewriter(
-        local_add_canonizer, local_fill_sink, apply_all_rewrites=True
+        local_add_canonizer, local_second_sink, apply_all_rewrites=True
     ),
     name="add_canonizer_group",
 )
@@ -3749,21 +3729,16 @@ def local_reciprocal_1_plus_exp(fgraph, node):
         if len(nonconsts) == 1:
             if nonconsts[0].owner and nonconsts[0].owner.op == exp:
                 if scalars_ and isclose(np.sum(scalars_), 1):
-                    out = [
-                        alloc_like(
-                            sigmoid(neg(nonconsts[0].owner.inputs[0])),
-                            node.outputs[0],
-                            fgraph,
-                        )
-                    ]
+                    new_out = sigmoid(neg(nonconsts[0].owner.inputs[0]))
+                    new_out = broadcast_like_elemwise(new_out, node, fgraph=fgraph)
                     # keep combined stack traces of
                     #     exp(x):           nonconsts[0],
                     #     1 + exp(x):       reciprocal_arg,
                     #     1 / (1 + exp(x)): node.outputs[0]
                     copy_stack_trace(
-                        [nonconsts[0], reciprocal_arg, node.outputs[0]], out
+                        [nonconsts[0], reciprocal_arg, node.outputs[0]], new_out
                     )
-                    return out
+                    return [new_out]
 
 
 # 1 - sigmoid(x) -> sigmoid(-x)

--- a/pytensor/tensor/rewriting/shape.py
+++ b/pytensor/tensor/rewriting/shape.py
@@ -27,7 +27,7 @@ from pytensor.tensor.basic import (
     register_infer_shape,
     stack,
 )
-from pytensor.tensor.elemwise import DimShuffle, Elemwise
+from pytensor.tensor.elemwise import DimShuffle, Elemwise, input_offset
 from pytensor.tensor.exceptions import NotScalarConstantError, ShapeError
 from pytensor.tensor.rewriting.basic import (
     register_canonicalize,
@@ -1213,6 +1213,7 @@ def local_specify_shape_lift(fgraph, node):
             # We look for a sufficient input to assign all the specify_shape dims
             # We could consider distributing the SpecifyShape across multiple inputs, when none is sufficient
 
+            out_ndim = node.outputs[0].type.ndim
             nonbcast_dims = {
                 i
                 for i, (dim, bcast) in enumerate(
@@ -1222,12 +1223,18 @@ def local_specify_shape_lift(fgraph, node):
             }
             new_elem_inps = elem_inps.copy()
             for i, elem_inp in enumerate(elem_inps):
+                ipt_offset = input_offset(elem_inp, out_ndim)
+                # Check that this input has all the non-broadcastable dims we need
+                # (dims before ipt_offset are implicit leading 1s, always broadcastable)
+                inp_nonbcast_dims = {d for d in nonbcast_dims if d >= ipt_offset}
+                if inp_nonbcast_dims != nonbcast_dims:
+                    continue
                 if all(
-                    bcast_dim is False
-                    for dim, bcast_dim in enumerate(elem_inp.type.broadcastable)
-                    if dim in nonbcast_dims
+                    elem_inp.type.broadcastable[d - ipt_offset] is False
+                    for d in inp_nonbcast_dims
                 ):
-                    new_elem_inps[i] = specify_shape(elem_inp, shape)
+                    inp_shape = shape[ipt_offset:]
+                    new_elem_inps[i] = specify_shape(elem_inp, inp_shape)
                     break
             else:  # no-break, no sufficient candidate found
                 return None

--- a/pytensor/tensor/rewriting/subtensor_lift.py
+++ b/pytensor/tensor/rewriting/subtensor_lift.py
@@ -20,7 +20,13 @@ from pytensor.tensor.basic import (
     register_infer_shape,
 )
 from pytensor.tensor.blockwise import Blockwise
-from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
+from pytensor.tensor.elemwise import (
+    CAReduce,
+    DimShuffle,
+    Elemwise,
+    aligned_broadcastable_of,
+    input_offset,
+)
 from pytensor.tensor.exceptions import NotScalarConstantError
 from pytensor.tensor.extra_ops import squeeze
 from pytensor.tensor.math import Dot, ceil_intdiv, dot
@@ -221,43 +227,38 @@ def local_subtensor_of_batch_dims(fgraph, node):
         return [new_elem]
 
     elem_inputs = elem.owner.inputs
+    out_ndim = elem.type.ndim
     elem_bcast = elem.type.broadcastable[:batch_ndim]
-    if all(inp.type.broadcastable[:batch_ndim] == elem_bcast for inp in elem_inputs):
-        # No need to worry about implicit broadcasting.
-        indexed_inputs = [inp[idx_tuple] for inp in elem_inputs]
+
+    inp_offsets = [input_offset(inp, out_ndim) for inp in elem_inputs]
+    inp_aligned_bcasts = [
+        aligned_broadcastable_of(inp, out_ndim)[:batch_ndim] for inp in elem_inputs
+    ]
+
+    if all(abc == elem_bcast for abc in inp_aligned_bcasts):
+        # No broadcasting concerns, just skip indices for implicit dims
+        indexed_inputs = []
+        for inp, offset in zip(elem_inputs, inp_offsets):
+            inp_idx = idx_tuple[offset:]
+            indexed_inputs.append(inp[inp_idx] if inp_idx else inp)
 
     else:
-        # The original indices may not make sense on some of the broadcasted dimensions
-        new_idxs = [list(idx_tuple) for _ in elem_inputs]
-        for dim, (dim_idx, dim_bcast_out, *dim_bcast_inputs) in enumerate(
-            zip(
-                idx_tuple,
-                elem_bcast,
-                *(inp.type.broadcastable[:batch_ndim] for inp in elem_inputs),
-                # Indices can be shorter than input ndims
-                strict=False,
-            )
+        # Adapt indices for broadcasting and different ndims
+        indexed_inputs = []
+        for inp, offset, aligned_bc in zip(
+            elem_inputs, inp_offsets, inp_aligned_bcasts
         ):
-            if dim_idx == slice(None):
-                # Full slice can be safely applied to all inputs
-                continue
-
-            if all(dim_bcast_inp == elem_bcast for dim_bcast_inp in dim_bcast_inputs):
-                # This dim is not broadcasted for any of the inputs, original index can be applied to all inputs
-                continue
-
-            # Some dims are broadcasted, so we need to adapt their indices
-            # Slice indexing keeps the dimension, so we use a full slice for broadcasted inputs
-            # Integer indexing drops the dimension, so we index by zero for the broadcsated inputs
-            safe_bcast_dim_idx = slice(None) if isinstance(dim_idx, slice) else 0
-            for inp_idx, dim_bcast_inp in zip(new_idxs, dim_bcast_inputs, strict=True):
-                if dim_bcast_inp:
-                    inp_idx[dim] = safe_bcast_dim_idx
-
-        indexed_inputs = [
-            inp[tuple(new_idx)]
-            for inp, new_idx in zip(elem_inputs, new_idxs, strict=True)
-        ]
+            new_idx = []
+            for dim, dim_idx in enumerate(idx_tuple):
+                if dim < offset:
+                    # Implicit dim for this input: skip entirely
+                    continue
+                if aligned_bc[dim] and not elem_bcast[dim]:
+                    # Input is broadcastable but output isn't: adapt index
+                    new_idx.append(slice(None) if isinstance(dim_idx, slice) else 0)
+                else:
+                    new_idx.append(dim_idx)
+            indexed_inputs.append(inp[tuple(new_idx)] if new_idx else inp)
 
     [old_out] = node.outputs
 

--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -9,11 +9,11 @@ import scipy.linalg as scipy_linalg
 from scipy.linalg import get_lapack_funcs
 
 import pytensor
-from pytensor import ifelse
 from pytensor import tensor as pt
 from pytensor.gradient import DisconnectedType, disconnected_type
 from pytensor.graph.basic import Apply
 from pytensor.graph.op import Op
+from pytensor.ifelse import ifelse
 from pytensor.raise_op import Assert, CheckAndRaise
 from pytensor.tensor import TensorLike
 from pytensor.tensor import basic as ptb

--- a/tests/scan/test_printing.py
+++ b/tests/scan/test_printing.py
@@ -39,28 +39,27 @@ def test_debugprint_sitsot():
      │  │  │  │  │     │  └─ ExpandDims{axis=0} [id J]
      │  │  │  │  │     │     └─ Second [id K]
      │  │  │  │  │     │        ├─ A [id L]
-     │  │  │  │  │     │        └─ ExpandDims{axis=0} [id M]
-     │  │  │  │  │     │           └─ 1.0 [id N]
-     │  │  │  │  │     └─ 0 [id O]
-     │  │  │  │  └─ Subtensor{i} [id P]
+     │  │  │  │  │     │        └─ 1.0 [id M]
+     │  │  │  │  │     └─ 0 [id N]
+     │  │  │  │  └─ Subtensor{i} [id O]
      │  │  │  │     ├─ Shape [id I]
      │  │  │  │     │  └─ ···
-     │  │  │  │     └─ 1 [id Q]
+     │  │  │  │     └─ 1 [id P]
      │  │  │  ├─ ExpandDims{axis=0} [id J]
      │  │  │  │  └─ ···
-     │  │  │  └─ ScalarFromTensor [id R]
+     │  │  │  └─ ScalarFromTensor [id Q]
      │  │  │     └─ Subtensor{i} [id H]
      │  │  │        └─ ···
      │  │  └─ A [id L] (outer_in_non_seqs-0)
-     │  └─ 1 [id S]
-     └─ -1 [id T]
+     │  └─ 1 [id R]
+     └─ -1 [id S]
 
     Inner graphs:
 
     Scan{scan_fn, while_loop=False, inplace=none} [id C]
-     ← Mul [id U] (inner_out_sit_sot-0)
-        ├─ *0-<Vector(float64, shape=(?,))> [id V] -> [id E] (inner_in_sit_sot-0)
-        └─ *1-<Vector(float64, shape=(?,))> [id W] -> [id L] (inner_in_non_seqs-0)
+     ← Mul [id T] (inner_out_sit_sot-0)
+        ├─ *0-<Vector(float64, shape=(?,))> [id U] -> [id E] (inner_in_sit_sot-0)
+        └─ *1-<Vector(float64, shape=(?,))> [id V] -> [id L] (inner_in_non_seqs-0)
     """
 
     for truth, out in zip(expected_output.split("\n"), lines, strict=True):
@@ -96,28 +95,27 @@ def test_debugprint_sitsot_no_extra_info():
      │  │  │  │  │     │  └─ ExpandDims{axis=0} [id J]
      │  │  │  │  │     │     └─ Second [id K]
      │  │  │  │  │     │        ├─ A [id L]
-     │  │  │  │  │     │        └─ ExpandDims{axis=0} [id M]
-     │  │  │  │  │     │           └─ 1.0 [id N]
-     │  │  │  │  │     └─ 0 [id O]
-     │  │  │  │  └─ Subtensor{i} [id P]
+     │  │  │  │  │     │        └─ 1.0 [id M]
+     │  │  │  │  │     └─ 0 [id N]
+     │  │  │  │  └─ Subtensor{i} [id O]
      │  │  │  │     ├─ Shape [id I]
      │  │  │  │     │  └─ ···
-     │  │  │  │     └─ 1 [id Q]
+     │  │  │  │     └─ 1 [id P]
      │  │  │  ├─ ExpandDims{axis=0} [id J]
      │  │  │  │  └─ ···
-     │  │  │  └─ ScalarFromTensor [id R]
+     │  │  │  └─ ScalarFromTensor [id Q]
      │  │  │     └─ Subtensor{i} [id H]
      │  │  │        └─ ···
      │  │  └─ A [id L]
-     │  └─ 1 [id S]
-     └─ -1 [id T]
+     │  └─ 1 [id R]
+     └─ -1 [id S]
 
     Inner graphs:
 
     Scan{scan_fn, while_loop=False, inplace=none} [id C]
-     ← Mul [id U]
-        ├─ *0-<Vector(float64, shape=(?,))> [id V] -> [id E]
-        └─ *1-<Vector(float64, shape=(?,))> [id W] -> [id L]
+     ← Mul [id T]
+        ├─ *0-<Vector(float64, shape=(?,))> [id U] -> [id E]
+        └─ *1-<Vector(float64, shape=(?,))> [id V] -> [id L]
     """
 
     for truth, out in zip(expected_output.split("\n"), lines, strict=True):
@@ -263,44 +261,41 @@ def test_debugprint_nested_scans():
 
     Scan{scan_fn, while_loop=False, inplace=none} [id B]
      ← Mul [id Y] (inner_out_nit_sot-0)
-        ├─ ExpandDims{axis=0} [id Z]
-        │  └─ *0-<Scalar(float64, shape=())> [id BA] -> [id S] (inner_in_seqs-0)
-        └─ Pow [id BB]
-           ├─ Subtensor{i} [id BC]
-           │  ├─ Subtensor{start:} [id BD]
-           │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id BE] (outer_out_sit_sot-0)
-           │  │  │  ├─ *3-<Scalar(int32, shape=())> [id BF] -> [id X] (inner_in_non_seqs-1) (n_steps)
-           │  │  │  ├─ SetSubtensor{:stop} [id BG] (outer_in_sit_sot-0)
-           │  │  │  │  ├─ AllocEmpty{dtype='float64'} [id BH]
-           │  │  │  │  │  ├─ Add [id BI]
-           │  │  │  │  │  │  ├─ *3-<Scalar(int32, shape=())> [id BF] -> [id X] (inner_in_non_seqs-1)
-           │  │  │  │  │  │  └─ Subtensor{i} [id BJ]
-           │  │  │  │  │  │     ├─ Shape [id BK]
-           │  │  │  │  │  │     │  └─ ExpandDims{axis=0} [id BL]
-           │  │  │  │  │  │     │     └─ Second [id BM]
-           │  │  │  │  │  │     │        ├─ *2-<Vector(float64, shape=(?,))> [id BN] -> [id W] (inner_in_non_seqs-0)
-           │  │  │  │  │  │     │        └─ ExpandDims{axis=0} [id BO]
-           │  │  │  │  │  │     │           └─ 1.0 [id BP]
-           │  │  │  │  │  │     └─ 0 [id BQ]
-           │  │  │  │  │  └─ Subtensor{i} [id BR]
-           │  │  │  │  │     ├─ Shape [id BK]
+        ├─ *0-<Scalar(float64, shape=())> [id Z] -> [id S] (inner_in_seqs-0)
+        └─ Pow [id BA]
+           ├─ Subtensor{i} [id BB]
+           │  ├─ Subtensor{start:} [id BC]
+           │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id BD] (outer_out_sit_sot-0)
+           │  │  │  ├─ *3-<Scalar(int32, shape=())> [id BE] -> [id X] (inner_in_non_seqs-1) (n_steps)
+           │  │  │  ├─ SetSubtensor{:stop} [id BF] (outer_in_sit_sot-0)
+           │  │  │  │  ├─ AllocEmpty{dtype='float64'} [id BG]
+           │  │  │  │  │  ├─ Add [id BH]
+           │  │  │  │  │  │  ├─ *3-<Scalar(int32, shape=())> [id BE] -> [id X] (inner_in_non_seqs-1)
+           │  │  │  │  │  │  └─ Subtensor{i} [id BI]
+           │  │  │  │  │  │     ├─ Shape [id BJ]
+           │  │  │  │  │  │     │  └─ ExpandDims{axis=0} [id BK]
+           │  │  │  │  │  │     │     └─ Second [id BL]
+           │  │  │  │  │  │     │        ├─ *2-<Vector(float64, shape=(?,))> [id BM] -> [id W] (inner_in_non_seqs-0)
+           │  │  │  │  │  │     │        └─ 1.0 [id BN]
+           │  │  │  │  │  │     └─ 0 [id BO]
+           │  │  │  │  │  └─ Subtensor{i} [id BP]
+           │  │  │  │  │     ├─ Shape [id BJ]
            │  │  │  │  │     │  └─ ···
-           │  │  │  │  │     └─ 1 [id BS]
-           │  │  │  │  ├─ ExpandDims{axis=0} [id BL]
+           │  │  │  │  │     └─ 1 [id BQ]
+           │  │  │  │  ├─ ExpandDims{axis=0} [id BK]
            │  │  │  │  │  └─ ···
-           │  │  │  │  └─ ScalarFromTensor [id BT]
-           │  │  │  │     └─ Subtensor{i} [id BJ]
+           │  │  │  │  └─ ScalarFromTensor [id BR]
+           │  │  │  │     └─ Subtensor{i} [id BI]
            │  │  │  │        └─ ···
-           │  │  │  └─ *2-<Vector(float64, shape=(?,))> [id BN] -> [id W] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
-           │  │  └─ 1 [id BU]
-           │  └─ -1 [id BV]
-           └─ ExpandDims{axis=0} [id BW]
-              └─ *1-<Scalar(int64, shape=())> [id BX] -> [id U] (inner_in_seqs-1)
+           │  │  │  └─ *2-<Vector(float64, shape=(?,))> [id BM] -> [id W] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
+           │  │  └─ 1 [id BS]
+           │  └─ -1 [id BT]
+           └─ *1-<Scalar(int64, shape=())> [id BU] -> [id U] (inner_in_seqs-1)
 
-    Scan{scan_fn, while_loop=False, inplace=none} [id BE]
-     ← Mul [id BY] (inner_out_sit_sot-0)
-        ├─ *0-<Vector(float64, shape=(?,))> [id BZ] -> [id BG] (inner_in_sit_sot-0)
-        └─ *1-<Vector(float64, shape=(?,))> [id CA] -> [id BN] (inner_in_non_seqs-0)
+    Scan{scan_fn, while_loop=False, inplace=none} [id BD]
+     ← Mul [id BV] (inner_out_sit_sot-0)
+        ├─ *0-<Vector(float64, shape=(?,))> [id BW] -> [id BF] (inner_in_sit_sot-0)
+        └─ *1-<Vector(float64, shape=(?,))> [id BX] -> [id BM] (inner_in_non_seqs-0)
     """
 
     for truth, out in zip(expected_output.split("\n"), lines, strict=True):
@@ -359,46 +354,43 @@ def test_debugprint_nested_scans():
      → *2-<Vector(float64, shape=(?,))> [id BA] -> [id C] (inner_in_non_seqs-0)
      → *3-<Scalar(int32, shape=())> [id BB] -> [id B] (inner_in_non_seqs-1)
      ← Mul [id BC] (inner_out_nit_sot-0)
-        ├─ ExpandDims{axis=0} [id BD]
-        │  └─ *0-<Scalar(float64, shape=())> [id Y] (inner_in_seqs-0)
-        └─ Pow [id BE]
-           ├─ Subtensor{i} [id BF]
-           │  ├─ Subtensor{start:} [id BG]
-           │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id BH] (outer_out_sit_sot-0)
+        ├─ *0-<Scalar(float64, shape=())> [id Y] (inner_in_seqs-0)
+        └─ Pow [id BD]
+           ├─ Subtensor{i} [id BE]
+           │  ├─ Subtensor{start:} [id BF]
+           │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id BG] (outer_out_sit_sot-0)
            │  │  │  ├─ *3-<Scalar(int32, shape=())> [id BB] (inner_in_non_seqs-1) (n_steps)
-           │  │  │  ├─ SetSubtensor{:stop} [id BI] (outer_in_sit_sot-0)
-           │  │  │  │  ├─ AllocEmpty{dtype='float64'} [id BJ]
-           │  │  │  │  │  ├─ Add [id BK]
+           │  │  │  ├─ SetSubtensor{:stop} [id BH] (outer_in_sit_sot-0)
+           │  │  │  │  ├─ AllocEmpty{dtype='float64'} [id BI]
+           │  │  │  │  │  ├─ Add [id BJ]
            │  │  │  │  │  │  ├─ *3-<Scalar(int32, shape=())> [id BB] (inner_in_non_seqs-1)
-           │  │  │  │  │  │  └─ Subtensor{i} [id BL]
-           │  │  │  │  │  │     ├─ Shape [id BM]
-           │  │  │  │  │  │     │  └─ ExpandDims{axis=0} [id BN]
-           │  │  │  │  │  │     │     └─ Second [id BO]
+           │  │  │  │  │  │  └─ Subtensor{i} [id BK]
+           │  │  │  │  │  │     ├─ Shape [id BL]
+           │  │  │  │  │  │     │  └─ ExpandDims{axis=0} [id BM]
+           │  │  │  │  │  │     │     └─ Second [id BN]
            │  │  │  │  │  │     │        ├─ *2-<Vector(float64, shape=(?,))> [id BA] (inner_in_non_seqs-0)
-           │  │  │  │  │  │     │        └─ ExpandDims{axis=0} [id BP]
-           │  │  │  │  │  │     │           └─ 1.0 [id BQ]
-           │  │  │  │  │  │     └─ 0 [id BR]
-           │  │  │  │  │  └─ Subtensor{i} [id BS]
-           │  │  │  │  │     ├─ Shape [id BM]
+           │  │  │  │  │  │     │        └─ 1.0 [id BO]
+           │  │  │  │  │  │     └─ 0 [id BP]
+           │  │  │  │  │  └─ Subtensor{i} [id BQ]
+           │  │  │  │  │     ├─ Shape [id BL]
            │  │  │  │  │     │  └─ ···
-           │  │  │  │  │     └─ 1 [id BT]
-           │  │  │  │  ├─ ExpandDims{axis=0} [id BN]
+           │  │  │  │  │     └─ 1 [id BR]
+           │  │  │  │  ├─ ExpandDims{axis=0} [id BM]
            │  │  │  │  │  └─ ···
-           │  │  │  │  └─ ScalarFromTensor [id BU]
-           │  │  │  │     └─ Subtensor{i} [id BL]
+           │  │  │  │  └─ ScalarFromTensor [id BS]
+           │  │  │  │     └─ Subtensor{i} [id BK]
            │  │  │  │        └─ ···
            │  │  │  └─ *2-<Vector(float64, shape=(?,))> [id BA] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
-           │  │  └─ 1 [id BV]
-           │  └─ -1 [id BW]
-           └─ ExpandDims{axis=0} [id BX]
-              └─ *1-<Scalar(int64, shape=())> [id Z] (inner_in_seqs-1)
+           │  │  └─ 1 [id BT]
+           │  └─ -1 [id BU]
+           └─ *1-<Scalar(int64, shape=())> [id Z] (inner_in_seqs-1)
 
-    Scan{scan_fn, while_loop=False, inplace=none} [id BH]
-     → *0-<Vector(float64, shape=(?,))> [id BY] -> [id BI] (inner_in_sit_sot-0)
-     → *1-<Vector(float64, shape=(?,))> [id BZ] -> [id BA] (inner_in_non_seqs-0)
-     ← Mul [id CA] (inner_out_sit_sot-0)
-        ├─ *0-<Vector(float64, shape=(?,))> [id BY] (inner_in_sit_sot-0)
-        └─ *1-<Vector(float64, shape=(?,))> [id BZ] (inner_in_non_seqs-0)
+    Scan{scan_fn, while_loop=False, inplace=none} [id BG]
+     → *0-<Vector(float64, shape=(?,))> [id BV] -> [id BH] (inner_in_sit_sot-0)
+     → *1-<Vector(float64, shape=(?,))> [id BW] -> [id BA] (inner_in_non_seqs-0)
+     ← Mul [id BX] (inner_out_sit_sot-0)
+        ├─ *0-<Vector(float64, shape=(?,))> [id BV] (inner_in_sit_sot-0)
+        └─ *1-<Vector(float64, shape=(?,))> [id BW] (inner_in_non_seqs-0)
     """
 
     for truth, out in zip(expected_output.split("\n"), lines, strict=True):
@@ -515,101 +507,98 @@ def test_debugprint_mitmot():
      │  │  │  │     │  │  │     │  └─ ExpandDims{axis=0} [id M]
      │  │  │  │     │  │  │     │     └─ Second [id N]
      │  │  │  │     │  │  │     │        ├─ A [id O]
-     │  │  │  │     │  │  │     │        └─ ExpandDims{axis=0} [id P]
-     │  │  │  │     │  │  │     │           └─ 1.0 [id Q]
-     │  │  │  │     │  │  │     └─ 0 [id R]
-     │  │  │  │     │  │  └─ Subtensor{i} [id S]
+     │  │  │  │     │  │  │     │        └─ 1.0 [id P]
+     │  │  │  │     │  │  │     └─ 0 [id Q]
+     │  │  │  │     │  │  └─ Subtensor{i} [id R]
      │  │  │  │     │  │     ├─ Shape [id L]
      │  │  │  │     │  │     │  └─ ···
-     │  │  │  │     │  │     └─ 1 [id T]
+     │  │  │  │     │  │     └─ 1 [id S]
      │  │  │  │     │  ├─ ExpandDims{axis=0} [id M]
      │  │  │  │     │  │  └─ ···
-     │  │  │  │     │  └─ ScalarFromTensor [id U]
+     │  │  │  │     │  └─ ScalarFromTensor [id T]
      │  │  │  │     │     └─ Subtensor{i} [id K]
      │  │  │  │     │        └─ ···
      │  │  │  │     └─ A [id O] (outer_in_non_seqs-0)
-     │  │  │  └─ 0 [id V]
-     │  │  └─ 1 [id W]
-     │  ├─ Subtensor{:stop} [id X] (outer_in_seqs-0)
-     │  │  ├─ Subtensor{::step} [id Y]
-     │  │  │  ├─ Subtensor{:stop} [id Z]
+     │  │  │  └─ 0 [id U]
+     │  │  └─ 1 [id V]
+     │  ├─ Subtensor{:stop} [id W] (outer_in_seqs-0)
+     │  │  ├─ Subtensor{::step} [id X]
+     │  │  │  ├─ Subtensor{:stop} [id Y]
      │  │  │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  └─ ···
-     │  │  │  │  └─ -1 [id BA]
-     │  │  │  └─ -1 [id BB]
-     │  │  └─ ScalarFromTensor [id BC]
+     │  │  │  │  └─ -1 [id Z]
+     │  │  │  └─ -1 [id BA]
+     │  │  └─ ScalarFromTensor [id BB]
      │  │     └─ Sub [id C]
      │  │        └─ ···
-     │  ├─ Subtensor{:stop} [id BD] (outer_in_seqs-1)
-     │  │  ├─ Subtensor{:stop} [id BE]
-     │  │  │  ├─ Subtensor{::step} [id BF]
+     │  ├─ Subtensor{:stop} [id BC] (outer_in_seqs-1)
+     │  │  ├─ Subtensor{:stop} [id BD]
+     │  │  │  ├─ Subtensor{::step} [id BE]
      │  │  │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  └─ ···
-     │  │  │  │  └─ -1 [id BG]
-     │  │  │  └─ -1 [id BH]
-     │  │  └─ ScalarFromTensor [id BI]
+     │  │  │  │  └─ -1 [id BF]
+     │  │  │  └─ -1 [id BG]
+     │  │  └─ ScalarFromTensor [id BH]
      │  │     └─ Sub [id C]
      │  │        └─ ···
-     │  ├─ Subtensor{::step} [id BJ] (outer_in_mit_mot-0)
-     │  │  ├─ IncSubtensor{start:} [id BK]
-     │  │  │  ├─ Second [id BL]
+     │  ├─ Subtensor{::step} [id BI] (outer_in_mit_mot-0)
+     │  │  ├─ IncSubtensor{start:} [id BJ]
+     │  │  │  ├─ Second [id BK]
      │  │  │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  └─ ···
-     │  │  │  │  └─ ExpandDims{axes=[0, 1]} [id BM]
-     │  │  │  │     └─ 0.0 [id BN]
-     │  │  │  ├─ IncSubtensor{i} [id BO]
-     │  │  │  │  ├─ Second [id BP]
-     │  │  │  │  │  ├─ Subtensor{start:} [id BQ]
+     │  │  │  │  └─ 0.0 [id BL]
+     │  │  │  ├─ IncSubtensor{i} [id BM]
+     │  │  │  │  ├─ Second [id BN]
+     │  │  │  │  │  ├─ Subtensor{start:} [id BO]
      │  │  │  │  │  │  ├─ Scan{scan_fn, while_loop=False, inplace=none} [id F] (outer_out_sit_sot-0)
      │  │  │  │  │  │  │  └─ ···
-     │  │  │  │  │  │  └─ 1 [id BR]
-     │  │  │  │  │  └─ ExpandDims{axes=[0, 1]} [id BS]
-     │  │  │  │  │     └─ 0.0 [id BT]
-     │  │  │  │  ├─ Second [id BU]
-     │  │  │  │  │  ├─ Subtensor{i} [id BV]
-     │  │  │  │  │  │  ├─ Subtensor{start:} [id BQ]
+     │  │  │  │  │  │  └─ 1 [id BP]
+     │  │  │  │  │  └─ 0.0 [id BQ]
+     │  │  │  │  ├─ Second [id BR]
+     │  │  │  │  │  ├─ Subtensor{i} [id BS]
+     │  │  │  │  │  │  ├─ Subtensor{start:} [id BO]
      │  │  │  │  │  │  │  └─ ···
-     │  │  │  │  │  │  └─ -1 [id BW]
-     │  │  │  │  │  └─ ExpandDims{axis=0} [id BX]
-     │  │  │  │  │     └─ Second [id BY]
-     │  │  │  │  │        ├─ Sum{axes=None} [id BZ]
-     │  │  │  │  │        │  └─ Subtensor{i} [id BV]
+     │  │  │  │  │  │  └─ -1 [id BT]
+     │  │  │  │  │  └─ ExpandDims{axis=0} [id BU]
+     │  │  │  │  │     └─ Second [id BV]
+     │  │  │  │  │        ├─ Sum{axes=None} [id BW]
+     │  │  │  │  │        │  └─ Subtensor{i} [id BS]
      │  │  │  │  │        │     └─ ···
-     │  │  │  │  │        └─ 1.0 [id CA]
-     │  │  │  │  └─ -1 [id BW]
-     │  │  │  └─ 1 [id BR]
-     │  │  └─ -1 [id CB]
-     │  ├─ Alloc [id CC] (outer_in_sit_sot-0)
-     │  │  ├─ 0.0 [id CD]
-     │  │  ├─ Add [id CE]
+     │  │  │  │  │        └─ 1.0 [id BX]
+     │  │  │  │  └─ -1 [id BT]
+     │  │  │  └─ 1 [id BP]
+     │  │  └─ -1 [id BY]
+     │  ├─ Alloc [id BZ] (outer_in_sit_sot-0)
+     │  │  ├─ 0.0 [id CA]
+     │  │  ├─ Add [id CB]
      │  │  │  ├─ Sub [id C]
      │  │  │  │  └─ ···
-     │  │  │  └─ 1 [id CF]
-     │  │  └─ Subtensor{i} [id CG]
-     │  │     ├─ Shape [id CH]
+     │  │  │  └─ 1 [id CC]
+     │  │  └─ Subtensor{i} [id CD]
+     │  │     ├─ Shape [id CE]
      │  │     │  └─ A [id O]
-     │  │     └─ 0 [id CI]
+     │  │     └─ 0 [id CF]
      │  └─ A [id O] (outer_in_non_seqs-0)
-     └─ -1 [id CJ]
+     └─ -1 [id CG]
 
     Inner graphs:
 
     Scan{grad_of_scan_fn, while_loop=False, inplace=none} [id B]
-     ← Add [id CK] (inner_out_mit_mot-0-0)
-        ├─ Mul [id CL]
-        │  ├─ *2-<Vector(float64, shape=(?,))> [id CM] -> [id BJ] (inner_in_mit_mot-0-0)
-        │  └─ *5-<Vector(float64, shape=(?,))> [id CN] -> [id O] (inner_in_non_seqs-0)
-        └─ *3-<Vector(float64, shape=(?,))> [id CO] -> [id BJ] (inner_in_mit_mot-0-1)
-     ← Add [id CP] (inner_out_sit_sot-0)
-        ├─ Mul [id CQ]
-        │  ├─ *2-<Vector(float64, shape=(?,))> [id CM] -> [id BJ] (inner_in_mit_mot-0-0)
-        │  └─ *0-<Vector(float64, shape=(?,))> [id CR] -> [id X] (inner_in_seqs-0)
-        └─ *4-<Vector(float64, shape=(?,))> [id CS] -> [id CC] (inner_in_sit_sot-0)
+     ← Add [id CH] (inner_out_mit_mot-0-0)
+        ├─ Mul [id CI]
+        │  ├─ *2-<Vector(float64, shape=(?,))> [id CJ] -> [id BI] (inner_in_mit_mot-0-0)
+        │  └─ *5-<Vector(float64, shape=(?,))> [id CK] -> [id O] (inner_in_non_seqs-0)
+        └─ *3-<Vector(float64, shape=(?,))> [id CL] -> [id BI] (inner_in_mit_mot-0-1)
+     ← Add [id CM] (inner_out_sit_sot-0)
+        ├─ Mul [id CN]
+        │  ├─ *2-<Vector(float64, shape=(?,))> [id CJ] -> [id BI] (inner_in_mit_mot-0-0)
+        │  └─ *0-<Vector(float64, shape=(?,))> [id CO] -> [id W] (inner_in_seqs-0)
+        └─ *4-<Vector(float64, shape=(?,))> [id CP] -> [id BZ] (inner_in_sit_sot-0)
 
     Scan{scan_fn, while_loop=False, inplace=none} [id F]
-     ← Mul [id CT] (inner_out_sit_sot-0)
-        ├─ *0-<Vector(float64, shape=(?,))> [id CR] -> [id H] (inner_in_sit_sot-0)
-        └─ *1-<Vector(float64, shape=(?,))> [id CU] -> [id O] (inner_in_non_seqs-0)
+     ← Mul [id CQ] (inner_out_sit_sot-0)
+        ├─ *0-<Vector(float64, shape=(?,))> [id CO] -> [id H] (inner_in_sit_sot-0)
+        └─ *1-<Vector(float64, shape=(?,))> [id CR] -> [id O] (inner_in_non_seqs-0)
     """
 
     for truth, out in zip(expected_output.split("\n"), lines, strict=True):

--- a/tests/sparse/test_math.py
+++ b/tests/sparse/test_math.py
@@ -825,14 +825,13 @@ class TestUsmm:
 
         if not pytensor.config.blas__ldflags:
             # Usmm should not be inserted, because it relies on BLAS
-            assert len(topo) == 4, topo
+            assert len(topo) == 3, topo
             assert isinstance(topo[0].op, psm.Dot)
-            assert isinstance(topo[1].op, DimShuffle)
-            assert isinstance(topo[2].op, Elemwise) and isinstance(
-                topo[2].op.scalar_op, pytensor.scalar.Mul
+            assert isinstance(topo[1].op, Elemwise) and isinstance(
+                topo[1].op.scalar_op, pytensor.scalar.Mul
             )
-            assert isinstance(topo[3].op, Elemwise) and isinstance(
-                topo[3].op.scalar_op, pytensor.scalar.Sub
+            assert isinstance(topo[2].op, Elemwise) and isinstance(
+                topo[2].op.scalar_op, pytensor.scalar.Sub
             )
         elif (
             y.type.dtype == up
@@ -842,14 +841,7 @@ class TestUsmm:
             and up in ("float32", "float64")
         ):
             # The op UsmmCscDense should be inserted
-            assert (
-                sum(
-                    isinstance(node.op, Elemwise)
-                    and isinstance(node.op.scalar_op, pytensor.scalar.basic.Cast)
-                    for node in topo
-                )
-                == len(topo) - 5
-            )
+            # Filter out Cast and DimShuffle (from shape_padleft on scalar alpha)
             new_topo = [
                 node
                 for node in topo
@@ -857,9 +849,10 @@ class TestUsmm:
                     isinstance(node.op, Elemwise)
                     and isinstance(node.op.scalar_op, pytensor.scalar.basic.Cast)
                 )
+                and not isinstance(node.op, DimShuffle)
             ]
             topo = new_topo
-            assert len(topo) == 5, topo
+            assert len(topo) == 4, topo
 
             # Usmm is tested at the same time in debugmode
             # Check if the optimization local_usmm and local_usmm_csx is
@@ -869,18 +862,16 @@ class TestUsmm:
                 assert sum(isinstance(n.op, x) for n in topo) == 1
 
             check_once(CSMProperties)
-            check_once(DimShuffle)
             check_once(Subtensor)
             check_once(UsmmCscDense)
             check_once(Elemwise)
             if inplace:
-                assert topo[4].op.inplace
+                assert topo[3].op.inplace
         elif not fast_compile:
             # The op Usmm should be inserted
-            assert len(topo) == 3, topo
-            assert isinstance(topo[0].op, DimShuffle)
-            assert topo[1].op == pytensor.tensor.neg
-            assert isinstance(topo[2].op, psm.Usmm)
+            assert len(topo) == 2, topo
+            assert topo[0].op == pytensor.tensor.neg
+            assert isinstance(topo[1].op, psm.Usmm)
 
     @pytest.mark.parametrize(
         "params",

--- a/tests/tensor/random/rewriting/test_basic.py
+++ b/tests/tensor/random/rewriting/test_basic.py
@@ -870,7 +870,7 @@ def test_Subtensor_lift_restrictions():
     fg = FunctionGraph([rng], [z], clone=False, features=[ShapeFeature()])
     _ = EquilibriumGraphRewriter([local_subtensor_rv_lift], max_use_ratio=100).apply(fg)
 
-    subtensor_node = fg.outputs[0].owner.inputs[1].owner.inputs[0].owner
+    subtensor_node = fg.outputs[0].owner.inputs[1].owner
     assert subtensor_node == y.owner
     assert isinstance(subtensor_node.op, Subtensor)
     assert isinstance(subtensor_node.inputs[0].owner.op, NormalRV)
@@ -890,7 +890,7 @@ def test_Subtensor_lift_restrictions():
     fg = FunctionGraph([rng], [z], clone=False, features=[ShapeFeature()])
     EquilibriumGraphRewriter([local_subtensor_rv_lift], max_use_ratio=100).apply(fg)
 
-    rv_node = fg.outputs[0].owner.inputs[1].owner.inputs[0].owner
+    rv_node = fg.outputs[0].owner.inputs[1].owner
     assert isinstance(rv_node.op, NormalRV)
     assert isinstance(rv_node.inputs[-1].owner.op, Subtensor)
     assert isinstance(rv_node.inputs[-2].owner.op, Subtensor)

--- a/tests/tensor/rewriting/test_basic.py
+++ b/tests/tensor/rewriting/test_basic.py
@@ -70,7 +70,7 @@ from pytensor.tensor.rewriting.basic import (
     local_useless_elemwise,
     topo_constant_folding,
     topo_unconditional_constant_folding,
-    topological_fill_sink,
+    topological_second_sink,
 )
 from pytensor.tensor.rewriting.math import local_lift_transpose_through_dot
 from pytensor.tensor.rewriting.shape import ShapeFeature
@@ -246,7 +246,7 @@ def test_local_useless_fill():
     assert np.array_equal(res, exp_res)
 
 
-def test_local_fill_to_alloc():
+def test_local_second_to_alloc():
     x = dvector()
     m = dmatrix()
 
@@ -255,8 +255,8 @@ def test_local_fill_to_alloc():
 
     y = pt.fill(m, x)
 
-    mode = rewrite_mode.including("stabilize", "local_fill_to_alloc").excluding(
-        "useless", "local_useless_fill"
+    mode = rewrite_mode.including("stabilize", "local_second_to_alloc").excluding(
+        "useless", "local_useless_fill", "local_useless_alloc"
     )
 
     f = function([m, x], y, mode=mode)
@@ -325,7 +325,7 @@ class TestLocalCanonicalizeAlloc:
 
         # The rewrite `locall_fill_to_alloc` should call `pt.alloc`,
         # which should return `x` and not `alloc(x, ...)`
-        f = function([x], [y], mode=rewrite_mode.including("local_fill_to_alloc"))
+        f = function([x], [y], mode=rewrite_mode.including("local_second_to_alloc"))
         assert not any(isinstance(node.op, Alloc) for node in f.maker.fgraph.toposort())
 
     def test_basic_tile(self):
@@ -562,7 +562,9 @@ class TestTile:
 
 class TestUselessElemwise:
     def setup_method(self):
-        self.mode = get_default_mode().including("canonicalize", "local_fill_to_alloc")
+        self.mode = get_default_mode().including(
+            "canonicalize", "local_second_to_alloc"
+        )
 
     def test_eq(self):
         x = dmatrix()
@@ -1838,7 +1840,9 @@ class TestLocalElemwiseAlloc:
         z_opt = pytensor.function(
             [x, y],
             z,
-            mode=get_default_mode().including("local_elemwise_alloc"),
+            mode=get_default_mode().including(
+                "local_dimshuffle_alloc", "local_elemwise_alloc"
+            ),
             on_unused_input="ignore",
         )
 
@@ -1935,11 +1939,8 @@ class TestLocalElemwiseAlloc:
             self.alloc_w_dep_broad2 + self.mat,
             mode=self.fast_run_mode,
         )
-        # This graph requires one outer Alloc and an Assert
-        # To make sure `mat` is square since we end up doing
-        # broadcast_to(x, mat[..., None].shape) + mat[None, ...]
         self.verify_op_count(func, 1, Alloc)
-        self.verify_op_count(func, 1, Assert)
+        self.verify_op_count(func, 0, Assert)
 
     def test_remove_alloc_w_dimshuffle(self):
         func = function(
@@ -2041,7 +2042,7 @@ def test_shape_unsafe_tag():
         fn([0, 1], [2, 3, 4]), [0, 1]
 
 
-def test_topological_fill_sink_multi_output_client():
+def test_topological_second_sink_multi_output_client():
     x = float64("x")
     elem_op_with_2_outputs = Elemwise(Composite([x], [x + 1, x + 2]))
 
@@ -2051,13 +2052,13 @@ def test_topological_fill_sink_multi_output_client():
     out = pt.add(*elem_op_with_2_outputs(pt.exp(bcast_x)))
 
     fg = FunctionGraph([x, z], [out], copy_inputs=False)
-    topological_fill_sink.rewrite(fg)
+    topological_second_sink.rewrite(fg)
     [new_out] = fg.outputs
     expected_out = pt.full_like(z, pt.add(*elem_op_with_2_outputs(pt.exp(x))))
     assert equal_computations([new_out], [expected_out])
 
 
-def test_topological_fill_sink_broadcastable_change():
+def test_topological_second_sink_broadcastable_change():
     """Test rewrite doesn't fail after a graph replacement that provides a broadcastable change."""
     a = vector("a", shape=(1,))
     b = vector("b", shape=(1,))
@@ -2068,6 +2069,6 @@ def test_topological_fill_sink_broadcastable_change():
     out = graph_replace(initial_out, {zeros: pt.zeros((1,))}, strict=False)
 
     fg = FunctionGraph([a, b], [out], copy_inputs=False)
-    topological_fill_sink.rewrite(fg)
+    topological_second_sink.rewrite(fg)
     [new_out] = fg.outputs
     assert equal_computations([new_out], [a + b])

--- a/tests/tensor/rewriting/test_blas.py
+++ b/tests/tensor/rewriting/test_blas.py
@@ -124,14 +124,7 @@ def test_gemm_canonicalize():
     can = []
     fg = FunctionGraph([X, Y, v], [X + Y + v], clone=False)
     _gemm_canonicalize(fg, fg.outputs[0], 1.0, can, 0)
-    # [(1.0, X), (1.0, Y), (1.0, InplaceDimShuffle{x,0}(v))]
-    assert can[:2] == [(1.0, X), (1.0, Y)]
-    assert isinstance(can[2], tuple)
-    assert len(can[2]) == 2
-    assert can[2][0] == 1.0
-    assert can[2][1].owner
-    assert isinstance(can[2][1].owner.op, DimShuffle)
-    assert can[2][1].owner.inputs == [v]
+    assert can == [(1.0, X), (1.0, Y), (1.0, v)]
 
     can = []
     fg = FunctionGraph([X, Y, w], [X + Y + w], clone=False)

--- a/tests/tensor/rewriting/test_elemwise.py
+++ b/tests/tensor/rewriting/test_elemwise.py
@@ -18,8 +18,8 @@ from pytensor.graph.rewriting.basic import check_stack_trace, out2in
 from pytensor.graph.rewriting.db import RewriteDatabaseQuery
 from pytensor.graph.rewriting.utils import rewrite_graph
 from pytensor.raise_op import assert_op
-from pytensor.scalar.basic import Composite, float64
-from pytensor.tensor.basic import MakeVector
+from pytensor.scalar.basic import EQ, Composite, float64
+from pytensor.tensor.basic import MakeVector, constant
 from pytensor.tensor.elemwise import DimShuffle, Elemwise
 from pytensor.tensor.math import abs as pt_abs
 from pytensor.tensor.math import (
@@ -126,9 +126,10 @@ class TestDimshuffleLift:
         e = x + y + z
         g = FunctionGraph([x, y, z], [e], clone=False)
         dimshuffle_lift.rewrite(g)
+        # With implicit broadcasting, no DimShuffle padding exists to lift
         assert equal_computations(
             g.outputs,
-            [(x.dimshuffle("x", "x", 0) + y.dimshuffle("x", 0, 1)) + z],
+            [(x + y) + z],
         )
         # Check stacktrace was copied over correctly after rewrite was applied
         assert check_stack_trace(g, ops_to_check="all")
@@ -139,9 +140,13 @@ class TestDimshuffleLift:
         out = ((v + 42) * (m + 84)).T
         g = FunctionGraph([v, m], [out], clone=False)
         new_out = local_dimshuffle_lift.transform(g, g.outputs[0].owner)
+
         assert equal_computations(
             new_out,
-            [(v.dimshuffle(0, "x") + 42) * (m.T + 84)],
+            [
+                (v[:, None] + constant(42)[None, None])
+                * (m.T + constant(84)[None, None])
+            ],
         )
         # Check stacktrace was copied over correctly after rewrite was applied
         new_g = FunctionGraph(g.inputs, new_out, clone=False)
@@ -557,7 +562,7 @@ class TestFusion:
                 (fwx.sum()) + (fwx) + (fy + fz),
                 (fw, fx, fy, fz),
                 (fwv, fxv, fyv, fzv),
-                4,
+                3,
                 (fwv + fxv).sum() + fwv + fxv + fyv + fzv,
                 "float32",
             ),
@@ -884,18 +889,18 @@ class TestFusion:
                 fv + fy**fz,
                 (fv, fy, fz),
                 (fvv, fyv, fzv),
-                2,
+                1,
                 fvv + fyv**fzv,
                 "float32",
-            ),  # fused with a dimshuffle #65
+            ),  # 65
             (
                 fv - fy + tanh(fz),
                 (fv, fy, fz),
                 (fvv, fyv, fzv),
-                2,
+                1,
                 fvv - fyv + np.tanh(fzv),
                 "float32",
-            ),  # fused with a dimshuffle
+            ),
             # Cases where the same input is reused many times.
             (
                 mul(fx, fx, fx, fx),
@@ -932,13 +937,12 @@ class TestFusion:
                 1e-5,
             ),  # 70
             # Cases with different broadcast pattern. They should not
-            # be merged as this would duplicate computation
-            # The graph should have 2 elemwise and 1 dimshuffle
+            # be merged as this would duplicate computation.
             (
                 fx * sin(fs),
                 (fx, fs),
                 (fxv, fsv),
-                3,
+                2,
                 fxv * np.sin(fsv),
                 "float32",
             ),
@@ -993,7 +997,7 @@ class TestFusion:
                 ),
                 (fx,),
                 (fxv,),
-                4,
+                3,
                 (np.sum(fxv + 5) * np.exp(fxv) / (fxv + 5),),
                 ("float32",),
             ),
@@ -1341,17 +1345,16 @@ class TestFusion:
 
         f = pytensor.function([xs, xm], esm, mode=self.mode)
         apply_nodes = f.maker.fgraph.toposort()
-        assert len(apply_nodes) == 3
-        assert isinstance(apply_nodes[0].op, DimShuffle)
+        assert len(apply_nodes) == 2
         # Inner Vector output Composite
-        assert isinstance(apply_nodes[1].op.scalar_op, Composite)
-        assert {node.op for node in apply_nodes[1].op.scalar_op.fgraph.apply_nodes} == {
+        assert isinstance(apply_nodes[0].op.scalar_op, Composite)
+        assert {node.op for node in apply_nodes[0].op.scalar_op.fgraph.apply_nodes} == {
             ps.add,
             ps.log,
         }
         # Outer Matrix output Composite
-        assert isinstance(apply_nodes[2].op.scalar_op, Composite)
-        assert {node.op for node in apply_nodes[2].op.scalar_op.fgraph.apply_nodes} == {
+        assert isinstance(apply_nodes[1].op.scalar_op, Composite)
+        assert {node.op for node in apply_nodes[1].op.scalar_op.fgraph.apply_nodes} == {
             ps.sub,
             ps.exp,
             ps.mul,
@@ -1570,12 +1573,17 @@ def test_local_inline_composite_constants(op, np_op, const_shape):
     fn = pytensor.function(
         [x, y], out, mode=get_default_mode().including("specialize", "fusion")
     )
-    # There should be a single Composite after optimization
-    [node] = [
+    # There should be a single Composite Elemwise after optimization
+    # There may be another Elemwise for the equality of shapes.
+    nodes = [
         node for node in fn.maker.fgraph.apply_nodes if isinstance(node.op, Elemwise)
     ]
-    assert isinstance(node.op.scalar_op, Composite)
-    assert len(node.inputs) == 2  # x and y, but not const
+    if len(nodes) == 2:
+        [composite_node] = [n for n in nodes if isinstance(n.op.scalar_op, Composite)]
+        assert sum([isinstance(n.op.scalar_op, EQ) for n in nodes]) == 1
+    else:
+        [composite_node] = [n for n in nodes if isinstance(n.op.scalar_op, Composite)]
+    assert len(composite_node.inputs) == 2  # x and y, but not const
 
     x_test_value = np.arange(5).astype(config.floatX)
     y_test_value = np.ones(5).astype(config.floatX)

--- a/tests/tensor/rewriting/test_math.py
+++ b/tests/tensor/rewriting/test_math.py
@@ -272,7 +272,7 @@ class TestAlgebraicCanonizer:
             # ((x / x) * (y / y), None),
             (
                 (-1 * x) / y / (-2 * z),
-                (pt.as_tensor([[0.5]], dtype="floatX") * x) / (y * z),
+                (pt.as_tensor(0.5, dtype="floatX") * x) / (y * z),
             ),
         ],
     )
@@ -574,7 +574,7 @@ class TestAlgebraicCanonizer:
         mode = get_default_mode()
 
         rewrite_query = RewriteDatabaseQuery(["canonicalize"])
-        rewrite_query = rewrite_query.including("ShapeOpt", "local_fill_to_alloc")
+        rewrite_query = rewrite_query.including("ShapeOpt", "local_second_to_alloc")
         rewrite_query = rewrite_query.excluding("local_elemwise_fusion")
         mode = mode.__class__(linker=mode.linker, optimizer=rewrite_query)
         # test x / x -> 1
@@ -590,15 +590,7 @@ class TestAlgebraicCanonizer:
             out = f(*val_inputs)
             assert (out == np.ones(shp, dtype=out_dtype)).all()
             topo = f.maker.fgraph.toposort()
-            if sym_inputs[0].broadcastable[0]:
-                assert len(topo) == 2
-                assert isinstance(topo[0].op, Shape_i)
-                assert isinstance(topo[1].op, Alloc)
-            else:
-                assert len(topo) == 3
-                assert isinstance(topo[0].op, Shape_i)
-                assert isinstance(topo[1].op, Shape_i)
-                assert isinstance(topo[2].op, Alloc)
+            assert any(isinstance(n.op, Alloc) for n in topo)
             assert out_dtype == out.dtype
 
         # test (x * y) / x -> y
@@ -630,10 +622,8 @@ class TestAlgebraicCanonizer:
                 ((dv / dy) / dv, [dv, dy], [dvv, dyv], 1, "float64"),
                 ((fv / fy) / fv, [fv, fy], [fvv, fyv], 1, "float32"),
                 # must broadcast as there is a dimshuffle in the computation
-                ((dx / dv) / dx, [dx, dv], [dxv, dvv], 2, "float64"),
-                # topo: [Shape_i, Shape_i, Elemwise{reciprocal,no_inplace}(<TensorType(float64, row)>), Alloc]
-                ((fx / fv) / fx, [fx, fv], [fxv, fvv], 2, "float32"),
-                # topo: [Shape_i, Shape_i, Elemwise{reciprocal,no_inplace}(<TensorType(float32, row)>), Alloc]
+                ((dx / dv) / dx, [dx, dv], [dxv, dvv], 1, "float64"),
+                ((fx / fv) / fx, [fx, fv], [fxv, fvv], 1, "float32"),
             ]
         ):
             f = function(list(sym_inputs), g, mode=mode)
@@ -1008,7 +998,7 @@ class TestAlgebraicCanonizer:
         new_out = rewrite_graph(
             out, custom_rewrite=in2out(local_mul_canonizer, name="test")
         )
-        expected_out = np.array([2.0]).astype(config.floatX) * specify_shape(x, (5,))
+        expected_out = np.array(2.0).astype(config.floatX) * specify_shape(x, (5,))
         assert equal_computations([new_out], [expected_out])
 
     def test_broadcasted_by_constant(self):
@@ -1019,7 +1009,7 @@ class TestAlgebraicCanonizer:
         new_out = rewrite_graph(
             out, custom_rewrite=in2out(local_mul_canonizer, name="test")
         )
-        expected_out = second(const, np.array([[2.0]], dtype=config.floatX) * x)
+        expected_out = second(const, np.array(2.0, dtype=config.floatX) * x)
         assert equal_computations([new_out], [expected_out])
 
 
@@ -1225,7 +1215,7 @@ def test_local_elemwise_sub_zeros():
             "canonicalize",
             "uncanonicalize",
             "ShapeOpt",
-            "local_fill_to_alloc",
+            "local_second_to_alloc",
             "local_elemwise_alloc",
         )
         .including("local_elemwise_sub_zeros")
@@ -1982,9 +1972,9 @@ class TestExpLog:
             f.maker.fgraph.outputs,
             [
                 pt.switch(
-                    x >= np.array([[0]], dtype=np.int8),
+                    x >= np.array(0, dtype=np.int8),
                     pt.log1p(x),
-                    np.array([[np.nan]], dtype=np.float32),
+                    np.array(np.nan, dtype=np.float32),
                 )
             ],
         )
@@ -2006,9 +1996,9 @@ class TestExpLog:
             f.maker.fgraph.outputs,
             [
                 pt.switch(
-                    x >= np.array([[0]], dtype=np.int8),
+                    x >= np.array(0, dtype=np.int8),
                     pt.log1p(-x),
-                    np.array([[np.nan]], dtype=np.float32),
+                    np.array(np.nan, dtype=np.float32),
                 )
             ],
         )
@@ -2029,9 +2019,9 @@ class TestExpLog:
             f.maker.fgraph.outputs,
             [
                 pt.switch(
-                    x <= np.array([[0]], dtype=np.int8),
+                    x <= np.array(0, dtype=np.int8),
                     x,
-                    np.array([[np.nan]], dtype=np.float32),
+                    np.array(np.nan, dtype=np.float32),
                 )
             ],
         )
@@ -2069,7 +2059,7 @@ def test_log_sqrt() -> None:
 
     assert utt.assert_equal_computations(
         [out],
-        [mul(pt.as_tensor_variable([[0.5]], dtype=x.dtype), log(x))],
+        [mul(pt.as_tensor_variable(0.5, dtype=x.dtype), log(x))],
     )
 
 
@@ -2095,9 +2085,9 @@ class TestSqrSqrt:
         out = rewrite_graph(out, include=["canonicalize", "specialize", "stabilize"])
 
         expected = switch(
-            ge(x, np.zeros((1, 1), dtype="int8")),
+            ge(x, np.zeros((), dtype="int8")),
             x,
-            np.full((1, 1), np.nan, dtype=x.type.dtype),
+            np.full((), np.nan, dtype=x.type.dtype),
         )
 
         assert equal_computations([out], [expected])
@@ -3027,6 +3017,68 @@ class TestLocalSumProd:
 
             rewritten_out = rewrite_graph(out, custom_rewrite=rewrite)
             assert equal_computations([rewritten_out], [expected_out])
+
+            rewritten_out_fn = pytensor.function(
+                inputs, rewritten_out, mode=mode, on_unused_input="ignore"
+            )
+            np.testing.assert_allclose(
+                out_fn(*test_vals),
+                rewritten_out_fn(*test_vals),
+            )
+
+    def test_sum_of_mixed_ndim_mul(self):
+        """Test local_sum_prod_of_mul_or_div with mixed-ndim Elemwise inputs."""
+        mode = Mode("vm", optimizer="None")
+        rewrite = out2in(local_sum_prod_of_mul_or_div)
+
+        mat = matrix(shape=(None, None), dtype="float64")
+        vec = vector(dtype="float64")
+        scl = scalar(dtype="float64")
+
+        inputs = [mat, vec, scl]
+        test_vals = [
+            np.random.random((3, 4)),
+            np.random.random((4,)),
+            np.float64(2.5),
+        ]
+
+        for out, expected_out in [
+            # scalar is broadcastable on all axes, can be factored out
+            (
+                mul(mat, scl).sum(axis=0),
+                scl * mat.sum(axis=0),
+            ),
+            (
+                mul(mat, scl).sum(axis=1),
+                scl * mat.sum(axis=1),
+            ),
+            # vector is broadcastable on axis 0, can be factored out of sum over axis 0
+            (
+                mul(mat, vec).sum(axis=0),
+                vec * mat.sum(axis=0),
+            ),
+            # vector is NOT broadcastable on axis 1, stays inside
+            (
+                mul(mat, vec).sum(axis=1),
+                mul(mat, vec).sum(axis=1),
+            ),
+            # division: scalar denominator factored out
+            (
+                true_div(mat, scl).sum(axis=0),
+                true_div(mat.sum(axis=0), scl),
+            ),
+            # division: vector denominator factored out of sum over axis 0
+            (
+                true_div(mat, vec).sum(axis=0),
+                true_div(mat.sum(axis=0), vec),
+            ),
+        ]:
+            out_fn = pytensor.function(inputs, out, mode=mode, on_unused_input="ignore")
+
+            rewritten_out = rewrite_graph(out, custom_rewrite=rewrite)
+            assert equal_computations([rewritten_out], [expected_out]), debugprint(
+                [rewritten_out, expected_out], print_type=True
+            )
 
             rewritten_out_fn = pytensor.function(
                 inputs, rewritten_out, mode=mode, on_unused_input="ignore"

--- a/tests/tensor/rewriting/test_subtensor_lift.py
+++ b/tests/tensor/rewriting/test_subtensor_lift.py
@@ -99,11 +99,10 @@ class TestLocalSubtensorOfBatchDims:
         # assert check_stack_trace(f, ops_to_check=Subtensor)
 
         prog = f.maker.fgraph.toposort()
-        assert isinstance(prog[0].op, DimShuffle)
-        assert isinstance(prog[1].op.scalar_op, ps.Composite)  # Composite{add,exp}
+        assert isinstance(prog[0].op.scalar_op, ps.Composite)  # Composite{add,exp}
         # first subtensor
-        assert isinstance(prog[2].op, Subtensor)
-        assert len(prog) == 3
+        assert isinstance(prog[1].op, Subtensor)
+        assert len(prog) == 2
 
         x_test = np.array([[0, 1], [2, 3]]).astype(x.dtype)
         y_test = np.array([4, 5]).astype(y.dtype)
@@ -167,6 +166,26 @@ class TestLocalSubtensorOfBatchDims:
         np.testing.assert_allclose(
             opt_out.eval({x: x_test, y: y_test}, **eval_kwargs),
             out.eval({x: x_test, y: y_test}, **eval_kwargs),
+        )
+
+    def test_elemwise_mixed_ndim(self):
+        """Test local_subtensor_of_batch_dims with mixed-ndim Elemwise inputs."""
+        rng = np.random.default_rng(258)
+        x = pt.matrix("x", shape=(5, 3))
+        y = pt.vector("y", shape=(3,))
+        x_test = rng.normal(size=x.type.shape).astype(x.dtype)
+        y_test = rng.normal(size=y.type.shape).astype(y.dtype)
+
+        # Index into (matrix + vector) — vector has implicit leading dim
+        out = add(x, y)[2]
+        expected_out = add(x[2], y)
+        opt_out = rewrite_graph(out)
+        assert equal_computations([opt_out], [expected_out]), debugprint(
+            [expected_out, opt_out], print_type=True
+        )
+        np.testing.assert_allclose(
+            opt_out.eval({x: x_test, y: y_test}, mode=NO_OPTIMIZATION_MODE),
+            out.eval({x: x_test, y: y_test}, mode=NO_OPTIMIZATION_MODE),
         )
 
     def test_elemwise_multiple_clients(self):

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -205,7 +205,7 @@ TestSecondBroadcast = makeTester(
     ),
 )
 
-# We exclude local_fill_to_alloc because it optimizes the "second" node away from the graph.
+# We exclude local_second_to_alloc because it optimizes the "second" node away from the graph.
 TestSecondSameRank = makeTester(
     name="SecondSameRankTester",
     op=second,
@@ -215,7 +215,7 @@ TestSecondSameRank = makeTester(
         fail1=(random(4, 5), random(5, 4)),
         fail2=(integers(1, 5), integers(5, 4)),
     ),
-    mode=get_default_mode().excluding("local_fill_to_alloc", "local_useless_fill"),
+    mode=get_default_mode().excluding("local_second_to_alloc", "local_useless_fill"),
 )
 
 # Alloc

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -300,19 +300,18 @@ def test_debugprint():
     Gemv_op_name = "CGemv" if pytensor.config.blas__ldflags else "Gemv"
     exp_res = dedent(
         r"""
-        Composite{(i0 + (i1 - i2))} 4
+        Composite{(i0 + (i1 - i2))} 3
         ├─ A
-        ├─ ExpandDims{axis=0} v={0: [0]} 3
         """
-        f"        │  └─ {Gemv_op_name}{{inplace}} d={{0: [0]}} 2"
+        f"        ├─ {Gemv_op_name}{{inplace}} d={{0: [0]}} 2"
         r"""
-        │     ├─ AllocEmpty{dtype='float64'} 1
-        │     │  └─ Shape_i{0} 0
-        │     │     └─ B
-        │     ├─ 1.0
-        │     ├─ B
-        │     ├─ <Vector(float64, shape=(?,))>
-        │     └─ 0.0
+        │  ├─ AllocEmpty{dtype='float64'} 1
+        │  │  └─ Shape_i{0} 0
+        │  │     └─ B
+        │  ├─ 1.0
+        │  ├─ B
+        │  ├─ <Vector(float64, shape=(?,))>
+        │  └─ 0.0
         └─ D
 
         Inner graphs:

--- a/tests/test_raise_op.py
+++ b/tests/test_raise_op.py
@@ -11,7 +11,6 @@ from pytensor.raise_op import Assert, CheckAndRaise, assert_op
 from pytensor.scalar.basic import ScalarType, float64
 from pytensor.sparse import as_sparse_variable
 from pytensor.tensor.basic import second
-from pytensor.tensor.elemwise import DimShuffle
 from tests import unittest_tools as utt
 
 
@@ -227,8 +226,7 @@ def test_vectorize():
     vect_out = vectorize_graph(out, {x: x, y: batch_y})
     assert vect_out.type.shape == (2, None)
     assert vect_out.owner.op == second  # broadcast
-    assert isinstance(vect_out.owner.inputs[1].owner.op, DimShuffle)
-    assert isinstance(vect_out.owner.inputs[1].owner.inputs[0].owner.op, CheckAndRaise)
+    assert isinstance(vect_out.owner.inputs[1].owner.op, CheckAndRaise)
     np.testing.assert_array_equal(
         vect_out.eval({x: test_x, batch_y: test_batch_y}),
         np.broadcast_to(test_x, (2, *test_x.shape)),

--- a/tests/xtensor/test_shape.py
+++ b/tests/xtensor/test_shape.py
@@ -15,6 +15,7 @@ from xarray import full_like as xr_full_like
 from xarray import ones_like as xr_ones_like
 from xarray import zeros_like as xr_zeros_like
 
+from pytensor.compile.mode import get_default_mode
 from pytensor.tensor import scalar, vector
 from pytensor.xtensor.shape import (
     broadcast,
@@ -561,11 +562,15 @@ class TestBroadcast:
             xr_assert_allclose(res, expected_res)
 
         # Test invalid shape raises an error
-        # Note: We might decide not to raise an error in the lowered graphs for performance reasons
         if "d" not in exclude:
+            fn_safe = xr_function(
+                [x, y, z],
+                out,
+                mode=get_default_mode().excluding("shape_unsafe"),
+            )
             z_test_bad = xr_arange_like(xtensor(dims=z.dims, shape=(4, 7)))
             with pytest.raises(Exception):
-                fn(x_test, y_test, z_test_bad)
+                fn_safe(x_test, y_test, z_test_bad)
 
     def test_broadcast_excluded_dims_in_different_order(self):
         """Test broadcasting excluded dims are aligned with user input."""

--- a/tests/xtensor/test_vectorization.py
+++ b/tests/xtensor/test_vectorization.py
@@ -77,8 +77,8 @@ class TestVectorizeGraph:
         assert out_vec.type.dims == ("c", "b", "a")
         expected = as_xtensor(
             (
-                x_new.transpose("c", "a").values[:, None]
-                + y_new.transpose("b", "a").values[None, :]
+                x_new.transpose("c", "a").values[:, :, None]
+                + y_new.transpose("b", "a").values
             ),
             dims=("c", "b", "a"),
         )


### PR DESCRIPTION
Mostly written by claude

The idea is to get rid of the left expand_dims we use to align input dimensions of Elemwise (and in follow up Blockwise/RandomVariables).

This simplifies the graphs by removing a bunch of "useless" nodes. I started thinking about this after #1961 and thinking that we want to get rid of dummy dimensions as soon as possible, and only introduce them at the end of the graph (if we really need them). This allows us to reduce book-keping checks in the loops of Elemwise/Blockwise/RV/CAReduce.

But our current machinery tries to push them as early as possible towards the inputs (any dimshuffle, not just expand_dims). I think this happens because we needed them anyway at most inputs. So if you did elemwise `bar(foo(scalar, vec), mat)`, you ended up with `bar(foo(scalar[None], vec)[None, :], mat)` anyway, so why not start with `bar(foo(scalar[None, None], vec[None, :]), mat)`? At least no DimShuffle in between the elemwise, so we can reason about them cleanly.

I agree we should push squeeze towards inputs (less axes), and we can do also transpose (just to pick a canonical form), but I don't think we should do this for left expand_dims. We don't want to bookeep more than we need to (note how we ended up with an extra dummy dim in `foo(scalar[None, None], vec[None, :])` that wasn't ever needed.

After this PR you just have `bar(foo(scalar, vec), mat)` so both cleaner graph, and no extra bookkeeping.

It makes rewrites that reason about dimshuffle/broadcasting a bit more verbose, and probably harder to get right, but hopefully we need  less of them as well. 

