### PR TITLE
MLX Elementwise and scalar dispatches

### DIFF
--- a/pytensor/link/mlx/dispatch/__init__.py
+++ b/pytensor/link/mlx/dispatch/__init__.py
@@ -3,6 +3,7 @@ from pytensor.link.mlx.dispatch.basic import mlx_funcify, mlx_typify
 
 import pytensor.link.mlx.dispatch.math
 import pytensor.link.mlx.dispatch.basic
+import pytensor.link.mlx.dispatch.scalar
 import pytensor.link.mlx.dispatch.elemwise
 import pytensor.link.mlx.dispatch.shape
 import pytensor.link.mlx.dispatch.subtensor

--- a/pytensor/link/mlx/dispatch/elemwise.py
+++ b/pytensor/link/mlx/dispatch/elemwise.py
@@ -4,19 +4,15 @@ import mlx.core as mx
 import mlx.nn as mlx_nn
 import numpy as np
 
-from pytensor.link.mlx.dispatch.basic import convert_dtype_to_mlx, mlx_funcify
+from pytensor.link.mlx.dispatch.basic import mlx_funcify
 from pytensor.scalar.basic import (
     AND,
     OR,
     Add,
-    Cast,
-    Composite,
     Maximum,
     Minimum,
     Mul,
-    ScalarOp,
 )
-from pytensor.scalar.math import Erfc, Erfcx, Sigmoid, Softplus
 from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
 from pytensor.tensor.special import LogSoftmax, Softmax, SoftmaxGrad
 
@@ -128,153 +124,6 @@ def mlx_funcify_LogSoftmax(op, **kwargs):
         return mlx_nn.log_softmax(x, axis=axis)
 
     return log_softmax
-
-
-# MLX name overrides for nfunc_spec names that don't match mlx.core
-MLX_NFUNC_OVERRIDES = {
-    "true_divide": "divide",
-    "invert": "bitwise_invert",
-}
-
-
-@mlx_funcify.register(ScalarOp)
-def mlx_funcify_ScalarOp(op, node=None, **kwargs):
-    """Generic handler for scalar ops, using nfunc_spec for auto-resolution.
-
-    Most scalar ops have a ``nfunc_spec`` attribute like ``('add', 2, 1)`` that names the corresponding numpy function,
-    along with the number of inputs and outputs.
-    Since MLX mirrors numpy's API, we can resolve most ops via ``getattr(mx, name)``.
-    """
-    nfunc_spec = getattr(op, "nfunc_spec", None)
-    if nfunc_spec is None:
-        raise NotImplementedError(
-            f"No MLX conversion for scalar op {op}. "
-            "It has no nfunc_spec and no specific dispatch."
-        )
-
-    func_name = nfunc_spec[0]
-    # Strip scipy prefix — MLX doesn't have scipy submodules
-    if func_name.startswith("scipy."):
-        raise NotImplementedError(
-            f"No MLX conversion for scalar op {op} (scipy function: {func_name})"
-        )
-
-    func_name = MLX_NFUNC_OVERRIDES.get(func_name, func_name)
-    mlx_func = getattr(mx, func_name, None)
-    if mlx_func is None:
-        raise NotImplementedError(
-            f"No MLX conversion for scalar op {op} (mx.{func_name} not found)"
-        )
-
-    # Handle variadic ops (e.g. Add with 3+ inputs)
-    if node is not None and len(node.inputs) > nfunc_spec[1]:
-        variadic_name = getattr(op, "nfunc_variadic", None)
-        if variadic_name:
-            mlx_variadic_func = getattr(mx, variadic_name, None)
-            if mlx_variadic_func:
-
-                def variadic_fn(*args):
-                    return mlx_variadic_func(mx.stack(list(args), axis=0), axis=0)
-
-                return variadic_fn
-
-        # Fallback: fold binary op
-        def fold_fn(*args):
-            result = args[0]
-            for arg in args[1:]:
-                result = mlx_func(result, arg)
-            return result
-
-        return fold_fn
-
-    return mlx_func
-
-
-@mlx_funcify.register(Cast)
-def mlx_funcify_Cast(op, **kwargs):
-    # Cast can be called as a tensor-level op (op.scalar_op.o_type)
-    # or as a scalar op directly (op.o_type). Handle both.
-    scalar_op = getattr(op, "scalar_op", op)
-
-    def cast(x):
-        dtype = convert_dtype_to_mlx(scalar_op.o_type.dtype)
-        try:
-            return x.astype(dtype)
-        except ValueError as e:
-            if "is not supported on the GPU" in str(e):
-                import warnings
-
-                warnings.warn(
-                    f"MLX GPU limitation: {e}. Attempting automatic fallback casting.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-                fallback_dtype = convert_dtype_to_mlx(
-                    scalar_op.o_type.dtype, auto_cast_unsupported=True
-                )
-                return x.astype(fallback_dtype)
-            else:
-                raise
-
-    return cast
-
-
-@mlx_funcify.register(Sigmoid)
-def mlx_funcify_Sigmoid(op, **kwargs):
-    return mx.sigmoid
-
-
-@mlx_funcify.register(Erfc)
-def mlx_funcify_Erfc(op, **kwargs):
-    def erfc(x):
-        return 1.0 - mx.erf(x)
-
-    return erfc
-
-
-@mlx_funcify.register(Erfcx)
-def mlx_funcify_Erfcx(op, **kwargs):
-    def erfcx(x):
-        return mx.exp(x * x) * (1.0 - mx.erf(x))
-
-    return erfcx
-
-
-@mlx_funcify.register(Softplus)
-def mlx_funcify_Softplus(op, **kwargs):
-    def softplus(x):
-        return mx.where(
-            x < -37.0,
-            mx.exp(x),
-            mx.where(
-                x < 18.0,
-                mx.log1p(mx.exp(x)),
-                mx.where(
-                    x < 33.3,
-                    x + mx.exp(-x),
-                    x,
-                ),
-            ),
-        )
-
-    return softplus
-
-
-@mlx_funcify.register(Composite)
-def mlx_funcify_Composite(op, node=None, **kwargs):
-    mlx_impl = mlx_funcify(op.fgraph)
-
-    if len(op.fgraph.outputs) == 1:
-
-        def composite(*args):
-            return mlx_impl(*args)[0]
-
-    else:
-
-        def composite(*args):
-            return mlx_impl(*args)
-
-    return composite
 
 
 @mlx_funcify.register(Elemwise)

