### PR TITLE
Fix Scan higher order derivatives

### DIFF
--- a/pytensor/scan/op.py
+++ b/pytensor/scan/op.py
@@ -2687,7 +2687,37 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
             else:
                 dC_dXtm1s.append(safe_new(x))
 
+        # Skip accumulation for "overlapping" mit-mot taps.
+        #
+        # A mit-mot tap "overlaps" when the same tap index appears in both the input
+        # and output slices of a single mit-mot state. This means the output *overwrites*
+        # the input at that buffer position — analogous to set_subtensor(x, y, i).
+        #
+        # The gradient of an overwrite must zero out the direct pass-through from the
+        # old value; the only gradient path is through the output expression that replaced
+        # it (already captured by compute_all_gradients via known_grads).
+        #
+        # The gradient for an overlapping tap is NOT zero — the chain-rule contribution
+        # through the output expression remains. We only skip the extra dC_dXtm1
+        # accumulation term, which would incorrectly treat the old value as if it also
+        # passes through unchanged to future steps, double-counting the gradient.
+        #
+        # Overlapping taps arise naturally when differentiating sit-sot or mit-sot scans:
+        # their L_op converts the recurrence into a mit-mot where one tap serves as both
+        # read and write (e.g. in_taps=(0,1), out_taps=(1,) — tap 1 overlaps).
+        overlapping_taps = set()
+        dx_offset = 0
+        for idx in range(info.n_mit_mot):
+            in_taps = info.mit_mot_in_slices[idx]
+            out_taps = info.mit_mot_out_slices[idx]
+            for k, tap in enumerate(in_taps):
+                if tap in out_taps:
+                    overlapping_taps.add(dx_offset + k)
+            dx_offset += len(in_taps)
+
         for dx, dC_dXtm1 in enumerate(dC_dXtm1s):
+            if dx in overlapping_taps:
+                continue  # gradient truncates here
             if isinstance(dC_dinps_t[dx + info.n_seqs].type, NullType):
                 # The accumulated gradient is undefined
                 pass

--- a/pytensor/scan/op.py
+++ b/pytensor/scan/op.py
@@ -2437,12 +2437,19 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         return connection_pattern
 
     def L_op(self, inputs, outs, dC_douts):
-        # `grad_step` equals the number of steps the original scan node has
-        # done (if the original scan is a while loop than this number is the
-        # length of the output sequence)
-        # We do not know what kind of outputs the original scan has, so we
-        # try first to see if it has a nit_sot output, then a sit_sot and
-        # then a mit_sot
+        # Computes the gradient of this Scan by constructing a new backward Scan
+        # that runs in reverse. The method:
+        # 1. Differentiates the inner function symbolically (compute_all_gradients)
+        # 2. Adds accumulation terms for state inputs at preserved buffer positions
+        # 3. Builds reversed sequences from the forward outputs
+        # 4. Converts all recurrent states (sit-sot, mit-sot, mit-mot) into mit-mot
+        #    form in the backward scan (initialized with output gradients, accumulate
+        #    total gradients after evaluation)
+        # 5. Constructs and runs the backward Scan, then re-orders its outputs
+
+        # Determine the number of gradient steps from the output shapes (not from
+        # inputs[0] directly, because while-loop scans may execute fewer steps than
+        # the allocated buffer size).
         info = self.info
         if info.n_nit_sot > 0:
             grad_steps = self.outer_nitsot_outs(outs)[0].shape[0]
@@ -2457,8 +2464,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         if info.as_while:
             n_steps = outs[0].shape[0]
 
-        # Restrict the number of grad steps according to
-        # self.truncate_gradient
+        # Restrict the number of grad steps according to self.truncate_gradient
         if self.truncate_gradient != -1:
             grad_steps = minimum(grad_steps, self.truncate_gradient)
 
@@ -2540,13 +2546,11 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
             ]
             gmp = {}
 
