### PR TITLE
Add MLX dispatch for IfElse

### DIFF
--- a/pytensor/link/mlx/dispatch/basic.py
+++ b/pytensor/link/mlx/dispatch/basic.py
@@ -11,6 +11,7 @@ from pytensor.compile.mode import MLX
 from pytensor.compile.ops import DeepCopyOp
 from pytensor.graph import Constant
 from pytensor.graph.fg import FunctionGraph
+from pytensor.ifelse import IfElse
 from pytensor.link.utils import fgraph_to_python
 from pytensor.raise_op import Assert, CheckAndRaise
 
@@ -160,6 +161,17 @@ def mlx_funcify_DeepCopyOp(op, **kwargs):
 
     return deepcopyop
 
+
+@mlx_funcify.register(IfElse)
+def mlx_funcify_IfElse(op, **kwargs):
+    n_outs = op.n_outs
+
+    def ifelse(cond, *args, n_outs=n_outs):
+        # MLX has no conditional Op, the best we can do is mx.where to select between branches elementwise.
+        res = tuple(mx.where(cond, args[i], args[n_outs + i]) for i in range(n_outs))
+        return res if n_outs > 1 else res[0]
+
+    return ifelse
 
 @mlx_funcify.register(Assert)
 @mlx_funcify.register(CheckAndRaise)

--- a/pytensor/link/mlx/dispatch/basic.py
+++ b/pytensor/link/mlx/dispatch/basic.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from pytensor.compile.builders import OpFromGraph
 from pytensor.compile.mode import MLX
-from pytensor.compile.ops import DeepCopyOp
+from pytensor.compile.ops import DeepCopyOp, TypeCastingOp
 from pytensor.graph import Constant
 from pytensor.graph.fg import FunctionGraph
 from pytensor.ifelse import IfElse
@@ -162,6 +162,14 @@ def mlx_funcify_DeepCopyOp(op, **kwargs):
     return deepcopyop
 
 
+@mlx_funcify.register(TypeCastingOp)
+def mlx_funcify_TypeCastingOp(op, **kwargs):
+    def type_cast(x):
+        return x
+
+    return type_cast
+
+
 @mlx_funcify.register(IfElse)
 def mlx_funcify_IfElse(op, **kwargs):
     n_outs = op.n_outs
@@ -172,6 +180,7 @@ def mlx_funcify_IfElse(op, **kwargs):
         return res if n_outs > 1 else res[0]
 
     return ifelse
+
 
 @mlx_funcify.register(Assert)
 @mlx_funcify.register(CheckAndRaise)

--- a/tests/link/mlx/test_basic.py
+++ b/tests/link/mlx/test_basic.py
@@ -15,6 +15,7 @@ from pytensor.compile.function import function
 from pytensor.compile.mode import MLX, Mode
 from pytensor.graph import RewriteDatabaseQuery
 from pytensor.graph.basic import Variable
+from pytensor.ifelse import ifelse
 from pytensor.link.mlx import MLXLinker
 from pytensor.raise_op import assert_op
 
@@ -330,3 +331,19 @@ def test_OpFromGraph():
     zv = np.ones((2, 2), dtype=config.floatX) * 5
 
     compare_mlx_and_py([x, y, z], [out], [xv, yv, zv])
+
+
+def test_mlx_ifelse():
+    true_vals = np.r_[1, 2, 3]
+    false_vals = np.r_[-1, -2, -3]
+
+    x = ifelse(np.array(True), true_vals, false_vals)
+    compare_mlx_and_py([], [x], [], must_be_device_array=False)
+
+    a = pt.scalar("a")
+    a_test = np.array(0.2, dtype="float64")
+    x = ifelse(a < 0.5, true_vals, false_vals)
+    compare_mlx_and_py([a], [x], [a_test])
+
+    a_test = np.array(0.8, dtype="float64")
+    compare_mlx_and_py([a], [x], [a_test])

--- a/tests/link/mlx/test_shape.py
+++ b/tests/link/mlx/test_shape.py
@@ -98,7 +98,6 @@ def test_mlx_Reshape_shape_graph_input():
     )
 
 
-@pytest.mark.xfail(reason="ViewOp Op is not supported yet")
 def test_mlx_compile_ops():
     x = DeepCopyOp()(pt.as_tensor_variable(1.1))
     compare_mlx_and_py([], [x], [])


### PR DESCRIPTION
There's no support for conditional logic in MLX, so the best we can do is `mx.where`. It ends up being similar to the limitations in jax -- `jax.lax.cond` gets rewritten to `jax.lax.select`, which is also where `jnp.where` ends up if you pass all 3 inputs (which we do in this case).

So IfElse sucks again -- it will evaluate both branches. But I submit that it's better than nothing.