--- a/pytensor/link/mlx/dispatch/elemwise.py
+++ b/pytensor/link/mlx/dispatch/elemwise.py
@@ -10,6 +10,7 @@ from pytensor.scalar.basic import (
     OR,
     Add,
     Cast,
+    Composite,
     Maximum,
     Minimum,
     Mul,
@@ -257,6 +258,23 @@ def mlx_funcify_Softplus(op, **kwargs):
         )
 
     return softplus
+
+
+@mlx_funcify.register(Composite)
+def mlx_funcify_Composite(op, node=None, **kwargs):
+    mlx_impl = mlx_funcify(op.fgraph)
+
+    if len(op.fgraph.outputs) == 1:
+
+        def composite(*args):
+            return mlx_impl(*args)[0]
+
+    else:
+
+        def composite(*args):
+            return mlx_impl(*args)
+
+    return composite
 
 
 @mlx_funcify.register(Elemwise)

--- a/pytensor/link/mlx/dispatch/elemwise.py
+++ b/pytensor/link/mlx/dispatch/elemwise.py
@@ -7,36 +7,13 @@ import numpy as np
 from pytensor.link.mlx.dispatch.basic import convert_dtype_to_mlx, mlx_funcify
 from pytensor.scalar.basic import (
     AND,
-    EQ,
-    GE,
-    GT,
-    LE,
-    LT,
-    NEQ,
     OR,
-    Abs,
     Add,
     Cast,
-    Cos,
-    Exp,
-    IntDiv,
-    Invert,
-    IsInf,
-    IsNan,
-    Log,
-    Log1p,
     Maximum,
     Minimum,
     Mul,
-    Neg,
-    Pow,
-    Sign,
-    Sin,
-    Sqr,
-    Sqrt,
-    Sub,
-    Switch,
-    TrueDiv,
+    ScalarOp,
 )
 from pytensor.scalar.math import Erfc, Erfcx, Sigmoid, Softplus
 from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
@@ -152,6 +129,116 @@ def mlx_funcify_LogSoftmax(op, **kwargs):
     return log_softmax
 
 