-            # Required in case there is a pair of variables X and Y, with X
-            # used to compute Y, for both of which there is an external
-            # gradient signal. Without this, the total gradient signal on X
-            # will be the external gradient  signalknown_grads[X]. With this,
-            # it will be the sum of the external gradient signal and the
-            # gradient obtained by propagating Y's external gradient signal
-            # to X.
+            # The .copy() creates fresh variable nodes so that grad() treats them
+            # as new outputs "equal to" the originals, rather than matching them by
+            # identity to variables already in the graph. This forces grad() to
+            # propagate the known_grads values backward through the computation
+            # instead of short-circuiting at a wrt target.
             known_grads = {k.copy(): v for (k, v) in known_grads.items()}
 
             grads = grad(
@@ -2588,17 +2592,15 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
                 Xt_placeholder = safe_new(Xt)
                 Xts.append(Xt_placeholder)
 
-            # Different processing based on whether Xt is a nitsot output
-            # or not. NOTE : This cannot be done by using
-            # "if Xt not in self.inner_nitsot_outs(self_outputs)" because
-            # the exact same variable can be used as multiple outputs.
+            # Different processing based on whether Xt is a nitsot output or not.
+            # NOTE : This cannot be done by using "if Xt not in self.inner_nitsot_outs(self_outputs)"
+            # because the exact same variable can be used as multiple outputs.
             if idx < idx_nitsot_out_start or idx >= idx_nitsot_out_end:
-                # What we do here is loop through dC_douts and collect all
+                # loop through dC_douts and collect all
                 # those that are connected to the specific one and do an
                 # upcast on all of their dtypes to get the dtype for this
                 # specific output. Deciding if the gradient with this
-                # specific previous step is defined or not is done somewhere
-                # else.
+                # specific previous step is defined or not is done somewhere else.
                 dtypes = []
                 for pos, inp in enumerate(states):
                     if inp in graph_inputs([Xt]):
@@ -2637,9 +2639,9 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
                 continue
 
             # Just some trouble to avoid a +0
-            if diff_outputs[i] in known_grads:
+            try:
                 known_grads[diff_outputs[i]] += dC_dXts[dc_dxts_idx]
-            else:
+            except KeyError:
                 known_grads[diff_outputs[i]] = dC_dXts[dc_dxts_idx]
             dc_dxts_idx += 1
 
@@ -2655,6 +2657,9 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
                 )
             else:
                 disconnected_dC_dinps_t[dx] = False
+                # Replace inner output subexpressions with placeholders wired to the
+                # saved forward values, so the backward scan reuses them instead of
+                # recomputing them. See forced_replace docstring for details.
                 for Xt, Xt_placeholder in zip(
                     diff_outputs[info.n_mit_mot_outs :], Xts, strict=True
                 ):
@@ -2663,21 +2668,20 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
 
         # construct dX_dtm1
         dC_dXtm1s = []
+        n_internal_recurrent_states = sum(
+            len(t)
+            for t in chain(
+                info.mit_mot_in_slices,
+                info.mit_sot_in_slices,
+                info.sit_sot_in_slices,
+            )
+        )
         for pos, x in enumerate(dC_dinps_t[info.n_seqs :]):
-            # Get the index of the first inner input corresponding to the
-            # pos-ieth inner input state
+            # Get the index of the first inner input corresponding to the pos-ieth inner input state
             idxs = var_mappings["inner_out_from_inner_inp"][info.n_seqs + pos]
 
-            # Check if the pos-th input is associated with one of the
-            # recurrent states
-            x_is_state = pos < sum(
-                len(t)
-                for t in chain(
-                    info.mit_mot_in_slices,
-                    info.mit_sot_in_slices,
-                    info.sit_sot_in_slices,
-                )
-            )
+            # Check if the pos-th input is associated with one of the recurrent states
+            x_is_state = pos < n_internal_recurrent_states
 
             if x_is_state and len(idxs) > 0:
                 opos = idxs[0]
