### PR TITLE
feat(mlx): pt.random support with mlx backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ unfixable = [
 
 [tool.ruff.lint.isort]
 lines-after-imports = 2
+known-first-party = ["pytensor", "tests"]
 
 [tool.ruff.lint.per-file-ignores]
 # TODO: Get rid of these:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ unfixable = [
 
 [tool.ruff.lint.isort]
 lines-after-imports = 2
+known-first-party = ["pytensor", "tests"]
 
 [tool.ruff.lint.per-file-ignores]
 # TODO: Get rid of these:

--- a/pytensor/link/mlx/dispatch/__init__.py
+++ b/pytensor/link/mlx/dispatch/__init__.py
@@ -18,4 +18,5 @@ import pytensor.link.mlx.dispatch.pad
 import pytensor.link.mlx.dispatch.sort
 import pytensor.link.mlx.dispatch.slinalg
 import pytensor.link.mlx.dispatch.nlinalg
+import pytensor.link.mlx.dispatch.random
 # isort: on

--- a/pytensor/link/mlx/dispatch/__init__.py
+++ b/pytensor/link/mlx/dispatch/__init__.py
@@ -17,4 +17,5 @@ import pytensor.link.mlx.dispatch.extra_ops
 import pytensor.link.mlx.dispatch.pad
 import pytensor.link.mlx.dispatch.sort
 import pytensor.link.mlx.dispatch.linalg
+import pytensor.link.mlx.dispatch.random
 # isort: on

--- a/pytensor/link/mlx/dispatch/random.py
+++ b/pytensor/link/mlx/dispatch/random.py
@@ -91,10 +91,7 @@ def mlx_sample_fn_uniform(op, node):
 def mlx_sample_fn_bernoulli(op, node):
     def sample_fn(rng_key, size, dtype, p):
         p = mx.array(p)
-        if size is None:
-            shape = p.shape
-        else:
-            shape = mlx_to_list_shape(size)
+        shape = mlx_to_list_shape(size) if size is not None else None
         return mx.random.bernoulli(p=p, shape=shape, key=rng_key)
 
     return sample_fn
@@ -112,18 +109,41 @@ def mlx_sample_fn_categorical(op, node):
 
 @mlx_sample_fn.register(ptr.MvNormalRV)
 def mlx_sample_fn_mvnormal(op, node):
+    method = op.method
+
     def sample_fn(rng_key, size, dtype, mean, cov):
         mlx_dtype = convert_dtype_to_mlx(dtype)
-        shape = mlx_to_list_shape(size) if size is not None else []
-        # multivariate_normal uses SVD internally, which requires mx.cpu in MLX.
-        return mx.random.multivariate_normal(
-            mean=mean,
-            cov=cov,
-            shape=shape,
-            dtype=mlx_dtype,
-            key=rng_key,
-            stream=mx.cpu,
-        )
+        mean = mx.array(mean, dtype=mlx_dtype)
+        cov = mx.array(cov, dtype=mlx_dtype)
+        n = cov.shape[-1]
+        batch_shape = mlx_to_list_shape(size) if size is not None else []
+        if batch_shape:
+            # size is given: PyTensor pads param dims with leading 1s via ExpandDims;
+            # reshape to 2D/1D to strip those before decomposition.
+            cov_2d = cov.reshape(n, n)
+            mean_1d = mean.reshape(n)
+            if method == "cholesky":
+                A = mx.linalg.cholesky(cov_2d, stream=mx.cpu)
+            elif method == "svd":
+                U, s, _ = mx.linalg.svd(cov_2d, stream=mx.cpu)
+                A = U * mx.sqrt(s)[None, :]
+            else:  # eigh
+                w, vecs = mx.linalg.eigh(cov_2d, stream=mx.cpu)
+                A = vecs * mx.sqrt(w)[None, :]
+            z = mx.random.normal(shape=[*batch_shape, n], dtype=mlx_dtype, key=rng_key)
+            return (z @ A.T) + mean_1d
+        else:
+            # size is None: param shape is the true batch (or scalar).
+            if method == "cholesky":
+                A = mx.linalg.cholesky(cov, stream=mx.cpu)
+            elif method == "svd":
+                U, s, _ = mx.linalg.svd(cov, stream=mx.cpu)
+                A = U * mx.sqrt(s)[..., None, :]
+            else:  # eigh
+                w, vecs = mx.linalg.eigh(cov, stream=mx.cpu)
+                A = vecs * mx.sqrt(w)[..., None, :]
+            z = mx.random.normal(shape=mean.shape, dtype=mlx_dtype, key=rng_key)
+            return (z[..., None, :] @ A.swapaxes(-1, -2))[..., 0, :] + mean
 
     return sample_fn
 
@@ -163,12 +183,12 @@ def mlx_sample_fn_gumbel(op, node):
 @mlx_sample_fn.register(ptr.PermutationRV)
 def mlx_sample_fn_permutation(op, node):
     batch_ndim = op.batch_ndim(node)
+    if batch_ndim:
+        raise NotImplementedError(
+            "MLX random.permutation does not support batch dimensions."
+        )
 
     def sample_fn(rng_key, size, dtype, x):
-        if batch_ndim:
-            raise NotImplementedError(
-                "MLX random.permutation does not support batch dimensions."
-            )
         return mx.random.permutation(x, key=rng_key)
 
     return sample_fn

--- a/pytensor/link/mlx/dispatch/random.py
+++ b/pytensor/link/mlx/dispatch/random.py
@@ -1,0 +1,188 @@
+from functools import singledispatch
+
+import mlx.core as mx
+from numpy.random import Generator
+
+import pytensor.tensor.random.basic as ptr
+from pytensor.link.mlx.dispatch.basic import mlx_funcify, mlx_typify
+from pytensor.link.mlx.dispatch.core import convert_dtype_to_mlx, mlx_to_list_shape
+
+
+def _truncate_pcg64_state_to_uint64(rng: Generator) -> int:
+    return int(rng.bit_generator.state["state"]["state"]) & 0xFFFFFFFFFFFFFFFF
+
+
+def numpy_generator_to_mlx_key(rng: Generator) -> mx.array:
+    """Convert a NumPy Generator to an MLX random key.
+
+    MLX uses a functional RNG model where each random call takes an explicit
+    key rather than mutating shared state. This extracts the lower 64 bits of
+    the PCG64 state integer as a seed for the MLX key.
+    """
+    return mx.random.key(_truncate_pcg64_state_to_uint64(rng))
+
+
+@mlx_typify.register(Generator)
+def mlx_typify_Generator(rng, **kwargs):
+    return numpy_generator_to_mlx_key(rng)
+
+
+@mlx_funcify.register(ptr.RandomVariable)
+def mlx_funcify_RandomVariable(op, node, **kwargs):
+    rv = node.outputs[1]
+    out_dtype = rv.type.dtype
+
+    sample_fn_inner = mlx_sample_fn(op, node)
+
+    def sample_fn(rng, size, *parameters):
+        new_keys = mx.random.split(rng, num=2)
+        new_rng = new_keys[0]
+        sampling_key = new_keys[1]
+        sample = sample_fn_inner(sampling_key, size, out_dtype, *parameters)
+        return (new_rng, sample)
+
+    return sample_fn
+
+
+@singledispatch
+def mlx_sample_fn(op, node):
+    raise NotImplementedError(
+        f"No MLX implementation for the given distribution: {op.name}"
+    )
+
+
+@mlx_sample_fn.register(ptr.NormalRV)
+def mlx_sample_fn_normal(op, node):
+    def sample_fn(rng_key, size, dtype, mu, sigma):
+        mlx_dtype = convert_dtype_to_mlx(dtype)
+        mu = mx.array(mu, dtype=mlx_dtype)
+        sigma = mx.array(sigma, dtype=mlx_dtype)
+        if size is None:
+            shape = mx.broadcast_arrays(mu, sigma)[0].shape
+        else:
+            shape = mlx_to_list_shape(size)
+        s = mx.random.normal(shape=shape, dtype=mlx_dtype, key=rng_key)
+        return mu + sigma * s
+
+    return sample_fn
+
+
+@mlx_sample_fn.register(ptr.UniformRV)
+def mlx_sample_fn_uniform(op, node):
+    def sample_fn(rng_key, size, dtype, low, high):
+        mlx_dtype = convert_dtype_to_mlx(dtype)
+        low = mx.array(low, dtype=mlx_dtype)
+        high = mx.array(high, dtype=mlx_dtype)
+        if size is None:
+            shape = mx.broadcast_arrays(low, high)[0].shape
+        else:
+            shape = mlx_to_list_shape(size)
+        return mx.random.uniform(
+            low=low, high=high, shape=shape, dtype=mlx_dtype, key=rng_key
+        )
+
+    return sample_fn
+
+
+@mlx_sample_fn.register(ptr.BernoulliRV)
+def mlx_sample_fn_bernoulli(op, node):
+    def sample_fn(rng_key, size, dtype, p):
+        p = mx.array(p)
+        if size is None:
+            shape = p.shape
+        else:
+            shape = mlx_to_list_shape(size)
+        return mx.random.bernoulli(p=p, shape=shape, key=rng_key)
+
+    return sample_fn
+
+
+@mlx_sample_fn.register(ptr.CategoricalRV)
+def mlx_sample_fn_categorical(op, node):
+    def sample_fn(rng_key, size, dtype, p):
+        logits = mx.log(mx.array(p))
+        shape = mlx_to_list_shape(size) if size is not None else None
+        return mx.random.categorical(logits=logits, axis=-1, shape=shape, key=rng_key)
+
+    return sample_fn
+
+
+@mlx_sample_fn.register(ptr.MvNormalRV)
+def mlx_sample_fn_mvnormal(op, node):
+    def sample_fn(rng_key, size, dtype, mean, cov):
+        mlx_dtype = convert_dtype_to_mlx(dtype)
+        shape = mlx_to_list_shape(size) if size is not None else []
+        # multivariate_normal uses SVD internally, which requires mx.cpu in MLX.
+        return mx.random.multivariate_normal(
+            mean=mean,
+            cov=cov,
+            shape=shape,
+            dtype=mlx_dtype,
+            key=rng_key,
+            stream=mx.cpu,
+        )
+
+    return sample_fn
+
+
+@mlx_sample_fn.register(ptr.LaplaceRV)
+def mlx_sample_fn_laplace(op, node):
+    def sample_fn(rng_key, size, dtype, loc, scale):
+        mlx_dtype = convert_dtype_to_mlx(dtype)
+        loc = mx.array(loc, dtype=mlx_dtype)
+        scale = mx.array(scale, dtype=mlx_dtype)
+        if size is None:
+            shape = mx.broadcast_arrays(loc, scale)[0].shape
+        else:
+            shape = mlx_to_list_shape(size)
+        s = mx.random.laplace(shape=shape, dtype=mlx_dtype, key=rng_key)
+        return loc + scale * s
+
+    return sample_fn
+
+
+@mlx_sample_fn.register(ptr.GumbelRV)
+def mlx_sample_fn_gumbel(op, node):
+    def sample_fn(rng_key, size, dtype, loc, scale):
+        mlx_dtype = convert_dtype_to_mlx(dtype)
+        loc = mx.array(loc, dtype=mlx_dtype)
+        scale = mx.array(scale, dtype=mlx_dtype)
+        if size is None:
+            shape = mx.broadcast_arrays(loc, scale)[0].shape
+        else:
+            shape = mlx_to_list_shape(size)
+        s = mx.random.gumbel(shape=shape, dtype=mlx_dtype, key=rng_key)
+        return loc + scale * s
+
+    return sample_fn
+
+
+@mlx_sample_fn.register(ptr.PermutationRV)
+def mlx_sample_fn_permutation(op, node):
+    batch_ndim = op.batch_ndim(node)
+
+    def sample_fn(rng_key, size, dtype, x):
+        if batch_ndim:
+            raise NotImplementedError(
+                "MLX random.permutation does not support batch dimensions."
+            )
+        return mx.random.permutation(x, key=rng_key)
+
+    return sample_fn
+
+
+@mlx_sample_fn.register(ptr.IntegersRV)
+def mlx_sample_fn_integers(op, node):
+    def sample_fn(rng_key, size, dtype, low, high):
+        mlx_dtype = convert_dtype_to_mlx(dtype)
+        low = mx.array(low, dtype=mlx_dtype)
+        high = mx.array(high, dtype=mlx_dtype)
+        if size is None:
+            shape = mx.broadcast_arrays(low, high)[0].shape
+        else:
+            shape = mlx_to_list_shape(size)
+        return mx.random.randint(
+            low=low, high=high, shape=shape, dtype=mlx_dtype, key=rng_key
+        )
+
+    return sample_fn

--- a/pytensor/link/mlx/dispatch/random.py
+++ b/pytensor/link/mlx/dispatch/random.py
@@ -8,18 +8,18 @@ from pytensor.link.mlx.dispatch.basic import mlx_funcify, mlx_typify
 from pytensor.link.mlx.dispatch.core import convert_dtype_to_mlx, mlx_to_list_shape
 
 
-def _truncate_pcg64_state_to_uint64(rng: Generator) -> int:
-    return int(rng.bit_generator.state["state"]["state"]) & 0xFFFFFFFFFFFFFFFF
-
-
 def numpy_generator_to_mlx_key(rng: Generator) -> mx.array:
     """Convert a NumPy Generator to an MLX random key.
 
     MLX uses a functional RNG model where each random call takes an explicit
-    key rather than mutating shared state. This extracts the lower 64 bits of
-    the PCG64 state integer as a seed for the MLX key.
+    key rather than mutating shared state. The PCG64 state is 128 bits, which
+    MLX cannot accept directly. We fold both 64-bit halves together via XOR
+    to use all 128 bits of entropy in a single 64-bit seed.
     """
-    return mx.random.key(_truncate_pcg64_state_to_uint64(rng))
+    state_128 = int(rng.bit_generator.state["state"]["state"])
+    upper = (state_128 >> 64) & 0xFFFFFFFFFFFFFFFF
+    lower = state_128 & 0xFFFFFFFFFFFFFFFF
+    return mx.random.key(upper ^ lower)
 
 
 @mlx_typify.register(Generator)

--- a/pytensor/link/mlx/dispatch/random.py
+++ b/pytensor/link/mlx/dispatch/random.py
@@ -5,7 +5,10 @@ from numpy.random import Generator
 
 import pytensor.tensor.random.basic as ptr
 from pytensor.link.mlx.dispatch.basic import mlx_funcify, mlx_typify
-from pytensor.link.mlx.dispatch.core import convert_dtype_to_mlx, mlx_to_list_shape
+from pytensor.link.mlx.dispatch.tensor_basic import (
+    convert_dtype_to_mlx,
+    mlx_to_list_shape,
+)
 
 
 def numpy_generator_to_mlx_key(rng: Generator) -> mx.array:

--- a/pytensor/link/mlx/dispatch/random.py
+++ b/pytensor/link/mlx/dispatch/random.py
@@ -19,10 +19,27 @@ def numpy_generator_to_mlx_key(rng: Generator) -> mx.array:
     MLX cannot accept directly. We fold both 64-bit halves together via XOR
     to use all 128 bits of entropy in a single 64-bit seed.
     """
-    state_128 = int(rng.bit_generator.state["state"]["state"])
+    state = rng.bit_generator.state
+    if state["bit_generator"] not in ("PCG64", "PCG64DXSM"):
+        raise NotImplementedError(
+            "MLX RNG conversion only supports the PCG64 bit generator, got "
+            f"{state['bit_generator']}."
+        )
+    state_128 = int(state["state"]["state"])
     upper = (state_128 >> 64) & 0xFFFFFFFFFFFFFFFF
     lower = state_128 & 0xFFFFFFFFFFFFFFFF
     return mx.random.key(upper ^ lower)
+
+
+def _shape_from_size(size, *parameters) -> list[int] | tuple[int, ...]:
+    """Resolve the sampling shape for a draw.
+
+    When ``size`` is given PyTensor has already computed the full output shape;
+    otherwise the shape is the broadcast of the distribution parameters.
+    """
+    if size is not None:
+        return mlx_to_list_shape(size)
+    return mx.broadcast_shapes(*(p.shape for p in parameters))
 
 
 @mlx_typify.register(Generator)
@@ -38,9 +55,7 @@ def mlx_funcify_RandomVariable(op, node, **kwargs):
     sample_fn_inner = mlx_sample_fn(op, node)
 
     def sample_fn(rng, size, *parameters):
-        new_keys = mx.random.split(rng, num=2)
-        new_rng = new_keys[0]
-        sampling_key = new_keys[1]
+        new_rng, sampling_key = mx.random.split(rng, num=2)
         sample = sample_fn_inner(sampling_key, size, out_dtype, *parameters)
         return (new_rng, sample)
 
@@ -55,16 +70,23 @@ def mlx_sample_fn(op, node):
 
 
 @mlx_sample_fn.register(ptr.NormalRV)
-def mlx_sample_fn_normal(op, node):
-    def sample_fn(rng_key, size, dtype, mu, sigma):
+@mlx_sample_fn.register(ptr.LaplaceRV)
+@mlx_sample_fn.register(ptr.GumbelRV)
+def mlx_sample_fn_loc_scale(op, node):
+    """Loc-scale families whose standardized variate MLX exposes directly.
+
+    MLX names the standardized sampler the same as the PyTensor Op, so we can
+    draw it and apply the affine ``loc + scale * z`` shift, mirroring the JAX
+    dispatch.
+    """
+    mlx_op = getattr(mx.random, op.name)
+
+    def sample_fn(rng_key, size, dtype, loc, scale):
         mlx_dtype = convert_dtype_to_mlx(dtype)
-        mu = mx.array(mu, dtype=mlx_dtype)
-        sigma = mx.array(sigma, dtype=mlx_dtype)
-        if size is None:
-            return mx.random.normal(loc=mu, scale=sigma, dtype=mlx_dtype, key=rng_key)
-        shape = mlx_to_list_shape(size)
-        s = mx.random.normal(shape=shape, dtype=mlx_dtype, key=rng_key)
-        return mu + sigma * s
+        loc = mx.array(loc, dtype=mlx_dtype)
+        scale = mx.array(scale, dtype=mlx_dtype)
+        shape = _shape_from_size(size, loc, scale)
+        return loc + scale * mlx_op(shape=shape, dtype=mlx_dtype, key=rng_key)
 
     return sample_fn
 
@@ -75,13 +97,27 @@ def mlx_sample_fn_uniform(op, node):
         mlx_dtype = convert_dtype_to_mlx(dtype)
         low = mx.array(low, dtype=mlx_dtype)
         high = mx.array(high, dtype=mlx_dtype)
-        if size is None:
-            shape = mx.broadcast_arrays(low, high)[0].shape
-        else:
-            shape = mlx_to_list_shape(size)
+        shape = _shape_from_size(size, low, high)
         return mx.random.uniform(
             low=low, high=high, shape=shape, dtype=mlx_dtype, key=rng_key
         )
+
+    return sample_fn
+
+
+@mlx_sample_fn.register(ptr.IntegersRV)
+def mlx_sample_fn_integers(op, node):
+    def sample_fn(rng_key, size, dtype, low, high):
+        low = mx.array(low)
+        high = mx.array(high)
+        shape = _shape_from_size(size, low, high)
+        # Sample within the original bounds at full int64 width, then cast the
+        # result. PyTensor casts the output (not the bounds), so a narrow dtype
+        # wraps rather than collapsing the half-open interval, and wide bounds
+        # are not clipped to MLX's default int32 sampling dtype.
+        return mx.random.randint(
+            low=low, high=high, shape=shape, dtype=mx.int64, key=rng_key
+        ).astype(convert_dtype_to_mlx(dtype))
 
     return sample_fn
 
@@ -91,7 +127,10 @@ def mlx_sample_fn_bernoulli(op, node):
     def sample_fn(rng_key, size, dtype, p):
         p = mx.array(p)
         shape = mlx_to_list_shape(size) if size is not None else None
-        return mx.random.bernoulli(p=p, shape=shape, key=rng_key)
+        # MLX returns a boolean draw; cast to the integer dtype PyTensor declares.
+        return mx.random.bernoulli(p=p, shape=shape, key=rng_key).astype(
+            convert_dtype_to_mlx(dtype)
+        )
 
     return sample_fn
 
@@ -101,7 +140,10 @@ def mlx_sample_fn_categorical(op, node):
     def sample_fn(rng_key, size, dtype, p):
         logits = mx.log(mx.array(p))
         shape = mlx_to_list_shape(size) if size is not None else None
-        return mx.random.categorical(logits=logits, axis=-1, shape=shape, key=rng_key)
+        # MLX returns ``uint32``; cast to the integer dtype PyTensor declares.
+        return mx.random.categorical(
+            logits=logits, axis=-1, shape=shape, key=rng_key
+        ).astype(convert_dtype_to_mlx(dtype))
 
     return sample_fn
 
@@ -114,75 +156,38 @@ def mlx_sample_fn_mvnormal(op, node):
         mlx_dtype = convert_dtype_to_mlx(dtype)
         mean = mx.array(mean, dtype=mlx_dtype)
         cov = mx.array(cov, dtype=mlx_dtype)
+
         n = cov.shape[-1]
-        batch_shape = mlx_to_list_shape(size) if size is not None else []
-        if batch_shape:
-            # size is given: PyTensor pads param dims with leading 1s via ExpandDims;
-            # reshape to 2D/1D to strip those before decomposition.
-            cov_2d = cov.reshape(n, n)
-            mean_1d = mean.reshape(n)
-            if method == "cholesky":
-                A = mx.linalg.cholesky(cov_2d, stream=mx.cpu)
-            elif method == "svd":
-                U, s, _ = mx.linalg.svd(cov_2d, stream=mx.cpu)
-                A = U * mx.sqrt(s)[None, :]
-            else:  # eigh
-                w, vecs = mx.linalg.eigh(cov_2d, stream=mx.cpu)
-                A = vecs * mx.sqrt(w)[None, :]
-            z = mx.random.normal(shape=[*batch_shape, n], dtype=mlx_dtype, key=rng_key)
-            return (z @ A.T) + mean_1d
+        if size is not None:
+            batch_shape = mlx_to_list_shape(size)
         else:
-            # size is None: param shape is the true batch (or scalar).
-            if method == "cholesky":
-                A = mx.linalg.cholesky(cov, stream=mx.cpu)
-            elif method == "svd":
-                U, s, _ = mx.linalg.svd(cov, stream=mx.cpu)
-                A = U * mx.sqrt(s)[..., None, :]
-            else:  # eigh
-                w, vecs = mx.linalg.eigh(cov, stream=mx.cpu)
-                A = vecs * mx.sqrt(w)[..., None, :]
-            z = mx.random.normal(shape=mean.shape, dtype=mlx_dtype, key=rng_key)
-            return (z[..., None, :] @ A.swapaxes(-1, -2))[..., 0, :] + mean
+            batch_shape = mx.broadcast_shapes(mean.shape[:-1], cov.shape[:-2])
 
-    return sample_fn
+        if 0 in tuple(batch_shape):
+            # An empty batch dim crashes the MLX compiled matmul path; the draw
+            # is trivially an empty array of the broadcast output shape.
+            return mx.broadcast_to(mean, [*batch_shape, n])
 
+        # Factor ``cov = A @ A.T`` so that ``mean + A @ z`` has covariance ``cov``.
+        if method == "cholesky":
+            A = mx.linalg.cholesky(cov, stream=mx.cpu)
+        elif method == "svd":
+            U, s, _ = mx.linalg.svd(cov, stream=mx.cpu)
+            A = U * mx.sqrt(s)[..., None, :]
+        else:  # eigh
+            w, vecs = mx.linalg.eigh(cov, stream=mx.cpu)
+            A = vecs * mx.sqrt(w)[..., None, :]
 
-@mlx_sample_fn.register(ptr.LaplaceRV)
-def mlx_sample_fn_laplace(op, node):
-    def sample_fn(rng_key, size, dtype, loc, scale):
-        mlx_dtype = convert_dtype_to_mlx(dtype)
-        loc = mx.array(loc, dtype=mlx_dtype)
-        scale = mx.array(scale, dtype=mlx_dtype)
-        if size is None:
-            shape = mx.broadcast_arrays(loc, scale)[0].shape
-        else:
-            shape = mlx_to_list_shape(size)
-        s = mx.random.laplace(shape=shape, dtype=mlx_dtype, key=rng_key)
-        return loc + scale * s
-
-    return sample_fn
-
-
-@mlx_sample_fn.register(ptr.GumbelRV)
-def mlx_sample_fn_gumbel(op, node):
-    def sample_fn(rng_key, size, dtype, loc, scale):
-        mlx_dtype = convert_dtype_to_mlx(dtype)
-        loc = mx.array(loc, dtype=mlx_dtype)
-        scale = mx.array(scale, dtype=mlx_dtype)
-        if size is None:
-            shape = mx.broadcast_arrays(loc, scale)[0].shape
-        else:
-            shape = mlx_to_list_shape(size)
-        s = mx.random.gumbel(shape=shape, dtype=mlx_dtype, key=rng_key)
-        return loc + scale * s
+        z = mx.random.normal(shape=[*batch_shape, n], dtype=mlx_dtype, key=rng_key)
+        # Broadcasting matmul handles both batched params and leading size dims.
+        return mean + (A @ z[..., None])[..., 0]
 
     return sample_fn
 
 
 @mlx_sample_fn.register(ptr.PermutationRV)
 def mlx_sample_fn_permutation(op, node):
-    batch_ndim = op.batch_ndim(node)
-    if batch_ndim:
+    if op.batch_ndim(node):
         raise NotImplementedError(
             "MLX random.permutation does not support batch dimensions."
         )
@@ -193,34 +198,13 @@ def mlx_sample_fn_permutation(op, node):
     return sample_fn
 
 
-@mlx_sample_fn.register(ptr.IntegersRV)
-def mlx_sample_fn_integers(op, node):
-    def sample_fn(rng_key, size, dtype, low, high):
-        mlx_dtype = convert_dtype_to_mlx(dtype)
-        low = mx.array(low, dtype=mlx_dtype)
-        high = mx.array(high, dtype=mlx_dtype)
-        if size is None:
-            shape = mx.broadcast_arrays(low, high)[0].shape
-        else:
-            shape = mlx_to_list_shape(size)
-        return mx.random.randint(
-            low=low, high=high, shape=shape, dtype=mlx_dtype, key=rng_key
-        )
-
-    return sample_fn
-
-
 @mlx_sample_fn.register(ptr.LogNormalRV)
 def mlx_sample_fn_lognormal(op, node):
     def sample_fn(rng_key, size, dtype, mu, sigma):
         mlx_dtype = convert_dtype_to_mlx(dtype)
         mu = mx.array(mu, dtype=mlx_dtype)
         sigma = mx.array(sigma, dtype=mlx_dtype)
-        if size is None:
-            return mx.exp(
-                mx.random.normal(loc=mu, scale=sigma, dtype=mlx_dtype, key=rng_key)
-            )
-        shape = mlx_to_list_shape(size)
+        shape = _shape_from_size(size, mu, sigma)
         z = mx.random.normal(shape=shape, dtype=mlx_dtype, key=rng_key)
         return mx.exp(mu + sigma * z)
 
@@ -233,13 +217,9 @@ def mlx_sample_fn_halfnormal(op, node):
         mlx_dtype = convert_dtype_to_mlx(dtype)
         loc = mx.array(loc, dtype=mlx_dtype)
         scale = mx.array(scale, dtype=mlx_dtype)
-        if size is None:
-            return mx.abs(
-                mx.random.normal(loc=loc, scale=scale, dtype=mlx_dtype, key=rng_key)
-            )
-        shape = mlx_to_list_shape(size)
+        shape = _shape_from_size(size, loc, scale)
         z = mx.random.normal(shape=shape, dtype=mlx_dtype, key=rng_key)
-        return mx.abs(loc + scale * z)
+        return loc + scale * mx.abs(z)
 
     return sample_fn
 
@@ -249,10 +229,7 @@ def mlx_sample_fn_exponential(op, node):
     def sample_fn(rng_key, size, dtype, scale):
         mlx_dtype = convert_dtype_to_mlx(dtype)
         scale = mx.array(scale, dtype=mlx_dtype)
-        if size is None:
-            shape = scale.shape
-        else:
-            shape = mlx_to_list_shape(size)
+        shape = _shape_from_size(size, scale)
         u = mx.random.uniform(shape=shape, dtype=mlx_dtype, key=rng_key)
         return -scale * mx.log(u)
 
@@ -265,10 +242,7 @@ def mlx_sample_fn_logistic(op, node):
         mlx_dtype = convert_dtype_to_mlx(dtype)
         loc = mx.array(loc, dtype=mlx_dtype)
         scale = mx.array(scale, dtype=mlx_dtype)
-        if size is None:
-            shape = mx.broadcast_arrays(loc, scale)[0].shape
-        else:
-            shape = mlx_to_list_shape(size)
+        shape = _shape_from_size(size, loc, scale)
         u = mx.random.uniform(shape=shape, dtype=mlx_dtype, key=rng_key)
         return loc + scale * mx.log(u / (1 - u))
 
@@ -281,10 +255,7 @@ def mlx_sample_fn_cauchy(op, node):
         mlx_dtype = convert_dtype_to_mlx(dtype)
         loc = mx.array(loc, dtype=mlx_dtype)
         scale = mx.array(scale, dtype=mlx_dtype)
-        if size is None:
-            shape = mx.broadcast_arrays(loc, scale)[0].shape
-        else:
-            shape = mlx_to_list_shape(size)
+        shape = _shape_from_size(size, loc, scale)
         u = mx.random.uniform(shape=shape, dtype=mlx_dtype, key=rng_key)
         return loc + scale * mx.tan(mx.pi * (u - 0.5))
 

--- a/pytensor/link/mlx/dispatch/random.py
+++ b/pytensor/link/mlx/dispatch/random.py
@@ -61,9 +61,8 @@ def mlx_sample_fn_normal(op, node):
         mu = mx.array(mu, dtype=mlx_dtype)
         sigma = mx.array(sigma, dtype=mlx_dtype)
         if size is None:
-            shape = mx.broadcast_arrays(mu, sigma)[0].shape
-        else:
-            shape = mlx_to_list_shape(size)
+            return mx.random.normal(loc=mu, scale=sigma, dtype=mlx_dtype, key=rng_key)
+        shape = mlx_to_list_shape(size)
         s = mx.random.normal(shape=shape, dtype=mlx_dtype, key=rng_key)
         return mu + sigma * s
 

--- a/pytensor/link/mlx/dispatch/random.py
+++ b/pytensor/link/mlx/dispatch/random.py
@@ -208,3 +208,84 @@ def mlx_sample_fn_integers(op, node):
         )
 
     return sample_fn
+
+
+@mlx_sample_fn.register(ptr.LogNormalRV)
+def mlx_sample_fn_lognormal(op, node):
+    def sample_fn(rng_key, size, dtype, mu, sigma):
+        mlx_dtype = convert_dtype_to_mlx(dtype)
+        mu = mx.array(mu, dtype=mlx_dtype)
+        sigma = mx.array(sigma, dtype=mlx_dtype)
+        if size is None:
+            return mx.exp(
+                mx.random.normal(loc=mu, scale=sigma, dtype=mlx_dtype, key=rng_key)
+            )
+        shape = mlx_to_list_shape(size)
+        z = mx.random.normal(shape=shape, dtype=mlx_dtype, key=rng_key)
+        return mx.exp(mu + sigma * z)
+
+    return sample_fn
+
+
+@mlx_sample_fn.register(ptr.HalfNormalRV)
+def mlx_sample_fn_halfnormal(op, node):
+    def sample_fn(rng_key, size, dtype, loc, scale):
+        mlx_dtype = convert_dtype_to_mlx(dtype)
+        loc = mx.array(loc, dtype=mlx_dtype)
+        scale = mx.array(scale, dtype=mlx_dtype)
+        if size is None:
+            return mx.abs(
+                mx.random.normal(loc=loc, scale=scale, dtype=mlx_dtype, key=rng_key)
+            )
+        shape = mlx_to_list_shape(size)
+        z = mx.random.normal(shape=shape, dtype=mlx_dtype, key=rng_key)
+        return mx.abs(loc + scale * z)
+
+    return sample_fn
+
+
+@mlx_sample_fn.register(ptr.ExponentialRV)
+def mlx_sample_fn_exponential(op, node):
+    def sample_fn(rng_key, size, dtype, scale):
+        mlx_dtype = convert_dtype_to_mlx(dtype)
+        scale = mx.array(scale, dtype=mlx_dtype)
+        if size is None:
+            shape = scale.shape
+        else:
+            shape = mlx_to_list_shape(size)
+        u = mx.random.uniform(shape=shape, dtype=mlx_dtype, key=rng_key)
+        return -scale * mx.log(u)
+
+    return sample_fn
+
+
+@mlx_sample_fn.register(ptr.LogisticRV)
+def mlx_sample_fn_logistic(op, node):
+    def sample_fn(rng_key, size, dtype, loc, scale):
+        mlx_dtype = convert_dtype_to_mlx(dtype)
+        loc = mx.array(loc, dtype=mlx_dtype)
+        scale = mx.array(scale, dtype=mlx_dtype)
+        if size is None:
+            shape = mx.broadcast_arrays(loc, scale)[0].shape
+        else:
+            shape = mlx_to_list_shape(size)
+        u = mx.random.uniform(shape=shape, dtype=mlx_dtype, key=rng_key)
+        return loc + scale * mx.log(u / (1 - u))
+
+    return sample_fn
+
+
+@mlx_sample_fn.register(ptr.CauchyRV)
+def mlx_sample_fn_cauchy(op, node):
+    def sample_fn(rng_key, size, dtype, loc, scale):
+        mlx_dtype = convert_dtype_to_mlx(dtype)
+        loc = mx.array(loc, dtype=mlx_dtype)
+        scale = mx.array(scale, dtype=mlx_dtype)
+        if size is None:
+            shape = mx.broadcast_arrays(loc, scale)[0].shape
+        else:
+            shape = mlx_to_list_shape(size)
+        u = mx.random.uniform(shape=shape, dtype=mlx_dtype, key=rng_key)
+        return loc + scale * mx.tan(mx.pi * (u - 0.5))
+
+    return sample_fn

--- a/pytensor/link/mlx/dispatch/random.py
+++ b/pytensor/link/mlx/dispatch/random.py
@@ -14,10 +14,8 @@ from pytensor.link.mlx.dispatch.tensor_basic import (
 def numpy_generator_to_mlx_key(rng: Generator) -> mx.array:
     """Convert a NumPy Generator to an MLX random key.
 
-    MLX uses a functional RNG model where each random call takes an explicit
-    key rather than mutating shared state. The PCG64 state is 128 bits, which
-    MLX cannot accept directly. We fold both 64-bit halves together via XOR
-    to use all 128 bits of entropy in a single 64-bit seed.
+    MLX keys are 64-bit, so we XOR-fold the two halves of the 128-bit PCG64
+    state to keep all of its entropy.
     """
     state = rng.bit_generator.state
     if state["bit_generator"] not in ("PCG64", "PCG64DXSM"):
@@ -32,14 +30,10 @@ def numpy_generator_to_mlx_key(rng: Generator) -> mx.array:
 
 
 def _shape_from_size(size, *parameters) -> list[int] | tuple[int, ...]:
-    """Resolve the sampling shape for a draw.
-
-    When ``size`` is given PyTensor has already computed the full output shape;
-    otherwise the shape is the broadcast of the distribution parameters.
-    """
+    """Sampling shape: ``size`` if given, else the broadcast of the parameters."""
     if size is not None:
         return mlx_to_list_shape(size)
-    return mx.broadcast_shapes(*(p.shape for p in parameters))
+    return tuple(mx.broadcast_shapes(*(p.shape for p in parameters)))
 
 
 @mlx_typify.register(Generator)
@@ -73,12 +67,8 @@ def mlx_sample_fn(op, node):
 @mlx_sample_fn.register(ptr.LaplaceRV)
 @mlx_sample_fn.register(ptr.GumbelRV)
 def mlx_sample_fn_loc_scale(op, node):
-    """Loc-scale families whose standardized variate MLX exposes directly.
-
-    MLX names the standardized sampler the same as the PyTensor Op, so we can
-    draw it and apply the affine ``loc + scale * z`` shift, mirroring the JAX
-    dispatch.
-    """
+    """Loc-scale families: MLX names the standard sampler like the Op, so draw
+    it and apply ``loc + scale * z`` (mirrors the JAX dispatch)."""
     mlx_op = getattr(mx.random, op.name)
 
     def sample_fn(rng_key, size, dtype, loc, scale):
@@ -111,10 +101,8 @@ def mlx_sample_fn_integers(op, node):
         low = mx.array(low)
         high = mx.array(high)
         shape = _shape_from_size(size, low, high)
-        # Sample within the original bounds at full int64 width, then cast the
-        # result. PyTensor casts the output (not the bounds), so a narrow dtype
-        # wraps rather than collapsing the half-open interval, and wide bounds
-        # are not clipped to MLX's default int32 sampling dtype.
+        # Sample at full int64 width and cast the result: PyTensor casts the
+        # output, not the bounds, so narrow/wide dtypes don't corrupt the range.
         return mx.random.randint(
             low=low, high=high, shape=shape, dtype=mx.int64, key=rng_key
         ).astype(convert_dtype_to_mlx(dtype))
@@ -127,7 +115,7 @@ def mlx_sample_fn_bernoulli(op, node):
     def sample_fn(rng_key, size, dtype, p):
         p = mx.array(p)
         shape = mlx_to_list_shape(size) if size is not None else None
-        # MLX returns a boolean draw; cast to the integer dtype PyTensor declares.
+        # MLX draws bool; PyTensor declares an int dtype.
         return mx.random.bernoulli(p=p, shape=shape, key=rng_key).astype(
             convert_dtype_to_mlx(dtype)
         )
@@ -140,7 +128,7 @@ def mlx_sample_fn_categorical(op, node):
     def sample_fn(rng_key, size, dtype, p):
         logits = mx.log(mx.array(p))
         shape = mlx_to_list_shape(size) if size is not None else None
-        # MLX returns ``uint32``; cast to the integer dtype PyTensor declares.
+        # MLX draws uint32; PyTensor declares an int dtype.
         return mx.random.categorical(
             logits=logits, axis=-1, shape=shape, key=rng_key
         ).astype(convert_dtype_to_mlx(dtype))
@@ -164,8 +152,7 @@ def mlx_sample_fn_mvnormal(op, node):
             batch_shape = mx.broadcast_shapes(mean.shape[:-1], cov.shape[:-2])
 
         if 0 in tuple(batch_shape):
-            # An empty batch dim crashes the MLX compiled matmul path; the draw
-            # is trivially an empty array of the broadcast output shape.
+            # Empty batch dim crashes MLX's compiled matmul; the draw is empty anyway.
             return mx.broadcast_to(mean, [*batch_shape, n])
 
         # Factor ``cov = A @ A.T`` so that ``mean + A @ z`` has covariance ``cov``.
@@ -179,7 +166,6 @@ def mlx_sample_fn_mvnormal(op, node):
             A = vecs * mx.sqrt(w)[..., None, :]
 
         z = mx.random.normal(shape=[*batch_shape, n], dtype=mlx_dtype, key=rng_key)
-        # Broadcasting matmul handles both batched params and leading size dims.
         return mean + (A @ z[..., None])[..., 0]
 
     return sample_fn

--- a/pytensor/link/mlx/dispatch/random.py
+++ b/pytensor/link/mlx/dispatch/random.py
@@ -64,19 +64,39 @@ def mlx_sample_fn(op, node):
 
 
 @mlx_sample_fn.register(ptr.NormalRV)
-@mlx_sample_fn.register(ptr.LaplaceRV)
-@mlx_sample_fn.register(ptr.GumbelRV)
-def mlx_sample_fn_loc_scale(op, node):
-    """Loc-scale families: MLX names the standard sampler like the Op, so draw
-    it and apply ``loc + scale * z`` (mirrors the JAX dispatch)."""
-    mlx_op = getattr(mx.random, op.name)
-
+def mlx_sample_fn_normal(op, node):
     def sample_fn(rng_key, size, dtype, loc, scale):
         mlx_dtype = convert_dtype_to_mlx(dtype)
         loc = mx.array(loc, dtype=mlx_dtype)
         scale = mx.array(scale, dtype=mlx_dtype)
         shape = _shape_from_size(size, loc, scale)
-        return loc + scale * mlx_op(shape=shape, dtype=mlx_dtype, key=rng_key)
+        return loc + scale * mx.random.normal(shape=shape, dtype=mlx_dtype, key=rng_key)
+
+    return sample_fn
+
+
+@mlx_sample_fn.register(ptr.LaplaceRV)
+def mlx_sample_fn_laplace(op, node):
+    def sample_fn(rng_key, size, dtype, loc, scale):
+        mlx_dtype = convert_dtype_to_mlx(dtype)
+        loc = mx.array(loc, dtype=mlx_dtype)
+        scale = mx.array(scale, dtype=mlx_dtype)
+        shape = _shape_from_size(size, loc, scale)
+        return loc + scale * mx.random.laplace(
+            shape=shape, dtype=mlx_dtype, key=rng_key
+        )
+
+    return sample_fn
+
+
+@mlx_sample_fn.register(ptr.GumbelRV)
+def mlx_sample_fn_gumbel(op, node):
+    def sample_fn(rng_key, size, dtype, loc, scale):
+        mlx_dtype = convert_dtype_to_mlx(dtype)
+        loc = mx.array(loc, dtype=mlx_dtype)
+        scale = mx.array(scale, dtype=mlx_dtype)
+        shape = _shape_from_size(size, loc, scale)
+        return loc + scale * mx.random.gumbel(shape=shape, dtype=mlx_dtype, key=rng_key)
 
     return sample_fn
 
@@ -217,7 +237,8 @@ def mlx_sample_fn_exponential(op, node):
         scale = mx.array(scale, dtype=mlx_dtype)
         shape = _shape_from_size(size, scale)
         u = mx.random.uniform(shape=shape, dtype=mlx_dtype, key=rng_key)
-        return -scale * mx.log(u)
+        # log1p(-u) avoids -inf when u=0 (u is in [0, 1))
+        return -scale * mx.log1p(-u)
 
     return sample_fn
 

--- a/pytensor/link/mlx/dispatch/random.py
+++ b/pytensor/link/mlx/dispatch/random.py
@@ -46,11 +46,18 @@ def mlx_funcify_RandomVariable(op, node, **kwargs):
     rv = node.outputs[1]
     out_dtype = rv.type.dtype
 
+    # MLX random primitives reject float64 regardless of device, so sample in
+    # float32 and widen the draw to the declared output dtype afterwards.
+    mlx_out_dtype = convert_dtype_to_mlx(out_dtype)
+    sample_dtype = mx.float32 if mlx_out_dtype == mx.float64 else mlx_out_dtype
+
     sample_fn_inner = mlx_sample_fn(op, node)
 
     def sample_fn(rng, size, *parameters):
         new_rng, sampling_key = mx.random.split(rng, num=2)
-        sample = sample_fn_inner(sampling_key, size, out_dtype, *parameters)
+        sample = sample_fn_inner(sampling_key, size, sample_dtype, *parameters)
+        if sample.dtype != mlx_out_dtype:
+            sample = sample.astype(mlx_out_dtype)
         return (new_rng, sample)
 
     return sample_fn

--- a/pytensor/link/mlx/dispatch/tensor_basic.py
+++ b/pytensor/link/mlx/dispatch/tensor_basic.py
@@ -249,6 +249,16 @@ def _coerce_to_int(value):
         raise
 
 
+def mlx_to_list_shape(size) -> list[int]:
+    """Convert a size value (mx.array, np.ndarray, or sequence) to a plain Python list of ints.
+
+    Used by random variable dispatch to normalise the ``size`` argument, which
+    PyTensor may pass as an ``mx.array`` or ``np.ndarray`` rather than a plain
+    Python list.
+    """
+    return [_coerce_to_int(x) for x in size]
+
+
 def _rethrow_dynamic_shape_error(exc):
     msg = str(exc)
     if "[eval] Attempting to eval an array during function transformations" in msg:

--- a/pytensor/link/mlx/dispatch/tensor_basic.py
+++ b/pytensor/link/mlx/dispatch/tensor_basic.py
@@ -239,6 +239,16 @@ def _coerce_to_int(value):
         raise
 
 
+def mlx_to_list_shape(size) -> list[int]:
+    """Convert a size value (mx.array, np.ndarray, or sequence) to a plain Python list of ints.
+
+    Used by random variable dispatch to normalise the ``size`` argument, which
+    PyTensor may pass as an ``mx.array`` or ``np.ndarray`` rather than a plain
+    Python list.
+    """
+    return [_coerce_to_int(x) for x in size]
+
+
 def _rethrow_dynamic_shape_error(exc):
     msg = str(exc)
     if "[eval] Attempting to eval an array during function transformations" in msg:

--- a/pytensor/link/mlx/linker.py
+++ b/pytensor/link/mlx/linker.py
@@ -1,3 +1,6 @@
+import warnings
+
+from pytensor.compile.sharedvalue import SharedVariable, shared
 from pytensor.link.basic import JITLinker
 
 
@@ -18,7 +21,7 @@ class MLXLinker(JITLinker):
         self.gen_functors = []
         self.use_compile = use_compile
 
-    def fgraph_convert(self, fgraph, **kwargs):
+    def fgraph_convert(self, fgraph, input_storage, storage_map, **kwargs):
         """Convert a PyTensor FunctionGraph to an MLX-compatible function.
 
         Parameters
@@ -32,9 +35,63 @@ class MLXLinker(JITLinker):
             An MLX-compatible function
         """
         from pytensor.link.mlx.dispatch import mlx_funcify
+        from pytensor.tensor.random.type import RandomType
+
+        shared_rng_inputs = [
+            inp
+            for inp in fgraph.inputs
+            if (isinstance(inp, SharedVariable) and isinstance(inp.type, RandomType))
+        ]
+
+        # Replace any shared RNG inputs so that their values can be updated in place
+        # without affecting the original RNG container. This is necessary because
+        # MLX does not accept Generators as inputs, and they will have to
+        # be typified
+        if shared_rng_inputs:
+            warnings.warn(
+                f"The RandomType SharedVariables {shared_rng_inputs} will not be used "
+                f"in the compiled MLX graph. Instead a copy will be used.",
+                UserWarning,
+            )
+            new_shared_rng_inputs = [
+                shared(inp.get_value(borrow=False)) for inp in shared_rng_inputs
+            ]
+
+            fgraph.replace_all(
+                zip(shared_rng_inputs, new_shared_rng_inputs, strict=True),
+                import_missing=True,
+                reason="MLXLinker.fgraph_convert",
+            )
+
+            for old_inp, new_inp in zip(
+                shared_rng_inputs, new_shared_rng_inputs, strict=True
+            ):
+                new_inp_storage = [new_inp.get_value(borrow=True)]
+                storage_map[new_inp] = new_inp_storage
+                old_inp_storage = storage_map.pop(old_inp)
+                # Find index of old_inp_storage in input_storage
+                for input_storage_idx, input_storage_item in enumerate(input_storage):
+                    # We have to establish equality based on identity because input_storage may contain numpy arrays
+                    if input_storage_item is old_inp_storage:
+                        break
+                else:  # no break
+                    raise ValueError()
+                input_storage[input_storage_idx] = new_inp_storage
+                # We need to change the order of the inputs of the FunctionGraph
+                # so that the new input is in the same position as to old one,
+                # to align with the storage_map. We hope this is safe!
+                old_inp_fgraph_index = fgraph.inputs.index(old_inp)
+                fgraph.remove_input(
+                    old_inp_fgraph_index,
+                    reason="MLXLinker.fgraph_convert",
+                )
+                fgraph.inputs.remove(new_inp)
+                fgraph.inputs.insert(old_inp_fgraph_index, new_inp)
 
         return mlx_funcify(
             fgraph,
+            input_storage=input_storage,
+            storage_map=storage_map,
             **kwargs,
         )
 

--- a/pytensor/link/mlx/linker.py
+++ b/pytensor/link/mlx/linker.py
@@ -70,9 +70,16 @@ class MLXLinker(JITLinker):
         list
             The inputs for the thunk
         """
+        from numpy.random import Generator
+
+        from pytensor.link.mlx.dispatch import mlx_typify
+
         thunk_inputs = []
         for n in self.fgraph.inputs:
             sinput = storage_map[n]
+            if isinstance(sinput[0], Generator):
+                # Convert Generator into MLX PRNG key
+                sinput[0] = mlx_typify(sinput[0])
             thunk_inputs.append(sinput)
 
         return thunk_inputs

--- a/pytensor/link/mlx/linker.py
+++ b/pytensor/link/mlx/linker.py
@@ -1,3 +1,6 @@
+import warnings
+
+from pytensor.compile.sharedvalue import SharedVariable, shared
 from pytensor.link.basic import JITLinker
 
 
@@ -19,7 +22,7 @@ class MLXLinker(JITLinker):
         self.gen_functors = []
         self.use_compile = use_compile
 
-    def fgraph_convert(self, fgraph, **kwargs):
+    def fgraph_convert(self, fgraph, input_storage, storage_map, **kwargs):
         """Convert a PyTensor FunctionGraph to an MLX-compatible function.
 
         Parameters
@@ -33,9 +36,63 @@ class MLXLinker(JITLinker):
             An MLX-compatible function
         """
         from pytensor.link.mlx.dispatch import mlx_funcify
+        from pytensor.tensor.random.type import RandomType
+
+        shared_rng_inputs = [
+            inp
+            for inp in fgraph.inputs
+            if (isinstance(inp, SharedVariable) and isinstance(inp.type, RandomType))
+        ]
+
+        # Replace any shared RNG inputs so that their values can be updated in place
+        # without affecting the original RNG container. This is necessary because
+        # MLX does not accept Generators as inputs, and they will have to
+        # be typified
+        if shared_rng_inputs:
+            warnings.warn(
+                f"The RandomType SharedVariables {shared_rng_inputs} will not be used "
+                f"in the compiled MLX graph. Instead a copy will be used.",
+                UserWarning,
+            )
+            new_shared_rng_inputs = [
+                shared(inp.get_value(borrow=False)) for inp in shared_rng_inputs
+            ]
+
+            fgraph.replace_all(
+                zip(shared_rng_inputs, new_shared_rng_inputs, strict=True),
+                import_missing=True,
+                reason="MLXLinker.fgraph_convert",
+            )
+
+            for old_inp, new_inp in zip(
+                shared_rng_inputs, new_shared_rng_inputs, strict=True
+            ):
+                new_inp_storage = [new_inp.get_value(borrow=True)]
+                storage_map[new_inp] = new_inp_storage
+                old_inp_storage = storage_map.pop(old_inp)
+                # Find index of old_inp_storage in input_storage
+                for input_storage_idx, input_storage_item in enumerate(input_storage):
+                    # We have to establish equality based on identity because input_storage may contain numpy arrays
+                    if input_storage_item is old_inp_storage:
+                        break
+                else:  # no break
+                    raise ValueError()
+                input_storage[input_storage_idx] = new_inp_storage
+                # We need to change the order of the inputs of the FunctionGraph
+                # so that the new input is in the same position as to old one,
+                # to align with the storage_map. We hope this is safe!
+                old_inp_fgraph_index = fgraph.inputs.index(old_inp)
+                fgraph.remove_input(
+                    old_inp_fgraph_index,
+                    reason="MLXLinker.fgraph_convert",
+                )
+                fgraph.inputs.remove(new_inp)
+                fgraph.inputs.insert(old_inp_fgraph_index, new_inp)
 
         return mlx_funcify(
             fgraph,
+            input_storage=input_storage,
+            storage_map=storage_map,
             **kwargs,
         )
 

--- a/pytensor/link/mlx/linker.py
+++ b/pytensor/link/mlx/linker.py
@@ -71,9 +71,16 @@ class MLXLinker(JITLinker):
         list
             The inputs for the thunk
         """
+        from numpy.random import Generator
+
+        from pytensor.link.mlx.dispatch import mlx_typify
+
         thunk_inputs = []
         for n in self.fgraph.inputs:
             sinput = storage_map[n]
+            if isinstance(sinput[0], Generator):
+                # Convert Generator into MLX PRNG key
+                sinput[0] = mlx_typify(sinput[0])
             thunk_inputs.append(sinput)
 
         return thunk_inputs

--- a/tests/link/mlx/test_random.py
+++ b/tests/link/mlx/test_random.py
@@ -3,7 +3,7 @@ import pytest
 
 import pytensor
 import pytensor.tensor as pt
-from pytensor.compile.function import function
+from pytensor.compile.maker import function
 from pytensor.compile.sharedvalue import shared
 from pytensor.tensor.random.utils import RandomStream
 

--- a/tests/link/mlx/test_random.py
+++ b/tests/link/mlx/test_random.py
@@ -3,7 +3,9 @@ import pytest
 
 import pytensor
 import pytensor.tensor as pt
+from pytensor.compile.function import function
 from pytensor.compile.mode import MLX, Mode
+from pytensor.compile.sharedvalue import shared
 from pytensor.link.mlx.linker import MLXLinker
 from pytensor.tensor.random.utils import RandomStream
 
@@ -173,3 +175,82 @@ def test_beta_not_implemented():
     rv = srng.beta(alpha=2.0, beta=5.0, size=(3,))
     with pytest.raises(NotImplementedError, match="No MLX implementation"):
         pytensor.function([], rv, mode="MLX", updates=srng.updates())
+
+
+def compile_shared_rng_function(*args, mode="MLX", **kwargs):
+    with pytest.warns(
+        UserWarning, match=r"The RandomType SharedVariables \[.+\] will not be used"
+    ):
+        return function(*args, mode=mode, **kwargs)
+
+
+def test_random_updates():
+    original_value = np.random.default_rng(seed=98)
+    rng = shared(original_value, name="original_rng", borrow=False)
+    next_rng, x = pt.random.normal(name="x", rng=rng).owner.outputs
+
+    f = compile_shared_rng_function([], [x], updates={rng: next_rng})
+    assert f() != f()
+
+    # Check that the original shared variable was not overwritten when typifying
+    assert all(
+        a == b if not isinstance(a, np.ndarray) else np.array_equal(a, b)
+        for a, b in zip(
+            rng.get_value().bit_generator.state,
+            original_value.bit_generator.state,
+            strict=True,
+        )
+    )
+
+
+@pytest.mark.parametrize("noise_first", (False, True))
+def test_replaced_shared_rng_storage_order(noise_first):
+    # Test that replacing the RNG variable in the linker does not cause
+    # a disalignment between the compiled graph and the storage_map.
+
+    mu = pytensor.shared(np.array(1.0), name="mu")
+    rng = pytensor.shared(np.random.default_rng(123))
+    next_rng, noise = pt.random.normal(rng=rng).owner.outputs
+
+    out = noise * mu if noise_first else mu * noise
+
+    updates = {
+        mu: pt.grad(out, mu),
+        rng: next_rng,
+    }
+    f = compile_shared_rng_function([], [out], updates=updates)
+
+    # Confirm that input_storage type and fgraph input order are aligned
+    for storage, fgraph_input in zip(
+        f.input_storage, f.maker.fgraph.inputs, strict=True
+    ):
+        assert storage.type == fgraph_input.type
+
+    assert mu.get_value() == 1
+    f()
+    assert mu.get_value() != 1
+
+
+def test_replaced_shared_rng_storage_ordering_equality():
+    """Test that storage identity comparison works when numpy arrays precede
+    the RNG in input_storage (regression test for issue #314)."""
+    pt_rng = RandomStream(1)
+
+    batchshape = (3, 1, 4, 4)
+    inp_shared = pytensor.shared(
+        np.zeros(batchshape, dtype="float64"), name="inp_shared"
+    )
+
+    inp = pt.tensor4(dtype="float64", name="inp")
+    inp_update = inp + pt_rng.normal(size=inp.shape, loc=5, scale=1e-5)
+
+    fn = compile_shared_rng_function(
+        inputs=[],
+        outputs=[],
+        updates={inp_shared: inp_update},
+        givens={inp: inp_shared},
+    )
+    fn()
+    np.testing.assert_allclose(np.array(inp_shared.get_value()), 5, rtol=1e-2)
+    fn()
+    np.testing.assert_allclose(np.array(inp_shared.get_value()), 10, rtol=1e-2)

--- a/tests/link/mlx/test_random.py
+++ b/tests/link/mlx/test_random.py
@@ -4,18 +4,11 @@ import pytest
 import pytensor
 import pytensor.tensor as pt
 from pytensor.compile.function import function
-from pytensor.compile.mode import MLX, Mode
 from pytensor.compile.sharedvalue import shared
-from pytensor.link.mlx.linker import MLXLinker
 from pytensor.tensor.random.utils import RandomStream
 
 
 mx = pytest.importorskip("mlx.core")
-
-# MLX mode without mx.compile — needed for ops that use CPU streams internally
-# (e.g. multivariate_normal, which uses SVD via mx.cpu stream and is
-# incompatible with mx.compile's tracing).
-MLX_NO_COMPILE = Mode(linker=MLXLinker(use_compile=False), optimizer=MLX.optimizer)
 
 
 def test_normal_cumsum():
@@ -118,13 +111,23 @@ def test_categorical_shape():
 def test_mvnormal_shape():
     mean = np.zeros(4, dtype=np.float32)
     cov = np.eye(4, dtype=np.float32)
-    # multivariate_normal uses SVD internally (CPU-only in MLX), which is
-    # incompatible with mx.compile — use the no-compile mode.
     check_shape_and_dtype(
         lambda srng: srng.multivariate_normal(mean=mean, cov=cov, size=(6,)),
         (6, 4),
         "float32",
-        mode=MLX_NO_COMPILE,
+    )
+
+
+@pytest.mark.parametrize("method", ["cholesky", "svd", "eigh"])
+def test_mvnormal_decomposition_method(method):
+    mean = np.zeros(4, dtype=np.float32)
+    cov = np.eye(4, dtype=np.float32)
+    check_shape_and_dtype(
+        lambda srng: srng.multivariate_normal(
+            mean=mean, cov=cov, size=(6,), method=method
+        ),
+        (6, 4),
+        "float32",
     )
 
 

--- a/tests/link/mlx/test_random.py
+++ b/tests/link/mlx/test_random.py
@@ -1,0 +1,175 @@
+import numpy as np
+import pytest
+
+import pytensor
+import pytensor.tensor as pt
+from pytensor.compile.mode import MLX, Mode
+from pytensor.link.mlx.linker import MLXLinker
+from pytensor.tensor.random.utils import RandomStream
+
+
+mx = pytest.importorskip("mlx.core")
+
+# MLX mode without mx.compile — needed for ops that use CPU streams internally
+# (e.g. multivariate_normal, which uses SVD via mx.cpu stream and is
+# incompatible with mx.compile's tracing).
+MLX_NO_COMPILE = Mode(linker=MLXLinker(use_compile=False), optimizer=MLX.optimizer)
+
+
+def test_normal_cumsum():
+    out = pt.random.normal(size=(52,)).cumsum()
+    result = out.eval(mode="MLX")
+    assert isinstance(result, mx.array)
+    assert result.shape == (52,)
+
+
+def check_shape_and_dtype(
+    make_rv, expected_shape, expected_dtype=None, n_evals=2, mode="MLX"
+):
+    """Compile and run an RV under MLX, assert shape and dtype, and verify
+    that two successive draws differ (RNG state is properly threaded).
+
+    Parameters
+    ----------
+    make_rv : callable(srng) -> rv_var
+        Factory that creates the RV using the provided RandomStream.
+    expected_shape : tuple
+    expected_dtype : str or None
+    n_evals : int
+    mode : str or Mode
+    """
+    srng = RandomStream(seed=12345)
+    rv = make_rv(srng)
+    f = pytensor.function([], rv, mode=mode, updates=srng.updates())
+    results = [np.array(f()) for _ in range(n_evals)]
+
+    for r in results:
+        assert r.shape == expected_shape, (
+            f"Expected shape {expected_shape}, got {r.shape}"
+        )
+        if expected_dtype is not None:
+            assert r.dtype == np.dtype(expected_dtype), (
+                f"Expected dtype {expected_dtype}, got {r.dtype}"
+            )
+
+    assert not np.array_equal(results[0], results[1]), (
+        "Two draws were identical — RNG not advancing"
+    )
+
+    return results
+
+
+def test_normal_shape_dtype():
+    check_shape_and_dtype(
+        lambda srng: srng.normal(loc=0.0, scale=1.0, size=(3, 4)),
+        (3, 4),
+        "float32",
+    )
+
+
+def test_normal_scalar():
+    check_shape_and_dtype(
+        lambda srng: srng.normal(loc=2.0, scale=0.5),
+        (),
+    )
+
+
+def test_normal_array_params():
+    result = pt.random.normal(loc=[0, 1], scale=[1.0, 0.3], size=(100, 2)).eval(
+        mode="MLX"
+    )
+    assert result.shape == (100, 2)
+    means = np.array(result).mean(axis=0)
+    assert abs(means[0]) < 0.3
+    assert abs(means[1] - 1.0) < 0.3
+
+
+def test_uniform_shape_dtype():
+    results = check_shape_and_dtype(
+        lambda srng: srng.uniform(low=0.0, high=1.0, size=(10,)),
+        (10,),
+        "float32",
+    )
+    r = np.array(results[0])
+    assert np.all(r >= 0.0)
+    assert np.all(r < 1.0)
+
+
+def test_bernoulli_shape():
+    check_shape_and_dtype(
+        lambda srng: srng.bernoulli(p=0.7, size=(5, 5)),
+        (5, 5),
+    )
+
+
+def test_categorical_shape():
+    probs = np.array([0.1, 0.4, 0.5], dtype=np.float32)
+    results = check_shape_and_dtype(
+        lambda srng: srng.categorical(p=probs, size=(8,)),
+        (8,),
+    )
+    r = np.array(results[0])
+    assert np.all(r < 3)
+    assert np.all(r >= 0)
+
+
+def test_mvnormal_shape():
+    mean = np.zeros(4, dtype=np.float32)
+    cov = np.eye(4, dtype=np.float32)
+    # multivariate_normal uses SVD internally (CPU-only in MLX), which is
+    # incompatible with mx.compile — use the no-compile mode.
+    check_shape_and_dtype(
+        lambda srng: srng.multivariate_normal(mean=mean, cov=cov, size=(6,)),
+        (6, 4),
+        "float32",
+        mode=MLX_NO_COMPILE,
+    )
+
+
+def test_laplace_shape_dtype():
+    check_shape_and_dtype(
+        lambda srng: srng.laplace(loc=0.0, scale=1.0, size=(7,)),
+        (7,),
+        "float32",
+    )
+
+
+def test_gumbel_shape_dtype():
+    check_shape_and_dtype(
+        lambda srng: srng.gumbel(loc=0.0, scale=1.0, size=(6,)),
+        (6,),
+        "float32",
+    )
+
+
+def test_integers_shape():
+    results = check_shape_and_dtype(
+        lambda srng: srng.integers(low=0, high=10, size=(12,)),
+        (12,),
+    )
+    r = np.array(results[0])
+    assert np.all(r >= 0)
+    assert np.all(r < 10)
+
+
+def test_permutation_shape():
+    x = np.arange(8, dtype=np.int32)
+    results = check_shape_and_dtype(
+        lambda srng: srng.permutation(x),
+        (8,),
+    )
+    assert sorted(np.array(results[0]).tolist()) == list(range(8))
+
+
+def test_gamma_not_implemented():
+    srng = RandomStream(seed=1)
+    rv = srng.gamma(shape=1.0, scale=1.0, size=(3,))
+    with pytest.raises(NotImplementedError, match="No MLX implementation"):
+        pytensor.function([], rv, mode="MLX", updates=srng.updates())
+
+
+def test_beta_not_implemented():
+    srng = RandomStream(seed=1)
+    rv = srng.beta(alpha=2.0, beta=5.0, size=(3,))
+    with pytest.raises(NotImplementedError, match="No MLX implementation"):
+        pytensor.function([], rv, mode="MLX", updates=srng.updates())

--- a/tests/link/mlx/test_random.py
+++ b/tests/link/mlx/test_random.py
@@ -166,6 +166,64 @@ def test_permutation_shape():
     assert sorted(np.array(results[0]).tolist()) == list(range(8))
 
 
+def test_lognormal_shape_dtype():
+    results = check_shape_and_dtype(
+        lambda srng: srng.lognormal(mu=0.0, sigma=1.0, size=(5,)),
+        (5,),
+        "float32",
+    )
+    r = np.array(results[0])
+    assert np.all(r > 0)
+
+
+def test_lognormal_scalar():
+    check_shape_and_dtype(
+        lambda srng: srng.lognormal(mu=0.0, sigma=1.0),
+        (),
+    )
+
+
+def test_halfnormal_shape_dtype():
+    check_shape_and_dtype(
+        lambda srng: srng.halfnormal(loc=0.0, scale=1.0, size=(4,)),
+        (4,),
+        "float32",
+    )
+
+
+def test_halfnormal_scalar():
+    check_shape_and_dtype(
+        lambda srng: srng.halfnormal(loc=0.0, scale=1.0),
+        (),
+    )
+
+
+def test_exponential_shape_dtype():
+    results = check_shape_and_dtype(
+        lambda srng: srng.exponential(scale=1.0, size=(6,)),
+        (6,),
+        "float32",
+    )
+    r = np.array(results[0])
+    assert np.all(r > 0)
+
+
+def test_logistic_shape_dtype():
+    check_shape_and_dtype(
+        lambda srng: srng.logistic(loc=0.0, scale=1.0, size=(7,)),
+        (7,),
+        "float32",
+    )
+
+
+def test_cauchy_shape_dtype():
+    check_shape_and_dtype(
+        lambda srng: srng.cauchy(loc=0.0, scale=1.0, size=(8,)),
+        (8,),
+        "float32",
+    )
+
+
 def test_gamma_not_implemented():
     srng = RandomStream(seed=1)
     rv = srng.gamma(shape=1.0, scale=1.0, size=(3,))

--- a/tests/link/mlx/test_random.py
+++ b/tests/link/mlx/test_random.py
@@ -21,18 +21,8 @@ def test_normal_cumsum():
 def check_shape_and_dtype(
     make_rv, expected_shape, expected_dtype=None, n_evals=2, mode="MLX"
 ):
-    """Compile and run an RV under MLX, assert shape and dtype, and verify
-    that two successive draws differ (RNG state is properly threaded).
-
-    Parameters
-    ----------
-    make_rv : callable(srng) -> rv_var
-        Factory that creates the RV using the provided RandomStream.
-    expected_shape : tuple
-    expected_dtype : str or None
-    n_evals : int
-    mode : str or Mode
-    """
+    """Compile and run an RV under MLX; assert shape/dtype and that successive
+    draws differ (RNG state is threaded)."""
     srng = RandomStream(seed=12345)
     rv = make_rv(srng)
     f = pytensor.function([], rv, mode=mode, updates=srng.updates())
@@ -185,9 +175,8 @@ def test_integers_shape():
 
 
 def test_integers_narrow_dtype_wraps():
-    # Bounds must be applied before the dtype cast: sampling [250, 300) and
-    # casting to uint8 wraps (regression for casting the bounds first, which
-    # collapsed the interval to a single value).
+    # Sampling [250, 300) then casting to uint8 must wrap (regression for
+    # casting the bounds first, which collapsed the interval to one value).
     r = np.array(
         pt.random.integers(low=250, high=300, size=(20_000,), dtype="uint8").eval(
             mode="MLX"

--- a/tests/link/mlx/test_random.py
+++ b/tests/link/mlx/test_random.py
@@ -91,17 +91,21 @@ def test_uniform_shape_dtype():
 
 
 def test_bernoulli_shape():
+    # MLX draws bools; the dispatch must cast back to the int dtype PyTensor declares.
     check_shape_and_dtype(
         lambda srng: srng.bernoulli(p=0.7, size=(5, 5)),
         (5, 5),
+        "int64",
     )
 
 
 def test_categorical_shape():
     probs = np.array([0.1, 0.4, 0.5], dtype=np.float32)
+    # MLX draws uint32; the dispatch must cast back to the int dtype PyTensor declares.
     results = check_shape_and_dtype(
         lambda srng: srng.categorical(p=probs, size=(8,)),
         (8,),
+        "int64",
     )
     r = np.array(results[0])
     assert np.all(r < 3)
@@ -131,6 +135,29 @@ def test_mvnormal_decomposition_method(method):
     )
 
 
+def test_mvnormal_batched_params_with_size():
+    # Batched covariances combined with an explicit ``size`` must broadcast
+    # rather than reshape a single matrix (regression for a reshape crash).
+    mean = np.zeros((2, 3), dtype=np.float32)
+    cov = np.stack([np.eye(3) * 0.01, np.eye(3) * 9.0]).astype(np.float32)
+    check_shape_and_dtype(
+        lambda srng: srng.multivariate_normal(mean=mean, cov=cov, size=(2,)),
+        (2, 3),
+        "float32",
+    )
+
+
+def test_mvnormal_empty_batch():
+    # An empty batch dim used to segfault the MLX compiled matmul path; it must
+    # return an empty array of the broadcast output shape instead.
+    mean = np.zeros(3, dtype=np.float32)
+    cov = np.eye(3, dtype=np.float32)
+    result = pt.random.multivariate_normal(mean=mean, cov=cov, size=(0,)).eval(
+        mode="MLX"
+    )
+    assert np.array(result).shape == (0, 3)
+
+
 def test_laplace_shape_dtype():
     check_shape_and_dtype(
         lambda srng: srng.laplace(loc=0.0, scale=1.0, size=(7,)),
@@ -155,6 +182,28 @@ def test_integers_shape():
     r = np.array(results[0])
     assert np.all(r >= 0)
     assert np.all(r < 10)
+
+
+def test_integers_narrow_dtype_wraps():
+    # Bounds must be applied before the dtype cast: sampling [250, 300) and
+    # casting to uint8 wraps (regression for casting the bounds first, which
+    # collapsed the interval to a single value).
+    r = np.array(
+        pt.random.integers(low=250, high=300, size=(20_000,), dtype="uint8").eval(
+            mode="MLX"
+        )
+    )
+    assert r.dtype == np.uint8
+    assert len(np.unique(r)) > 1
+
+
+def test_integers_wide_bounds():
+    # Default int64 draws must sample at full width, not MLX's default int32
+    # (regression for bounds above 2**31 piling up at the int32 max).
+    r = np.array(
+        pt.random.integers(low=0, high=3_000_000_000, size=(20_000,)).eval(mode="MLX")
+    )
+    assert r.max() > 2**31
 
 
 def test_permutation_shape():
@@ -198,6 +247,17 @@ def test_halfnormal_scalar():
     )
 
 
+def test_halfnormal_nonzero_loc():
+    # HalfNormal is ``loc + scale * |z|`` (support ``[loc, inf)``), not
+    # ``|loc + scale * z|``. Draw a large sample and check the support bound.
+    loc, scale = 5.0, 2.0
+    r = np.array(
+        pt.random.halfnormal(loc=loc, scale=scale, size=(100_000,)).eval(mode="MLX")
+    )
+    assert r.min() >= loc - 1e-4
+    assert abs(r.mean() - (loc + scale * np.sqrt(2 / np.pi))) < 0.1
+
+
 def test_exponential_shape_dtype():
     results = check_shape_and_dtype(
         lambda srng: srng.exponential(scale=1.0, size=(6,)),
@@ -222,6 +282,15 @@ def test_cauchy_shape_dtype():
         (8,),
         "float32",
     )
+
+
+def test_non_pcg64_generator_raises():
+    # Only PCG64 state can be folded into an MLX key; other bit generators must
+    # fail loudly rather than with an opaque KeyError.
+    from pytensor.link.mlx.dispatch.random import numpy_generator_to_mlx_key
+
+    with pytest.raises(NotImplementedError, match="PCG64"):
+        numpy_generator_to_mlx_key(np.random.Generator(np.random.MT19937(0)))
 
 
 def test_gamma_not_implemented():

--- a/tests/link/mlx/test_random.py
+++ b/tests/link/mlx/test_random.py
@@ -92,7 +92,7 @@ def test_uniform_values():
     results = check_shape_and_dtype(
         lambda srng: srng.uniform(low=0.0, high=1.0, size=(10,)),
         (10,),
-        "float32",
+        "float",
     )
     r = np.array(results[0])
     assert np.all(r >= 0.0)
@@ -117,7 +117,7 @@ def test_mvnormal_shape():
     check_shape_and_dtype(
         lambda srng: srng.multivariate_normal(mean=mean, cov=cov, size=(6,)),
         (6, 4),
-        "float32",
+        "float",
     )
 
 
@@ -130,7 +130,7 @@ def test_mvnormal_decomposition_method(method):
             mean=mean, cov=cov, size=(6,), method=method
         ),
         (6, 4),
-        "float32",
+        "float",
     )
 
 
@@ -142,7 +142,7 @@ def test_mvnormal_batched_params_with_size():
     check_shape_and_dtype(
         lambda srng: srng.multivariate_normal(mean=mean, cov=cov, size=(2,)),
         (2, 3),
-        "float32",
+        "float",
     )
 
 
@@ -201,7 +201,7 @@ def test_lognormal_shape_dtype():
     results = check_shape_and_dtype(
         lambda srng: srng.lognormal(mu=0.0, sigma=1.0, size=(5,)),
         (5,),
-        "float32",
+        "float",
     )
     r = np.array(results[0])
     assert np.all(r > 0)
@@ -222,7 +222,7 @@ def test_exponential_shape_dtype():
     results = check_shape_and_dtype(
         lambda srng: srng.exponential(scale=1.0, size=(6,)),
         (6,),
-        "float32",
+        "float",
     )
     r = np.array(results[0])
     assert np.all(r > 0)

--- a/tests/link/mlx/test_random.py
+++ b/tests/link/mlx/test_random.py
@@ -44,19 +44,33 @@ def check_shape_and_dtype(
     return results
 
 
-def test_normal_shape_dtype():
-    check_shape_and_dtype(
-        lambda srng: srng.normal(loc=0.0, scale=1.0, size=(3, 4)),
-        (3, 4),
-        "float32",
-    )
-
-
-def test_normal_scalar():
-    check_shape_and_dtype(
-        lambda srng: srng.normal(loc=2.0, scale=0.5),
-        (),
-    )
+@pytest.mark.parametrize(
+    "make_rv,expected_shape,expected_dtype",
+    [
+        (lambda srng: srng.normal(loc=0.0, scale=1.0, size=(3, 4)), (3, 4), "float32"),
+        (lambda srng: srng.normal(loc=2.0, scale=0.5), (), None),
+        (lambda srng: srng.uniform(low=0.0, high=1.0, size=(10,)), (10,), "float32"),
+        (lambda srng: srng.bernoulli(p=0.7, size=(5, 5)), (5, 5), "int64"),
+        (
+            lambda srng: srng.categorical(
+                p=np.array([0.1, 0.4, 0.5], dtype="float32"), size=(8,)
+            ),
+            (8,),
+            "int64",
+        ),
+        (lambda srng: srng.laplace(loc=0.0, scale=1.0, size=(7,)), (7,), "float32"),
+        (lambda srng: srng.gumbel(loc=0.0, scale=1.0, size=(6,)), (6,), "float32"),
+        (lambda srng: srng.lognormal(mu=0.0, sigma=1.0, size=(5,)), (5,), "float32"),
+        (lambda srng: srng.lognormal(mu=0.0, sigma=1.0), (), None),
+        (lambda srng: srng.halfnormal(loc=0.0, scale=1.0, size=(4,)), (4,), "float32"),
+        (lambda srng: srng.halfnormal(loc=0.0, scale=1.0), (), None),
+        (lambda srng: srng.exponential(scale=1.0, size=(6,)), (6,), "float32"),
+        (lambda srng: srng.logistic(loc=0.0, scale=1.0, size=(7,)), (7,), "float32"),
+        (lambda srng: srng.cauchy(loc=0.0, scale=1.0, size=(8,)), (8,), "float32"),
+    ],
+)
+def test_shape_dtype(make_rv, expected_shape, expected_dtype):
+    check_shape_and_dtype(make_rv, expected_shape, expected_dtype)
 
 
 def test_normal_array_params():
@@ -69,7 +83,7 @@ def test_normal_array_params():
     assert abs(means[1] - 1.0) < 0.3
 
 
-def test_uniform_shape_dtype():
+def test_uniform_values():
     results = check_shape_and_dtype(
         lambda srng: srng.uniform(low=0.0, high=1.0, size=(10,)),
         (10,),
@@ -80,18 +94,8 @@ def test_uniform_shape_dtype():
     assert np.all(r < 1.0)
 
 
-def test_bernoulli_shape():
-    # MLX draws bools; the dispatch must cast back to the int dtype PyTensor declares.
-    check_shape_and_dtype(
-        lambda srng: srng.bernoulli(p=0.7, size=(5, 5)),
-        (5, 5),
-        "int64",
-    )
-
-
-def test_categorical_shape():
+def test_categorical_values():
     probs = np.array([0.1, 0.4, 0.5], dtype=np.float32)
-    # MLX draws uint32; the dispatch must cast back to the int dtype PyTensor declares.
     results = check_shape_and_dtype(
         lambda srng: srng.categorical(p=probs, size=(8,)),
         (8,),
@@ -148,22 +152,6 @@ def test_mvnormal_empty_batch():
     assert np.array(result).shape == (0, 3)
 
 
-def test_laplace_shape_dtype():
-    check_shape_and_dtype(
-        lambda srng: srng.laplace(loc=0.0, scale=1.0, size=(7,)),
-        (7,),
-        "float32",
-    )
-
-
-def test_gumbel_shape_dtype():
-    check_shape_and_dtype(
-        lambda srng: srng.gumbel(loc=0.0, scale=1.0, size=(6,)),
-        (6,),
-        "float32",
-    )
-
-
 def test_integers_shape():
     results = check_shape_and_dtype(
         lambda srng: srng.integers(low=0, high=10, size=(12,)),
@@ -214,28 +202,6 @@ def test_lognormal_shape_dtype():
     assert np.all(r > 0)
 
 
-def test_lognormal_scalar():
-    check_shape_and_dtype(
-        lambda srng: srng.lognormal(mu=0.0, sigma=1.0),
-        (),
-    )
-
-
-def test_halfnormal_shape_dtype():
-    check_shape_and_dtype(
-        lambda srng: srng.halfnormal(loc=0.0, scale=1.0, size=(4,)),
-        (4,),
-        "float32",
-    )
-
-
-def test_halfnormal_scalar():
-    check_shape_and_dtype(
-        lambda srng: srng.halfnormal(loc=0.0, scale=1.0),
-        (),
-    )
-
-
 def test_halfnormal_nonzero_loc():
     # HalfNormal is ``loc + scale * |z|`` (support ``[loc, inf)``), not
     # ``|loc + scale * z|``. Draw a large sample and check the support bound.
@@ -257,22 +223,6 @@ def test_exponential_shape_dtype():
     assert np.all(r > 0)
 
 
-def test_logistic_shape_dtype():
-    check_shape_and_dtype(
-        lambda srng: srng.logistic(loc=0.0, scale=1.0, size=(7,)),
-        (7,),
-        "float32",
-    )
-
-
-def test_cauchy_shape_dtype():
-    check_shape_and_dtype(
-        lambda srng: srng.cauchy(loc=0.0, scale=1.0, size=(8,)),
-        (8,),
-        "float32",
-    )
-
-
 def test_non_pcg64_generator_raises():
     # Only PCG64 state can be folded into an MLX key; other bit generators must
     # fail loudly rather than with an opaque KeyError.
@@ -280,20 +230,6 @@ def test_non_pcg64_generator_raises():
 
     with pytest.raises(NotImplementedError, match="PCG64"):
         numpy_generator_to_mlx_key(np.random.Generator(np.random.MT19937(0)))
-
-
-def test_gamma_not_implemented():
-    srng = RandomStream(seed=1)
-    rv = srng.gamma(shape=1.0, scale=1.0, size=(3,))
-    with pytest.raises(NotImplementedError, match="No MLX implementation"):
-        pytensor.function([], rv, mode="MLX", updates=srng.updates())
-
-
-def test_beta_not_implemented():
-    srng = RandomStream(seed=1)
-    rv = srng.beta(alpha=2.0, beta=5.0, size=(3,))
-    with pytest.raises(NotImplementedError, match="No MLX implementation"):
-        pytensor.function([], rv, mode="MLX", updates=srng.updates())
 
 
 def compile_shared_rng_function(*args, mode="MLX", **kwargs):

--- a/tests/link/mlx/test_random.py
+++ b/tests/link/mlx/test_random.py
@@ -33,9 +33,14 @@ def check_shape_and_dtype(
             f"Expected shape {expected_shape}, got {r.shape}"
         )
         if expected_dtype is not None:
-            assert r.dtype == np.dtype(expected_dtype), (
-                f"Expected dtype {expected_dtype}, got {r.dtype}"
-            )
+            if expected_dtype == "float":
+                assert np.issubdtype(r.dtype, np.floating), (
+                    f"Expected a float dtype, got {r.dtype}"
+                )
+            else:
+                assert r.dtype == np.dtype(expected_dtype), (
+                    f"Expected dtype {expected_dtype}, got {r.dtype}"
+                )
 
     assert not np.array_equal(results[0], results[1]), (
         "Two draws were identical — RNG not advancing"
@@ -47,9 +52,9 @@ def check_shape_and_dtype(
 @pytest.mark.parametrize(
     "make_rv,expected_shape,expected_dtype",
     [
-        (lambda srng: srng.normal(loc=0.0, scale=1.0, size=(3, 4)), (3, 4), "float32"),
+        (lambda srng: srng.normal(loc=0.0, scale=1.0, size=(3, 4)), (3, 4), "float"),
         (lambda srng: srng.normal(loc=2.0, scale=0.5), (), None),
-        (lambda srng: srng.uniform(low=0.0, high=1.0, size=(10,)), (10,), "float32"),
+        (lambda srng: srng.uniform(low=0.0, high=1.0, size=(10,)), (10,), "float"),
         (lambda srng: srng.bernoulli(p=0.7, size=(5, 5)), (5, 5), "int64"),
         (
             lambda srng: srng.categorical(
@@ -58,15 +63,15 @@ def check_shape_and_dtype(
             (8,),
             "int64",
         ),
-        (lambda srng: srng.laplace(loc=0.0, scale=1.0, size=(7,)), (7,), "float32"),
-        (lambda srng: srng.gumbel(loc=0.0, scale=1.0, size=(6,)), (6,), "float32"),
-        (lambda srng: srng.lognormal(mu=0.0, sigma=1.0, size=(5,)), (5,), "float32"),
+        (lambda srng: srng.laplace(loc=0.0, scale=1.0, size=(7,)), (7,), "float"),
+        (lambda srng: srng.gumbel(loc=0.0, scale=1.0, size=(6,)), (6,), "float"),
+        (lambda srng: srng.lognormal(mu=0.0, sigma=1.0, size=(5,)), (5,), "float"),
         (lambda srng: srng.lognormal(mu=0.0, sigma=1.0), (), None),
-        (lambda srng: srng.halfnormal(loc=0.0, scale=1.0, size=(4,)), (4,), "float32"),
+        (lambda srng: srng.halfnormal(loc=0.0, scale=1.0, size=(4,)), (4,), "float"),
         (lambda srng: srng.halfnormal(loc=0.0, scale=1.0), (), None),
-        (lambda srng: srng.exponential(scale=1.0, size=(6,)), (6,), "float32"),
-        (lambda srng: srng.logistic(loc=0.0, scale=1.0, size=(7,)), (7,), "float32"),
-        (lambda srng: srng.cauchy(loc=0.0, scale=1.0, size=(8,)), (8,), "float32"),
+        (lambda srng: srng.exponential(scale=1.0, size=(6,)), (6,), "float"),
+        (lambda srng: srng.logistic(loc=0.0, scale=1.0, size=(7,)), (7,), "float"),
+        (lambda srng: srng.cauchy(loc=0.0, scale=1.0, size=(8,)), (8,), "float"),
     ],
 )
 def test_shape_dtype(make_rv, expected_shape, expected_dtype):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->

Basic support for `mlx` random generation.

```python
import pytensor.tensor as pt

data = pt.random.normal(size=(52, 3))

# Works now
data.eval(mode="MLX")
```

They have limited support. Missing Gamma distribution. Could support additional ones
with basic transformations. i.e. `pt.abs(pt.random.normal(...))` ~ Half Normal

MLX Reference: https://ml-explore.github.io/mlx/build/html/python/random.html 

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->