+# MLX name overrides for nfunc_spec names that don't match mlx.core
+MLX_NFUNC_OVERRIDES = {
+    "true_divide": "divide",
+    "invert": "bitwise_invert",
+}
+
+
+@mlx_funcify.register(ScalarOp)
+def mlx_funcify_ScalarOp(op, node=None, **kwargs):
+    """Generic handler for scalar ops, using nfunc_spec for auto-resolution.
+
+    Most scalar ops have a ``nfunc_spec`` attribute like ``('add', 2, 1)`` that names the corresponding numpy function,
+    along with the number of inputs and outputs.
+    Since MLX mirrors numpy's API, we can resolve most ops via ``getattr(mx, name)``.
+    """
+    nfunc_spec = getattr(op, "nfunc_spec", None)
+    if nfunc_spec is None:
+        raise NotImplementedError(
+            f"No MLX conversion for scalar op {op}. "
+            "It has no nfunc_spec and no specific dispatch."
+        )
+
+    func_name = nfunc_spec[0]
+    # Strip scipy prefix — MLX doesn't have scipy submodules
+    if func_name.startswith("scipy."):
+        raise NotImplementedError(
+            f"No MLX conversion for scalar op {op} (scipy function: {func_name})"
+        )
+
+    func_name = MLX_NFUNC_OVERRIDES.get(func_name, func_name)
+    mlx_func = getattr(mx, func_name, None)
+    if mlx_func is None:
+        raise NotImplementedError(
+            f"No MLX conversion for scalar op {op} (mx.{func_name} not found)"
+        )
+
+    # Handle variadic ops (e.g. Add with 3+ inputs)
+    if node is not None and len(node.inputs) > nfunc_spec[1]:
+        variadic_name = getattr(op, "nfunc_variadic", None)
+        if variadic_name:
+            mlx_variadic_func = getattr(mx, variadic_name, None)
+            if mlx_variadic_func:
+
+                def variadic_fn(*args):
+                    return mlx_variadic_func(mx.stack(list(args), axis=0), axis=0)
+
+                return variadic_fn
+
+        # Fallback: fold binary op
+        def fold_fn(*args):
+            result = args[0]
+            for arg in args[1:]:
+                result = mlx_func(result, arg)
+            return result
+
+        return fold_fn
+
+    return mlx_func
+
+
+@mlx_funcify.register(Cast)
+def mlx_funcify_Cast(op, **kwargs):
+    # Cast can be called as a tensor-level op (op.scalar_op.o_type)
+    # or as a scalar op directly (op.o_type). Handle both.
+    scalar_op = getattr(op, "scalar_op", op)
+
+    def cast(x):
+        dtype = convert_dtype_to_mlx(scalar_op.o_type.dtype)
+        try:
+            return x.astype(dtype)
+        except ValueError as e:
+            if "is not supported on the GPU" in str(e):
+                import warnings
+
+                warnings.warn(
+                    f"MLX GPU limitation: {e}. Attempting automatic fallback casting.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                fallback_dtype = convert_dtype_to_mlx(
+                    scalar_op.o_type.dtype, auto_cast_unsupported=True
+                )
+                return x.astype(fallback_dtype)
+            else:
+                raise
+
+    return cast
+
+
+@mlx_funcify.register(Sigmoid)
+def mlx_funcify_Sigmoid(op, **kwargs):
+    return mx.sigmoid
+
+
+@mlx_funcify.register(Erfc)
+def mlx_funcify_Erfc(op, **kwargs):
+    def erfc(x):
+        return 1.0 - mx.erf(x)
+
+    return erfc
+
+
+@mlx_funcify.register(Erfcx)
+def mlx_funcify_Erfcx(op, **kwargs):
+    def erfcx(x):
+        return mx.exp(x * x) * (1.0 - mx.erf(x))
+
+    return erfcx
+
+
 @mlx_funcify.register(Softplus)
 def mlx_funcify_Softplus(op, **kwargs):
     def softplus(x):
@@ -172,285 +259,7 @@ def mlx_funcify_Softplus(op, **kwargs):
     return softplus
 
 