@@ -2688,23 +2692,12 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
                 dC_dXtm1s.append(safe_new(x))
 
         # Skip accumulation for "overlapping" mit-mot taps.
-        #
         # A mit-mot tap "overlaps" when the same tap index appears in both the input
         # and output slices of a single mit-mot state. This means the output *overwrites*
         # the input at that buffer position — analogous to set_subtensor(x, y, i).
-        #
         # The gradient of an overwrite must zero out the direct pass-through from the
         # old value; the only gradient path is through the output expression that replaced
         # it (already captured by compute_all_gradients via known_grads).
-        #
-        # The gradient for an overlapping tap is NOT zero — the chain-rule contribution
-        # through the output expression remains. We only skip the extra dC_dXtm1
-        # accumulation term, which would incorrectly treat the old value as if it also
-        # passes through unchanged to future steps, double-counting the gradient.
-        #
-        # Overlapping taps arise naturally when differentiating sit-sot or mit-sot scans:
-        # their L_op converts the recurrence into a mit-mot where one tap serves as both
-        # read and write (e.g. in_taps=(0,1), out_taps=(1,) — tap 1 overlaps).
         overlapping_taps = set()
         dx_offset = 0
         for idx in range(info.n_mit_mot):
@@ -2791,8 +2784,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         outer_inp_seqs += [x[::-1][:-1] for x in self.outer_sitsot_outs(outs)]
         outer_inp_seqs += [x[::-1] for x in self.outer_nitsot_outs(outs)]
 
-        # Restrict the length of the outer sequences to the number of grad
-        # steps
+        # Restrict the length of the outer sequences to the number of grad steps
         outer_inp_seqs = [s_[:grad_steps] for s_ in outer_inp_seqs]
 
         inner_inp_seqs = self.inner_seqs(self_inputs)
@@ -2801,7 +2793,14 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         inner_inp_seqs += self.inner_sitsot(self_inputs)
         inner_inp_seqs += self.inner_nitsot_outs(dC_dXts)
         inner_inp_seqs += Xts
-        # mitmot
+        # Build backward scan's mit-mot states.
+        # Every forward recurrent state (sit-sot, mit-sot, mit-mot) becomes
+        # a mit-mot in the backward scan. The conversion negates the taps:
+        #   forward output tap t  →  backward input tap -t  (gradient signal)
+        #   forward input tap t   →  backward output tap -t (gradient to propagate)
+        # Each backward output tap also needs a backward input tap at the same
+        # position to carry the accumulated gradient (the recurrence). If one
+        # already exists from the first rule, they share the buffer slot.
         outer_inp_mitmot = []
         inner_inp_mitmot = []
         inner_out_mitmot = []
@@ -2840,8 +2839,8 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
                     inner_inp_mitmot.append(dC_dXtm1s[ins_pos - info.n_seqs])
 
                 if isinstance(dC_dinps_t[ins_pos].type, NullType):
-                    # We cannot use Null in the inner graph, so we
-                    # use a zero tensor of the appropriate shape instead.
+                    # We cannot use Null in the inner graph,
+                    # so we use a zero tensor of the appropriate shape instead.
                     inner_out_mitmot.append(
                         pt.zeros(diff_inputs[ins_pos].shape, dtype=config.floatX)
                     )
@@ -2949,9 +2948,8 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
                 outer_inp_mitmot.append(dC_douts[idx + offset][::-1])
             else:
                 if isinstance(dC_dinps_t[ins_pos].type, NullType):
-                    # Cannot use dC_dinps_t[ins_pos].dtype, so we use
-                    # floatX instead, as it is a dummy value that will not
-                    # be used anyway.
+                    # Cannot use dC_dinps_t[ins_pos].dtype, so we use floatX instead,
+                    # as it is a dummy value that will not be used anyway.
                     outer_inp_mitmot.append(
                         pt.zeros(outs[idx + offset].shape, dtype=config.floatX)
                     )
