### PR TITLE
Add MLX dispatch for BatchedDot

### DIFF
--- a/pytensor/link/mlx/dispatch/__init__.py
+++ b/pytensor/link/mlx/dispatch/__init__.py
@@ -1,6 +1,7 @@
 # isort: off
 from pytensor.link.mlx.dispatch.basic import mlx_funcify, mlx_typify
 
+import pytensor.link.mlx.dispatch.blas
 import pytensor.link.mlx.dispatch.math
 import pytensor.link.mlx.dispatch.basic
 import pytensor.link.mlx.dispatch.elemwise

--- a/pytensor/link/mlx/dispatch/blas.py
+++ b/pytensor/link/mlx/dispatch/blas.py
@@ -1,0 +1,14 @@
+import mlx.core as mx
+
+from pytensor.link.mlx.dispatch import mlx_funcify
+from pytensor.tensor.blas import BatchedDot
+
+
+@mlx_funcify.register(BatchedDot)
+def mlx_funcify_BatchedDot(op, **kwargs):
+    def batched_dot(a, b):
+        if a.shape[0] != b.shape[0]:
+            raise TypeError("Shapes must match along the first dimension of BatchedDot")
+        return mx.matmul(a, b)
+
+    return batched_dot

--- a/tests/link/mlx/test_blas.py
+++ b/tests/link/mlx/test_blas.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-from pytensor.compile.function import function
 from pytensor.compile.mode import Mode
 from pytensor.configdefaults import config
 from pytensor.graph.rewriting.db import RewriteDatabaseQuery
@@ -22,12 +21,14 @@ def test_mlx_BatchedDot():
         np.linspace(1, -1, 10 * 3 * 2).astype(config.floatX).reshape((10, 3, 2))
     )
     out = pt_blas.BatchedDot()(a, b)
-    compare_mlx_and_py([a, b], [out], [a_test_value, b_test_value])
+
+    opts = RewriteDatabaseQuery(include=[None], exclude=["cxx_only", "BlasOpt"])
+    mlx_mode = Mode(MLXLinker(), opts)
+    pytensor_mlx_fn, _ = compare_mlx_and_py(
+        [a, b], [out], [a_test_value, b_test_value], mlx_mode=mlx_mode
+    )
 
     # A dimension mismatch should raise a TypeError for compatibility
     inputs = [a_test_value[:-1], b_test_value]
-    opts = RewriteDatabaseQuery(include=[None], exclude=["cxx_only", "BlasOpt"])
-    mlx_mode = Mode(MLXLinker(), opts)
-    pytensor_mlx_fn = function([a, b], [out], mode=mlx_mode)
     with pytest.raises(TypeError):
         pytensor_mlx_fn(*inputs)

--- a/tests/link/mlx/test_blas.py
+++ b/tests/link/mlx/test_blas.py
@@ -1,0 +1,33 @@
+import numpy as np
+import pytest
+
+from pytensor.compile.function import function
+from pytensor.compile.mode import Mode
+from pytensor.configdefaults import config
+from pytensor.graph.rewriting.db import RewriteDatabaseQuery
+from pytensor.link.mlx import MLXLinker
+from pytensor.tensor import blas as pt_blas
+from pytensor.tensor.type import tensor3
+from tests.link.mlx.test_basic import compare_mlx_and_py
+
+
+def test_mlx_BatchedDot():
+    # tensor3 . tensor3
+    a = tensor3("a")
+    a_test_value = (
+        np.linspace(-1, 1, 10 * 5 * 3).astype(config.floatX).reshape((10, 5, 3))
+    )
+    b = tensor3("b")
+    b_test_value = (
+        np.linspace(1, -1, 10 * 3 * 2).astype(config.floatX).reshape((10, 3, 2))
+    )
+    out = pt_blas.BatchedDot()(a, b)
+    compare_mlx_and_py([a, b], [out], [a_test_value, b_test_value])
+
+    # A dimension mismatch should raise a TypeError for compatibility
+    inputs = [a_test_value[:-1], b_test_value]
+    opts = RewriteDatabaseQuery(include=[None], exclude=["cxx_only", "BlasOpt"])
+    mlx_mode = Mode(MLXLinker(), opts)
+    pytensor_mlx_fn = function([a, b], [out], mode=mlx_mode)
+    with pytest.raises(TypeError):
+        pytensor_mlx_fn(*inputs)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
MLX's `mlx.core.matmul` is natively batched, so the dispatch for `BatchedDot` is trivial

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