-@mlx_funcify.register(Cast)
-def mlx_funcify_Cast(op, **kwargs):
-    def cast(x):
-        dtype = convert_dtype_to_mlx(op.scalar_op.o_type.dtype)
-        try:
-            return x.astype(dtype)
-        except ValueError as e:
-            if "is not supported on the GPU" in str(e):
-                # MLX GPU limitation - try auto-casting with warning
-                import warnings
-
-                warnings.warn(
-                    f"MLX GPU limitation: {e}. Attempting automatic fallback casting.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-                # Get the auto-cast version
-                fallback_dtype = convert_dtype_to_mlx(
-                    op.scalar_op.o_type.dtype, auto_cast_unsupported=True
-                )
-                return x.astype(fallback_dtype)
-            else:
-                # Re-raise other ValueError exceptions
-                raise
-
-    return cast
-
-
-@singledispatch
-def mlx_funcify_Elemwise_scalar_op(scalar_op):
-    """Simplified implementation for MLX scalar operations."""
-
-    # Try using the operation name directly (most common case)
-    op_name = getattr(scalar_op, "name", None)
-    if op_name is not None:
-        try:
-            mlx_func = getattr(mx, op_name)
-            # Handle variadic functions like Add
-            if hasattr(scalar_op, "inputs") and len(scalar_op.inputs) > 2:
-
-                def variadic_func(*args):
-                    result = args[0]
-                    for arg in args[1:]:
-                        result = mlx_func(result, arg)
-                    return result
-
-                return variadic_func
-            else:
-                return mlx_func
-        except AttributeError:
-            pass
-
-    raise NotImplementedError(f"MLX does not support Elemwise scalar op {scalar_op}")
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Add)
-def mlx_funcify_Elemwise_scalar_Add(scalar_op):
-    def add(*args):
-        result = args[0]
-        for arg in args[1:]:
-            result = mx.add(result, arg)
-        return result
-
-    return add
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Sub)
-def mlx_funcify_Elemwise_scalar_Sub(scalar_op):
-    return mx.subtract
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Mul)
-def mlx_funcify_Elemwise_scalar_Mul(scalar_op):
-    def mul(*args):
-        result = args[0]
-        for arg in args[1:]:
-            result = mx.multiply(result, arg)
-        return result
-
-    return mul
-
-
-@mlx_funcify_Elemwise_scalar_op.register(TrueDiv)
-def mlx_funcify_Elemwise_scalar_TrueDiv(scalar_op):
-    return mx.divide
-
-
-@mlx_funcify_Elemwise_scalar_op.register(IntDiv)
-def mlx_funcify_Elemwise_scalar_IntDiv(scalar_op):
-    return mx.floor_divide
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Pow)
-def mlx_funcify_Elemwise_scalar_Pow(scalar_op):
-    return mx.power
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Exp)
-def mlx_funcify_Elemwise_scalar_Exp(scalar_op):
-    return mx.exp
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Log)
-def mlx_funcify_Elemwise_scalar_Log(scalar_op):
-    return mx.log
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Log1p)
-def mlx_funcify_Elemwise_scalar_Log1p(scalar_op):
-    return mx.log1p
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Sin)
-def mlx_funcify_Elemwise_scalar_Sin(scalar_op):
-    return mx.sin
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Cos)
-def mlx_funcify_Elemwise_scalar_Cos(scalar_op):
-    return mx.cos
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Sqrt)
-def mlx_funcify_Elemwise_scalar_Sqrt(scalar_op):
-    return mx.sqrt
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Sqr)
-def mlx_funcify_Elemwise_scalar_Sqr(scalar_op):
-    return mx.square
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Abs)
-def mlx_funcify_Elemwise_scalar_Abs(scalar_op):
-    return mx.abs
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Neg)
-def mlx_funcify_Elemwise_scalar_Neg(scalar_op):
-    return mx.negative
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Sign)
-def mlx_funcify_Elemwise_scalar_Sign(scalar_op):
-    return mx.sign
-
-
-@mlx_funcify_Elemwise_scalar_op.register(LE)
-def mlx_funcify_Elemwise_scalar_LE(scalar_op):
-    return mx.less_equal
-
-
-@mlx_funcify_Elemwise_scalar_op.register(LT)
-def mlx_funcify_Elemwise_scalar_LT(scalar_op):
-    return mx.less
-
-
-@mlx_funcify_Elemwise_scalar_op.register(GE)
-def mlx_funcify_Elemwise_scalar_GE(scalar_op):
-    return mx.greater_equal
-
-
-@mlx_funcify_Elemwise_scalar_op.register(GT)
-def mlx_funcify_Elemwise_scalar_GT(scalar_op):
-    return mx.greater
-
-
-@mlx_funcify_Elemwise_scalar_op.register(EQ)
-def mlx_funcify_Elemwise_scalar_EQ(scalar_op):
-    return mx.equal
-
-
-@mlx_funcify_Elemwise_scalar_op.register(NEQ)
-def mlx_funcify_Elemwise_scalar_NEQ(scalar_op):
-    return mx.not_equal
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Switch)
-def mlx_funcify_Elemwise_scalar_Switch(scalar_op):
-    return mx.where
-
-
-@mlx_funcify_Elemwise_scalar_op.register(AND)
-def mlx_funcify_Elemwise_scalar_AND(scalar_op):
-    return mx.bitwise_and
-
-
-@mlx_funcify_Elemwise_scalar_op.register(OR)
-def mlx_funcify_Elemwise_scalar_OR(scalar_op):
-    return mx.bitwise_or
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Maximum)
-def mlx_funcify_Elemwise_scalar_Maximum(scalar_op):
-    return mx.maximum
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Minimum)
-def mlx_funcify_Elemwise_scalar_Minimum(scalar_op):
-    return mx.minimum
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Cast)
-def mlx_funcify_Elemwise_scalar_Cast(scalar_op):
-    def cast(x):
-        dtype = convert_dtype_to_mlx(scalar_op.o_type.dtype)
-        try:
-            return x.astype(dtype)
-        except ValueError as e:
-            if "is not supported on the GPU" in str(e):
-                import warnings
-
-                warnings.warn(
-                    f"MLX GPU limitation: {e}. Attempting automatic fallback casting.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-                fallback_dtype = convert_dtype_to_mlx(
-                    scalar_op.o_type.dtype, auto_cast_unsupported=True
-                )
-                return x.astype(fallback_dtype)
-            else:
-                raise e
-
-    return cast
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Sigmoid)
-def mlx_funcify_Elemwise_scalar_Sigmoid(scalar_op):
-    return mx.sigmoid
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Invert)
-def mlx_funcify_Elemwise_scalar_Invert(scalar_op):
-    return mx.bitwise_invert
-
-
-@mlx_funcify_Elemwise_scalar_op.register(IsNan)
-def mlx_funcify_Elemwise_scalar_IsNan(scalar_op):
-    return mx.isnan
-
-
-@mlx_funcify_Elemwise_scalar_op.register(IsInf)
-def mlx_funcify_Elemwise_scalar_IsInf(scalar_op):
-    return mx.isinf
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Erfc)
-def mlx_funcify_Elemwise_scalar_Erfc(scalar_op):
-    def erfc(x):
-        return 1.0 - mx.erf(x)
-
-    return erfc
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Erfcx)
-def mlx_funcify_Elemwise_scalar_Erfcx(scalar_op):
-    def erfcx(x):
-        return mx.exp(x * x) * (1.0 - mx.erf(x))
-
-    return erfcx
-
-
-@mlx_funcify_Elemwise_scalar_op.register(Softplus)
-def mlx_funcify_Elemwise_scalar_softplus(scalar_op):
-    def softplus(x):
-        # Numerically stable implementation of log(1 + exp(x))
-        # Following the same logic as the original PyTensor implementation
-        return mx.where(
-            x < -37.0,
-            mx.exp(x),
-            mx.where(
-                x < 18.0, mx.log1p(mx.exp(x)), mx.where(x < 33.3, x + mx.exp(-x), x)
-            ),
-        )
-
-    return softplus
-
-
 @mlx_funcify.register(Elemwise)
 def mlx_funcify_Elemwise(op, node, **kwargs):