@@ -2963,8 +2961,8 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
                     )
 
             if isinstance(dC_dinps_t[ins_pos].type, NullType):
-                # We cannot use Null in the inner graph, so we
-                # use a zero tensor of the appropriate shape instead.
+                # We cannot use Null in the inner graph,
+                # so we use a zero tensor of the appropriate shape instead.
                 inner_out_mitmot.append(
                     pt.zeros(diff_inputs[ins_pos].shape, dtype=config.floatX)
                 )
@@ -3004,8 +3002,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
                     through_untraced = True
             if isinstance(vl.type, NullType):
                 type_outs.append(vl.type.why_null)
-                # Replace the inner output with a zero tensor of
-                # the right shape
+                # Replace the inner output with a zero tensor of the right shape
                 inner_out_sitsot[_p] = pt.zeros(
                     diff_inputs[ins_pos + _p].shape, dtype=config.floatX
                 )
@@ -3023,8 +3020,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
                     through_untraced = True
             if isinstance(vl.type, NullType):
                 type_outs.append(vl.type.why_null)
-                # Replace the inner output with a zero tensor of
-                # the right shape
+                # Replace the inner output with a zero tensor of the right shape
                 inner_out_nitsot[_p] = pt.zeros(
                     diff_inputs[_p].shape, dtype=config.floatX
                 )
@@ -3119,9 +3115,8 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
             )
         ):
             if t == "connected":
-                # If the forward scan is in as_while mode, we need to pad
-                # the gradients, so that they match the size of the input
-                # sequences.
+                # If the forward scan is in as_while mode, we need to pad the gradients,
+                # so that they match the size of the input sequences.
                 if info.as_while:
                     n_zeros = inputs[0] - n_steps
                     shp = (n_zeros,)
@@ -3147,9 +3142,8 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         end = info.n_mit_mot + info.n_mit_sot + info.n_sit_sot
         for p, (x, t) in enumerate(zip(outputs[:end], type_outs[:end], strict=True)):
             if t == "connected":
-                # If the forward scan is in as_while mode, we need to pad
-                # the gradients, so that they match the size of the input
-                # sequences.
+                # If the forward scan is in as_while mode, we need to pad the gradients,
+                # so that they match the size of the input sequences.
                 if info.as_while:
                     n_zeros = inputs[0] - grad_steps
                     shp = (n_zeros,)

