### PR TITLE
Rename MLX core.py to tensor_basic.py

### DIFF
--- a/pytensor/link/mlx/dispatch/__init__.py
+++ b/pytensor/link/mlx/dispatch/__init__.py
@@ -6,7 +6,7 @@ import pytensor.link.mlx.dispatch.basic
 import pytensor.link.mlx.dispatch.elemwise
 import pytensor.link.mlx.dispatch.shape
 import pytensor.link.mlx.dispatch.subtensor
-import pytensor.link.mlx.dispatch.core
+import pytensor.link.mlx.dispatch.tensor_basic
 import pytensor.link.mlx.dispatch.signal
 import pytensor.link.mlx.dispatch.signal.conv
 import pytensor.link.mlx.dispatch.blockwise

--- a/pytensor/link/mlx/dispatch/basic.py
+++ b/pytensor/link/mlx/dispatch/basic.py
@@ -13,6 +13,82 @@ from pytensor.link.utils import fgraph_to_python
 from pytensor.raise_op import Assert, CheckAndRaise
 
 
+def convert_dtype_to_mlx(dtype_str, auto_cast_unsupported=True):
+    """Convert PyTensor dtype strings to MLX dtype objects.
+
+    MLX expects dtype objects rather than string literals for type conversion.
+    This function maps common dtype strings to their MLX equivalents.
+
+    Parameters
+    ----------
+    dtype_str : str or MLX dtype
+        The dtype to convert
+    auto_cast_unsupported : bool
+        If True, automatically cast unsupported dtypes to supported ones with warnings
+
+    Returns
+    -------
+    MLX dtype object
+    """
+    import warnings
+
+    if isinstance(dtype_str, str):
+        if dtype_str == "bool":
+            return mx.bool_
+        elif dtype_str == "int8":
+            return mx.int8
+        elif dtype_str == "int16":
+            return mx.int16
+        elif dtype_str == "int32":
+            return mx.int32
+        elif dtype_str == "int64":
+            return mx.int64
+        elif dtype_str == "uint8":
+            return mx.uint8
+        elif dtype_str == "uint16":
+            return mx.uint16
+        elif dtype_str == "uint32":
+            return mx.uint32
+        elif dtype_str == "uint64":
+            return mx.uint64
+        elif dtype_str == "float16":
+            return mx.float16
+        elif dtype_str == "float32":
+            return mx.float32
+        elif dtype_str == "float64":
+            if auto_cast_unsupported:
+                warnings.warn(
+                    "MLX does not support float64 on GPU. Automatically casting to float32. "
+                    "This may result in reduced precision. To avoid this warning, "
+                    "explicitly use float32 in your code or set floatX='float32' in PyTensor config.",
+                    UserWarning,
+                    stacklevel=3,
+                )
+                return mx.float32
+            else:
+                return mx.float64
+        elif dtype_str == "bfloat16":
+            return mx.bfloat16
+        elif dtype_str == "complex64":
+            return mx.complex64
+        elif dtype_str == "complex128":
+            if auto_cast_unsupported:
+                warnings.warn(
+                    "MLX does not support complex128. Automatically casting to complex64. "
+                    "This may result in reduced precision. To avoid this warning, "
+                    "explicitly use complex64 in your code.",
+                    UserWarning,
+                    stacklevel=3,
+                )
+                return mx.complex64
+            else:
+                # Return the original even though it might fail
+                # This allows users to opt out of auto-casting if needed
+                return mx.complex64  # MLX doesn't have complex128, so fallback
+    # Return as is if it's already an MLX dtype or not a recognized string
+    return dtype_str
+
+
 @singledispatch
 def mlx_typify(data, **kwargs):
     raise NotImplementedError(f"mlx_typify is not implemented for {type(data)}")

--- a/pytensor/link/mlx/dispatch/elemwise.py
+++ b/pytensor/link/mlx/dispatch/elemwise.py
@@ -4,8 +4,7 @@ import mlx.core as mx
 import mlx.nn as mlx_nn
 import numpy as np
 