-    return mlx_funcify_Elemwise_scalar_op(op.scalar_op)
+    scalar_op = op.scalar_op
+    return mlx_funcify(scalar_op, node=node, **kwargs)

--- a/pytensor/link/mlx/dispatch/scalar.py
+++ b/pytensor/link/mlx/dispatch/scalar.py
@@ -5,6 +5,7 @@ from pytensor.scalar.basic import (
     Cast,
     Composite,
     Identity,
+    Mod,
     ScalarOp,
     Second,
 )
@@ -95,6 +96,15 @@ def mlx_funcify_Cast(op, **kwargs):
                 raise
 
     return cast
+
+
+@mlx_funcify.register(Mod)
+def mlx_funcify_Mod(op, **kwargs):
+    def mlx_mod(x, y):
+        _, res = mx.divmod(x, y)
+        return res
+
+    return mlx_mod
 
 
 @mlx_funcify.register(Identity)

--- a/pytensor/link/mlx/dispatch/scalar.py
+++ b/pytensor/link/mlx/dispatch/scalar.py
@@ -1,0 +1,141 @@
+import mlx.core as mx
+
+from pytensor.link.mlx.dispatch.basic import convert_dtype_to_mlx, mlx_funcify
+from pytensor.scalar.basic import Cast, Composite, Identity, Mod, ScalarOp, Second
+from pytensor.scalar.math import Erfc, Erfcx, Log1mexp, Sigmoid, Softplus
+
+
+# MLX name overrides for nfunc_spec names that don't match mlx.core
+MLX_NFUNC_OVERRIDES = {
+    "true_divide": "divide",
+    "invert": "bitwise_invert",
+}
+
+
+@mlx_funcify.register(ScalarOp)
+def mlx_funcify_ScalarOp(op, node=None, **kwargs):
+    """Generic handler for scalar ops, using nfunc_spec for auto-resolution.
+
+    Most scalar ops have a ``nfunc_spec`` attribute like ``('add', 2, 1)`` that
+    names the corresponding numpy function, along with the number of inputs and
+    outputs. Since MLX mirrors numpy's API, we resolve most ops via
+    ``getattr(mx, name)``.
+    """
+    nfunc_spec = getattr(op, "nfunc_spec", None)
+    if nfunc_spec is None:
+        raise NotImplementedError(
+            f"No MLX conversion for scalar op {op}. "
+            "It has no nfunc_spec and no specific dispatch."
+        )
+
+    func_name = nfunc_spec[0]
+    # MLX doesn't have scipy submodules
+    if func_name.startswith("scipy."):
+        raise NotImplementedError(
+            f"No MLX conversion for scalar op {op} (scipy function: {func_name})"
+        )
+
+    func_name = MLX_NFUNC_OVERRIDES.get(func_name, func_name)
+    mlx_func = getattr(mx, func_name, None)
+    if mlx_func is None:
+        raise NotImplementedError(
+            f"No MLX conversion for scalar op {op} (mx.{func_name} not found)"
+        )
+
+    # Handle variadic ops (e.g. Add with 3+ inputs)
+    if node is not None and len(node.inputs) > nfunc_spec[1]:
+        variadic_name = getattr(op, "nfunc_variadic", None)
+        if variadic_name:
+            mlx_variadic_func = getattr(mx, variadic_name, None)
+            if mlx_variadic_func:
+
+                def variadic_fn(*args):
+                    return mlx_variadic_func(mx.stack(list(args), axis=0), axis=0)
+
+                return variadic_fn
+
+        # Fallback: fold binary op
+        def fold_fn(*args):
+            result = args[0]
+            for arg in args[1:]:
+                result = mlx_func(result, arg)
+            return result
+
+        return fold_fn
+
+    return mlx_func
+
+
+@mlx_funcify.register(Cast)
+def mlx_funcify_Cast(op, **kwargs):
+    # Cast can be called as a tensor-level op (op.scalar_op.o_type)
+    # or as a scalar op directly (op.o_type). Handle both.
+    scalar_op = getattr(op, "scalar_op", op)
+
+    def cast(x):
+        dtype = convert_dtype_to_mlx(scalar_op.o_type.dtype)
+        try:
+            return x.astype(dtype)
+        except ValueError as e:
+            if "is not supported on the GPU" in str(e):
+                import warnings
+
+                warnings.warn(
+                    f"MLX GPU limitation: {e}. Attempting automatic fallback casting.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                fallback_dtype = convert_dtype_to_mlx(
+                    scalar_op.o_type.dtype, auto_cast_unsupported=True
+                )
+                return x.astype(fallback_dtype)
+            else:
+                raise
+
+    return cast
+
+
+@mlx_funcify.register(Sigmoid)
+def mlx_funcify_Sigmoid(op, **kwargs):
+    return mx.sigmoid
+
+
+@mlx_funcify.register(Erfc)
+def mlx_funcify_Erfc(op, **kwargs):
+    def erfc(x):
+        return 1.0 - mx.erf(x)
+
+    return erfc
+
+
+@mlx_funcify.register(Erfcx)
+def mlx_funcify_Erfcx(op, **kwargs):
+    def erfcx(x):
+        return mx.exp(x * x) * (1.0 - mx.erf(x))
+
+    return erfcx
+
+
+@mlx_funcify.register(Softplus)
+def mlx_funcify_Softplus(op, **kwargs):
+    def softplus(x):
+        return mx.where(
+            x < -37.0,
+            mx.exp(x),
+            mx.where(
+                x < 18.0,
+                mx.log1p(mx.exp(x)),
+                mx.where(
+                    x < 33.3,
+                    x + mx.exp(-x),
+                    x,
+                ),
+            ),
+        )
+
+    return softplus
+
+
+@mlx_funcify.register(Composite)
+def mlx_funcify_Composite(op, node=None, **kwargs):
+    return mlx_funcify(op.fgraph, squeeze_output=True)