--- a/pytensor/scan/rewriting.py
+++ b/pytensor/scan/rewriting.py
@@ -1279,6 +1279,12 @@ def scan_save_mem_rewrite(fgraph, node, backend_supports_output_pre_allocation: 
     The scan perform implementation takes the output sizes into consideration,
     saving the newest results over the oldest ones whenever the buffer is filled.
 
+    This rewrite must only run at compilation time, after grad() has already
+    built the backward scan. The backward scan needs all intermediate forward
+    states as sequence inputs (to evaluate f'(x[t])). If this rewrite truncates
+    buffers before grad() is called, the gradient will be silently wrong.
+    TODO: Use a subclass that raises explicitly on `L_op`
+
     Paramaters
     ----------
     backend_supports_output_pre_allocation: bool

--- a/pytensor/scan/utils.py
+++ b/pytensor/scan/utils.py
@@ -1099,9 +1099,22 @@ class ScanArgs:
 
 def forced_replace(out, x, y):
     """
-    Check all internal values of the graph that compute the variable ``out``
-    for occurrences of values identical with ``x``. If such occurrences are
-    encountered then they are replaced with variable ``y``.
+    Replace subexpressions in ``out`` that are structurally equal to ``x``
+    with ``y``, using ``equal_computations`` for matching.
+
+    Unlike ``graph_replace`` (which matches by variable identity),
+    this detects when a subexpression *recomputes* ``x`` without
+    being the same variable object. This is used by ``Scan.L_op``
+    to substitute inner-function outputs with placeholders wired to
+    the saved forward values, avoiding redundant recomputation in
+    the backward scan. For example, if ``exp(x).L_op`` returns
+    ``output_gradient * exp(x)`` by recreating ``exp(x)`` instead
+    of referencing the existing output variable, a plain identity
+    check would miss it, but ``equal_computations`` catches it.
+
+    This is not comprehensive: structurally different but semantically
+    equivalent expressions (e.g. ``exp(x + 0)`` vs ``exp(x)``) will
+    not match.
 
     Parameters
     ----------
@@ -1117,7 +1130,7 @@ def forced_replace(out, x, y):
 
     Notes
     -----
-    When it find a match, it don't continue on the corresponding inputs.
+    When it finds a match, it does not continue into that node's inputs.
     """
     if out is None:
         return None

--- a/tests/scan/test_basic.py
+++ b/tests/scan/test_basic.py
@@ -1332,6 +1332,46 @@ class TestScan:
         sum_of_grads = sum(g.sum() for g in gradients)
         grad(sum_of_grads, inputs[0])
 
+    def test_high_order_grad_sitsot(self):
+        """Test higher-order derivatives through a sit-sot scan.
+
+        The L_op of a sit-sot scan creates a mit-mot backward scan where
+        one buffer position is both read and written.
+        This is analogous to set_subtensor(x, y, i): the gradient w.r.t. x
+        must zero out position i, routing gradient only through y.
+
+        A bug in the accumulation logic added a spurious gradient at
+        the overwritten position, as if the old value also passed
+        through unchanged. The 2nd derivative graph was wrong but
+        evaluated correctly (the spurious contribution only affected
+        the mit-mot output, which is not on the gradient path for
+        scalar derivatives). The error became visible at the 3rd
+        derivative, where symbolic differentiation through the wrong
+        graph produced incorrect values.
+        """
+        # Avoid costly rewrite/compilation of Scans
+        mode = Mode(linker="py", optimizer=None)
+        x = pt.scalar("x")
+        x_val = np.float64(0.95)
+        ys = scan(
+            fn=lambda xtm1: xtm1**2, outputs_info=[x], n_steps=4, return_updates=False
+        )
+        y = ys[-1]
+
+        # Sanity check
+        np.testing.assert_allclose(y.eval({x: x_val}, mode=mode), x_val**16)
+
+        # Evaluate higher order derivatives
+        deriv = y
+        for order in range(1, 5):
+            deriv = grad(deriv, x)
+            deriv_value = deriv.eval({x: x_val}, mode=mode)
+            # xs[-1] = x^16, so the n-th derivative is 16!/(16-n)! * x^(16-n)
+            expected_deriv_value = np.prod((16, 15, 14, 13)[:order]) * x_val ** (
+                16 - order
+            )
+            np.testing.assert_allclose(deriv_value, expected_deriv_value)
+
     def test_grad_dtype_change(self):
         x = fscalar("x")
         y = fscalar("y")


### PR DESCRIPTION
Closes #1772 

I let Claude take a stab at this as it was not priority (broken since ever?). It's a bit over my head because if there's anything more complex than the ScanOp, it's the gradient of the ScanOp (derivatives are simpler anyone?).

Here is the best AI guess as to how it is organized: https://gist.github.com/ricardoV94/809a2c25ec61d149209336ab0add6f30. I corrected it several times, so take it with a big grain of salt.

Anyway it sounds like the gradient of a mit-mot output was wrong. Ignoring, where they come from, a mit-mot represents a tape that is read and written into multiple positions at each step. The reverse pass of this process should not flow through the written positions into the past (the same way that the reverse pass of x[0].set(y), wrt to x truncates at 0). 

And apparently (or so Claude tried to persuade me), this truncation was not happening. The error only shows up if you differentiate more than twice, don't ask me why.

I won't spend more time understanding the L_op right now, so I would rest on the fact that it makes some conceptual sense and that the tests now pass.

And some sparse documentation on L_op and related functionality