-from pytensor.link.mlx.dispatch.basic import mlx_funcify
-from pytensor.link.mlx.dispatch.core import convert_dtype_to_mlx
+from pytensor.link.mlx.dispatch.basic import convert_dtype_to_mlx, mlx_funcify
 from pytensor.scalar.basic import (
     AND,
     EQ,

--- a/pytensor/link/mlx/dispatch/tensor_basic.py
+++ b/pytensor/link/mlx/dispatch/tensor_basic.py
@@ -6,6 +6,7 @@ from pytensor.tensor import get_vector_length
 from pytensor.tensor.basic import (
     Alloc,
     AllocEmpty,
+    ARange,
     ExtractDiag,
     Eye,
     Join,
@@ -185,6 +186,34 @@ def mlx_funcify_Alloc(op, node, **kwargs):
         return result
 
     return alloc
+
+
+ARANGE_CONCRETE_VALUE_ERROR = (
+    "MLX's arange requires all arguments (start, stop, step) to be concrete "
+    "Python int/float values, not symbolic variables. Unlike NumPy and JAX, "
+    "MLX does not accept array inputs for arange at all."
+    "\n\nAn example of a valid graph:"
+    "\n>>> import pytensor.tensor as pt"
+    "\n>>> pt.arange(1, 10, 2)"
+)
+
+
+@mlx_funcify.register(ARange)
+def mlx_funcify_ARange(op, node, **kwargs):
+    # MLX's arange only accepts Python int/float, not arrays,
+    # so all arguments must be known at graph-construction time.
+    try:
+        start, stop, step = [
+            get_scalar_constant_value(arg).item() for arg in node.inputs
+        ]
+    except NotScalarConstantError:
+        raise NotImplementedError(ARANGE_CONCRETE_VALUE_ERROR)
+    dtype = convert_dtype_to_mlx(op.dtype)
+
+    def arange(*_args):
+        return mx.arange(start, stop, step, dtype=dtype)
+
+    return arange
 
 
 def _extract_static_dims(shape_inputs):

--- a/pytensor/link/mlx/dispatch/tensor_basic.py
+++ b/pytensor/link/mlx/dispatch/tensor_basic.py
@@ -1,7 +1,7 @@
 import mlx.core as mx
 import numpy as np
 
-from pytensor.link.mlx.dispatch.basic import mlx_funcify
+from pytensor.link.mlx.dispatch.basic import convert_dtype_to_mlx, mlx_funcify
 from pytensor.tensor import get_vector_length
 from pytensor.tensor.basic import (
     Alloc,
@@ -115,82 +115,6 @@ def mlx_funcify_Eye(op, node, **kwargs):
     return eye
 
 
-def convert_dtype_to_mlx(dtype_str, auto_cast_unsupported=True):
-    """Convert PyTensor dtype strings to MLX dtype objects.
-
-    MLX expects dtype objects rather than string literals for type conversion.
-    This function maps common dtype strings to their MLX equivalents.
-
-    Parameters
-    ----------
-    dtype_str : str or MLX dtype
-        The dtype to convert
-    auto_cast_unsupported : bool
-        If True, automatically cast unsupported dtypes to supported ones with warnings
-
-    Returns
-    -------
-    MLX dtype object
-    """
-    import warnings
-
-    if isinstance(dtype_str, str):
-        if dtype_str == "bool":
-            return mx.bool_
-        elif dtype_str == "int8":
-            return mx.int8
-        elif dtype_str == "int16":
-            return mx.int16
-        elif dtype_str == "int32":
-            return mx.int32
-        elif dtype_str == "int64":
-            return mx.int64
-        elif dtype_str == "uint8":
-            return mx.uint8
-        elif dtype_str == "uint16":
-            return mx.uint16
-        elif dtype_str == "uint32":
-            return mx.uint32
-        elif dtype_str == "uint64":
-            return mx.uint64
-        elif dtype_str == "float16":
-            return mx.float16
-        elif dtype_str == "float32":
-            return mx.float32
-        elif dtype_str == "float64":
-            if auto_cast_unsupported:
-                warnings.warn(
-                    "MLX does not support float64 on GPU. Automatically casting to float32. "
-                    "This may result in reduced precision. To avoid this warning, "
-                    "explicitly use float32 in your code or set floatX='float32' in PyTensor config.",
-                    UserWarning,
-                    stacklevel=3,
-                )
-                return mx.float32
-            else:
-                return mx.float64
-        elif dtype_str == "bfloat16":
-            return mx.bfloat16
-        elif dtype_str == "complex64":
-            return mx.complex64
-        elif dtype_str == "complex128":
-            if auto_cast_unsupported:
-                warnings.warn(
-                    "MLX does not support complex128. Automatically casting to complex64. "
-                    "This may result in reduced precision. To avoid this warning, "
-                    "explicitly use complex64 in your code.",
-                    UserWarning,
-                    stacklevel=3,
-                )
-                return mx.complex64
-            else:
-                # Return the original even though it might fail
-                # This allows users to opt out of auto-casting if needed
-                return mx.complex64  # MLX doesn't have complex128, so fallback
-    # Return as is if it's already an MLX dtype or not a recognized string
-    return dtype_str
-
-
 @mlx_funcify.register(MakeVector)
 def mlx_funcify_MakeVector(op, **kwargs):
     dtype = convert_dtype_to_mlx(op.dtype)
@@ -294,10 +218,6 @@ def _coerce_to_int(value):
     except (ValueError, TypeError) as exc:
         _rethrow_dynamic_shape_error(exc)
         raise
-    raise TypeError(
-        "MLX Alloc expects integer shape components; got value of type "
-        f"{type(value).__name__}."
-    )
 
 
 def _rethrow_dynamic_shape_error(exc):

--- a/tests/link/mlx/test_basic.py
+++ b/tests/link/mlx/test_basic.py
@@ -249,7 +249,7 @@ def test_mlx_float64_no_warning_when_disabled():
     """Test that auto-casting can be controlled."""
     import warnings
 
-    from pytensor.link.mlx.dispatch.core import convert_dtype_to_mlx
+    from pytensor.link.mlx.dispatch.basic import convert_dtype_to_mlx
 
     # Test that we can disable auto-casting
     with warnings.catch_warnings(record=True) as warning_list:
@@ -270,7 +270,7 @@ def test_mlx_complex128_auto_casting():
     """Test automatic casting of complex128 to complex64."""
     import warnings
 
-    from pytensor.link.mlx.dispatch.core import convert_dtype_to_mlx
+    from pytensor.link.mlx.dispatch.basic import convert_dtype_to_mlx
 
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always")

--- a/tests/link/mlx/test_tensor_basic.py
+++ b/tests/link/mlx/test_tensor_basic.py
@@ -19,7 +19,7 @@ def test_alloc_with_different_shape_types():
     This addresses the TypeError that occurred when shape parameters
     contained MLX arrays instead of Python integers.
     """
-    from pytensor.link.mlx.dispatch.core import (
+    from pytensor.link.mlx.dispatch.tensor_basic import (
         mlx_funcify_Alloc,
     )
 

--- a/tests/link/mlx/test_tensor_basic.py
+++ b/tests/link/mlx/test_tensor_basic.py
@@ -4,7 +4,7 @@ import pytest
 import pytensor
 from pytensor import config
 from pytensor import tensor as pt
-from pytensor.tensor.basic import Alloc
+from pytensor.tensor.basic import Alloc, arange
 from tests.link.mlx.test_basic import (
     compare_mlx_and_py,
     compile_mode,
@@ -164,3 +164,9 @@ def test_split_dynamic_axis_const_splits():
         ValueError, match="Symbolic axis is not supported in MLX Split implementation"
     ):
         compare_mlx_and_py([x, axis], outs, [test_input, np.array(1)])
+
+
+def test_arange():
+    out = arange(1, 10, 2)
+
+    compare_mlx_and_py([], [out], [])


### PR DESCRIPTION
The names of the files in the dispatch modules should match the pytensor files they implement, not the dispatch library. So I renamed `core.py` to `tensor_basic.py`. This now matches what Jax has.

I also implemented an `ARange` dispatch. It is super limited, because MLX doesn't allow broadcasting via the arguments of `mx.arange`. All of start, stop, and step have to be constants and have to be scalars. Still, that covers majority of the use case, so it's worth having.