--- a/pytensor/link/mlx/dispatch/scalar.py
+++ b/pytensor/link/mlx/dispatch/scalar.py
@@ -1,8 +1,13 @@
 import mlx.core as mx
 
 from pytensor.link.mlx.dispatch.basic import convert_dtype_to_mlx, mlx_funcify
-from pytensor.scalar.basic import Cast, Composite, Identity, Mod, ScalarOp, Second
-from pytensor.scalar.math import Erfc, Erfcx, Log1mexp, Sigmoid, Softplus
+from pytensor.scalar.basic import (
+    Cast,
+    Composite,
+    ScalarOp,
+    Second,
+)
+from pytensor.scalar.math import Erfc, Erfcx, Sigmoid, Softplus
 
 
 # MLX name overrides for nfunc_spec names that don't match mlx.core
@@ -93,6 +98,17 @@ def mlx_funcify_Cast(op, **kwargs):
                 raise
 
     return cast
+
+
+@mlx_funcify.register(Second)
+def mlx_funcify_Second(op, **kwargs):
+    def second(x, y):
+        x = mx.array(x)
+        y = mx.array(y)
+        _, out = mx.broadcast_arrays(x, y)
+        return out
+
+    return second
 
 
 @mlx_funcify.register(Sigmoid)

--- a/pytensor/link/mlx/dispatch/scalar.py
+++ b/pytensor/link/mlx/dispatch/scalar.py
@@ -4,6 +4,7 @@ from pytensor.link.mlx.dispatch.basic import convert_dtype_to_mlx, mlx_funcify
 from pytensor.scalar.basic import (
     Cast,
     Composite,
+    Identity,
     ScalarOp,
     Second,
 )
@@ -98,6 +99,14 @@ def mlx_funcify_Cast(op, **kwargs):
                 raise
 
     return cast
+
+
+@mlx_funcify.register(Identity)
+def mlx_funcify_Identity(op, **kwargs):
+    def identity(x):
+        return x
+
+    return identity
 
 
 @mlx_funcify.register(Second)

--- a/pytensor/link/mlx/dispatch/scalar.py
+++ b/pytensor/link/mlx/dispatch/scalar.py
@@ -9,7 +9,7 @@ from pytensor.scalar.basic import (
     ScalarOp,
     Second,
 )
-from pytensor.scalar.math import Erfc, Erfcx, Sigmoid, Softplus
+from pytensor.scalar.math import Erfc, Erfcx, Log1mexp, Sigmoid, Softplus
 
 
 # MLX name overrides for nfunc_spec names that don't match mlx.core
@@ -165,6 +165,14 @@ def mlx_funcify_Softplus(op, **kwargs):
         )
 
     return softplus
+
+
+@mlx_funcify.register(Log1mexp)
+def mlx_funcify_Log1mexp(op, node, **kwargs):
+    def log1mexp(x):
+        return mx.where(x < mx.log(0.5), mx.log1p(-mx.exp(x)), mx.log(-mx.expm1(x)))
+
+    return log1mexp
 
 
 @mlx_funcify.register(Composite)

--- a/pytensor/link/mlx/dispatch/scalar.py
+++ b/pytensor/link/mlx/dispatch/scalar.py
@@ -34,12 +34,8 @@ def mlx_funcify_ScalarOp(op, node=None, **kwargs):
             "It has no nfunc_spec and no specific dispatch."
         )
 
-    func_name = nfunc_spec[0]
-    # MLX doesn't have scipy submodules
-    if func_name.startswith("scipy."):
-        raise NotImplementedError(
-            f"No MLX conversion for scalar op {op} (scipy function: {func_name})"
-        )
+    # MLX doesn't have scipy submodules, everything is in the main mlx.core namespace
+    func_name = nfunc_spec[0].removeprefix("scipy.special.")
 
     func_name = MLX_NFUNC_OVERRIDES.get(func_name, func_name)
     mlx_func = getattr(mx, func_name, None)

--- a/pytensor/link/mlx/linker.py
+++ b/pytensor/link/mlx/linker.py
@@ -7,7 +7,7 @@ class MLXLinker(JITLinker):
     incompatible_rewrites = (
         "cxx_only",
         "BlasOpt",
-        "fusion",
+        "local_careduce_fusion",
         "inplace",
         "scan_save_mem_prealloc",
     )

