### PR TITLE
Reassociate add/mul to combine broadcast terms at lower rank

### DIFF
--- a/pytensor/tensor/rewriting/elemwise.py
+++ b/pytensor/tensor/rewriting/elemwise.py
@@ -1151,6 +1151,48 @@ def constant_fold_branches_of_add_mul(fgraph, node):
     return [new_out]
 
 
+@node_rewriter(tracks=[add, mul])
+def reassociate_broadcast_aware_add_mul(fgraph, node):
+    """Reassociate add/mul to group inputs with the same broadcasting pattern together"""
+    if len(node.inputs) <= 2:
+        return None
+
+    out_bcast = node.outputs[0].type.broadcastable
+    out_ndim = len(out_bcast)
+
+    grouped_inputs: dict[tuple[bool, ...], list[TensorVariable]] = {}
+    ordered_signatures: list[tuple[bool, ...]] = []
+    for inp in node.inputs:
+        inp_bcast = inp.type.broadcastable
+        inp_sig = (True,) * (out_ndim - len(inp_bcast)) + inp_bcast
+        if inp_sig not in grouped_inputs:
+            grouped_inputs[inp_sig] = []
+            ordered_signatures.append(inp_sig)
+        grouped_inputs[inp_sig].append(inp)
+
+    if len(grouped_inputs) <= 1:
+        return None
+
+    new_inputs = []
+    changed = False
+    for inp_sig in ordered_signatures:
+        same_sig_inputs = grouped_inputs[inp_sig]
+        if len(same_sig_inputs) > 1 and inp_sig != out_bcast:
+            new_subgroup = node.op(*same_sig_inputs)
+            copy_stack_trace(node.outputs[0], new_subgroup)
+            new_inputs.append(new_subgroup)
+            changed = True
+        else:
+            new_inputs.extend(same_sig_inputs)
+
+    if not changed:
+        return None
+
+    new_out = node.op(*new_inputs)
+    copy_stack_trace(node.outputs[0], new_out)
+    return [new_out]
+
+
 add_mul_fusion_seqopt = SequenceDB()
 optdb.register(
     "add_mul_fusion",
@@ -1170,6 +1212,13 @@ add_mul_fusion_seqopt.register(
     "fast_run",
     position=1,
 )
+add_mul_fusion_seqopt.register(
+    reassociate_broadcast_aware_add_mul.__name__,
+    in2out(reassociate_broadcast_aware_add_mul, ignore_newtrees=True),
+    "fast_run",
+    position=2,
+)
+
 
 # Register fusion database just before AddDestroyHandler(49.5) (inplace rewrites)
 fuse_seqopt = SequenceDB()

--- a/pytensor/tensor/rewriting/elemwise.py
+++ b/pytensor/tensor/rewriting/elemwise.py
@@ -1267,6 +1267,49 @@ def constant_fold_branches_of_add_mul(fgraph, node):
     return [new_out]
 
 
+@node_rewriter(tracks=[add, mul])
+def reassociate_broadcast_aware_add_mul(fgraph, node):
+    """Combine the ``add``/``mul`` terms that are broadcast along a shared axis first.
+
+    Terms broadcast along an axis of length K contribute the same value to all K
+    entries, so combining them at the lower rank costs K times fewer operations. Terms
+    group by being broadcast along the chosen axis, not by having identical broadcast
+    patterns: (N, 1, 1), (1, G, 1) and (N, G, 1) are all invariant along the last axis.
+    """
+    if len(node.inputs) <= 2:
+        return None
+
+    [out] = node.outputs
+
+    # Hoist along the axis that lets us combine the most terms. An axis that is
+    # broadcast in the output carries no repetition, so there is nothing to save there.
+    best_axis, best_count = None, 1
+    for axis, bcast_in_out in enumerate(out.type.broadcastable):
+        if bcast_in_out:
+            continue
+        count = sum(inp.type.broadcastable[axis] for inp in node.inputs)
+        # Static shapes can be refined to 1 without updating consumer types, so every
+        # term may be broadcast along an axis the output still reports as non-broadcast.
+        # Keeping a term outside the subgroup avoids rebuilding the node we fired on.
+        if best_count < count < len(node.inputs):
+            best_axis, best_count = axis, count
+    if best_axis is None:
+        return None
+
+    invariant = [inp for inp in node.inputs if inp.type.broadcastable[best_axis]]
+    rest = [inp for inp in node.inputs if not inp.type.broadcastable[best_axis]]
+
+    subgroup = node.op(*invariant)
+    if subgroup.type.dtype != out.type.dtype:
+        # The excluded terms may be the ones forcing the upcast, in which case the
+        # subgroup would be computed (and could overflow) in a narrower dtype.
+        return None
+    copy_stack_trace(out, subgroup)
+    new_out = node.op(subgroup, *rest)
+    copy_stack_trace(out, new_out)
+    return [new_out]
+
+
 add_mul_fusion_seqopt = SequenceDB()
 optdb.register(
     "add_mul_fusion",
@@ -1285,6 +1328,14 @@ add_mul_fusion_seqopt.register(
     in2out(constant_fold_branches_of_add_mul, ignore_newtrees=True),
     "fast_run",
     position=1,
+)
+add_mul_fusion_seqopt.register(
+    reassociate_broadcast_aware_add_mul.__name__,
+    # Each pass hoists one axis, so the subgroup and the node left behind have to be
+    # revisited to reach terms that are constant along a second axis.
+    out2in(reassociate_broadcast_aware_add_mul, ignore_newtrees=False),
+    "fast_run",
+    position=2,
 )
 
 # Register fusion database just before AddDestroyHandler(49.5) (inplace rewrites)

--- a/tests/tensor/rewriting/test_elemwise.py
+++ b/tests/tensor/rewriting/test_elemwise.py
@@ -1622,6 +1622,29 @@ def test_constant_fold_branches_add_mul(op):
     assert equal_computations([new_out], [op(py_op(a, b), c, x)])
 
 
+@pytest.mark.parametrize("op", (add, mul))
+def test_reassociate_broadcast_aware_add_mul(op):
+    a = pt.tensor("a", shape=(2,))
+    b = pt.tensor("b", shape=(2,))
+    c = pt.tensor("c", shape=(1000, 2))
+    out = op(op(a, b), c)
+
+    rewritten_out = rewrite_graph(out, include=("add_mul_fusion",))
+    fgraph = FunctionGraph([a, b, c], [rewritten_out], clone=False)
+    op_nodes = [
+        node
+        for node in fgraph.apply_nodes
+        if isinstance(node.op, Elemwise) and node.op == op
+    ]
+
+    # We should keep a smaller-rank subgroup op(a, b) instead of fully flattening.
+    assert any(
+        len(node.inputs) == 2 and node.outputs[0].type.ndim == 1 for node in op_nodes
+    )
+
+    assert equal_computations([rewritten_out], [out])
+
+
 def test_InplaceElemwiseOptimizer_bug():
     # Regression test for https://github.com/pymc-devs/pytensor/issues/1420
 

--- a/tests/tensor/rewriting/test_elemwise.py
+++ b/tests/tensor/rewriting/test_elemwise.py
@@ -76,6 +76,7 @@ from pytensor.tensor.type import (
     vectors,
 )
 from tests import unittest_tools as utt
+from tests.unittest_tools import RewriteTester
 
 
 dimshuffle_lift = out2in(local_dimshuffle_lift)
@@ -1609,17 +1610,68 @@ def test_constant_fold_branches_add_mul(op):
     x = pt.vector("x")
     a = rng.normal(size=(1, 512, 5))
     b = rng.normal(size=(1, 512, 1))
-    out = op(op(a, x), b)
-    new_out = rewrite_graph(out, include=("add_mul_fusion",))
-    assert len(new_out.owner.inputs) == 2
-    assert equal_computations([new_out], [op(py_op(a, b), x)])
 
-    # c shouldn't be folded as it would increase the memory usage
+    result = RewriteTester([x], [op(op(a, x), b)], include=["add_mul_fusion"])
+    result.assert_graph(op(py_op(a, b), x))
+
+    # c shouldn't be folded as it would increase the memory usage. The reassociation
+    # then groups the two axis-0-broadcast terms -- op(a, b) and x -- so that only one
+    # operation is left at the full (1024, 512, 5) rank instead of two.
     c = rng.normal(size=(1024, 1, 1))
-    out = op(op(op(a, x), c), b)
-    new_out = rewrite_graph(out, include=("add_mul_fusion",))
-    assert len(new_out.owner.inputs) == 3
-    assert equal_computations([new_out], [op(py_op(a, b), c, x)])
+
+    result = RewriteTester([x], [op(op(op(a, x), c), b)], include=["add_mul_fusion"])
+    result.assert_graph(op(op(py_op(a, b), x), c))
+
+
+@pytest.mark.parametrize("op", (add, mul))
+def test_reassociate_broadcast_aware_add_mul(op):
+    # Terms group by a shared broadcast axis, not by an identical pattern: no two of
+    # a, b, c have the same pattern, yet all three are constant along the last axis.
+    a = pt.tensor("a", shape=(20, 1, 1))
+    b = pt.tensor("b", shape=(1, 5, 1))
+    c = pt.tensor("c", shape=(20, 5, 1))
+    d = pt.tensor("d", shape=(20, 5, 7))
+    result = RewriteTester([a, b, c, d], [op(a, b, c, d)], include=["add_mul_fusion"])
+    result.assert_graph(op(op(a, b, c), d))
+
+    # Flattening dissolves the subgroup and it is put back, collapsed along every axis
+    # a and b share, not just the one they were selected on.
+    a = pt.tensor("a", shape=(1, 1, 5, 5, 1))
+    b = pt.tensor("b", shape=(1, 1, 5, 5, 1))
+    c = pt.tensor("c", shape=(5, 5, 5, 5, 5))
+    result = RewriteTester([a, b, c], [op(op(a, b), c)], include=["add_mul_fusion"])
+    result.assert_graph(op(op(a, b), c))
+
+    # The node a split leaves behind is revisited: a and b group on a second pass.
+    a = pt.tensor("a", shape=(1, 5, 6))
+    b = pt.tensor("b", shape=(1, 5, 6))
+    c = pt.tensor("c", shape=(4, 5, 1))
+    d = pt.tensor("d", shape=(4, 5, 1))
+    e = pt.tensor("e", shape=(4, 5, 1))
+    f = pt.tensor("f", shape=(4, 5, 6))
+    result = RewriteTester(
+        [a, b, c, d, e, f], [op(a, b, c, d, e, f)], include=["add_mul_fusion"]
+    )
+    result.assert_graph(op(op(a, b), op(c, d, e), f))
+
+    # Axis 2 holds four constant terms against two on axes 0 and 1, so it is hoisted
+    # first; the subgroup is then revisited and splits along both of the others.
+    a = pt.tensor("a", shape=(20, 1, 1))
+    b = pt.tensor("b", shape=(20, 1, 1))
+    c = pt.tensor("c", shape=(1, 5, 1))
+    d = pt.tensor("d", shape=(1, 5, 1))
+    e = pt.tensor("e", shape=(20, 5, 7))
+    result = RewriteTester(
+        [a, b, c, d, e], [op(a, b, c, d, e)], include=["add_mul_fusion"]
+    )
+    result.assert_graph(op(op(op(a, b), op(c, d)), e))
+
+    # No two terms share a broadcast axis, so there is nothing to hoist.
+    a = pt.tensor("a", shape=(1, 5, 6))
+    b = pt.tensor("b", shape=(4, 1, 6))
+    c = pt.tensor("c", shape=(4, 5, 1))
+    result = RewriteTester([a, b, c], [op(a, b, c)], include=["add_mul_fusion"])
+    result.assert_graph(op(a, b, c))
 
 
 def test_InplaceElemwiseOptimizer_bug():


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->
This PR adds a broadcast-aware reassociation rewrite for Add and Mul in the add_mul_fusion pipeline. The goal is to reduce redundant FLOPs when mixed broadcast shapes are present, while keeping the existing flatten and constant-fold behavior intact.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1966 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