--- a/tests/link/mlx/test_scalar.py
+++ b/tests/link/mlx/test_scalar.py
@@ -7,11 +7,17 @@ from pytensor.configdefaults import config
 from pytensor.graph.fg import FunctionGraph
 from pytensor.scalar.basic import Composite
 from pytensor.tensor.elemwise import Elemwise
+from pytensor.tensor.math import all as pt_all
 from pytensor.tensor.math import (
+    cosh,
     erf,
     erfc,
     erfcx,
     erfinv,
+    log,
+    log1mexp,
+    sigmoid,
+    softplus,
 )
 from pytensor.tensor.type import matrix, scalar, vector
 from tests.link.mlx.test_basic import compare_mlx_and_py
@@ -128,3 +134,107 @@ def test_erfcx():
     x = scalar("x")
     out = erfcx(x)
     compare_mlx_and_py([x], [out], [0.7])
+
+
+def test_log1mexp():
+    x = vector("x")
+    out = log1mexp(x)
+
+    compare_mlx_and_py([x], [out], [[-1.0, -0.75, -0.5, -0.25]])
+
+
+def test_nnet():
+    x = vector("x")
+    x_test_value = np.r_[1.0, 2.0].astype(config.floatX)
+
+    out = sigmoid(x)
+    compare_mlx_and_py([x], [out], [x_test_value])
+
+    out = softplus(x)
+    compare_mlx_and_py([x], [out], [x_test_value])
+
+
+def test_mlx_variadic_Scalar():
+    mu = vector("mu", dtype=config.floatX)
+    mu_test_value = np.r_[0.1, 1.1].astype(config.floatX)
+    tau = vector("tau", dtype=config.floatX)
+    tau_test_value = np.r_[1.0, 2.0].astype(config.floatX)
+
+    res = -tau * mu
+
+    compare_mlx_and_py([mu, tau], [res], [mu_test_value, tau_test_value])
+
+    res = -tau * (tau - mu) ** 2
+
+    compare_mlx_and_py([mu, tau], [res], [mu_test_value, tau_test_value])
+
+
+def test_add_scalars():
+    x = pt.matrix("x")
+    size = x.shape[0] + x.shape[0] + x.shape[1]
+    out = pt.ones(size).astype(config.floatX)
+
+    compare_mlx_and_py([x], [out], [np.ones((2, 3)).astype(config.floatX)])
+
+
+def test_mul_scalars():
+    x = pt.matrix("x")
+    size = x.shape[0] * x.shape[0] * x.shape[1]
+    out = pt.ones(size).astype(config.floatX)
+
+    compare_mlx_and_py([x], [out], [np.ones((2, 3)).astype(config.floatX)])
+
+
+def test_div_scalars():
+    x = pt.matrix("x")
+    size = x.shape[0] // x.shape[1]
+    out = pt.ones(size).astype(config.floatX)
+
+    compare_mlx_and_py([x], [out], [np.ones((12, 3)).astype(config.floatX)])
+
+
+def test_mod_scalars():
+    x = pt.matrix("x")
+    size = x.shape[0] % x.shape[1]
+    out = pt.ones(size).astype(config.floatX)
+
+    compare_mlx_and_py([x], [out], [np.ones((12, 3)).astype(config.floatX)])
+
+
+def test_mlx_multioutput():
+    x = vector("x")
+    x_test_value = np.r_[1.0, 2.0].astype(config.floatX)
+    y = vector("y")
+    y_test_value = np.r_[3.0, 4.0].astype(config.floatX)
+
+    w = cosh(x**2 + y / 3.0)
+    v = cosh(x / 3.0 + y**2)
+
+    compare_mlx_and_py([x, y], [w, v], [x_test_value, y_test_value])
+
+
+def test_mlx_logp():
+    mu = vector("mu")
+    mu_test_value = np.r_[0.0, 0.0].astype(config.floatX)
+    tau = vector("tau")
+    tau_test_value = np.r_[1.0, 1.0].astype(config.floatX)
+    sigma = vector("sigma")
+    sigma_test_value = (1.0 / tau_test_value).astype(config.floatX)
+    value = vector("value")
+    value_test_value = np.r_[0.1, -10].astype(config.floatX)
+
+    logp = (-tau * (value - mu) ** 2 + log(tau / np.pi / 2.0)) / 2.0
+    conditions = [sigma > 0]
+    alltrue = pt_all([pt_all(1 * val) for val in conditions])
+    normal_logp = pt.switch(alltrue, logp, -np.inf)
+
+    compare_mlx_and_py(
+        [mu, tau, sigma, value],
+        [normal_logp],
+        [
+            mu_test_value,
+            tau_test_value,
+            sigma_test_value,
+            value_test_value,
+        ],
+    )

--- a/tests/link/mlx/test_scalar.py
+++ b/tests/link/mlx/test_scalar.py
@@ -7,6 +7,12 @@ from pytensor.configdefaults import config
 from pytensor.graph.fg import FunctionGraph
 from pytensor.scalar.basic import Composite
 from pytensor.tensor.elemwise import Elemwise
+from pytensor.tensor.math import (
+    erf,
+    erfc,
+    erfcx,
+    erfinv,
+)
 from pytensor.tensor.type import matrix, scalar, vector
 from tests.link.mlx.test_basic import compare_mlx_and_py
 
@@ -98,3 +104,27 @@ def test_mlx_Composite_multi_output():
         outs,
         [np.arange(10, dtype=config.floatX)],
     )
+
+
+def test_erf():
+    x = scalar("x")
+    out = erf(x)
+    compare_mlx_and_py([x], [out], [1.0])
+
+
+def test_erfc():
+    x = scalar("x")
+    out = erfc(x)
+    compare_mlx_and_py([x], [out], [1.0])
+
+
+def test_erfinv():
+    x = scalar("x")
+    out = erfinv(x)
+    compare_mlx_and_py([x], [out], [0.95])
+
+
+def test_erfcx():
+    x = scalar("x")
+    out = erfcx(x)
+    compare_mlx_and_py([x], [out], [0.7])

--- a/tests/link/mlx/test_scalar.py
+++ b/tests/link/mlx/test_scalar.py
@@ -1,0 +1,100 @@
+import numpy as np
+import pytest
+
+import pytensor.scalar.basic as ps
+import pytensor.tensor as pt
+from pytensor.configdefaults import config
+from pytensor.graph.fg import FunctionGraph
+from pytensor.scalar.basic import Composite
+from pytensor.tensor.elemwise import Elemwise
+from pytensor.tensor.type import matrix, scalar, vector
+from tests.link.mlx.test_basic import compare_mlx_and_py
+
+
+mlx = pytest.importorskip("mlx.core")
+from pytensor.link.mlx.dispatch import mlx_funcify
+
+
+def test_second():
+    a0 = scalar("a0")
+    b = scalar("b")
+
+    out = ps.second(a0, b)
+    compare_mlx_and_py([a0, b], [out], [10.0, 5.0])
+
+    a1 = vector("a1")
+    out = pt.second(a1, b)
+    compare_mlx_and_py([a1, b], [out], [np.zeros([5], dtype=config.floatX), 5.0])
+
+    a2 = matrix("a2", shape=(1, None), dtype="float64")
+    b2 = matrix("b2", shape=(None, 1), dtype="int32")
+    out = pt.second(a2, b2)
+    compare_mlx_and_py(
+        [a2, b2],
+        [out],
+        [np.zeros((1, 3), dtype="float64"), np.ones((5, 1), dtype="int32")],
+    )
+
+
+def test_second_constant_scalar():
+    b = scalar("b", dtype="int32")
+    out = pt.second(0.0, b)
+    fgraph = FunctionGraph([b], [out])
+    # Test dispatch directly as useless second is removed during compilation
+    fn = mlx_funcify(fgraph)
+    [res] = fn(1)
+    assert res == 1
+
+    # Cast to numpy to get compariable dtypes
+    assert np.array(res).dtype == out.dtype
+
+
+def test_identity():
+    a = scalar("a")
+    a_test_value = 10
+
+    out = ps.identity(a)
+    compare_mlx_and_py([a], [out], [a_test_value])
+
+
+@pytest.mark.parametrize(
+    "x, y, x_val, y_val",
+    [
+        (scalar("x"), scalar("y"), np.array(10), np.array(20)),
+        (scalar("x"), vector("y"), np.array(10), np.arange(10, 20)),
+        (
+            matrix("x"),
+            vector("y"),
+            np.arange(10 * 20).reshape((20, 10)),
+            np.arange(10, 20),
+        ),
+    ],
+)
+def test_mlx_Composite_singe_output(x, y, x_val, y_val):
+    x_s = ps.float64("x")
+    y_s = ps.float64("y")
+
+    # Change exp -> cos relative to the JAX test, because exp overflows in float32 mode (MLX default)
+    comp_op = Elemwise(Composite([x_s, y_s], [x_s + y_s * 2 + ps.cos(x_s - y_s)]))
+
+    out = comp_op(x, y)
+
+    test_input_vals = [
+        x_val.astype(config.floatX),
+        y_val.astype(config.floatX),
+    ]
+
+    _ = compare_mlx_and_py([x, y], [out], test_input_vals)
+
+
+def test_mlx_Composite_multi_output():
+    x = vector("x")
+
+    x_s = ps.float64("xs")
+    outs = Elemwise(Composite(inputs=[x_s], outputs=[x_s + 1, x_s - 1]))(x)
+
+    compare_mlx_and_py(
+        [x],
+        outs,
+        [np.arange(10, dtype=config.floatX)],
+    )


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
Some simple/boring stuff for the MLX backend:

- Refactor scalar dispatches to copy the JAX template. We use `nfunc_name` to look in the `mx` namespace and get everything we can. There's a dictionary of overrides for stuff that doesn't follow the array standard (`invert` is `bitwise_invert` and `true_divide` is `divide`
- Move scalar stuff to scalar.py, leave CARReduce and Elementwise in elementwise.py
- Add second and identity dispatches
- Add Composite dispatch

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
