### PR TITLE
Numba: fuse AdvancedSubtensor->Elemwise->AdvancedIncSubtensor

### DIFF
--- a/pytensor/compile/executor.py
+++ b/pytensor/compile/executor.py
@@ -395,6 +395,23 @@ class Function:
         )
         fg_cpy.update_mapping = maker.fgraph.update_mapping
 
+        # Warn if any shared variable with a deleted update is being
+        # destroyed (mutated inplace) by a node in the copied graph.
+        # In that case the shared variable storage will still be mutated
+        # even though the update is not applied.
+        if delete_updates and hasattr(maker.fgraph, "destroyers"):
+            for in_idx in maker.fgraph.update_mapping.values():
+                input_var = maker.fgraph.inputs[in_idx]
+                for destroyer in maker.fgraph.destroyers(input_var):
+                    if destroyer in memo:
+                        warnings.warn(
+                            f"Shared variable '{input_var.name}' will still be mutated "
+                            "even though its update is being deleted, because an "
+                            "operation in the graph modifies it inplace.",
+                            UserWarning,
+                            stacklevel=2,
+                        )
+
         # Re initialize Outs and swap update and variable in Ins
         # By doing this, we can pass FunctionMaker.check_unused_inputs()
         if delete_updates:

--- a/pytensor/link/numba/dispatch/blockwise.py
+++ b/pytensor/link/numba/dispatch/blockwise.py
@@ -11,6 +11,9 @@ from pytensor.link.numba.dispatch.basic import (
     register_funcify_and_cache_key,
 )
 from pytensor.link.numba.dispatch.vectorize_codegen import (
+    NO_INDEXED_INPUTS,
+    NO_INDEXED_OUTPUTS,
+    NO_SIZE,
     _jit_options,
     _vectorized,
     encode_literals,
@@ -90,7 +93,9 @@ def numba_funcify_Blockwise(op: BlockwiseWithCoreShape, node, **kwargs):
                 (),  # constant_inputs
                 inputs,
                 tuple_core_shapes,
-                None,  # size
+                NO_SIZE,
+                NO_INDEXED_INPUTS,
+                NO_INDEXED_OUTPUTS,
             )
 
         return impl

--- a/pytensor/link/numba/dispatch/elemwise.py
+++ b/pytensor/link/numba/dispatch/elemwise.py
@@ -42,7 +42,6 @@ from pytensor.scalar.basic import (
     Mul,
     Sub,
     TrueDiv,
-    get_scalar_type,
 )
 from pytensor.tensor.blas import BatchedDot
 from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
@@ -632,8 +631,7 @@ def create_axis_apply_fn(fn, axis, ndim, dtype):
 
 @register_funcify_and_cache_key(Elemwise)
 def numba_funcify_Elemwise(op, node, **kwargs):
-    scalar_inputs = [get_scalar_type(dtype=input.dtype)() for input in node.inputs]
-    scalar_node = op.scalar_op.make_node(*scalar_inputs)
+    scalar_node = op.make_scalar_node(*node.inputs)
     scalar_op_fn, scalar_cache_key = numba_funcify_and_cache_key(
         op.scalar_op,
         node=scalar_node,

--- a/pytensor/link/numba/dispatch/elemwise.py
+++ b/pytensor/link/numba/dispatch/elemwise.py
@@ -27,6 +27,10 @@ from pytensor.link.numba.dispatch.string_codegen import (
     create_tuple_string,
 )
 from pytensor.link.numba.dispatch.vectorize_codegen import (
+    NO_INDEXED_INPUTS,
+    NO_INDEXED_OUTPUTS,
+    NO_SIZE,
+    _jit_options,
     _vectorized,
     encode_literals,
     store_core_outputs,
@@ -46,6 +50,7 @@ from pytensor.scalar.basic import (
 from pytensor.tensor.blas import BatchedDot
 from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
 from pytensor.tensor.math import Argmax, Dot, MulWithoutZeros
+from pytensor.tensor.rewriting.indexed_elemwise import IndexedElemwise
 
 
 @singledispatch
@@ -686,8 +691,10 @@ def numba_funcify_Elemwise(op, node, **kwargs):
                 True,  # allow_core_scalar
                 (),  # constant_inputs
                 inputs,
-                core_output_shapes,  # core_shapes
-                None,  # size
+                core_output_shapes,
+                NO_SIZE,
+                NO_INDEXED_INPUTS,
+                NO_INDEXED_OUTPUTS,
             )
 
         return impl
@@ -706,6 +713,107 @@ def numba_funcify_Elemwise(op, node, **kwargs):
         )
         elemwise_key = sha256(elemwise_key.encode()).hexdigest()
     return elemwise, elemwise_key
+
+
+@register_funcify_and_cache_key(IndexedElemwise)
+def numba_funcify_IndexedElemwise(op, node, **kwargs):
+    """Generate fused Elemwise Numba code with indexed reads and updates.
+
+    Reads indexed_inputs/indexed_outputs specs stored on the Op by the
+    rewriting pass, and generates a single vectorized loop with indirect
+    indexing.
+
+    fgraph inputs are ordered as::
+
+        [elemwise_inputs..., idx_0, idx_1, ..., update_target_0, ...]
+    """
+    [elemwise_node] = [n for n in op.fgraph.apply_nodes if isinstance(n.op, Elemwise)]
+
+    scalar_node = elemwise_node.op.make_scalar_node(*elemwise_node.inputs)
+    scalar_op_fn, scalar_cache_key = numba_funcify_and_cache_key(
+        elemwise_node.op.scalar_op, node=scalar_node, **kwargs
+    )
+
+    indexed_inputs = op.indexed_inputs
+    indexed_outputs = op.indexed_outputs
+    n_indices = len(indexed_inputs)
+    nin_elemwise = len(elemwise_node.inputs)
+    nout = len(elemwise_node.outputs)
+
+    inc_outputs = frozenset(
+        out_idx
+        for entry in indexed_outputs
+        if entry is not None
+        for out_idx in entry[0]
+        if entry[2] == "inc"
+    )
+
+    core_op_fn = store_core_outputs(
+        scalar_op_fn, nin=nin_elemwise, nout=nout, inc_outputs=inc_outputs
+    )
+
+    input_bc_patterns = tuple(inp.type.broadcastable for inp in elemwise_node.inputs)
+    output_bc_patterns = tuple(out.type.broadcastable for out in elemwise_node.outputs)
+    output_dtypes = tuple(out.type.dtype for out in node.outputs)
+    inplace_pattern = tuple(elemwise_node.op.inplace_pattern.items())
+    core_output_shapes = tuple(() for _ in range(nout))
+
+    idx_broadcastable = tuple(
+        node.inputs[nin_elemwise + k].type.broadcastable for k in range(n_indices)
+    )
+
+    input_bc_patterns_enc = encode_literals(input_bc_patterns)
+    output_bc_patterns_enc = encode_literals(output_bc_patterns)
+    output_dtypes_enc = encode_literals(output_dtypes)
+    inplace_pattern_enc = encode_literals(inplace_pattern)
+    indexed_inputs_enc = encode_literals((indexed_inputs, idx_broadcastable))
+    indexed_outputs_enc = encode_literals(indexed_outputs)
+
+    def indexed_elemwise_fn(*outer_inputs):
+        raise NotImplementedError(
+            "IndexedElemwise cannot be evaluated in Python (non-JIT) mode."
+        )
+
+    @overload(indexed_elemwise_fn, jit_options=_jit_options)
+    def ov_indexed_elemwise_fn(*outer_inputs):
+        def impl(*outer_inputs):
+            return _vectorized(
+                core_op_fn,
+                input_bc_patterns_enc,
+                output_bc_patterns_enc,
+                output_dtypes_enc,
+                inplace_pattern_enc,
+                True,  # allow_core_scalar
+                (),  # constant_inputs
+                outer_inputs,
+                core_output_shapes,
+                NO_SIZE,
+                indexed_inputs_enc,
+                indexed_outputs_enc,
+            )
+
+        return impl
+
+    cache_version = 1
+    if scalar_cache_key is None:
+        key = None
+    else:
+        key = str(
+            (
+                type(op),
+                "IndexedElemwise",
+                cache_version,
+                inplace_pattern,
+                input_bc_patterns,
+                indexed_inputs,
+                idx_broadcastable,
+                indexed_outputs,
+                scalar_cache_key,
+            )
+        )
+        key = sha256(key.encode()).hexdigest()
+
+    return indexed_elemwise_fn, key
 
 
 @register_funcify_and_cache_key(CAReduce)

--- a/pytensor/link/numba/dispatch/random.py
+++ b/pytensor/link/numba/dispatch/random.py
@@ -21,6 +21,9 @@ from pytensor.link.numba.dispatch.basic import (
 )
 from pytensor.link.numba.dispatch.compile_ops import numba_deepcopy
 from pytensor.link.numba.dispatch.vectorize_codegen import (
+    NO_INDEXED_INPUTS,
+    NO_INDEXED_OUTPUTS,
+    NO_SIZE,
     _jit_options,
     _vectorized,
     encode_literals,
@@ -482,9 +485,11 @@ def numba_funcify_RandomVariable(op: RandomVariableWithCoreShape, node, **kwargs
                 (rng,),
                 dist_params,
                 (numba_ndarray.to_fixed_tuple(core_shape, core_shape_len),),
-                None
+                NO_SIZE
                 if size_len is None
                 else numba_ndarray.to_fixed_tuple(size, size_len),
+                NO_INDEXED_INPUTS,
+                NO_INDEXED_OUTPUTS,
             )
             return rng, draws
 

--- a/pytensor/link/numba/dispatch/vectorize_codegen.py
+++ b/pytensor/link/numba/dispatch/vectorize_codegen.py
@@ -23,7 +23,9 @@ def encode_literals(literals: Sequence) -> str:
     return base64.encodebytes(pickle.dumps(literals)).decode()
 
 
-def store_core_outputs(core_op_fn: Callable, nin: int, nout: int) -> Callable:
+def store_core_outputs(
+    core_op_fn: Callable, nin: int, nout: int, inc_outputs: frozenset = frozenset()
+) -> Callable:
     """Create a Numba function that wraps a core function and stores its vectorized outputs.
 
     If ``core_op_fn`` has a ``handles_out=True`` attribute, it is assumed to
@@ -32,11 +34,11 @@ def store_core_outputs(core_op_fn: Callable, nin: int, nout: int) -> Callable:
     @njit
     def store_core_outputs(i0, i1, ..., in, o0, o1, ..., on):
         to0, to1, ..., ton = core_op_fn(i0, i1, ..., in)
-        o0[...] = to0
-        o1[...] = to1
+        o0[...] = to0      # direct outputs
+        o1 += to1          # inc outputs (in-place add works for 0d and Nd)
         ...
-        on[...] = ton
 
+    ``inc_outputs`` lists output indices that use ``+=`` instead of ``=``.
     """
     if getattr(core_op_fn, "handles_out", False):
         return core_op_fn
@@ -49,8 +51,12 @@ def store_core_outputs(core_op_fn: Callable, nin: int, nout: int) -> Callable:
     out_signature = ", ".join(outputs)
     inner_out_signature = ", ".join(inner_outputs)
     store_outputs = "\n".join(
-        f"{output}[...] = {inner_output}"
-        for output, inner_output in zip(outputs, inner_outputs, strict=True)
+        f"{output} += {inner_output}"
+        if i in inc_outputs
+        else f"{output}[...] = {inner_output}"
+        for i, (output, inner_output) in enumerate(
+            zip(outputs, inner_outputs, strict=True)
+        )
     )
     func_src = f"""
 def store_core_outputs({inp_signature}, {out_signature}):
@@ -84,6 +90,67 @@ def _decode_literal(val, name):
     if not isinstance(val, types.Literal):
         raise TypingError(f"{name} must be literal.")
     return pickle.loads(base64.decodebytes(val.literal_value.encode()))
+
+
+def _compute_idx_load_axes(indexed_inputs, indexed_outputs, idx_ndims):
+    """Compute which loop dimensions load each index array.
+
+    For a 1-D index on axis A this is ``(A,)``; for a 2-D index ``(A, A+1)``.
+    Multi-index groups (``x[idx_a, idx_b]``) share the group's minimum axis.
+
+    Parameters
+    ----------
+    indexed_inputs : tuple of ((tuple[int, ...], int) | None)
+        Per-index: (source input positions, source axis) or None.
+    indexed_outputs : tuple of ((tuple[int, ...], int, str) | None)
+        Per-index: (output positions, axis, mode) or None.
+    idx_ndims : tuple of int
+        Number of dimensions of each index array.
+    """
+    n_indices = len(indexed_inputs)
+    if n_indices == 0:
+        return ()
+
+    src_to_indices: dict = {}
+    for k, entry in enumerate(indexed_inputs):
+        if entry is not None:
+            for src in entry[0]:
+                src_to_indices.setdefault(src, []).append(k)
+    for k, entry in enumerate(indexed_outputs):
+        if entry is not None:
+            for out_idx in entry[0]:
+                src_to_indices.setdefault(("w", out_idx), []).append(k)
+
+    parent = list(range(n_indices))
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for indices in src_to_indices.values():
+        for i in range(1, len(indices)):
+            a, b = find(indices[0]), find(indices[i])
+            if a != b:
+                parent[a] = b
+
+    group_min_axis: dict[int, int] = {}
+    for k, entry in enumerate(indexed_inputs):
+        if entry is not None:
+            _, axis = entry
+            root = find(k)
+            group_min_axis[root] = min(group_min_axis.get(root, axis), axis)
+    for k, entry in enumerate(indexed_outputs):
+        if entry is not None:
+            root = find(k)
+            _, out_axis, _ = entry
+            group_min_axis[root] = min(group_min_axis.get(root, out_axis), out_axis)
+
+    return tuple(
+        tuple(range(group_min_axis[find(k)], group_min_axis[find(k)] + idx_ndims[k]))
+        for k in range(n_indices)
+    )
 
 
 def _compute_vectorized_types(
@@ -180,6 +247,8 @@ def _codegen_return_outputs(
     )
 
 
+NO_INDEXED_INPUTS = encode_literals(((), ()))
+NO_INDEXED_OUTPUTS = encode_literals(())
 NO_SIZE = None
 
 
@@ -285,7 +354,13 @@ def make_outputs(
     inputs: tuple[Any, ...],
     input_types: tuple[Any, ...],
     output_core_shapes: tuple,
+    update_outputs: dict | None = None,
 ) -> tuple[list[ir.Value], list[types.Array]]:
+    """Allocate output arrays for vectorized loop.
+
+    ``update_outputs`` maps ``{output_idx: (array, array_type)}`` for outputs
+    that reuse an indexed-write target buffer instead of being freshly allocated.
+    """
     output_arrays = []
     output_arry_types = []
     one = ir.IntType(64)(1)
@@ -293,6 +368,10 @@ def make_outputs(
     for i, (core_shape, bc, dtype) in enumerate(
         zip(output_core_shapes, out_bc, dtypes, strict=True)
     ):
+        if update_outputs is not None and i in update_outputs:
+            output_arrays.append(update_outputs[i][0])
+            output_arry_types.append(update_outputs[i][1])
+            continue
         if i in inplace_dict:
             output_arrays.append(inputs[inplace_dict[i]])
             output_arry_types.append(input_types[inplace_dict[i]])
@@ -314,7 +393,7 @@ def make_outputs(
 
     # If there is no inplace operation, we know that all output arrays
     # don't alias. Informing llvm can make it easier to vectorize.
-    if not inplace:
+    if not inplace and not update_outputs:
         arg = builder.function.args[0]
         arg.add_attribute("noalias")
     return output_arrays, output_arry_types
@@ -335,6 +414,12 @@ def make_loop_call(
     input_types: tuple[Any, ...],
     output_types: tuple[Any, ...],
     core_scalar: bool = True,
+    input_read_spec: tuple[tuple[tuple[int, int], ...] | None, ...] | None = None,
+    idx_arrays: list | None = None,
+    idx_arrays_type: tuple | None = None,
+    idx_load_axes: tuple[tuple[int, ...], ...] | None = None,
+    idx_bc: tuple[tuple[bool, ...], ...] | None = None,
+    output_write_spec: tuple[tuple[tuple[int, int], ...] | None, ...] | None = None,
 ):
     safe = (False, False)
 
@@ -351,6 +436,18 @@ def make_loop_call(
     # output_scope_set = mod.add_metadata([input_scope, output_scope])
 
     zero = ir.Constant(ir.IntType(64), 0)
+
+    def _wrap_negative_index(idx_val, dim_size, signed):
+        """Wrap a negative index by adding the dimension size: idx + size if idx < 0.
+
+        Only emits the branch for signed index dtypes; unsigned indices are
+        returned as-is since they cannot be negative.
+        """
+        if not signed:
+            return idx_val
+        is_neg = builder.icmp_signed("<", idx_val, zero)
+        wrapped = builder.add(idx_val, dim_size)
+        return builder.select(is_neg, wrapped, idx_val)
 
     # Setup loops and initialize accumulators for outputs
     # This part corresponds to opening the loops
@@ -374,14 +471,119 @@ def make_loop_call(
     # Code in the inner most loop...
     loop_idxs = [loopval.index for loopval in loops]
 
+    # Load indirect indices from all index arrays (1-D vectors).
+    indirect_idxs = []
+    if idx_arrays is not None:
+        assert idx_arrays_type is not None
+        assert idx_load_axes is not None
+        for idx_counter, (idx_arr, idx_arr_type, load_axes) in enumerate(
+            zip(idx_arrays, idx_arrays_type, idx_load_axes)
+        ):
+            read_idxs = []
+            for d, ax in enumerate(load_axes):
+                is_bc = (
+                    idx_bc[idx_counter][d]
+                    if idx_bc and len(idx_bc[idx_counter]) > d
+                    else False
+                )
+                read_idxs.append(zero if is_bc else loop_idxs[ax])
+            ptr = cgutils.get_item_pointer2(
+                context,
+                builder,
+                idx_arr.data,
+                cgutils.unpack_tuple(builder, idx_arr.shape),
+                cgutils.unpack_tuple(builder, idx_arr.strides),
+                idx_arr_type.layout,
+                read_idxs,
+                False,
+                False,
+            )
+            val = builder.load(ptr)
+            i64 = ir.IntType(64)
+            if val.type != i64:
+                if idx_arr_type.dtype.signed:
+                    val = builder.sext(val, i64)
+                else:
+                    val = builder.zext(val, i64)
+            indirect_idxs.append(val)
+
     # Load values from input arrays
     input_vals = []
-    for inp, inp_type, inp_bc in zip(inputs, input_types, input_bc, strict=True):
-        core_ndim = inp_type.ndim - len(inp_bc)
+    for input_i, (inp, inp_type, inp_bc) in enumerate(
+        zip(inputs, input_types, input_bc, strict=True)
+    ):
+        spec = input_read_spec[input_i] if input_read_spec is not None else None
+        n_indexed = len(spec) if spec else 0
+        # n_indexed source axes are replaced by the index arrays' broadcast
+        # loop dims.  n_index_loop_dims = max ndim of the index arrays in the
+        # group (1 for 1D vectors, 2 for 2D matrices, etc.).
+        if spec:
+            assert idx_arrays_type is not None
+            n_index_loop_dims = max(
+                (idx_arrays_type[idx_k].ndim for idx_k, _ in spec), default=0
+            )
+        else:
+            n_index_loop_dims = 0
+        core_ndim = inp_type.ndim - len(inp_bc) - n_indexed + n_index_loop_dims
 
-        read_idx = [
-            zero if bc else idx for idx, bc in zip(loop_idxs, inp_bc, strict=True)
-        ] + [zero] * core_ndim
+        if spec is not None:
+            assert idx_arrays_type is not None
+            indexed_axes = {src_axis: idx_k for idx_k, src_axis in spec}
+            inp_shape = cgutils.unpack_tuple(builder, inp.shape)
+            read_idx = []
+            # result_dim is a cursor into the output loop dimensions.  It
+            # advances by 1 for regular source dims, but jumps by the index
+            # ndim for indexed dims (1-D idx → +1, 2-D mat → +2).
+            # idxs[result_dim] selects which loop counter loads each dim.
+            #
+            # Ex 1: z = x[idx] + y — x(5,3), idx(4,), y(4,3) → z(4,3)
+            #   output loops: i over 4, j over 3
+            #   x (indexed on axis 0):        result_dim
+            #     src 0 → indexed, use idx[i]     0 (+1) → 1
+            #     src 1 → loop counter j           1 (+1) → 2
+            #     loads as: x[idx[i], j]
+            #   y (not indexed):
+            #     loads as: y[i, j]
+            #
+            # Ex 2: z = x[mat] — x(5,3), mat(2,4) → z(2,4,3)
+            #   output loops: i over 2, j over 4, k over 3
+            #   x (indexed on axis 0, 2-D index): result_dim
+            #     src 0 → indexed, use mat[i,j]    0 (+2) → 2
+            #     src 1 → loop counter k            2 (+1) → 3
+            #     loads as: x[mat[i,j], k]
+            #
+            # Ex 3: z = x[:, idx] — x(3,5,2), idx(4,) on axis 1 → z(3,4,2)
+            #   output loops: i over 3, j over 4, k over 2
+            #   x (indexed on axis 1):            result_dim
+            #     src 0 → loop counter i            0 (+1) → 1
+            #     src 1 → indexed, use idx[j]      1 (+1) → 2
+            #     src 2 → loop counter k            2 (+1) → 3
+            #     loads as: x[i, idx[j], k]
+            result_dim = 0
+            for src_dim in range(inp_type.ndim):
+                if src_dim in indexed_axes:
+                    idx_k = indexed_axes[src_dim]
+                    idx_val = _wrap_negative_index(
+                        indirect_idxs[idx_k],
+                        inp_shape[src_dim],
+                        signed=idx_arrays_type[idx_k].dtype.signed,
+                    )
+                    read_idx.append(idx_val)
+                    if src_dim == max(indexed_axes):
+                        result_dim += n_index_loop_dims
+                elif result_dim < len(inp_bc):
+                    read_idx.append(
+                        zero if inp_bc[result_dim] else loop_idxs[result_dim]
+                    )
+                    result_dim += 1
+                else:
+                    read_idx.append(zero)
+                    result_dim += 1
+        else:
+            read_idx = [
+                zero if bc else idx for idx, bc in zip(loop_idxs, inp_bc, strict=True)
+            ] + [zero] * core_ndim
+
         read_ptr = cgutils.get_item_pointer2(
             context,
             builder,
@@ -428,15 +630,51 @@ def make_loop_call(
 
     # Create output slices to pass to inner func
     output_slices = []
-    for out, out_type, out_bc in zip(outputs, output_types, output_bc, strict=True):
+    for output_i, (out, out_type, out_bc) in enumerate(
+        zip(outputs, output_types, output_bc, strict=True)
+    ):
         core_ndim = out_type.ndim - len(out_bc)
         size_type = out.shape.type.element  # pyright: ignore[reportAttributeAccessIssue]
         output_shape = cgutils.unpack_tuple(builder, out.shape)  # pyright: ignore[reportAttributeAccessIssue]
         output_strides = cgutils.unpack_tuple(builder, out.strides)  # pyright: ignore[reportAttributeAccessIssue]
 
-        write_idx = [
-            zero if bc else idx for idx, bc in zip(loop_idxs, out_bc, strict=True)
-        ] + [zero] * core_ndim
+        # Same cursor logic as indexed reads (see read_idx above):
+        # iterate over target dims, use indirect index for indexed axes,
+        # loop counter for the rest.
+        spec = output_write_spec[output_i] if output_write_spec is not None else None
+        if spec is not None:
+            assert idx_arrays_type is not None
+            indexed_axes = {src_axis: idx_k for idx_k, src_axis in spec}
+            n_indexed = len(indexed_axes)
+            n_index_loop_dims = max(idx_arrays_type[idx_k].ndim for idx_k, _ in spec)
+            # Multi-axis indexing: N indexed axes contribute max(idx.ndim)
+            # loop dims, so the target can have more batch dims than the loop.
+            n_target_batch = n_indexed + len(out_bc) - n_index_loop_dims
+            target_core_ndim = out_type.ndim - n_target_batch
+            write_idx = []
+            result_dim = 0
+            for tgt_dim in range(n_target_batch):
+                if tgt_dim in indexed_axes:
+                    idx_k = indexed_axes[tgt_dim]
+                    idx_val = _wrap_negative_index(
+                        indirect_idxs[idx_k],
+                        output_shape[tgt_dim],
+                        signed=idx_arrays_type[idx_k].dtype.signed,
+                    )
+                    write_idx.append(idx_val)
+                    if tgt_dim == max(indexed_axes):
+                        result_dim += n_index_loop_dims
+                else:
+                    write_idx.append(
+                        zero if out_bc[result_dim] else loop_idxs[result_dim]
+                    )
+                    result_dim += 1
+            write_idx += [zero] * target_core_ndim
+        else:
+            write_idx = [
+                zero if bc else idx for idx, bc in zip(loop_idxs, out_bc, strict=True)
+            ] + [zero] * core_ndim
+        effective_core_ndim = target_core_ndim if spec is not None else core_ndim
         write_ptr = cgutils.get_item_pointer2(
             context,
             builder,
@@ -448,11 +686,15 @@ def make_loop_call(
             *safe,
         )
         write_array_type = types.Array(
-            dtype=out_type.dtype, ndim=core_ndim, layout=out_type.layout
+            dtype=out_type.dtype, ndim=effective_core_ndim, layout=out_type.layout
         )
         write_array = context.make_array(write_array_type)(context, builder)
-        core_shape = output_shape[-core_ndim:] if core_ndim > 0 else []
-        core_strides = output_strides[-core_ndim:] if core_ndim > 0 else []
+        core_shape = (
+            output_shape[-effective_core_ndim:] if effective_core_ndim > 0 else []
+        )
+        core_strides = (
+            output_strides[-effective_core_ndim:] if effective_core_ndim > 0 else []
+        )
         itemsize = context.get_abi_sizeof(context.get_data_type(out_type.dtype))
         context.populate_array(
             write_array,
@@ -489,10 +731,28 @@ def _vectorized(
     inplace_pattern,
     allow_core_scalar,
     constant_inputs_types,
-    input_types,
+    outer_input_types,
     output_core_shape_types,
     size_type,
+    indexed_inputs,
+    indexed_outputs,
 ):
+    """Vectorized intrinsic with optional indirect indexing for reads and writes.
+
+    For indexed operations, outer inputs are ordered as
+    ``[core_inputs..., idx_0, idx_1, ..., write_target_0, ...]``.
+
+    ``indexed_inputs`` groups core input positions by which index they
+    read through: e.g. ``((0, 2), (1,))`` means idx_0 reads inputs 0 and 2,
+    idx_1 reads input 1.  ``None`` entries are update-only indices (no reads).
+
+    ``indexed_outputs`` has one entry per index array (same length as
+    ``indexed_inputs``).  ``None`` means that index is not used for updates.
+    ``((out_0, out_1), mode)`` means that index updates outputs out_0 and
+    out_1 with *mode* ``"set"`` or ``"inc"``.
+
+    For non-indexed calls, both are ``()``.
+    """
     arg_types = [
         core_func,
         input_bc_patterns,
@@ -501,21 +761,105 @@ def _vectorized(
         inplace_pattern,
         allow_core_scalar,
         constant_inputs_types,
-        input_types,
+        outer_input_types,
         output_core_shape_types,
         size_type,
+        indexed_inputs,
+        indexed_outputs,
     ]
 
     input_bc_patterns = _decode_literal(input_bc_patterns, "input_bc_patterns")
     output_bc_patterns = _decode_literal(output_bc_patterns, "output_bc_patterns")
     output_dtypes = _decode_literal(output_dtypes, "output_dtypes")
     inplace_pattern = _decode_literal(inplace_pattern, "inplace_pattern")
+    indexed_inputs, idx_broadcastable = _decode_literal(
+        indexed_inputs, "indexed_inputs"
+    )
+    indexed_outputs = _decode_literal(indexed_outputs, "indexed_outputs")
 
     if not isinstance(allow_core_scalar, types.Literal):
         raise TypingError("allow_core_scalar must be literal.")
     allow_core_scalar = allow_core_scalar.literal_value
 
-    core_input_types, core_out_types, _out_types, ret_type = _compute_vectorized_types(
+    # Count write targets (one per unique output index)
+    write_out_idxs = set()
+    for entry in indexed_outputs:
+        if entry is not None:
+            write_out_idxs.update(entry[0])
+    n_write_targets = len(write_out_idxs)
+
+    inplace_pattern = tuple(
+        (out_idx, inp_idx)
+        for out_idx, inp_idx in inplace_pattern
+        if out_idx not in write_out_idxs
+    )
+
+    n_indices = len(indexed_inputs)
+    n_core_inputs = len(outer_input_types) - n_indices - n_write_targets
+    source_input_types = tuple(outer_input_types[i] for i in range(n_core_inputs))
+    idx_types = tuple(outer_input_types[n_core_inputs + k] for k in range(n_indices))
+    write_target_types = tuple(
+        outer_input_types[n_core_inputs + n_indices + j] for j in range(n_write_targets)
+    )
+
+    idx_ndims = tuple(idx_types[k].ndim for k in range(n_indices))
+    idx_load_axes = _compute_idx_load_axes(indexed_inputs, indexed_outputs, idx_ndims)
+
+    # Aggregate per-input: which (idx_k, source_axis) pairs apply.
+    read_spec_dict: dict[int, list[tuple[int, int]]] = {}
+    for k, entry in enumerate(indexed_inputs):
+        if entry is not None:
+            sources, source_axis = entry
+            for src in sources:
+                read_spec_dict.setdefault(src, []).append((k, source_axis))
+    input_read_spec = tuple(
+        tuple(read_spec_dict[p]) if p in read_spec_dict else None
+        for p in range(n_core_inputs)
+    )
+
+    # Build effective input types that match input_bc_patterns ndim.
+    # For ND indices, the source ndim differs from the result ndim:
+    # a 2-D index on 1 axis expands 1 source axis into 2 loop dims.
+    input_types = []
+    for p, src_type in enumerate(source_input_types):
+        spec = input_read_spec[p]
+        if spec is not None:
+            n_indexed_axes = len(spec)
+            n_index_loop_dims = max(idx_types[idx_k].ndim for idx_k, _ in spec)
+            if n_indexed_axes != n_index_loop_dims:
+                effective_ndim = src_type.ndim - n_indexed_axes + n_index_loop_dims
+                input_types.append(
+                    types.Array(src_type.dtype, effective_ndim, src_type.layout)
+                )
+            else:
+                input_types.append(src_type)
+        else:
+            input_types.append(src_type)
+    input_types = tuple(input_types)
+
+    # Per-output: tuple of (idx_k, source_axis) pairs, or None.
+    # Same format as input_read_spec.
+    # indexed_outputs entries are (sources, source_axis, mode) or None.
+    write_spec_dict: dict[int, list[tuple[int, int]]] = {}
+    for k, entry in enumerate(indexed_outputs):
+        if entry is None:
+            continue
+        sources, source_axis, _mode = entry
+        for out_idx in sources:
+            write_spec_dict.setdefault(out_idx, []).append((k, source_axis))
+    # Write target buffers are appended to the outer inputs in ascending output
+    # index order (see the rewriter's sorted(write_targets.items())), so the
+    # target buffer index of an output is its rank among the write outputs.
+    out_idx_to_write_target = {
+        out_idx: target_idx
+        for target_idx, out_idx in enumerate(sorted(write_spec_dict))
+    }
+    output_write_spec = tuple(
+        tuple(write_spec_dict[p]) if p in write_spec_dict else None
+        for p in range(len(output_bc_patterns))
+    )
+
+    core_input_types, core_out_types, out_types, ret_type = _compute_vectorized_types(
         input_types,
         input_bc_patterns,
         output_bc_patterns,
@@ -525,33 +869,179 @@ def _vectorized(
         output_core_shape_types,
     )
 
+    if out_idx_to_write_target:
+        core_out_types = list(core_out_types)
+        out_types = list(out_types)
+        batch_ndim = len(input_bc_patterns[0])
+        for out_idx, target_idx in out_idx_to_write_target.items():
+            target_type = write_target_types[target_idx]
+            out_types[out_idx] = target_type
+            # Multi-axis indexing: N indexed axes contribute max(idx.ndim)
+            # loop dims, so the target can have more batch dims than the loop.
+            spec = output_write_spec[out_idx]
+            if spec is not None:
+                n_indexed = len(spec)
+                n_index_loop_dims = max(idx_types[idx_k].ndim for idx_k, _ in spec)
+                n_target_batch = n_indexed + batch_ndim - n_index_loop_dims
+            else:
+                n_target_batch = batch_ndim
+            core_out_types[out_idx] = types.Array(
+                dtype=target_type.dtype,
+                ndim=target_type.ndim - n_target_batch,
+                layout=target_type.layout,
+            )
+        out_types = tuple(out_types)
+        core_out_types = tuple(core_out_types)
+
+        if len(out_types) == 1:
+            ret_type = out_types[0]
+        else:
+            ret_type = types.Tuple(out_types)
+
     sig = ret_type(*arg_types)
 
     size_is_none = isinstance(size_type, NoneType)
+    write_idx_set = frozenset(
+        k for k, entry in enumerate(indexed_outputs) if entry is not None
+    )
 
     def codegen(ctx, builder, sig, args):
-        [_, _, _, _, _, _, constant_inputs, inputs, output_core_shapes, size] = args
+        [
+            _,
+            _,
+            _,
+            _,
+            _,
+            _,
+            constant_inputs,
+            outer_inputs,
+            output_core_shapes,
+            size,
+            _,
+            _,
+        ] = args
 
         constant_inputs = cgutils.unpack_tuple(builder, constant_inputs)
-        inputs = cgutils.unpack_tuple(builder, inputs)
+        all_outer = cgutils.unpack_tuple(builder, outer_inputs)
         output_core_shapes = [
             cgutils.unpack_tuple(builder, shape)
             for shape in cgutils.unpack_tuple(builder, output_core_shapes)
         ]
         size = None if size_is_none else cgutils.unpack_tuple(builder, size)
 
+        # First n_core_inputs outer inputs are source arrays
         inputs = [
-            arrayobj.make_array(ty)(ctx, builder, val)
-            for ty, val in zip(input_types, inputs, strict=True)
+            arrayobj.make_array(source_input_types[i])(ctx, builder, all_outer[i])
+            for i in range(n_core_inputs)
         ]
         in_shapes = [cgutils.unpack_tuple(builder, obj.shape) for obj in inputs]
 
-        iter_shape = compute_itershape(
-            ctx,
-            builder,
-            in_shapes,
-            input_bc_patterns,
-            size,
+        # Next n_indices inputs are index arrays
+        idx_arrs = [
+            arrayobj.make_array(idx_types[k])(
+                ctx, builder, all_outer[n_core_inputs + k]
+            )
+            for k in range(n_indices)
+        ]
+
+        # Remaining inputs are write target buffers
+        write_target_arrs = [
+            arrayobj.make_array(write_target_types[j])(
+                ctx, builder, all_outer[n_core_inputs + n_indices + j]
+            )
+            for j in range(len(write_target_types))
+        ]
+
+        idx_shapes = [
+            cgutils.unpack_tuple(builder, idx_arrs[k].shape) for k in range(n_indices)
+        ]
+
+        one = ir.IntType(64)(1)
+        iter_shapes = list(in_shapes)
+        iter_bc = list(input_bc_patterns)
+
+        for p, spec in enumerate(input_read_spec):
+            if spec is None:
+                continue
+            indexed_axes = {src_axis: idx_k for idx_k, src_axis in spec}
+            n_indexed = len(indexed_axes)
+            n_index_loop_dims = max(idx_types[idx_k].ndim for idx_k, _ in spec)
+            if n_indexed == n_index_loop_dims:
+                iter_shapes[p] = list(iter_shapes[p])
+                for idx_k, axis in spec:
+                    iter_shapes[p][axis] = idx_shapes[idx_k][0]
+            else:
+                batch_ndim = len(input_bc_patterns[p])
+                max_axis = max(a for _, a in spec)
+                new_shape = []
+                new_bc = []
+                src_d = 0
+                idx_d = 0
+                for loop_d in range(batch_ndim):
+                    if src_d in indexed_axes and idx_d < n_index_loop_dims:
+                        new_shape.append(one)
+                        new_bc.append(True)
+                        idx_d += 1
+                        if idx_d >= n_index_loop_dims:
+                            src_d = max_axis + 1
+                    else:
+                        new_shape.append(in_shapes[p][src_d])
+                        new_bc.append(iter_bc[p][loop_d])
+                        src_d += 1
+                iter_shapes[p] = new_shape
+                iter_bc[p] = tuple(new_bc)
+
+        # Each index array participates in iter_shape validation.
+        # Write indices can broadcast against each other, but if ALL write
+        # indices on a given loop dim are bc=True, none constrains the loop
+        # size.  Force bc=False in that case so compute_itershape requires
+        # the index length to match the loop.
+        batch_ndim = len(input_bc_patterns[0]) if input_bc_patterns else 0
+
+        write_all_bc = [True] * batch_ndim
+        for k in range(n_indices):
+            if k not in write_idx_set:
+                continue
+            for d, ax in enumerate(idx_load_axes[k]):
+                if ax < batch_ndim:
+                    idx_bc_on_d = (
+                        idx_broadcastable[k][d]
+                        if d < len(idx_broadcastable[k])
+                        else False
+                    )
+                    if not idx_bc_on_d:
+                        write_all_bc[ax] = False
+
+        for k in range(n_indices):
+            is_write = k in write_idx_set
+            idx_shape_entry = [one] * batch_ndim
+            bc_entry = [True] * batch_ndim
+            for d, ax in enumerate(idx_load_axes[k]):
+                if ax < batch_ndim and d < len(idx_shapes[k]):
+                    idx_shape_entry[ax] = idx_shapes[k][d]
+                idx_bc_on_d = (
+                    idx_broadcastable[k][d] if d < len(idx_broadcastable[k]) else False
+                )
+                if is_write and idx_bc_on_d and write_all_bc[ax]:
+                    idx_bc_on_d = False
+                if ax < batch_ndim:
+                    bc_entry[ax] = idx_bc_on_d
+            iter_shapes.append(idx_shape_entry)
+            iter_bc.append(tuple(bc_entry))
+
+        iter_shape = compute_itershape(ctx, builder, iter_shapes, tuple(iter_bc), size)
+
+        # Build update_outputs dict for make_outputs: out_idx -> (array, type)
+        update_outputs_dict = (
+            {
+                out_idx: (
+                    write_target_arrs[target_idx],
+                    write_target_types[target_idx],
+                )
+                for out_idx, target_idx in out_idx_to_write_target.items()
+            }
+            if out_idx_to_write_target
+            else None
         )
 
         outputs, output_types = make_outputs(
@@ -562,8 +1052,9 @@ def _vectorized(
             output_dtypes,
             inplace_pattern,
             inputs,
-            input_types,
+            source_input_types,
             output_core_shapes,
+            update_outputs=update_outputs_dict,
         )
 
         core_signature = typingctx.resolve_function_type(
@@ -588,9 +1079,15 @@ def _vectorized(
             outputs,
             input_bc_patterns,
             output_bc_patterns,
-            input_types,
+            source_input_types,
             output_types,
             core_scalar=allow_core_scalar,
+            input_read_spec=input_read_spec,
+            idx_arrays=idx_arrs,
+            idx_arrays_type=idx_types,
+            idx_load_axes=idx_load_axes,
+            idx_bc=idx_broadcastable,
+            output_write_spec=output_write_spec,
         )
 
         return _codegen_return_outputs(
@@ -599,6 +1096,7 @@ def _vectorized(
             sig,
             outputs,
             inplace_pattern,
+            extra_incref=frozenset(out_idx_to_write_target),
         )
 
     return sig, codegen

--- a/pytensor/link/numba/dispatch/vectorize_codegen.py
+++ b/pytensor/link/numba/dispatch/vectorize_codegen.py
@@ -80,73 +80,27 @@ _jit_options = {
 }
 
 
-@numba.extending.intrinsic(jit_options=_jit_options, prefer_literal=True)
-def _vectorized(
-    typingctx,
-    core_func,
+def _decode_literal(val, name):
+    if not isinstance(val, types.Literal):
+        raise TypingError(f"{name} must be literal.")
+    return pickle.loads(base64.decodebytes(val.literal_value.encode()))
+
+
+def _compute_vectorized_types(
+    input_types,
     input_bc_patterns,
     output_bc_patterns,
     output_dtypes,
     inplace_pattern,
     allow_core_scalar,
-    constant_inputs_types,
-    input_types,
     output_core_shape_types,
-    size_type,
 ):
-    arg_types = [
-        core_func,
-        input_bc_patterns,
-        output_bc_patterns,
-        output_dtypes,
-        inplace_pattern,
-        allow_core_scalar,
-        constant_inputs_types,
-        input_types,
-        output_core_shape_types,
-        size_type,
-    ]
-
-    if not isinstance(input_bc_patterns, types.Literal):
-        raise TypingError("input_bc_patterns must be literal.")
-    input_bc_patterns = input_bc_patterns.literal_value
-    input_bc_patterns = pickle.loads(base64.decodebytes(input_bc_patterns.encode()))
-
-    if not isinstance(output_bc_patterns, types.Literal):
-        raise TypeError("output_bc_patterns must be literal.")
-    output_bc_patterns = output_bc_patterns.literal_value
-    output_bc_patterns = pickle.loads(base64.decodebytes(output_bc_patterns.encode()))
-
-    if not isinstance(output_dtypes, types.Literal):
-        raise TypeError("output_dtypes must be literal.")
-    output_dtypes = output_dtypes.literal_value
-    output_dtypes = pickle.loads(base64.decodebytes(output_dtypes.encode()))
-
-    if not isinstance(inplace_pattern, types.Literal):
-        raise TypeError("inplace_pattern must be literal.")
-    inplace_pattern = inplace_pattern.literal_value
-    inplace_pattern = pickle.loads(base64.decodebytes(inplace_pattern.encode()))
-
-    if not isinstance(allow_core_scalar, types.Literal):
-        raise TypeError("allow_core_scalar must be literal.")
-    allow_core_scalar = allow_core_scalar.literal_value
-
+    """Compute core input/output types and return type for vectorized intrinsics."""
     batch_ndim = len(input_bc_patterns[0])
-    nin = len(constant_inputs_types) + len(input_types)
-    nout = len(output_bc_patterns)
 
-    if nin == 0:
-        raise TypingError("Empty argument list to vectorized op.")
-
-    if nout == 0:
-        raise TypingError("Empty list of outputs for vectorized op.")
-
-    if not all(isinstance(input, types.Array) for input in input_types):
+    if not all(isinstance(t, types.Array) for t in input_types):
         raise TypingError("Vectorized inputs must be arrays.")
-
-    if not all(
-        len(pattern) == batch_ndim for pattern in input_bc_patterns + output_bc_patterns
-    ):
+    if not all(len(p) == batch_ndim for p in input_bc_patterns + output_bc_patterns):
         raise TypingError(
             "Vectorized broadcastable patterns must have the same length."
         )
@@ -155,12 +109,15 @@ def _vectorized(
     for input_type, bc_pattern in zip(input_types, input_bc_patterns, strict=True):
         core_ndim = input_type.ndim - len(bc_pattern)
         if allow_core_scalar and core_ndim == 0:
-            core_input_type = input_type.dtype
+            core_input_types.append(input_type.dtype)
         else:
-            core_input_type = types.Array(
-                dtype=input_type.dtype, ndim=core_ndim, layout=input_type.layout
+            # FIXME: inheriting layout from the full array is wrong for F-order
+            # inputs with batch dims — the core slice won't be F-contiguous.
+            core_input_types.append(
+                types.Array(
+                    dtype=input_type.dtype, ndim=core_ndim, layout=input_type.layout
+                )
             )
-        core_input_types.append(core_input_type)
 
     core_out_types = [
         types.Array(numba.from_dtype(np.dtype(dtype)), len(output_core_shape), "C")
@@ -178,115 +135,52 @@ def _vectorized(
         )
     ]
 
-    for output_idx, input_idx in inplace_pattern:
-        output_type = input_types[input_idx]
+    for output_idx, inp_idx in inplace_pattern:
+        output_type = input_types[inp_idx]
         core_out_types[output_idx] = types.Array(
             dtype=output_type.dtype,
             ndim=output_type.ndim - batch_ndim,
-            layout=input_type.layout,
+            layout=output_type.layout,
         )
         out_types[output_idx] = output_type
 
     ret_type = types.Tuple(out_types)
-
     if len(output_dtypes) == 1:
         ret_type = ret_type.types[0]
-    sig = ret_type(*arg_types)
 
-    # So we can access the constant values in codegen...
-    input_bc_patterns_val = input_bc_patterns
-    output_bc_patterns_val = output_bc_patterns
-    output_dtypes_val = output_dtypes
-    inplace_pattern_val = inplace_pattern
-    input_types = input_types
-    size_is_none = isinstance(size_type, NoneType)
+    return core_input_types, core_out_types, out_types, ret_type
 
-    def codegen(
-        ctx,
-        builder,
-        sig,
-        args,
-    ):
-        [_, _, _, _, _, _, constant_inputs, inputs, output_core_shapes, size] = args
 
-        constant_inputs = cgutils.unpack_tuple(builder, constant_inputs)
-        inputs = cgutils.unpack_tuple(builder, inputs)
-        output_core_shapes = [
-            cgutils.unpack_tuple(builder, shape)
-            for shape in cgutils.unpack_tuple(builder, output_core_shapes)
-        ]
-        size = None if size_is_none else cgutils.unpack_tuple(builder, size)
+def _codegen_return_outputs(
+    ctx, builder, sig, outputs, inplace_pattern, extra_incref=frozenset()
+):
+    """Generate LLVM IR to return output arrays, handling incref for inplace.
 
-        inputs = [
-            arrayobj.make_array(ty)(ctx, builder, val)
-            for ty, val in zip(input_types, inputs, strict=True)
-        ]
-        in_shapes = [cgutils.unpack_tuple(builder, obj.shape) for obj in inputs]
+    Parameters
+    ----------
+    extra_incref : frozenset
+        Additional output indices (e.g. indexed-update outputs) that alias an input
+        buffer and need an incref before returning, beyond inplace outputs.
+    """
+    incref_set = set(dict(inplace_pattern).keys()) | set(extra_incref)
 
-        iter_shape = compute_itershape(
-            ctx,
+    if len(outputs) == 1:
+        if incref_set:
+            ctx.nrt.incref(builder, sig.return_type, outputs[0]._getvalue())
+        return outputs[0]._getvalue()
+
+    for idx in sorted(incref_set):
+        ctx.nrt.incref(
             builder,
-            in_shapes,
-            input_bc_patterns_val,
-            size,
+            sig.return_type.types[idx],
+            outputs[idx]._getvalue(),
         )
+    return ctx.make_tuple(
+        builder, sig.return_type, [out._getvalue() for out in outputs]
+    )
 
-        outputs, output_types = make_outputs(
-            ctx,
-            builder,
-            iter_shape,
-            output_bc_patterns_val,
-            output_dtypes_val,
-            inplace_pattern_val,
-            inputs,
-            input_types,
-            output_core_shapes,
-        )
 
-        core_signature = typingctx.resolve_function_type(
-            core_func,
-            [
-                *constant_inputs_types,
-                *core_input_types,
-                *core_out_types,
-            ],
-            {},
-        )
-
-        make_loop_call(
-            typingctx,
-            ctx,
-            builder,
-            core_func,
-            core_signature,
-            iter_shape,
-            constant_inputs,
-            inputs,
-            outputs,
-            input_bc_patterns_val,
-            output_bc_patterns_val,
-            input_types,
-            output_types,
-            core_scalar=allow_core_scalar,
-        )
-
-        if len(outputs) == 1:
-            if inplace_pattern:
-                assert inplace_pattern[0][0] == 0
-                ctx.nrt.incref(builder, sig.return_type, outputs[0]._getvalue())
-            return outputs[0]._getvalue()
-
-        for inplace_idx in dict(inplace_pattern):
-            ctx.nrt.incref(
-                builder,
-                sig.return_type.types[inplace_idx],
-                outputs[inplace_idx]._getvalue(),
-            )
-        return ctx.make_tuple(
-            builder, sig.return_type, [out._getvalue() for out in outputs]
-        )
-
-    return sig, codegen
+NO_SIZE = None
 
 
 def compute_itershape(
@@ -421,7 +315,6 @@ def make_outputs(
     # If there is no inplace operation, we know that all output arrays
     # don't alias. Informing llvm can make it easier to vectorize.
     if not inplace:
-        # The first argument is the output pointer
         arg = builder.function.args[0]
         arg.add_attribute("noalias")
     return output_arrays, output_arry_types
@@ -466,116 +359,113 @@ def make_loop_call(
     output_accumulator: list[tuple[Any | None, int | None]] = [(None, None)] * n_outputs
     for dim, length in enumerate(iter_shape):
         # Find outputs that only have accumulations left
-        for output in range(n_outputs):
-            if output_accumulator[output][0] is not None:
+        for out in range(n_outputs):
+            if output_accumulator[out][0] is not None:
                 continue
-            if all(output_bc[output][dim:]):
-                value = outputs[output][0].type.pointee(0)
+            if all(output_bc[out][dim:]):
+                value = outputs[out][0].type.pointee(0)
                 accu = cgutils.alloca_once_value(builder, value)
-                output_accumulator[output] = (accu, dim)
+                output_accumulator[out] = (accu, dim)
 
         loop = cgutils.for_range(builder, length)
         loop_stack.append(loop)
         loops.append(loop.__enter__())
 
     # Code in the inner most loop...
-    idxs = [loopval.index for loopval in loops]
+    loop_idxs = [loopval.index for loopval in loops]
 
     # Load values from input arrays
     input_vals = []
-    for input, input_type, bc in zip(inputs, input_types, input_bc, strict=True):
-        core_ndim = input_type.ndim - len(bc)
+    for inp, inp_type, inp_bc in zip(inputs, input_types, input_bc, strict=True):
+        core_ndim = inp_type.ndim - len(inp_bc)
 
-        idxs_bc = [zero if bc else idx for idx, bc in zip(idxs, bc, strict=True)] + [
-            zero
-        ] * core_ndim
-        ptr = cgutils.get_item_pointer2(
+        read_idx = [
+            zero if bc else idx for idx, bc in zip(loop_idxs, inp_bc, strict=True)
+        ] + [zero] * core_ndim
+        read_ptr = cgutils.get_item_pointer2(
             context,
             builder,
-            input.data,
-            cgutils.unpack_tuple(builder, input.shape),
-            cgutils.unpack_tuple(builder, input.strides),
-            input_type.layout,
-            idxs_bc,
+            inp.data,
+            cgutils.unpack_tuple(builder, inp.shape),
+            cgutils.unpack_tuple(builder, inp.strides),
+            inp_type.layout,
+            read_idx,
             *safe,
         )
         if core_scalar and core_ndim == 0:
             # Retrive scalar item at index
-            val = builder.load(ptr)
-            # val.set_metadata("alias.scope", input_scope_set)
-            # val.set_metadata("noalias", output_scope_set)
+            read_val = builder.load(read_ptr)
+            # read_val.set_metadata("alias.scope", input_scope_set)
+            # read_val.set_metadata("noalias", output_scope_set)
         else:
             # Retrieve array item at index
             # This is a streamlined version of Numba's `GUArrayArg.load`
             # TODO check layout arg!
-            core_arry_type = types.Array(
-                dtype=input_type.dtype, ndim=core_ndim, layout=input_type.layout
+            read_array_type = types.Array(
+                dtype=inp_type.dtype, ndim=core_ndim, layout=inp_type.layout
             )
-            core_array = context.make_array(core_arry_type)(context, builder)
-            core_shape = cgutils.unpack_tuple(builder, input.shape)[
-                input_type.ndim - core_ndim :
+            read_array = context.make_array(read_array_type)(context, builder)
+            core_shape = cgutils.unpack_tuple(builder, inp.shape)[
+                inp_type.ndim - core_ndim :
             ]
-            core_strides = cgutils.unpack_tuple(builder, input.strides)[
-                input_type.ndim - core_ndim :
+            core_strides = cgutils.unpack_tuple(builder, inp.strides)[
+                inp_type.ndim - core_ndim :
             ]
-            itemsize = context.get_abi_sizeof(context.get_data_type(input_type.dtype))
+            itemsize = context.get_abi_sizeof(context.get_data_type(inp_type.dtype))
             context.populate_array(
-                core_array,
+                read_array,
                 # TODO whey do we need to bitcast?
-                data=builder.bitcast(ptr, core_array.data.type),
+                data=builder.bitcast(read_ptr, read_array.data.type),
                 shape=core_shape,
                 strides=core_strides,
                 itemsize=context.get_constant(types.intp, itemsize),
                 # TODO what is meminfo about?
                 meminfo=None,
             )
-            val = core_array._getvalue()
+            read_val = read_array._getvalue()
 
-        input_vals.append(val)
+        input_vals.append(read_val)
 
     # Create output slices to pass to inner func
     output_slices = []
-    for output, output_type, bc in zip(outputs, output_types, output_bc, strict=True):
-        core_ndim = output_type.ndim - len(bc)
-        size_type = output.shape.type.element  # pyright: ignore[reportAttributeAccessIssue]
-        output_shape = cgutils.unpack_tuple(builder, output.shape)  # pyright: ignore[reportAttributeAccessIssue]
-        output_strides = cgutils.unpack_tuple(builder, output.strides)  # pyright: ignore[reportAttributeAccessIssue]
+    for out, out_type, out_bc in zip(outputs, output_types, output_bc, strict=True):
+        core_ndim = out_type.ndim - len(out_bc)
+        size_type = out.shape.type.element  # pyright: ignore[reportAttributeAccessIssue]
+        output_shape = cgutils.unpack_tuple(builder, out.shape)  # pyright: ignore[reportAttributeAccessIssue]
+        output_strides = cgutils.unpack_tuple(builder, out.strides)  # pyright: ignore[reportAttributeAccessIssue]
 
-        idxs_bc = [zero if bc else idx for idx, bc in zip(idxs, bc, strict=True)] + [
-            zero
-        ] * core_ndim
-        ptr = cgutils.get_item_pointer2(
+        write_idx = [
+            zero if bc else idx for idx, bc in zip(loop_idxs, out_bc, strict=True)
+        ] + [zero] * core_ndim
+        write_ptr = cgutils.get_item_pointer2(
             context,
             builder,
-            output.data,
+            out.data,
             output_shape,
             output_strides,
-            output_type.layout,
-            idxs_bc,
+            out_type.layout,
+            write_idx,
             *safe,
         )
-
-        # Retrieve array item at index
-        # This is a streamlined version of Numba's `GUArrayArg.load`
-        core_arry_type = types.Array(
-            dtype=output_type.dtype, ndim=core_ndim, layout=output_type.layout
+        write_array_type = types.Array(
+            dtype=out_type.dtype, ndim=core_ndim, layout=out_type.layout
         )
-        core_array = context.make_array(core_arry_type)(context, builder)
+        write_array = context.make_array(write_array_type)(context, builder)
         core_shape = output_shape[-core_ndim:] if core_ndim > 0 else []
         core_strides = output_strides[-core_ndim:] if core_ndim > 0 else []
-        itemsize = context.get_abi_sizeof(context.get_data_type(output_type.dtype))
+        itemsize = context.get_abi_sizeof(context.get_data_type(out_type.dtype))
         context.populate_array(
-            core_array,
+            write_array,
             # TODO whey do we need to bitcast?
-            data=builder.bitcast(ptr, core_array.data.type),
+            data=builder.bitcast(write_ptr, write_array.data.type),
             shape=cgutils.pack_array(builder, core_shape, ty=size_type),
             strides=cgutils.pack_array(builder, core_strides, ty=size_type),
             itemsize=context.get_constant(types.intp, itemsize),
             # TODO what is meminfo about?
             meminfo=None,
         )
-        val = core_array._getvalue()
-        output_slices.append(val)
+        write_val = write_array._getvalue()
+        output_slices.append(write_val)
 
     inner_codegen = context.get_function(core_func, core_signature)
 
@@ -585,7 +475,130 @@ def make_loop_call(
     inner_codegen(builder, [*constant_inputs, *input_vals, *output_slices])
 
     # Close the loops
-    for depth, loop in enumerate(loop_stack[::-1]):
+    for loop in loop_stack[::-1]:
         loop.__exit__(None, None, None)
 
-    return
+
+@numba.extending.intrinsic(jit_options=_jit_options, prefer_literal=True)
+def _vectorized(
+    typingctx,
+    core_func,
+    input_bc_patterns,
+    output_bc_patterns,
+    output_dtypes,
+    inplace_pattern,
+    allow_core_scalar,
+    constant_inputs_types,
+    input_types,
+    output_core_shape_types,
+    size_type,
+):
+    arg_types = [
+        core_func,
+        input_bc_patterns,
+        output_bc_patterns,
+        output_dtypes,
+        inplace_pattern,
+        allow_core_scalar,
+        constant_inputs_types,
+        input_types,
+        output_core_shape_types,
+        size_type,
+    ]
+
+    input_bc_patterns = _decode_literal(input_bc_patterns, "input_bc_patterns")
+    output_bc_patterns = _decode_literal(output_bc_patterns, "output_bc_patterns")
+    output_dtypes = _decode_literal(output_dtypes, "output_dtypes")
+    inplace_pattern = _decode_literal(inplace_pattern, "inplace_pattern")
+
+    if not isinstance(allow_core_scalar, types.Literal):
+        raise TypingError("allow_core_scalar must be literal.")
+    allow_core_scalar = allow_core_scalar.literal_value
+
+    core_input_types, core_out_types, _out_types, ret_type = _compute_vectorized_types(
+        input_types,
+        input_bc_patterns,
+        output_bc_patterns,
+        output_dtypes,
+        inplace_pattern,
+        allow_core_scalar,
+        output_core_shape_types,
+    )
+
+    sig = ret_type(*arg_types)
+
+    size_is_none = isinstance(size_type, NoneType)
+
+    def codegen(ctx, builder, sig, args):
+        [_, _, _, _, _, _, constant_inputs, inputs, output_core_shapes, size] = args
+
+        constant_inputs = cgutils.unpack_tuple(builder, constant_inputs)
+        inputs = cgutils.unpack_tuple(builder, inputs)
+        output_core_shapes = [
+            cgutils.unpack_tuple(builder, shape)
+            for shape in cgutils.unpack_tuple(builder, output_core_shapes)
+        ]
+        size = None if size_is_none else cgutils.unpack_tuple(builder, size)
+
+        inputs = [
+            arrayobj.make_array(ty)(ctx, builder, val)
+            for ty, val in zip(input_types, inputs, strict=True)
+        ]
+        in_shapes = [cgutils.unpack_tuple(builder, obj.shape) for obj in inputs]
+
+        iter_shape = compute_itershape(
+            ctx,
+            builder,
+            in_shapes,
+            input_bc_patterns,
+            size,
+        )
+
+        outputs, output_types = make_outputs(
+            ctx,
+            builder,
+            iter_shape,
+            output_bc_patterns,
+            output_dtypes,
+            inplace_pattern,
+            inputs,
+            input_types,
+            output_core_shapes,
+        )
+
+        core_signature = typingctx.resolve_function_type(
+            core_func,
+            [
+                *constant_inputs_types,
+                *core_input_types,
+                *core_out_types,
+            ],
+            {},
+        )
+
+        make_loop_call(
+            typingctx,
+            ctx,
+            builder,
+            core_func,
+            core_signature,
+            iter_shape,
+            constant_inputs,
+            inputs,
+            outputs,
+            input_bc_patterns,
+            output_bc_patterns,
+            input_types,
+            output_types,
+            core_scalar=allow_core_scalar,
+        )
+
+        return _codegen_return_outputs(
+            ctx,
+            builder,
+            sig,
+            outputs,
+            inplace_pattern,
+        )
+
+    return sig, codegen

--- a/pytensor/tensor/elemwise.py
+++ b/pytensor/tensor/elemwise.py
@@ -395,14 +395,22 @@ class Elemwise(OpenMPOp):
         self.nfunc = None
         self.inplace_pattern = frozendict(self.inplace_pattern)
 
+    def make_scalar_node(self, *inputs):
+        """Create a scalar Apply node matching the dtypes of tensor inputs.
+
+        Used by get_output_info, grad, and backend dispatchers to obtain
+        the scalar-level graph corresponding to this Elemwise operation.
+        """
+        return self.scalar_op.make_node(
+            *[get_scalar_type(dtype=i.type.dtype).make_variable() for i in inputs]
+        )
+
     def get_output_info(self, *inputs):
         """Return the outputs dtype and broadcastable pattern and the
         dimshuffled inputs.
 
         """
-        shadow = self.scalar_op.make_node(
-            *[get_scalar_type(dtype=i.type.dtype).make_variable() for i in inputs]
-        )
+        shadow = self.make_scalar_node(*inputs)
 
         target_length = max(input.type.ndim for input in inputs)
 

--- a/pytensor/tensor/rewriting/elemwise.py
+++ b/pytensor/tensor/rewriting/elemwise.py
@@ -2,6 +2,7 @@ import abc
 import itertools
 import operator
 import sys
+from collections import defaultdict
 from collections.abc import Generator, Sequence
 from functools import cache, reduce
 from heapq import heapify, heappop, heappush
@@ -557,7 +558,7 @@ class FusionOptimizer(GraphRewriter):
 
         def find_fuseable_subgraphs(
             fg: FunctionGraph,
-        ) -> Generator[tuple[tuple[Variable], tuple[Variable]], None, None]:
+        ) -> Generator[tuple[tuple[Variable, ...], tuple[Variable, ...]], None, None]:
             """Find subgraphs of Elemwise nodes that can be fused together.
 
             In general, there is no single solution. We try to find large subgraphs eagerly
@@ -668,7 +669,9 @@ class FusionOptimizer(GraphRewriter):
 
             # Start main loop to find collection of fuseable subgraphs. We collect them in
             # discovery order; the final yield order is topologically sorted at the end.
-            discovered_subgraphs: list[tuple[tuple[Variable], tuple[Variable]]] = []
+            discovered_subgraphs: list[
+                tuple[int, tuple[tuple[Variable], tuple[Variable]]]
+            ] = []
             # Keep a bitset of nodes that have been claimed by subgraphs
             all_subgraphs_bitset = 0
             # Start exploring in reverse topological order from candidate sink nodes
@@ -831,28 +834,148 @@ class FusionOptimizer(GraphRewriter):
                     )
 
                 # Collect the subgraph
-                discovered_subgraphs.append((subgraph_inputs, subgraph_outputs))
+                discovered_subgraphs.append(
+                    (subgraph_bitset, (subgraph_inputs, subgraph_outputs))
+                )
                 all_subgraphs_bitset |= subgraph_bitset
+
+            # Merge sibling groups: independent subgraphs or remaining
+            # candidate nodes that share inputs but have no producer-consumer
+            # edge between them. The eager expansion above only walks
+            # producer-consumer edges, so it misses siblings like f(x) and
+            # g(x) that share an input without one feeding into the other.
+            sibling_candidates: list = list(discovered_subgraphs)
+            n_discovered = len(sibling_candidates)
+            for node, bf in nodes_bitflags.items():
+                if node not in candidate_starting_nodes:
+                    continue
+                if not (bf & all_subgraphs_bitset):
+                    sibling_candidates.append(
+                        (bf, (tuple(dict.fromkeys(node.inputs)), node.outputs))
+                    )
+            # Create a mapping from inputs to sibling groups that consume them.
+            # Skip scalar constants as they get inlined later and don't
+            # represent meaningful shared computation between siblings.
+            input_to_sibling_idxs: dict[Variable, list[int]] = defaultdict(list)
+            for sibling_idx, (_, (inputs, outputs)) in enumerate(sibling_candidates):
+                out_bcast = outputs[0].type.broadcastable
+                for inp in inputs:
+                    if isinstance(inp, TensorConstant) and inp.unique_value is not None:
+                        continue
+                    # Only group siblings through inputs that aren't broadcasted
+                    # As we may be dealing with sibiling of different shapes.
+                    # This is conservative, we could check if other shared inputs
+                    # jointly imply equal shapes (or look at static shapes if available)
+                    if inp.type.broadcastable != out_bcast:
+                        continue
+                    input_to_sibling_idxs[inp].append(sibling_idx)
+
+            # Track which candidate each index was merged into (union-find)
+            merged_into: dict[int, int] = {}
+            merge_targets: set[int] = set()
+
+            def find_canonical(idx):
+                """Follow merge chain to find the live candidate."""
+                try:
+                    while True:
+                        idx = merged_into[idx]
+                except KeyError:
+                    return idx
+
+            for sibling_idxs in input_to_sibling_idxs.values():
+                if len(sibling_idxs) < 2:
+                    continue
+
+                for i in range(len(sibling_idxs) - 1):
+                    sibling_i = find_canonical(sibling_idxs[i])
+
+                    bitset_i, (inputs_i, outputs_i) = sibling_candidates[sibling_i]
+                    bcast_i = outputs_i[0].type.broadcastable
+                    merged = False
+                    for sibling_j in sibling_idxs[i + 1 :]:
+                        sibling_j = find_canonical(sibling_j)
+                        if sibling_j == sibling_i:
+                            continue
+                        bitset_j, (inputs_j, outputs_j) = sibling_candidates[sibling_j]
+                        if bcast_i != outputs_j[0].type.broadcastable:
+                            continue
+
+                        # Independence: neither is ancestor of the other
+                        if (
+                            bitset_i & ancestors_bitsets[outputs_j[0].owner]
+                            or bitset_j & ancestors_bitsets[outputs_i[0].owner]
+                        ):
+                            continue
+
+                        # Merge sibling_j into sibling_i
+                        merged_bitset = bitset_i | bitset_j
+                        merged_outputs = (*outputs_i, *outputs_j)
+                        merged_inputs = list(inputs_i)
+                        merged_inputs_set = set(inputs_i)
+                        for input_j in inputs_j:
+                            if input_j not in merged_inputs_set:
+                                merged_inputs.append(input_j)
+                                merged_inputs_set.add(input_j)
+                        merged_into[sibling_j] = sibling_i
+                        merge_targets.add(sibling_i)
+
+                        # Update ancestor bitsets so that any node
+                        # depending on part of the merged group now
+                        # depends on all of it (mirrors the main loop).
+                        merged_ancestors = reduce(
+                            or_,
+                            (ancestors_bitsets[o.owner] for o in merged_outputs),
+                        )
+                        ancestors_bitsets |= (
+                            (n, n_anc | merged_ancestors)
+                            for n, n_anc in ancestors_bitsets.items()
+                            if n_anc & merged_bitset
+                        )
+
+                        # Update locals for next iteration
+                        bitset_i = merged_bitset
+                        inputs_i = tuple(merged_inputs)
+                        outputs_i = merged_outputs
+                        merged = True
+
+                    if merged:
+                        sibling_candidates[sibling_i] = (
+                            bitset_i,
+                            (inputs_i, outputs_i),
+                        )
+                        all_subgraphs_bitset |= bitset_i
+
+            # Build final list from canonical entries only.
+            # Singleton nodes added as sibling candidates are only included
+            # if they were actually merged with another subgraph.
+            discovered_subgraphs_io: list[
+                tuple[tuple[Variable, ...], tuple[Variable, ...]]
+            ] = [
+                io
+                for idx, (_, io) in enumerate(sibling_candidates)
+                if find_canonical(idx) == idx
+                and (idx < n_discovered or idx in merge_targets)
+            ]
 
             # Yield sorted subgraphs
             # A client must be fused before its direct ancestors,
             # otherwise it would reintroduce the old nodes back into the graph.
             # Indirect ancestry through non-fused variables is order-independent.
-
             # Map each subgraph output variable to the respective subgraph index
             # Materialized list ensures the same int objects are reused everywhere,
             # which is required by walk_toposort's identity-based dependency removal.
-            subgraph_indices = list(range(len(discovered_subgraphs)))
+            subgraph_indices = list(range(len(discovered_subgraphs_io)))
             sg_idx_of_out = {
                 out: idx
-                for idx, (_, sg_outputs) in zip(subgraph_indices, discovered_subgraphs)
+                for idx, (_, sg_outputs) in zip(
+                    subgraph_indices, discovered_subgraphs_io
+                )
                 for out in sg_outputs
             }
 
             def direct_ancestors(
-                i, sg_idx_of_out=sg_idx_of_out, sgs=discovered_subgraphs
+                i, sg_idx_of_out=sg_idx_of_out, sgs=discovered_subgraphs_io
             ):
-                # Return edges: inputs of this subgraph that are outputs of another subgraph
                 sg_inputs, _ = sgs[i]
                 return [
                     ancestor_sg_idx
@@ -863,7 +986,7 @@ class FusionOptimizer(GraphRewriter):
             for i in reversed(
                 tuple(walk_toposort(subgraph_indices, deps=direct_ancestors))  # type: ignore[type-var]
             ):
-                yield discovered_subgraphs[i]
+                yield discovered_subgraphs_io[i]
 
         max_operands = elemwise_max_operands_fct(None)
         reason = self.__class__.__name__

--- a/pytensor/tensor/rewriting/elemwise.py
+++ b/pytensor/tensor/rewriting/elemwise.py
@@ -74,6 +74,91 @@ class InplaceGraphOptimizer(GraphRewriter):
     ) -> Apply:
         pass
 
+    def _get_protected_inputs(self, fgraph):
+        """Collect inputs protected from in-place destruction."""
+        protected = set(
+            itertools.chain.from_iterable(
+                f.protected for f in fgraph._features if isinstance(f, Supervisor)
+            )
+        )
+        protected.update(fgraph.outputs)
+        return protected
+
+    def try_inplace_on_node(
+        self,
+        fgraph,
+        node,
+        candidate_pairs=None,
+        reason="inplace_optimizer",
+        extra_protected_inputs=frozenset(),
+    ):
+        """Try to make a single node operate in-place.
+
+        First attempts all candidate pairs at once, then falls back to
+        one-at-a-time. Returns the (possibly replaced) node.
+
+        Parameters
+        ----------
+        candidate_pairs
+            Pre-filtered and sorted list of ``((out_idx, out), (in_idx, inp))``
+            pairs. If None, computed from ``filter_candidate_pairs`` using
+            the standard protections plus ``extra_protected_inputs``.
+        extra_protected_inputs
+            Additional variables that must not be used as in-place targets,
+            only used when ``candidate_pairs`` is None.
+        """
+        if candidate_pairs is None:
+            protected_inputs = self._get_protected_inputs(fgraph)
+            protected_inputs.update(extra_protected_inputs)
+            candidate_pairs = self.filter_candidate_pairs(
+                fgraph, node, protected_inputs
+            )
+        if not candidate_pairs:
+            return node
+
+        # Try in-placing all outputs at once
+        tried_inputs = set()
+        inplace_pattern = {}
+        for (o, _), (i, _) in candidate_pairs:
+            if o not in inplace_pattern and i not in tried_inputs:
+                inplace_pattern[o] = [i]
+                tried_inputs.add(i)
+
+        inplace_node = self.create_inplace_node(node, inplace_pattern)
+        if inplace_node.op.destroy_map == inplace_pattern:
+            replacements = tuple(zip(node.outputs, inplace_node.outputs))
+            try:
+                fgraph.replace_all_validate(replacements, reason=reason)
+            except InconsistencyError:
+                pass
+            else:
+                copy_stack_trace(node.outputs, inplace_node.outputs)
+                return inplace_node
+
+        # Fall back to one output/input at a time
+        tried_inputs = set()
+        inplace_pattern = {}
+        original_node = node
+        for (o, _), (i, _) in candidate_pairs:
+            if o not in inplace_pattern and i not in tried_inputs:
+                inplace_pattern[o] = [i]
+                tried_inputs.add(i)
+
+                inplace_node = self.create_inplace_node(node, inplace_pattern)
+                if inplace_node.op.destroy_map != inplace_pattern:
+                    # This Op can't respect this partial inplace pattern,
+                    # We assume it can't support any other cases
+                    break
+                replacements = tuple(zip(node.outputs, inplace_node.outputs))
+                try:
+                    fgraph.replace_all_validate(replacements, reason=reason)
+                    node = inplace_node
+                except InconsistencyError:
+                    inplace_pattern.pop(o)
+        if node is not original_node:
+            copy_stack_trace(original_node.outputs, node.outputs)
+        return node
+
     def apply(self, fgraph):
         r"""
 
@@ -127,12 +212,7 @@ class InplaceGraphOptimizer(GraphRewriter):
         }
         large_graph = len(fgraph.apply_nodes) > 500
 
-        protected_inputs = set(
-            itertools.chain.from_iterable(
-                f.protected for f in fgraph._features if isinstance(f, Supervisor)
-            )
-        )
-        protected_inputs.update(fgraph.outputs)
+        protected_inputs = self._get_protected_inputs(fgraph)
         root_destroyer = fgraph.destroy_handler.root_destroyer
 
         self_op = self.op
@@ -170,7 +250,7 @@ class InplaceGraphOptimizer(GraphRewriter):
                 indirect_update_pairs = []
                 other_update_pairs = []
                 for pair in candidate_pairs:
-                    ((o, out), (i, inp)) = pair
+                    ((_o, out), (_i, inp)) = pair
                     if out in node_updates:
                         direct_update_inp = op_updates[out]
                         if direct_update_inp is inp:
@@ -190,54 +270,11 @@ class InplaceGraphOptimizer(GraphRewriter):
                     direct_update_pairs + indirect_update_pairs + other_update_pairs
                 )
 
-            # Try in-placing all outputs at once
-            tried_inputs = set()
-            inplace_pattern = {}
-            for (o, _), (i, _) in sorted_candidate_pairs:
-                if o not in inplace_pattern and i not in tried_inputs:
-                    inplace_pattern[o] = [i]
-                    tried_inputs.add(i)
-
-            inplace_node = self.create_inplace_node(node, inplace_pattern)
-            if inplace_node.op.destroy_map == inplace_pattern:
-                replacements = tuple(zip(node.outputs, inplace_node.outputs))
-                try:
-                    fgraph.replace_all_validate(replacements, reason=reason)
-                except InconsistencyError:
-                    prof["nb_eager_inconsistent"] += 1
-                else:
-                    prof["nb_replaced"] += 1
-                    copy_stack_trace(node.outputs, inplace_node.outputs)
-                    continue
-
-            # If it fails or doesn't match the desired inplace pattern, try one output/input at a time
-            tried_inputs = set()
-            inplace_pattern = {}
-            replaced = False
-            original_node = node
-            for (o, _), (i, _) in sorted_candidate_pairs:
-                if o not in inplace_pattern and i not in tried_inputs:
-                    inplace_pattern[o] = [i]
-                    tried_inputs.add(i)
-
-                    inplace_node = self.create_inplace_node(node, inplace_pattern)
-                    if inplace_node.op.destroy_map != inplace_pattern:
-                        # This Op can't respect this partial inplace pattern,
-                        # We assume it can't support any other cases
-                        break
-                    else:
-                        replacements = tuple(zip(node.outputs, inplace_node.outputs))
-                        try:
-                            fgraph.replace_all_validate(replacements, reason=reason)
-                            node = inplace_node
-                            replaced = True
-                        except InconsistencyError:
-                            prof["nb_inconsistent"] += 1
-                            # The input, not the output caused inconsistencies
-                            inplace_pattern.pop(o)
-            if replaced:
-                copy_stack_trace(original_node.outputs, node.outputs)
-                prof["nb_replaced"] += replaced
+            result = self.try_inplace_on_node(
+                fgraph, node, sorted_candidate_pairs, reason=reason
+            )
+            if result is not node:
+                prof["nb_replaced"] += 1
 
         return prof
 

--- a/pytensor/tensor/rewriting/indexed_elemwise.py
+++ b/pytensor/tensor/rewriting/indexed_elemwise.py
@@ -1,0 +1,774 @@
+"""Fuse indexed reads and updates into Elemwise iteration loops.
+
+Introduces ``IndexedElemwise``, an ``OpFromGraph`` that wraps
+``AdvancedSubtensor1`` + ``Elemwise`` + ``AdvancedIncSubtensor1`` subgraphs
+so the Numba backend can generate a single loop with indirect indexing,
+eliminating materialised intermediate arrays.
+"""
+
+from pytensor.compile import optdb
+from pytensor.compile.builders import OpFromGraph
+from pytensor.graph import node_rewriter
+from pytensor.graph.rewriting.basic import GraphRewriter, dfs_rewriter
+from pytensor.graph.rewriting.db import SequenceDB
+from pytensor.graph.rewriting.unify import OpPattern
+from pytensor.graph.utils import InconsistencyError
+from pytensor.printing import op_debug_information
+from pytensor.scalar.basic import Composite
+from pytensor.tensor.elemwise import DimShuffle, Elemwise
+from pytensor.tensor.rewriting.elemwise import InplaceElemwiseOptimizer
+from pytensor.tensor.shape import Reshape, shape_padright
+from pytensor.tensor.subtensor import (
+    AdvancedIncSubtensor,
+    AdvancedIncSubtensor1,
+    AdvancedSubtensor,
+    AdvancedSubtensor1,
+)
+from pytensor.tensor.variable import TensorVariable
+
+
+def _view_root(view_i, var):
+    """Follow the destroy-handler view chain to the underlying buffer.
+
+    ``view_i`` maps each view variable to the variable it directly views
+    (e.g. ``SpecifyShape(x, ...) -> x``).  Two variables alias the same memory
+    iff they resolve to the same root, so comparing roots — rather than the
+    variables themselves — catches aliasing through intervening view ops.
+    """
+    while var in view_i:
+        var = view_i[var]
+    return var
+
+
+def _unwrap_axis_swapped_subtensor1(fgraph, var):
+    """Unwrap ``AdvancedSubtensor1`` with optional ``DimShuffle`` axis-swap.
+
+    Detects two patterns (all intermediates must be single-client):
+
+    - ``AdvancedSubtensor1(source, idx)`` → ``(source, idx, 0)``
+    - ``DimShuffle{swap}(AdvancedSubtensor1(DimShuffle{swap}(source), idx))``
+      → ``(source, idx, axis)`` where *axis* is the non-zero swapped axis.
+    """
+    if var.owner is None:
+        return None
+
+    # Bare AdvancedSubtensor1 on axis 0
+    if isinstance(var.owner.op, AdvancedSubtensor1):
+        if len(fgraph.clients[var]) != 1:
+            return None
+        return var.owner.inputs[0], var.owner.inputs[1], 0
+
+    # Check for axis-swap DimShuffle wrapping AdvancedSubtensor1
+    if not isinstance(var.owner.op, DimShuffle) or not var.owner.op.is_transpose:
+        return None
+
+    # Find the swapped axis: exactly two positions differ from identity
+    order = var.owner.op.new_order
+    swapped = [i for i, o in enumerate(order) if o != i]
+    if len(swapped) != 2:
+        return None
+    ax_a, ax_b = swapped
+    if order[ax_a] != ax_b or order[ax_b] != ax_a:
+        return None
+    axis = max(ax_a, ax_b)  # the non-zero axis (0 was swapped to axis)
+
+    # Inner must be a single-client AdvancedSubtensor1
+    asub1_out = var.owner.inputs[0]
+    if len(fgraph.clients[asub1_out]) != 1:
+        return None
+    match asub1_out.owner_op_and_inputs:
+        case AdvancedSubtensor1(), inner_ds_var, idx_var:
+            pass
+        case _:
+            return None
+
+    # AdvancedSubtensor1's input must be a single-client inverse DimShuffle (same swap)
+    if len(fgraph.clients[inner_ds_var]) != 1:
+        return None
+    match inner_ds_var.owner_op_and_inputs:
+        case DimShuffle(is_transpose=True, new_order=new_order), source:
+            if new_order != tuple(order):
+                return None
+        case _:
+            return None
+
+    return source, idx_var, axis
+
+
+@node_rewriter([OpPattern(DimShuffle, is_transpose=True)])
+def undo_take_dimshuffle_for_fusion(fgraph, node):
+    """Undo ``DimShuffle(AdvancedSubtensor1(DimShuffle(x), idx))`` -> ``AdvancedSubtensor(x, :, ..., idx, :, ...)``.
+
+    The ``local_replace_AdvancedSubtensor`` specialize rewrite converts
+    ``x[:, idx]`` into ``x.T[idx].T`` (axis-swap + AdvancedSubtensor1 +
+    axis-swap).  This rewrite undoes that when the result feeds a single
+    Elemwise, so ``FuseIndexedElemwise`` can absorb the indexing directly
+    on the correct axis.
+
+    See also ``undo_take_reshape_for_fusion`` which handles the analogous
+    Reshape+flatten pattern for ND indices.
+    """
+    # Outer DimShuffle must be consumed only by a single Elemwise
+    clients = fgraph.clients[node.outputs[0]]
+    if len(clients) != 1:
+        return None
+    client_node, _client_idx = clients[0]
+    if not isinstance(client_node.op, Elemwise):
+        return None
+
+    result = _unwrap_axis_swapped_subtensor1(fgraph, node.outputs[0])
+    if result is None:
+        return None
+    source, idx_var, axis = result
+
+    # Build AdvancedSubtensor: x[:, ..., idx, :, ...]
+    idx_list = [slice(None)] * (axis + 1)
+    idx_list[axis] = 0  # pointer to the single index variable
+    new_out = AdvancedSubtensor(idx_list=idx_list)(source, idx_var)
+    return [new_out]
+
+
+@node_rewriter([Reshape])
+def undo_take_reshape_for_fusion(fgraph, node):
+    """Undo ``Reshape(AdvancedSubtensor1(x, flatten(idx)), shape)`` for ND indices.
+
+    ``transform_take`` rewrites ``x[mat_idx]`` (ND integer index) into
+    ``AdvancedSubtensor1(x, mat_idx.ravel()).reshape(mat_idx.shape + ...)``,
+    possibly with DimShuffle axis-swaps for non-zero axes.  This rewrite
+    undoes that so ``FuseIndexedElemwise`` can absorb the ND index directly.
+    """
+    [reshape_out] = node.outputs
+
+    # Must feed a single Elemwise (or chain to one via another pre-fusion rewrite)
+    clients = fgraph.clients[reshape_out]
+    if len(clients) != 1:
+        return None
+    client_node, _ = clients[0]
+    if not isinstance(client_node.op, Elemwise):
+        return None
+
+    result = _unwrap_axis_swapped_subtensor1(fgraph, node.inputs[0])
+    if result is None:
+        return None
+    source, flat_idx, axis = result
+
+    # The index input to AdvancedSubtensor1 must be Reshape{1}(mat_idx, [-1]) (flatten)
+    if flat_idx.owner is None or not isinstance(flat_idx.owner.op, Reshape):
+        return None
+    if flat_idx.owner.op.ndim != 1:
+        return None
+    mat_idx = flat_idx.owner.inputs[0]
+    if mat_idx.ndim < 2:
+        return None
+
+    # Build AdvancedSubtensor: source[:, ..., mat_idx, :, ...]
+    src_ndim = source.type.ndim
+    idx_list = [slice(None)] * src_ndim
+    idx_list[axis] = 0  # pointer to the single index variable
+    new_out = AdvancedSubtensor(idx_list=idx_list)(source, mat_idx)
+    return [new_out]
+
+
+indexed_elemwise_optdb = SequenceDB()
+optdb.register(
+    "fuse_indexed_into_elemwise",
+    indexed_elemwise_optdb,
+    "numba",
+    # symbolic_op_recognition is excluded from OpFromGraph inner-graph
+    # compilation, preventing recursive fusion.
+    "symbolic_op_recognition",
+    # After inplace_elemwise (position=50.5) so we see final inplace patterns,
+    # same position as other numba-specific rewrites (BlockwiseWithCoreShape).
+    position=100,
+)
+
+indexed_elemwise_optdb.register(
+    "undo_take_dimshuffle_for_fusion",
+    dfs_rewriter(undo_take_dimshuffle_for_fusion),
+    "numba",
+    position=0,
+)
+
+indexed_elemwise_optdb.register(
+    "undo_take_reshape_for_fusion",
+    dfs_rewriter(undo_take_reshape_for_fusion),
+    "numba",
+    position=0.5,
+)
+
+
+class IndexedElemwise(OpFromGraph):
+    """Fuse indexed reads and updates into a single Elemwise iteration loop.
+
+    Absorbs ``AdvancedSubtensor1`` (indexed reads on inputs) and
+    ``AdvancedIncSubtensor1`` (indexed updates on outputs) into one loop,
+    avoiding materialisation of intermediate arrays.
+
+    Inner fgraph contains the unfused subgraph.
+    Non-Numba backends run it as-is via ``OpFromGraph.perform``.
+    The Numba backend generates a single loop with indirect indexing.
+
+    Outer inputs are ordered as::
+
+        [elemwise_inputs..., idx_0, idx_1, ..., update_target_0, ...]
+
+    Parameters
+    ----------
+    indexed_inputs : tuple of ((tuple[int, ...], int) | None)
+        One entry per index array k (at outer input position n_elemwise + k).
+        ``None`` if index k has no read role (write-only).
+        Otherwise ``(sources, source_axis)``:
+
+        - ``sources``: which elemwise input positions read through this
+          index.  Inputs that share the same ``(idx, axis)`` are grouped
+          so the codegen loads the index once and reuses the indirect
+          lookup for all of them.
+          E.g. ``x[idx] + y[idx]`` sharing the same ``idx`` → ``(0, 1)``.
+        - ``source_axis``: which axis of the source array is indexed
+          (not the index array's own axes).
+          E.g. ``x[:, idx]`` on a 3-D array → ``source_axis=1``.
+
+        The grouping key is ``(idx_var, source_axis)``, so the same index variable
+        on different axes produces separate entries.
+
+        Examples::
+
+            z = x[idx] + y[idx]          → [((0,1), 0)]
+            z = x[idx_a] + y[idx_b]      → [((0,), 0), ((1,), 0)]
+            write-only inc(tgt, v, idx)  → [None]
+
+    indexed_outputs : tuple of ((tuple[int, ...], int, str) | None)
+        One entry per index array k, parallel to ``indexed_inputs``.
+        ``None`` if index k has no write role.
+        Otherwise ``(sources, source_axis, mode)``:
+
+        - ``sources``: which Elemwise output positions are written
+          through this index into the update target buffer.
+        - ``source_axis``: which target-array axis is indexed.
+        - ``mode``: ``"inc"`` (accumulate) or ``"set"`` (overwrite).
+
+        Examples::
+
+            tgt[idx] += exp(x)   → indexed_outputs=[((0,), 0, "inc")]
+    """
+
+    def __init__(self, *args, indexed_inputs=(), indexed_outputs=(), **kwargs):
+        self.indexed_inputs = indexed_inputs
+        self.indexed_outputs = indexed_outputs
+        # A read buffer can occupy multiple input slots (e.g. read through
+        # several indices); construct_nominal_fgraph dedupes those to one
+        # nominal, leaving the extra slots as unused NominalVariables, which is
+        # safe because reads don't destroy. Write targets always get their own
+        # fresh inner input (see FuseIndexedElemwise) so a destroyed buffer is
+        # never deduped onto a read source.
+        super().__init__(*args, on_unused_input="ignore", accept_inplace=True, **kwargs)
+
+    def __str__(self):
+        for node in self.fgraph.apply_nodes:
+            if isinstance(node.op, Elemwise):
+                return f"IndexedElemwise{{{node.op!s}}}"
+        return "IndexedElemwise"
+
+
+@op_debug_information.register(IndexedElemwise)
+def _op_debug_information_IndexedElemwise(op, node):
+    info = {}
+
+    n_idx = len(op.indexed_inputs)
+    n_update_targets = sum(1 for e in op.indexed_outputs if e is not None)
+    n_elemwise = len(node.inputs) - n_idx - n_update_targets
+
+    # Annotate indexed-read inputs
+    for k, entry in enumerate(op.indexed_inputs):
+        if entry is None:
+            continue
+        sources, _source_axis = entry
+        idx_label = f"idx_{k}"
+        for src in sources:
+            if src < len(node.inputs):
+                info[node.inputs[src]] = f"indexed read ({idx_label})"
+
+    # Annotate index arrays (after elemwise inputs)
+    for k in range(n_idx):
+        idx_pos = n_elemwise + k
+        if idx_pos < len(node.inputs):
+            info[node.inputs[idx_pos]] = f"idx_{k}"
+
+    # Annotate update targets and outputs
+    buf_counter = 0
+    target_start = n_elemwise + n_idx
+    target_offset = 0
+    for k, entry in enumerate(op.indexed_outputs):
+        if entry is None:
+            continue
+        sources, _source_axis, mode = entry
+        buf_label = f"buf_{buf_counter}"
+        buf_counter += 1
+        idx_label = f"idx_{k}"
+
+        target_pos = target_start + target_offset
+        target_offset += 1
+        if target_pos < len(node.inputs):
+            info[node.inputs[target_pos]] = buf_label
+
+        for out_idx in sources:
+            if out_idx < len(node.outputs):
+                info[node.outputs[out_idx]] = (
+                    f"indexed {mode} ({buf_label}, {idx_label})"
+                )
+
+    return {node: info}
+
+
+class FuseIndexedElemwise(GraphRewriter):
+    """Fuse indexed reads and indexed updates into Elemwise loops.
+
+    Absorbs single-client ``AdvancedSubtensor1`` on inputs (indexed reads)
+    and single-client ``AdvancedIncSubtensor1`` on outputs (indexed updates)
+    into the Elemwise iteration, avoiding intermediate arrays.
+
+    Supports multiple index arrays: e.g. ``x[idx_a] + y[idx_b]`` produces
+    two index groups.  Index arrays are shared between reads and updates
+    when they refer to the same variable.
+    """
+
+    @staticmethod
+    def _extract_idx_axis_pairs(node, *, write=False):
+        """Extract ``(idx_var, axis)`` pairs from an Advanced(Inc)Subtensor node.
+
+        Returns a list of pairs, or ``None`` if the node uses non-consecutive
+        advanced indexing, boolean indices, or mixed slice/integer patterns
+        that we can't fuse.
+
+        Parameters
+        ----------
+        write : bool
+            If True, match write ops (AdvancedIncSubtensor variants).
+            If False (default), match read ops (AdvancedSubtensor variants).
+        """
+        op = node.op
+        if not write:
+            if isinstance(op, AdvancedSubtensor1):
+                return [(node.inputs[1], 0)]
+            if isinstance(op, AdvancedSubtensor):
+                n_skip = 1
+            else:
+                return None
+        else:
+            if isinstance(op, AdvancedIncSubtensor1):
+                return [(node.inputs[2], 0)]
+            if isinstance(op, AdvancedIncSubtensor):
+                n_skip = 2
+            else:
+                return None
+
+        if op.non_consecutive_adv_indexing(node):
+            return None
+        idx_vars = node.inputs[n_skip:]
+        pairs = []
+        for axis, entry in enumerate(op.idx_list):
+            if isinstance(entry, slice):
+                continue
+            idx = idx_vars[entry]
+            if not isinstance(idx, TensorVariable) or idx.type.dtype == "bool":
+                return None
+            pairs.append((idx, axis))
+        return pairs or None
+
+    @staticmethod
+    def _duplicate_multi_client_outputs(node, multi_client_outs):
+        """Add duplicate outputs for Elemwise results that have both write and non-write consumers.
+
+        Returns ``(new_node, dup_map)`` where *dup_map* maps each original
+        output index to its duplicate position.
+        """
+        scalar_op = node.op.scalar_op
+        if isinstance(scalar_op, Composite):
+            s_inputs = list(scalar_op.inputs)
+            s_outputs = list(scalar_op.outputs)
+        else:
+            scalar_node = scalar_op.make_node(
+                *[inp.type.to_scalar_type()() for inp in node.inputs]
+            )
+            s_inputs = list(scalar_node.inputs)
+            s_outputs = list(scalar_node.outputs)
+
+        dup_map = {}
+        for out_idx in sorted(multi_client_outs):
+            dup_map[out_idx] = len(s_outputs)
+            s_outputs.append(s_outputs[out_idx])
+
+        new_scalar_op = Composite(s_inputs, s_outputs)
+        new_node = Elemwise(new_scalar_op).make_node(*node.inputs)
+        return new_node, dup_map
+
+    @staticmethod
+    def transpose_non_indexed_write_axes(node, write_targets):
+        """Move excess leading non-indexed dims to the right of the write target.
+
+        Only the leftmost non-indexed dims that aren't covered by the Elemwise
+        loop are moved. Loop dims and indexed axes keep their relative order so
+        the val's dim layout stays aligned with the write slice.
+
+        Returns a list of ``(old_out, new_out)`` replacement pairs, or an
+        empty list if no write target needed transposing.
+        """
+        replacements = []
+        elemwise_batch_ndim = len(node.outputs[0].type.broadcastable)
+        for update_node in write_targets.values():
+            op = update_node.op
+            target, val, *idx_vars = update_node.inputs
+
+            idx_axes = [i for i, e in enumerate(op.idx_list) if e != slice(None)]
+            n_indexed_axes = len(idx_axes)
+            n_idx_dims = max(v.ndim for v in idx_vars)
+            source_batch = elemwise_batch_ndim + n_indexed_axes - n_idx_dims
+            if max(idx_axes) < source_batch:
+                # Indexed axes already within batch dims, no transpose needed
+                continue
+
+            # Move excess leading non-indexed axes to the right
+            non_idx_axes = [a for a in range(target.type.ndim) if a not in idx_axes]
+            excess = target.type.ndim - source_batch
+            excess_axes = non_idx_axes[:excess]
+            non_excess_axes = [
+                a for a in range(target.type.ndim) if a not in excess_axes
+            ]
+            perm = non_excess_axes + excess_axes
+            target_t = target.dimshuffle(perm)
+
+            # Pad val so it broadcasts with excess dims moved to the right.
+            # Non-indexed axes can't be between indexed axes (_extract_idx_axis_pairs rejects non-consecutive indexing).
+            val = shape_padright(val, excess)
+            new_idx_list = [op.idx_list[perm[i]] for i in range(len(perm))]
+
+            # Create new write node
+            props = op._props_dict()
+            props["idx_list"] = tuple(new_idx_list)
+            new_inc = type(op)(**props)(target_t, val, *idx_vars)
+
+            # Permute updated node so it behaves like original one
+            inv_perm = [0] * len(perm)
+            for i, p in enumerate(perm):
+                inv_perm[p] = i
+            new_update = new_inc.dimshuffle(inv_perm)
+
+            replacements.append((update_node.outputs[0], new_update))
+        return replacements
+
+    def apply(self, fgraph):
+        # Live reference to the destroy handler's view chain (mutated in place as
+        # we rewrite); used to resolve read/write buffers to their roots for the
+        # aliasing check below. replace_all_validate requires the destroy handler,
+        # so it is present whenever a fusion could actually be rejected for aliasing.
+        destroy_handler = getattr(fgraph, "destroy_handler", None)
+        view_i = destroy_handler.view_i if destroy_handler is not None else {}
+
+        worklist = list(reversed(fgraph.toposort()))
+        while worklist:
+            node = worklist.pop()
+            if not isinstance(node.op, Elemwise):
+                continue
+            if node not in fgraph.apply_nodes:
+                continue
+
+            idx_groups = {}  # (idx_var, axis) -> (reads: list[int], writes: list[int])
+
+            # Roots of the buffers we read through, used below to skip fusing a
+            # write whose target buffer aliases one of them (see aliasing check).
+            read_source_roots = set()
+
+            # Find indexed reads to fuse: single client AdvancedSubtensor(1)
+            for i, inp in enumerate(node.inputs):
+                inp_node = inp.owner
+                if inp_node is None or any(
+                    c is not node for c, _ in fgraph.clients[inp]
+                ):
+                    continue
+                idx_axis_pairs = self._extract_idx_axis_pairs(inp_node)
+                if idx_axis_pairs is None:
+                    continue
+                read_source_roots.add(_view_root(view_i, inp_node.inputs[0]))
+                for idx_axis_pair in idx_axis_pairs:
+                    if idx_axis_pair not in idx_groups:
+                        idx_groups[idx_axis_pair] = ([], [])
+                    idx_groups[idx_axis_pair][0].append(i)
+
+            # For indexed writes to fuse: single client AdvancedIncSubtensor(1)
+            # The write may be separated from the output by a right expand_dims DimShuffle
+            # All indexed write axes have to overlap and not broadcast the core Elemwise loop
+            # Our current vectorize codegen can't produce write only loops that don't force
+            # the recomputation of the core function in every step.
+            write_targets = {}  # out_idx -> update_node
+            must_transpose_write_axes = False
+            for out_idx, out in enumerate(node.outputs):
+                clients = fgraph.clients[out]
+                # Allow right expand_dims between elemwise and write
+                # buffer[idx].set(f(x)[..., None, None])
+                # These will be absorbed by broadcasting the result at each iteration of the loop
+                # into the sliced non-scalar indexed buffer, making use of vectorize_codegen with fake "core output dims"
+                # We actually move left broadcasted dims to the right below
+                right_pad = 0
+                if (
+                    len(clients) == 1
+                    and isinstance((ds_op := clients[0][0].op), DimShuffle)
+                    and ds_op.is_right_expand_dims
+                    and len(fgraph.clients[(ds_out := clients[0][0].outputs[0])]) == 1
+                ):
+                    right_pad = len(ds_op.augment)
+                    clients = fgraph.clients[ds_out]
+                inc_clients = [
+                    (c, ci)
+                    for c, ci in clients
+                    if ci == 1
+                    and isinstance(c.op, AdvancedIncSubtensor1 | AdvancedIncSubtensor)
+                ]
+                if len(inc_clients) != 1:
+                    # TODO: support multiple writes from the same Elemwise output via Composite duplication
+                    continue
+                [(client_node, _)] = inc_clients
+                idx_axis_pairs = self._extract_idx_axis_pairs(client_node, write=True)
+                if idx_axis_pairs is None:
+                    continue
+
+                target, _, *idx_vars = client_node.inputs
+
+                # Fusing an in-place write whose target is a buffer we also read
+                # through (same root) makes it two distinct inputs of one node, one
+                # read and one destroyed: the destroy handler rejects that aliasing.
+                # Leave such writes unfused (the reads still fuse, no added copy).
+                # Non-in-place writes are copied below, so their copy breaks the alias.
+                if client_node.op.inplace and _view_root(view_i, target) in (
+                    read_source_roots
+                ):
+                    continue
+
+                write_bcast = AdvancedSubtensor(idx_list=client_node.op.idx_list)(
+                    target, *idx_vars
+                ).type.broadcastable
+                indexed_write_bcast = (
+                    write_bcast[: len(write_bcast) - right_pad]
+                    if right_pad
+                    else write_bcast
+                )
+                left_pad = min(a for _, a in idx_axis_pairs)
+                if out.type.ndim + left_pad < len(indexed_write_bcast):
+                    # out does not cover all indexed write dims
+                    continue
+
+                if any(
+                    ob and not iwb
+                    for ob, iwb in zip(
+                        reversed(out.type.broadcastable), reversed(indexed_write_bcast)
+                    )
+                ):
+                    # TODO: support broadcast on non-indexed dims by squeezing them out of the Elemwise first
+                    continue
+
+                if len(indexed_write_bcast) > out.type.ndim:
+                    must_transpose_write_axes = True
+
+                for idx_axis_pair in idx_axis_pairs:
+                    if idx_axis_pair not in idx_groups:
+                        idx_groups[idx_axis_pair] = ([], [])
+                    idx_groups[idx_axis_pair][1].append(out_idx)
+                write_targets[out_idx] = client_node
+
+            if not idx_groups:
+                continue
+
+            if must_transpose_write_axes:
+                replacements = self.transpose_non_indexed_write_axes(
+                    node, write_targets
+                )
+                assert replacements
+                fgraph.replace_all(
+                    replacements,
+                    reason="fuse_indexed_elemwise_move_write_axes",
+                )
+                worklist.append(node)
+                continue
+
+            indexed_reads = {i for reads, _ in idx_groups.values() for i in reads}
+
+            # If any inplace targets an indexed-read input,
+            # strip and re-run inplace with those inputs protected
+            if any(
+                inp_idx in indexed_reads for inp_idx in node.op.inplace_pattern.values()
+            ):
+                stripped_node = Elemwise(node.op.scalar_op).make_node(*node.inputs)
+                fgraph.replace_all(
+                    zip(node.outputs, stripped_node.outputs),
+                    reason="fuse_indexed_elemwise_strip_inplace",
+                )
+                protected = frozenset(stripped_node.inputs[i] for i in indexed_reads)
+                # try_inplace_on_node does its own fgraph.replace_all internally,
+                # so the returned node is already in the fgraph
+                new_inplace_node = InplaceElemwiseOptimizer().try_inplace_on_node(
+                    fgraph,
+                    stripped_node,
+                    reason="fuse_indexed_elemwise_inplace_read_buffers",
+                    extra_protected_inputs=protected,
+                )
+                worklist.append(new_inplace_node)
+                continue
+
+            # If any indexed-write output also has other consumers,
+            # duplicate it via Composite so the write replaces the duplicate
+            # while the original stays available for non-write consumers.
+            # We still avoid one extra write loop,
+            # even if we can't skip the output materialization altogether
+            def _has_non_write_clients(out_idx):
+                update = write_targets[out_idx]
+                for c, _ in fgraph.clients[node.outputs[out_idx]]:
+                    if c is update:
+                        continue
+                    # Look through shape_padright from write normalization
+                    if (
+                        isinstance(c.op, DimShuffle)
+                        and c.op.is_right_expand_dims
+                        and len(ds_clients := fgraph.clients[c.outputs[0]]) == 1
+                        and ds_clients[0][0] is update
+                    ):
+                        continue
+                    return True
+                return False
+
+            if write_and_direct_use_outs := {
+                out_idx for out_idx in write_targets if _has_non_write_clients(out_idx)
+            }:
+                new_node, dup_map = self._duplicate_multi_client_outputs(
+                    node, write_and_direct_use_outs
+                )
+                replacements = list(
+                    zip(node.outputs, new_node.outputs[: len(node.outputs)])
+                )
+                for out_idx, dup_idx in dup_map.items():
+                    update_node = write_targets[out_idx]
+                    new_update_out = update_node.op(
+                        update_node.inputs[0],
+                        new_node.outputs[dup_idx],
+                        *update_node.inputs[2:],
+                    )
+                    replacements.append((update_node.outputs[0], new_update_out))
+                fgraph.replace_all(
+                    replacements,
+                    reason="fuse_indexed_elemwise_write_and_direct_outputs",
+                )
+                worklist.append(new_node)
+                continue
+
+            idx_vars = [idx for idx, _axis in idx_groups]
+
+            fgraph_destroy_map = {
+                out_idx: [inp_idx]
+                for out_idx, inp_idx in node.op.inplace_pattern.items()
+                if out_idx not in write_targets
+            }
+
+            # Fgraph inputs: substitute indexed sources back to their
+            # pre-subtensor arrays, append index arrays and update targets.
+            fgraph_inputs = [
+                inp.owner.inputs[0] if i in indexed_reads else inp
+                for i, inp in enumerate(node.inputs)
+            ] + idx_vars
+
+            # Non-inplace write targets need a copy so the original isn't destroyed
+            # Elemwise will always destroy the write buffers inplace afterwards.
+            copy_positions = set()
+            # Real outer buffer bound to each write-target input position. The inner
+            # fgraph uses a fresh variable there (see below), so the actual buffer
+            # (or its copy) is bound only at the outer call.
+            outer_write_targets = {}
+
+            # Inner fgraph outputs: Elemwise outputs, with write targets
+            # replaced by their AdvancedIncSubtensor result
+            fgraph_outputs = list(node.outputs)
+            for out_idx, update_node in sorted(write_targets.items()):
+                target = update_node.inputs[0]
+
+                # Use a fresh inner input for the write target so it stays distinct
+                # from a read source that is the same variable. Otherwise
+                # construct_nominal_fgraph would dedupe the two into one nominal and
+                # the copy bound below would be dead inside the inner graph, leaving
+                # the inner write to destroy the read buffer instead of the copy.
+                inner_target = target.type()
+                fgraph_inputs.append(inner_target)
+                target_pos = len(fgraph_inputs) - 1
+                outer_write_targets[target_pos] = target
+
+                if not update_node.op.inplace:
+                    copy_positions.add(target_pos)
+
+                # Build the indexed write for the inner fgraph, in-place on the fresh
+                # inner target buffer (Elemwise destroys the write buffers anyway).
+                if update_node.op.inplace:
+                    write_out = update_node.op(inner_target, *update_node.inputs[1:])
+                else:
+                    props = update_node.op._props_dict()
+                    props["inplace"] = True
+                    inplace_op = type(update_node.op)(**props)
+                    write_out = inplace_op(
+                        inner_target, node.outputs[out_idx], *update_node.inputs[2:]
+                    )
+
+                fgraph_outputs[out_idx] = write_out
+                fgraph_destroy_map[out_idx] = [target_pos]
+
+            # indexed_inputs_spec: ((read_positions, axis) | None, ...)
+            # indexed_outputs_spec: ((write_positions, axis, "inc"|"set") | None, ...)
+            indexed_inputs_spec = tuple(
+                (tuple(reads), axis) if reads else None
+                for (_, axis), (reads, _) in idx_groups.items()
+            )
+            indexed_outputs_spec = tuple(
+                (
+                    tuple(writes),
+                    key[1],
+                    "set" if write_targets[writes[0]].op.set_instead_of_inc else "inc",
+                )
+                if writes
+                else None
+                for key, (_, writes) in idx_groups.items()
+            )
+
+            outer_inputs = []
+            for i, inp in enumerate(fgraph_inputs):
+                val = outer_write_targets.get(i, inp)
+                outer_inputs.append(val.copy() if i in copy_positions else val)
+
+            new_outs = IndexedElemwise(
+                fgraph_inputs,
+                fgraph_outputs,
+                destroy_map=fgraph_destroy_map,
+                indexed_inputs=indexed_inputs_spec,
+                indexed_outputs=indexed_outputs_spec,
+            )(*outer_inputs, return_list=True)
+
+            replacements = []
+            for out_idx in range(len(node.outputs)):
+                if out_idx in write_targets:
+                    replacements.append(
+                        (write_targets[out_idx].outputs[0], new_outs[out_idx])
+                    )
+                else:
+                    replacements.append((node.outputs[out_idx], new_outs[out_idx]))
+
+            # Safety net for aliasing we didn't anticipate above (e.g. a write
+            # target that is a view of another input): skip this node rather than
+            # aborting the whole pass and leaving later nodes unfused.
+            try:
+                fgraph.replace_all_validate(
+                    replacements,
+                    reason="fuse_indexed_into_elemwise",
+                )
+            except InconsistencyError:
+                continue
+
+
+indexed_elemwise_optdb.register(
+    "fuse_indexed_elemwise",
+    FuseIndexedElemwise(),
+    "numba",
+    position=1,
+)

--- a/pytensor/tensor/rewriting/numba.py
+++ b/pytensor/tensor/rewriting/numba.py
@@ -1,3 +1,4 @@
+import pytensor.tensor.rewriting.indexed_elemwise  # noqa: F401
 from pytensor.compile import optdb
 from pytensor.graph import node_rewriter
 from pytensor.graph.rewriting.basic import dfs_rewriter

--- a/scripts/mypy-failing.txt
+++ b/scripts/mypy-failing.txt
@@ -1,6 +1,5 @@
 pytensor/compile/builders.py
 pytensor/compile/debug/debugmode.py
-pytensor/compile/debug/profiling.py
 pytensor/compile/executor.py
 pytensor/compile/maker.py
 pytensor/compile/rebuild.py
@@ -10,7 +9,6 @@ pytensor/ifelse.py
 pytensor/link/numba/dispatch/scan.py
 pytensor/printing.py
 pytensor/raise_op.py
-pytensor/scan/op.py
 pytensor/tensor/basic.py
 pytensor/tensor/blas_c.py
 pytensor/tensor/blas_headers.py

--- a/scripts/mypy-failing.txt
+++ b/scripts/mypy-failing.txt
@@ -1,5 +1,6 @@
 pytensor/compile/builders.py
 pytensor/compile/debug/debugmode.py
+pytensor/compile/debug/profiling.py
 pytensor/compile/executor.py
 pytensor/compile/maker.py
 pytensor/compile/rebuild.py
@@ -9,6 +10,7 @@ pytensor/ifelse.py
 pytensor/link/numba/dispatch/scan.py
 pytensor/printing.py
 pytensor/raise_op.py
+pytensor/scan/op.py
 pytensor/tensor/basic.py
 pytensor/tensor/blas_c.py
 pytensor/tensor/blas_headers.py

--- a/tests/benchmarks/test_gather_fusion.py
+++ b/tests/benchmarks/test_gather_fusion.py
@@ -1,0 +1,147 @@
+"""Micro-benchmarks for Elemwise fusion with indexed reads and updates.
+
+Tests the benefit of fusing AdvancedSubtensor1 (indexed reads) and
+AdvancedIncSubtensor1 (indexed updates) into Elemwise loops, avoiding
+materialization of intermediate arrays.
+"""
+
+import numpy as np
+import pytest
+
+import pytensor
+import pytensor.tensor as pt
+from pytensor import config
+from pytensor.compile.mode import get_mode
+from pytensor.tensor.rewriting.indexed_elemwise import IndexedElemwise
+from pytensor.tensor.subtensor import AdvancedIncSubtensor1, advanced_subtensor1
+
+
+@pytest.fixture(
+    params=[
+        (85, 919, 2, 6),  # radon-like: small
+        (1000, 100_000, 2, 4),  # medium
+    ],
+    ids=["small-85x919", "medium-1Kx100K"],
+)
+def read_benchmark_setup(request):
+    n_bins, n_data, n_read, n_direct = request.param
+
+    rng = np.random.default_rng(42)
+    idx = rng.integers(n_bins, size=n_data).astype(np.int64)
+    idx.sort()
+
+    sources = [pt.vector(f"src_{i}", shape=(n_bins,)) for i in range(n_read)]
+    directs = [pt.vector(f"dir_{i}", shape=(n_data,)) for i in range(n_direct)]
+
+    terms = [advanced_subtensor1(s, idx) for s in sources] + directs
+    out = terms[0]
+    for t in terms[1:]:
+        out = out + t
+
+    inputs = sources + directs
+    numba_mode = get_mode("NUMBA")
+
+    fn_fused = pytensor.function(inputs, out, mode=numba_mode, trust_input=True)
+    fn_unfused = pytensor.function(
+        inputs,
+        out,
+        mode=numba_mode.excluding("fuse_indexed_into_elemwise"),
+        trust_input=True,
+    )
+
+    assert any(
+        isinstance(n.op, IndexedElemwise) for n in fn_fused.maker.fgraph.toposort()
+    ), "IndexedElemwise not found in fused graph"
+    assert not any(
+        isinstance(n.op, IndexedElemwise) for n in fn_unfused.maker.fgraph.toposort()
+    ), "IndexedElemwise found in unfused graph"
+
+    rng = np.random.default_rng(1)
+    vals = [rng.normal(size=inp.type.shape).astype(config.floatX) for inp in inputs]
+
+    np.testing.assert_allclose(fn_fused(*vals), fn_unfused(*vals), rtol=1e-10)
+
+    return fn_fused, fn_unfused, vals
+
+
+def test_read_fusion_fused(read_benchmark_setup, benchmark):
+    fn_fused, _, vals = read_benchmark_setup
+    fn_fused(*vals)  # warmup
+    benchmark(fn_fused, *vals)
+
+
+def test_read_fusion_unfused(read_benchmark_setup, benchmark):
+    _, fn_unfused, vals = read_benchmark_setup
+    fn_unfused(*vals)  # warmup
+    benchmark(fn_unfused, *vals)
+
+
+@pytest.fixture(
+    params=[
+        (85, 919, 2, 6, "inc"),  # radon-like: small, inc mode
+        (85, 919, 2, 6, "set"),  # radon-like: small, set mode
+        (1000, 100_000, 2, 4, "inc"),  # medium, inc mode
+    ],
+    ids=["small-85x919-inc", "small-85x919-set", "medium-1Kx100K-inc"],
+)
+def write_benchmark_setup(request):
+    n_bins, n_data, n_read, n_direct, mode = request.param
+
+    rng = np.random.default_rng(42)
+    idx = rng.integers(n_bins, size=n_data).astype(np.int64)
+    idx.sort()
+
+    sources = [pt.vector(f"src_{i}", shape=(n_bins,)) for i in range(n_read)]
+    directs = [pt.vector(f"dir_{i}", shape=(n_data,)) for i in range(n_direct)]
+    target = pt.vector("target", shape=(n_bins,))
+
+    terms = [advanced_subtensor1(s, idx) for s in sources] + directs
+    elemwise_out = terms[0]
+    for t in terms[1:]:
+        elemwise_out = elemwise_out + t
+
+    if mode == "inc":
+        out = pt.inc_subtensor(target[idx], elemwise_out)
+    else:
+        out = pt.set_subtensor(target[idx], elemwise_out)
+
+    inputs = sources + directs + [target]
+    numba_mode = get_mode("NUMBA")
+
+    fn_fused = pytensor.function(inputs, out, mode=numba_mode, trust_input=True)
+    fn_unfused = pytensor.function(
+        inputs,
+        out,
+        mode=numba_mode.excluding("fuse_indexed_into_elemwise"),
+        trust_input=True,
+    )
+
+    assert any(
+        isinstance(n.op, IndexedElemwise) for n in fn_fused.maker.fgraph.toposort()
+    ), "IndexedElemwise not found in fused graph"
+    assert not any(
+        isinstance(n.op, AdvancedIncSubtensor1)
+        for n in fn_fused.maker.fgraph.toposort()
+    ), "AdvancedIncSubtensor1 still present in fused graph"
+    assert not any(
+        isinstance(n.op, IndexedElemwise) for n in fn_unfused.maker.fgraph.toposort()
+    ), "IndexedElemwise found in unfused graph"
+
+    rng = np.random.default_rng(1)
+    vals = [rng.normal(size=inp.type.shape).astype(config.floatX) for inp in inputs]
+
+    np.testing.assert_allclose(fn_fused(*vals), fn_unfused(*vals), rtol=1e-10)
+
+    return fn_fused, fn_unfused, vals
+
+
+def test_write_fusion_fused(write_benchmark_setup, benchmark):
+    fn_fused, _, vals = write_benchmark_setup
+    fn_fused(*vals)  # warmup
+    benchmark(fn_fused, *vals)
+
+
+def test_write_fusion_unfused(write_benchmark_setup, benchmark):
+    _, fn_unfused, vals = write_benchmark_setup
+    fn_unfused(*vals)  # warmup
+    benchmark(fn_unfused, *vals)

--- a/tests/benchmarks/test_rewriting.py
+++ b/tests/benchmarks/test_rewriting.py
@@ -45,7 +45,7 @@ def _deep_small_kernels(n):
     "graph_fn, n, expected_n_repl",
     [
         ("deep_small_kernels", 20, (20, 60)),
-        ("large_fuseable_graph", 25, (128, 876)),
+        ("large_fuseable_graph", 25, (55, 901)),
     ],
 )
 def test_fusion_rewrite_benchmark(graph_fn, n, expected_n_repl, benchmark):

--- a/tests/compile/test_executor.py
+++ b/tests/compile/test_executor.py
@@ -389,6 +389,8 @@ class TestFunction:
             assert in1.value is in2.value
 
     def test_copy_delete_updates(self):
+        from contextlib import nullcontext
+
         w = iscalar("w")
         x = fscalar("x")
         # SharedVariable for tests, one of them has update
@@ -396,19 +398,27 @@ class TestFunction:
         z = shared(value=2, name="z")
         out = x + y + z
 
-        # Test for different linkers
-        # for mode in ["FAST_RUN","FAST_COMPILE"]:
-        # second_time = False
-        for mode in ("FAST_RUN", "FAST_COMPILE"):
-            ori = function([x], out, mode=mode, updates={z: z * 2})
-            cpy = ori.copy(delete_updates=True)
+        inplace_warn = pytest.warns(UserWarning, match="will still be mutated")
 
-            assert cpy(1) == 4
-            assert cpy(1) == 4
-            assert cpy(1) == 4
+        for mode in ("FAST_RUN", "FAST_COMPILE"):
+            y.set_value(1)
+            z.set_value(2)
+            # FAST_RUN applies inplace rewrites, so z will be destroyed.
+            # A warning is issued because dropping the update doesn't prevent
+            # the shared variable storage from being mutated.
+            ctx = inplace_warn if mode == "FAST_RUN" else nullcontext()
+            ori = function([x], out, mode=mode, updates={z: z * 2})
+            with ctx:
+                cpy = ori.copy(delete_updates=True)
+            if mode == "FAST_COMPILE":
+                assert cpy(1) == 4
+                assert cpy(1) == 4
+                assert cpy(1) == 4
 
         # Test if unused implicit and explicit inputs from delete_updates
         # are ignored as intended.
+        # No inplace warning here because z is not reachable from the output,
+        # so the destroying node won't be in the cloned graph.
         for mode in ("FAST_RUN", "FAST_COMPILE"):
             ori = function([x], x, mode=mode, updates={z: z * 2})
             cpy = ori.copy(delete_updates=True)

--- a/tests/link/numba/test_indexed_elemwise.py
+++ b/tests/link/numba/test_indexed_elemwise.py
@@ -1,0 +1,605 @@
+"""Tests for IndexedElemwise fusion (indexed reads and updates in Elemwise loops)."""
+
+import numpy as np
+import pytest
+
+import pytensor
+import pytensor.tensor as pt
+from pytensor.compile.mode import Mode, get_mode
+from pytensor.tensor.rewriting.indexed_elemwise import IndexedElemwise
+from pytensor.tensor.subtensor import (
+    AdvancedIncSubtensor1,
+    AdvancedSubtensor,
+)
+
+
+numba = pytest.importorskip("numba")
+
+NUMBA_MODE = get_mode("NUMBA")
+NUMBA_NO_FUSION = NUMBA_MODE.excluding("fuse_indexed_into_elemwise")
+
+
+def fused_and_unfused(inputs, output):
+    """Compile fused and unfused versions of a graph."""
+    fn = pytensor.function(inputs, output, mode=NUMBA_MODE, trust_input=True)
+    fn_u = pytensor.function(inputs, output, mode=NUMBA_NO_FUSION, trust_input=True)
+    return fn, fn_u
+
+
+def assert_fused(fn):
+    """Assert that the compiled graph contains an IndexedElemwise node."""
+    assert any(isinstance(n.op, IndexedElemwise) for n in fn.maker.fgraph.toposort()), (
+        "IndexedElemwise not found in fused graph"
+    )
+
+
+class TestIndexedReadFusion:
+    """Test indexed reads (AdvancedSubtensor1) fused into Elemwise."""
+
+    def test_single_index_axis0(self):
+        rng = np.random.default_rng(42)
+        idx = rng.integers(85, size=919).astype(np.int64)
+        x = pt.vector("x", shape=(85,))
+        y = pt.vector("y", shape=(919,))
+        fn, fn_u = fused_and_unfused([x, y], x[idx] + y)
+        assert_fused(fn)
+        xv, yv = rng.normal(size=(85,)), rng.normal(size=(919,))
+        np.testing.assert_allclose(fn(xv, yv), fn_u(xv, yv), rtol=1e-10)
+
+    def test_multiple_read_sources(self):
+        rng = np.random.default_rng(42)
+        idx = rng.integers(85, size=919).astype(np.int64)
+        x1 = pt.vector("x1", shape=(85,))
+        x2 = pt.vector("x2", shape=(85,))
+        y = pt.vector("y", shape=(919,))
+        fn, fn_u = fused_and_unfused([x1, x2, y], x1[idx] + x2[idx] + y)
+        assert_fused(fn)
+        xv1, xv2, yv = (
+            rng.normal(size=(85,)),
+            rng.normal(size=(85,)),
+            rng.normal(size=(919,)),
+        )
+        np.testing.assert_allclose(fn(xv1, xv2, yv), fn_u(xv1, xv2, yv), rtol=1e-10)
+
+    def test_broadcast_index_axis0(self):
+        """Static shape=(1,) index on axis 0 broadcasts against larger direct input."""
+        x = pt.vector("x", shape=(100,))
+        y = pt.vector("y", shape=(50,))
+        idx = pt.vector("idx", dtype="int64", shape=(1,))
+        out = x[idx] + y
+        fn, fn_u = fused_and_unfused([x, y, idx], out)
+        assert_fused(fn)
+        xv = np.arange(100, dtype="float64")
+        yv = np.ones(50)
+        idxv = np.array([5], dtype=np.int64)
+        np.testing.assert_allclose(fn(xv, yv, idxv), fn_u(xv, yv, idxv), rtol=1e-10)
+
+    def test_broadcast_index_axis1(self):
+        """Static shape=(1,) index on axis 1 broadcasts against larger direct input."""
+        x = pt.matrix("x", shape=(3, 100))
+        y = pt.matrix("y", shape=(3, 50))
+        idx = pt.vector("idx", dtype="int64", shape=(1,))
+        out = x[:, idx] + y  # x[:, idx] has shape (3, 1), broadcasts to (3, 50)
+        fn, fn_u = fused_and_unfused([x, y, idx], out)
+        assert_fused(fn)
+        xv = np.arange(300.0).reshape(3, 100)
+        yv = np.ones((3, 50))
+        idxv = np.array([5], dtype=np.int64)
+        np.testing.assert_allclose(fn(xv, yv, idxv), fn_u(xv, yv, idxv), rtol=1e-10)
+
+    def test_nd_index_axis0(self):
+        """2D matrix index on axis 0."""
+        rng = np.random.default_rng(42)
+        x = pt.vector("x", shape=(100,))
+        mat_idx = pt.matrix("mat_idx", dtype="int64", shape=(10, 5))
+        y = pt.matrix("y", shape=(10, 5))
+        fn, fn_u = fused_and_unfused([x, mat_idx, y], pt.exp(x[mat_idx]) + y)
+        assert_fused(fn)
+        xv = rng.normal(size=(100,))
+        iv = rng.integers(100, size=(10, 5)).astype(np.int64)
+        yv = rng.normal(size=(10, 5))
+        np.testing.assert_allclose(fn(xv, iv, yv), fn_u(xv, iv, yv), rtol=1e-10)
+
+    def test_nd_index_axis1(self):
+        """2D matrix index on axis 1 (via undo_take_reshape_for_fusion)."""
+        rng = np.random.default_rng(42)
+        x = pt.matrix("x", shape=(3, 100))
+        mat_idx = pt.matrix("mat_idx", dtype="int64", shape=(10, 5))
+        fn, fn_u = fused_and_unfused([x, mat_idx], pt.exp(x[:, mat_idx]))
+        assert_fused(fn)
+        xv = rng.normal(size=(3, 100))
+        iv = rng.integers(100, size=(10, 5)).astype(np.int64)
+        np.testing.assert_allclose(fn(xv, iv), fn_u(xv, iv), rtol=1e-10)
+
+    def test_nd_index_with_trailing_dims(self):
+        """2D index on axis 0 with trailing source dims."""
+        rng = np.random.default_rng(42)
+        x = pt.matrix("x", shape=(100, 7))
+        mat_idx = pt.matrix("mat_idx", dtype="int64", shape=(10, 5))
+        fn, fn_u = fused_and_unfused([x, mat_idx], pt.exp(x[mat_idx]))
+        assert_fused(fn)
+        xv = rng.normal(size=(100, 7))
+        iv = rng.integers(100, size=(10, 5)).astype(np.int64)
+        np.testing.assert_allclose(fn(xv, iv), fn_u(xv, iv), rtol=1e-10)
+
+    def test_nd_index_broadcast(self):
+        """Broadcastable 2D index (shape (1, C)) broadcasts against direct input."""
+        rng = np.random.default_rng(42)
+        x = pt.vector("x", shape=(100,))
+        bc_idx = pt.matrix("bc_idx", dtype="int64", shape=(1, 5))
+        y = pt.matrix("y", shape=(10, 5))
+        fn, fn_u = fused_and_unfused([x, bc_idx, y], x[bc_idx] + y)
+        assert_fused(fn)
+        xv = rng.normal(size=(100,))
+        bcv = rng.integers(100, size=(1, 5)).astype(np.int64)
+        yv = rng.normal(size=(10, 5))
+        np.testing.assert_allclose(fn(xv, bcv, yv), fn_u(xv, bcv, yv), rtol=1e-10)
+
+    def test_scalar_and_vector_index(self):
+        """x[scalar_idx, vector_idx] — 0-d index broadcasts with 1-d index."""
+        rng = np.random.default_rng(42)
+        x = pt.matrix("x", shape=(100, 200))
+        scalar_idx = pt.scalar("scalar_idx", dtype="int64")
+        vec_idx = pt.vector("vec_idx", dtype="int64", shape=(50,))
+        y = pt.vector("y", shape=(50,))
+        fn, fn_u = fused_and_unfused(
+            [x, scalar_idx, vec_idx, y], x[scalar_idx, vec_idx] + y
+        )
+        assert_fused(fn)
+        xv = rng.normal(size=(100, 200))
+        sv = np.array(rng.integers(100), dtype=np.int64)
+        vv = rng.integers(200, size=50).astype(np.int64)
+        yv = rng.normal(size=50)
+        np.testing.assert_allclose(fn(xv, sv, vv, yv), fn_u(xv, sv, vv, yv), rtol=1e-10)
+
+    def test_vector_and_scalar_index(self):
+        """x[vector_idx, scalar_idx] — reversed order."""
+        rng = np.random.default_rng(42)
+        x = pt.matrix("x", shape=(100, 200))
+        vec_idx = pt.vector("vec_idx", dtype="int64", shape=(50,))
+        scalar_idx = pt.scalar("scalar_idx", dtype="int64")
+        y = pt.vector("y", shape=(50,))
+        fn, fn_u = fused_and_unfused(
+            [x, vec_idx, scalar_idx, y], x[vec_idx, scalar_idx] + y
+        )
+        assert_fused(fn)
+        xv = rng.normal(size=(100, 200))
+        vv = rng.integers(100, size=50).astype(np.int64)
+        sv = np.array(rng.integers(200), dtype=np.int64)
+        yv = rng.normal(size=50)
+        np.testing.assert_allclose(fn(xv, vv, sv, yv), fn_u(xv, vv, sv, yv), rtol=1e-10)
+
+    def test_scalar_and_vector_index_with_trailing_dim(self):
+        """x[scalar_idx, vector_idx] on a 3-d tensor with trailing dim."""
+        rng = np.random.default_rng(42)
+        x = pt.tensor3("x", shape=(100, 200, 7))
+        scalar_idx = pt.scalar("scalar_idx", dtype="int64")
+        vec_idx = pt.vector("vec_idx", dtype="int64", shape=(50,))
+        z = pt.matrix("z", shape=(50, 7))
+        fn, fn_u = fused_and_unfused(
+            [x, scalar_idx, vec_idx, z], x[scalar_idx, vec_idx] + z
+        )
+        assert_fused(fn)
+        xv = rng.normal(size=(100, 200, 7))
+        sv = np.array(rng.integers(100), dtype=np.int64)
+        vv = rng.integers(200, size=50).astype(np.int64)
+        zv = rng.normal(size=(50, 7))
+        np.testing.assert_allclose(fn(xv, sv, vv, zv), fn_u(xv, sv, vv, zv), rtol=1e-10)
+
+    def test_all_scalar_indices(self):
+        """AdvancedSubtensor with all 0-d indices (degenerate case)."""
+        rng = np.random.default_rng(42)
+        x = pt.matrix("x", shape=(100, 200))
+        si0 = pt.scalar("si0", dtype="int64")
+        si1 = pt.scalar("si1", dtype="int64")
+        y = pt.scalar("y", dtype="float64")
+        adv_sub = AdvancedSubtensor(idx_list=(0, 1))(x, si0, si1)
+        fn, fn_u = fused_and_unfused([x, si0, si1, y], adv_sub + y)
+        assert_fused(fn)
+        xv = rng.normal(size=(100, 200))
+        s0 = np.array(rng.integers(100), dtype=np.int64)
+        s1 = np.array(rng.integers(200), dtype=np.int64)
+        yv = np.array(rng.normal())
+        np.testing.assert_allclose(fn(xv, s0, s1, yv), fn_u(xv, s0, s1, yv), rtol=1e-10)
+
+    def test_negative_indices(self):
+        """Negative indices must be handled correctly (sign-extended, not zero-extended)."""
+        rng = np.random.default_rng(42)
+        # Use unknown static shape so negative indices can't be canonicalized away
+        x = pt.vector("x")
+        y = pt.vector("y")
+        idx = pt.vector("idx", dtype="int64")
+        fn, fn_u = fused_and_unfused([x, idx, y], x[idx] + y)
+        assert_fused(fn)
+        xv = rng.normal(size=100)
+        # Negative indices: -1 means last element, -2 second to last, etc.
+        idxv = np.array([-1, -2, -3, 0, 1], dtype=np.int64)
+        yv = rng.normal(size=5)
+        np.testing.assert_allclose(fn(xv, idxv, yv), fn_u(xv, idxv, yv), rtol=1e-10)
+
+    def test_same_index_both_axes(self):
+        """x[idx, idx] — same 1-D index on both axes (diagonal read)."""
+        rng = np.random.default_rng(42)
+        x = pt.matrix("x", shape=(10, 10))
+        idx = pt.vector("idx", dtype="int64", shape=(5,))
+        y = pt.vector("y", shape=(5,))
+        fn, fn_u = fused_and_unfused([x, idx, y], pt.exp(x[idx, idx]) + y)
+        assert_fused(fn)
+        xv = rng.normal(size=(10, 10))
+        iv = rng.integers(10, size=5).astype(np.int64)
+        yv = rng.normal(size=5)
+        np.testing.assert_allclose(fn(xv, iv, yv), fn_u(xv, iv, yv), rtol=1e-10)
+
+
+class TestIndexedWriteFusion:
+    """Test indexed updates (AdvancedIncSubtensor1) fused into Elemwise."""
+
+    def test_no_fusion_when_idx_axes_outside_elemwise_loop(self):
+        """Don't fuse if the indexed axes are not within the Elemwise loop.
+
+        Here the index is on axis 0 of target(5, 10), but the Elemwise
+        output (10,) corresponds to axis 1 (the non-indexed trailing axis).
+        The indexed axis doesn't overlap with the Elemwise computation, so
+        fusing would misalign which input dims map to which target dims.
+        """
+        rng = np.random.default_rng(42)
+        idx = rng.integers(5, size=10).astype(np.int64)
+        target = pt.matrix("target", shape=(5, 10))
+        x = pt.vector("x", shape=(85,))
+        y = pt.vector("y", shape=(10,))
+        elemwise_out = x[idx] + y  # shape (10,)
+        out = target[idx].inc(elemwise_out)
+        fn, fn_u = fused_and_unfused([x, y, target], out)
+        # Write not fused — the Elemwise loop dim is the non-indexed axis,
+        # not the indexed axis. Read fusion may still create an
+        # IndexedElemwise, but the AdvancedIncSubtensor1 must remain outside.
+        assert any(
+            isinstance(n.op, AdvancedIncSubtensor1) for n in fn.maker.fgraph.toposort()
+        )
+        xv = rng.normal(size=(85,))
+        yv = rng.normal(size=(10,))
+        tv = rng.normal(size=(5, 10))
+        np.testing.assert_allclose(fn(xv, yv, tv), fn_u(xv, yv, tv), rtol=1e-10)
+
+    def test_no_fusion_when_val_broadcasts_along_index_dim(self):
+        """Don't fuse if val is broadcastable on the index loop dim."""
+        rng = np.random.default_rng(42)
+        idx = rng.integers(5, size=10).astype(np.int64)
+        target = pt.vector("target", shape=(5,))
+        x = pt.tensor("x", shape=(1,))
+        out = target[idx].inc(pt.exp(x))
+        fn, fn_u = fused_and_unfused([x, target], out)
+        assert any(
+            isinstance(n.op, AdvancedIncSubtensor1) for n in fn.maker.fgraph.toposort()
+        )
+        xv = rng.normal(size=(1,))
+        tv = rng.normal(size=(5,))
+        np.testing.assert_allclose(fn(xv, tv), fn_u(xv, tv), rtol=1e-10)
+
+    @pytest.mark.parametrize(
+        "target_trailing, should_fuse",
+        [(3, False), (1, True)],
+        ids=["target_not_bcast", "target_bcast"],
+    )
+    def test_val_broadcasts_along_trailing_dim(self, target_trailing, should_fuse):
+        """Reject when val broadcasts in a trailing dim where target doesn't.
+
+        target(5, T)[idx] += exp(col_vec) with col_vec shape (10, 1).
+        When T>1, the codegen write index uses constant 0 for broadcastable
+        dims, so only target[idx[i], 0] would be written.
+        When T=1, both broadcast so a single write is correct.
+        """
+        rng = np.random.default_rng(42)
+        idx = rng.integers(5, size=10).astype(np.int64)
+        target = pt.matrix("target", shape=(5, target_trailing))
+        x = pt.tensor("x", shape=(10, 1))
+        out = target[idx].inc(pt.exp(x))
+        fn, fn_u = fused_and_unfused([x, target], out)
+        if should_fuse:
+            assert_fused(fn)
+        else:
+            assert any(
+                isinstance(n.op, AdvancedIncSubtensor1)
+                for n in fn.maker.fgraph.toposort()
+            )
+        xv = rng.normal(size=(10, 1))
+        tv = rng.normal(size=(5, target_trailing))
+        np.testing.assert_allclose(fn(xv, tv), fn_u(xv, tv), rtol=1e-10)
+
+    @pytest.mark.parametrize(
+        "target_shape, val_shape",
+        [
+            ((5, 3), (5, 10)),
+            ((5, 3), (10,)),
+            ((2, 5, 3), (5, 10)),
+        ],
+        ids=["no_excess", "full_excess", "partial_excess"],
+    )
+    def test_write_with_non_indexed_leading_dims(self, target_shape, val_shape):
+        """Fuse writes when indexed axis has non-indexed dims to its left.
+
+        The Elemwise output may cover all non-indexed leading dims (no_excess),
+        none of them (full_excess), or only some (partial_excess).
+        Excess dims are moved right via transpose_non_indexed_write_axes.
+        """
+        rng = np.random.default_rng(42)
+        idx = rng.integers(target_shape[-1], size=10).astype(np.int64)
+        n_slices = len(target_shape) - 1
+        target = pt.tensor("target", shape=target_shape)
+        val = pt.tensor("val", shape=val_shape)
+        slices = (slice(None),) * n_slices
+        out = target[(*slices, idx)].inc(pt.exp(val))
+
+        mode = NUMBA_MODE.excluding(
+            "local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1"
+        )
+        mode_u = NUMBA_NO_FUSION.excluding(
+            "local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1"
+        )
+        fn = pytensor.function([val, target], out, mode=mode, trust_input=True)
+        fn_u = pytensor.function([val, target], out, mode=mode_u, trust_input=True)
+        assert_fused(fn)
+        valv = rng.normal(size=val_shape)
+        tv = rng.normal(size=target_shape)
+        np.testing.assert_allclose(fn(valv, tv), fn_u(valv, tv), rtol=1e-10)
+
+    def test_inc_subtensor(self):
+        rng = np.random.default_rng(42)
+        idx = rng.integers(85, size=919).astype(np.int64)
+        x = pt.vector("x", shape=(85,))
+        y = pt.vector("y", shape=(919,))
+        t = pt.vector("t", shape=(85,))
+        out = t[idx].inc(x[idx] + y)
+        fn, fn_u = fused_and_unfused([x, y, t], out)
+        assert_fused(fn)
+        xv, yv, tv = (
+            rng.normal(size=(85,)),
+            rng.normal(size=(919,)),
+            rng.normal(size=(85,)),
+        )
+        np.testing.assert_allclose(
+            fn(xv, yv, tv.copy()), fn_u(xv, yv, tv.copy()), rtol=1e-10
+        )
+
+    def test_set_subtensor(self):
+        rng = np.random.default_rng(42)
+        idx = rng.integers(85, size=919).astype(np.int64)
+        x = pt.vector("x", shape=(85,))
+        y = pt.vector("y", shape=(919,))
+        t = pt.vector("t", shape=(85,))
+        out = t[idx].set(x[idx] + y)
+        fn, fn_u = fused_and_unfused([x, y, t], out)
+        assert_fused(fn)
+        xv, yv, tv = (
+            rng.normal(size=(85,)),
+            rng.normal(size=(919,)),
+            rng.normal(size=(85,)),
+        )
+        np.testing.assert_allclose(
+            fn(xv, yv, tv.copy()), fn_u(xv, yv, tv.copy()), rtol=1e-10
+        )
+
+    def test_set_subtensor_same_index_both_axes(self):
+        """target[idx, idx].set(vals) — same 1-D index on both axes (diagonal write)."""
+        rng = np.random.default_rng(42)
+        x = pt.vector("x", shape=(5,))
+        target = pt.matrix("target", shape=(10, 10))
+        idx = pt.vector("idx", dtype="int64", shape=(5,))
+        out = target[idx, idx].set(pt.sqrt(x))
+        fn, fn_u = fused_and_unfused([x, target, idx], out)
+        assert_fused(fn)
+        xv = np.abs(rng.normal(size=5))
+        tv = rng.normal(size=(10, 10))
+        iv = np.arange(5, dtype=np.int64)
+        np.testing.assert_allclose(
+            fn(xv, tv.copy(), iv), fn_u(xv, tv.copy(), iv), rtol=1e-10
+        )
+
+    def test_target_not_modified_when_non_inplace(self):
+        """Non-inplace indexed write should not modify the original target."""
+        rng = np.random.default_rng(42)
+        idx = rng.integers(85, size=919).astype(np.int64)
+        x = pt.vector("x", shape=(85,))
+        y = pt.vector("y", shape=(919,))
+        t = pt.vector("t", shape=(85,))
+        out = t[idx].inc(x[idx] + y)
+        fn = pytensor.function([x, y, t], out, mode=NUMBA_MODE, trust_input=True)
+        xv, yv = rng.normal(size=(85,)), rng.normal(size=(919,))
+        tv = rng.normal(size=(85,))
+        tv_copy = tv.copy()
+        fn(xv, yv, tv)
+        np.testing.assert_array_equal(tv, tv_copy)
+
+    def test_multiple_write_targets_different_lengths(self):
+        """Sibling writes into different-length targets keyed by different indices.
+
+        Write-target buffers are matched to outputs by ascending output index; when
+        the index-group order disagrees with that (here the length-3 target is
+        written before the length-2 one), each output must still allocate its own
+        target buffer instead of a sibling's.
+        """
+        idx_s = np.array([0, 1, 0], dtype=np.int64)
+        idx_b = np.array([2, 0, 1], dtype=np.int64)
+        ts = pt.vector("ts", shape=(2,))
+        tb = pt.vector("tb", shape=(3,))
+
+        out_b = tb[idx_b].inc(pt.exp(ts[idx_s] + tb[idx_b]))
+        out_s = ts[idx_s].inc(pt.log1p(ts[idx_s] * tb[idx_b]))
+        fn, fn_u = fused_and_unfused([ts, tb], [out_b, out_s])
+        assert_fused(fn)
+
+        rng = np.random.default_rng(42)
+        tsv, tbv = rng.normal(size=2), rng.normal(size=3)
+        for fused_o, unfused_o in zip(fn(tsv, tbv), fn_u(tsv, tbv)):
+            np.testing.assert_allclose(fused_o, unfused_o, rtol=1e-10)
+
+    @pytest.mark.parametrize(
+        "read_idx, write_idx",
+        # Non-contiguous so the indices stay Advanced(Inc)Subtensor1 rather than
+        # being canonicalised into basic slices.
+        [
+            ([0, 2, 5], [1, 3, 7]),
+            ([0, 2, 5], [0, 2, 5]),
+            ([0, 2, 5], [5, 0, 2]),
+        ],
+        ids=["write_out_of_read_range", "write_equals_read", "write_permutes_read"],
+    )
+    def test_write_target_aliases_read_source(self, read_idx, write_idx):
+        """Indexed write into a buffer that is also read through the same Elemwise.
+
+        ``set_subtensor(b[write_idx], b[read_idx] * 2)`` reads and writes the same
+        buffer ``b``. Fusing the in-place write would alias the destroyed write
+        target with the live read input, so the write must stay external while the
+        read still fuses -- without raising an aliasing error or aborting the pass.
+
+        The aliasing is only genuinely unsafe when read and write indices overlap
+        in a *different order* (``write_permutes_read``): then an in-loop write
+        could clobber a position another iteration still has to read. When the
+        indices don't overlap (``write_out_of_read_range``) or overlap in the same
+        order (``write_equals_read``) the alias is harmless and could be fused in
+        the future via a ``tolerated_aliased`` flag. For now we conservatively skip
+        the write in all cases; this test pins the correctness of that behaviour.
+        """
+        rng = np.random.default_rng(42)
+        x = pt.vector("x", shape=(9,))
+        b = x + 1.0
+        read_idx = np.array(read_idx, dtype=np.int64)
+        write_idx = np.array(write_idx, dtype=np.int64)
+        out = b[write_idx].set(b[read_idx] * 2.0)
+        fn, fn_u = fused_and_unfused([x], out)
+        # The read fuses into an IndexedElemwise; the aliasing write stays external.
+        assert_fused(fn)
+        assert any(
+            isinstance(n.op, AdvancedIncSubtensor1) for n in fn.maker.fgraph.toposort()
+        )
+        xv = rng.normal(size=9)
+        np.testing.assert_allclose(fn(xv), fn_u(xv), rtol=1e-10)
+
+    def test_non_inplace_aliasing_write_preserves_input(self):
+        """A non-inplace write whose target is also a read source fuses with a copy.
+
+        Here ``t`` is read and written, and the write is non-inplace (``t`` is a
+        protected input), so it fuses by binding a *copy* of ``t`` to the write
+        slot. That slot must be a distinct inner input from the read source;
+        otherwise construct_nominal_fgraph dedupes them, the copy goes dead inside,
+        and the inner write destroys the read buffer -- silently mutating ``t``.
+
+        Checked through ``OpFromGraph.perform``, which runs the inner graph
+        literally; the numba backend uses the indexed-output spec and would not
+        expose the corruption.
+        """
+        t = pt.vector("t", shape=(None,))
+        idx = np.array([0, 2, 5], dtype=np.int64)
+        out = t[idx].set(t[idx] * 2.0)
+        fn = pytensor.function([t], out, mode=NUMBA_MODE, trust_input=True)
+
+        # The non-inplace write fuses fully -- no external AdvancedIncSubtensor1.
+        assert_fused(fn)
+        assert not any(
+            isinstance(n.op, AdvancedIncSubtensor1) for n in fn.maker.fgraph.toposort()
+        )
+
+        # The inner write must destroy exactly the input the op's destroy_map names.
+        [node] = [
+            n for n in fn.maker.fgraph.toposort() if isinstance(n.op, IndexedElemwise)
+        ]
+        [(_out_idx, [destroyed_pos])] = node.op.destroy_map.items()
+        [inner_write] = [
+            n for n in node.op.fgraph.apply_nodes if getattr(n.op, "destroy_map", None)
+        ]
+        assert inner_write.inputs[0] is node.op.fgraph.inputs[destroyed_pos]
+
+        # Run the inner graph via perform; the input buffer must be left untouched.
+        perform_outs = node.op(*node.inputs, return_list=True)
+        f_perform = pytensor.function(
+            [t],
+            perform_outs,
+            mode=Mode(linker="py", optimizer=None),
+            accept_inplace=True,
+            trust_input=True,
+        )
+        tv = np.arange(1, 10, dtype="float64")
+        expected = tv.copy()
+        expected[idx] = tv[idx] * 2.0
+        tv_in = tv.copy()
+        np.testing.assert_allclose(f_perform(tv_in)[0], expected, rtol=1e-10)
+        np.testing.assert_array_equal(tv_in, tv)
+
+
+class TestRepeatedAccumulationIndices:
+    """Test inc_subtensor with repeated indices (same position accumulated multiple times)."""
+
+    def test_repeated_inc_subtensor(self):
+        """inc_subtensor with repeated indices should accumulate correctly."""
+        rng = np.random.default_rng(42)
+        target = pt.vector("target", shape=(10,))
+        x = pt.vector("x", shape=(20,))
+        idx = np.array(
+            [0, 1, 2, 0, 1, 2, 3, 3, 3, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3],
+            dtype=np.int64,
+        )
+        out = target[idx].inc(pt.exp(x))
+        fn, fn_u = fused_and_unfused([target, x], out)
+        assert_fused(fn)
+        tv = rng.normal(size=10)
+        xv = rng.normal(size=20)
+        np.testing.assert_allclose(fn(tv.copy(), xv), fn_u(tv.copy(), xv), rtol=1e-10)
+
+    def test_repeated_set_subtensor(self):
+        """set_subtensor with repeated indices -- last write wins."""
+        rng = np.random.default_rng(42)
+        target = pt.vector("target", shape=(10,))
+        x = pt.vector("x", shape=(5,))
+        idx = np.array([0, 0, 1, 1, 2], dtype=np.int64)
+        out = target[idx].set(pt.exp(x))
+        fn, fn_u = fused_and_unfused([target, x], out)
+        assert_fused(fn)
+        tv = rng.normal(size=10)
+        xv = rng.normal(size=5)
+        np.testing.assert_allclose(fn(tv.copy(), xv), fn_u(tv.copy(), xv), rtol=1e-10)
+
+    def test_repeated_inc_with_read(self):
+        """Combined read + inc_subtensor with repeated indices."""
+        rng = np.random.default_rng(42)
+        source = pt.vector("source", shape=(10,))
+        target = pt.vector("target", shape=(10,))
+        idx = np.array([0, 1, 0, 1, 2, 2, 3, 3], dtype=np.int64)
+        out = target[idx].inc(source[idx] * 2.0)
+        fn, fn_u = fused_and_unfused([source, target], out)
+        assert_fused(fn)
+        sv = rng.normal(size=10)
+        tv = rng.normal(size=10)
+        np.testing.assert_allclose(fn(sv, tv.copy()), fn_u(sv, tv.copy()), rtol=1e-10)
+
+
+class TestShapeValidation:
+    """Test that mismatched index/input shapes raise runtime errors."""
+
+    def test_mismatched_index_and_direct_input(self):
+        """Index length doesn't match direct input on the same loop dim."""
+        x = pt.vector("x", shape=(None,))
+        y = pt.vector("y", shape=(None,))
+        idx = pt.vector("idx", dtype="int64", shape=(None,))
+        out = x[idx] + y
+        fn = pytensor.function([x, idx, y], out, mode=NUMBA_MODE, trust_input=True)
+        assert_fused(fn)
+        # Matching: idx=50, y=50 — should work
+        fn(np.zeros(100), np.zeros(50, dtype=np.int64), np.zeros(50))
+        # Mismatched: idx=50, y=49 — should error
+        with pytest.raises(Exception):
+            fn(np.zeros(100), np.zeros(50, dtype=np.int64), np.zeros(49))
+
+    def test_runtime_broadcast_on_index_dim(self):
+        """Symbolic shapes that happen to be 1 at runtime — broadcast check."""
+        x = pt.vector("x", shape=(None,))
+        y = pt.vector("y", shape=(None,))
+        idx = pt.vector("idx", dtype="int64", shape=(None,))
+        out = x[idx] + y
+        fn = pytensor.function([x, idx, y], out, mode=NUMBA_MODE, trust_input=True)
+        assert_fused(fn)
+        # Both idx and y have length 1 — should work (both agree on dim 0)
+        result = fn(np.zeros(100), np.zeros(1, dtype=np.int64), np.zeros(1))
+        assert result.shape == (1,)
+        # idx=1, y=5 — should error (shape mismatch, no static broadcast info)
+        with pytest.raises(Exception):
+            fn(np.zeros(100), np.zeros(1, dtype=np.int64), np.zeros(5))

--- a/tests/tensor/rewriting/test_elemwise.py
+++ b/tests/tensor/rewriting/test_elemwise.py
@@ -1004,16 +1004,13 @@ class TestFusion:
                 (np.sum(fxv + 5) * np.exp(fxv) / (fxv + 5),),
                 ("float32",),
             ),
-            pytest.param(
-                (
-                    (sin(exp(fx)), exp(sin(fx))),
-                    (fx,),
-                    (fxv,),
-                    1,
-                    (np.sin(np.exp(fxv)), np.exp(np.sin(fxv))),
-                    ("float32", "float32"),
-                ),
-                marks=pytest.mark.xfail,  # Not implemented yet
+            (
+                (sin(exp(fx)), exp(sin(fx))),
+                (fx,),
+                (fxv,),
+                1,
+                (np.sin(np.exp(fxv)), np.exp(np.sin(fxv))),
+                ("float32", "float32"),
             ),
         ],
     )
@@ -1148,7 +1145,6 @@ class TestFusion:
 
         new_out = f.maker.fgraph.outputs[0]
         assert isinstance(new_out.owner.op, Elemwise)
-        assert isinstance(new_out.owner.op.scalar_op, ps.basic.Add)
         assert len(new_out.owner.inputs) == 4
 
         # TODO: Do we really need to do this?

--- a/tests/tensor/rewriting/test_math.py
+++ b/tests/tensor/rewriting/test_math.py
@@ -4663,7 +4663,9 @@ def test_polygamma_specialization():
     y3 = polygamma(2, x)
 
     fn = pytensor.function(
-        [x], [y1, y2, y3], mode=get_default_mode().including("specialize")
+        [x],
+        [y1, y2, y3],
+        mode=get_default_mode().including("specialize").excluding("fusion"),
     )
     fn_outs = fn.maker.fgraph.outputs
     assert isinstance(fn_outs[0].owner.op.scalar_op, Psi)

--- a/tests/tensor/rewriting/test_subtensor.py
+++ b/tests/tensor/rewriting/test_subtensor.py
@@ -488,9 +488,13 @@ class TestLocalUselessSubtensor:
             assert len(prog) == 2
         else:
             # Arange-with-offset indices get rewritten to a Subtensor slice;
-            # other advanced indices stay as AdvancedSubtensor1.
+            # other advanced indices stay as AdvancedSubtensor1 (or get
+            # absorbed into IndexedElemwise by FuseIndexedElemwise).
+            from pytensor.tensor.rewriting.indexed_elemwise import IndexedElemwise
+
             assert any(
-                isinstance(node.op, AdvancedSubtensor1 | Subtensor) for node in prog
+                isinstance(node.op, AdvancedSubtensor1 | Subtensor | IndexedElemwise)
+                for node in prog
             )
 
         x_val = np.array([[0, 1, 2], [3, 4, 5]], dtype=pytensor.config.floatX)
@@ -1301,7 +1305,7 @@ class TestReadOfWriteSameIndices:
             "local_replace_AdvancedSubtensor",
             "local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1",
             "local_read_of_write_same_indices",
-        ).excluding("fusion")
+        ).excluding("fusion", "fuse_indexed_into_elemwise")
 
     @pytest.mark.parametrize(
         "dtype1, dtype2",
@@ -2019,9 +2023,13 @@ def test_local_set_to_inc_subtensor():
     g = s + 3
     r = set_subtensor(s, g)
 
-    mode = get_default_mode().including(
-        "local_replace_AdvancedSubtensor",
-        "local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1",
+    mode = (
+        get_default_mode()
+        .including(
+            "local_replace_AdvancedSubtensor",
+            "local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1",
+        )
+        .excluding("fuse_indexed_into_elemwise")
     )
     moder = mode.excluding("local_set_to_inc_subtensor")
     modet = mode.including("local_set_to_inc_subtensor")
@@ -2719,7 +2727,8 @@ def test_cholesky_unconstrain_grad(exp_before_materialize):
     loss = pt.sum(pt.log(pt.diagonal(L))) + pt.sum(Sigma)
     grad = pt.grad(loss, packed)
 
-    f = function([packed], [loss, grad])
+    mode = get_default_mode().excluding("fuse_indexed_into_elemwise")
+    f = function([packed], [loss, grad], mode=mode)
     f.dprint(print_shape=True)
 
     idx_types = (

--- a/tests/tensor/test_subtensor.py
+++ b/tests/tensor/test_subtensor.py
@@ -425,7 +425,7 @@ class TestSubtensor(utt.OptimizationTestMixin):
             "local_replace_AdvancedSubtensor",
             "local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1",
             "local_useless_subtensor",
-        ).excluding("bool_idx_to_nonzero")
+        ).excluding("bool_idx_to_nonzero", "fuse_indexed_into_elemwise")
         self.fast_compile = config.mode == "FAST_COMPILE"
 
     def function(

--- a/tests/tensor/test_variable.py
+++ b/tests/tensor/test_variable.py
@@ -427,11 +427,13 @@ class TestTensorInstanceMethods:
             X.take(indices, -1, mode="clip").eval({X: x}),
             x.take(indices, -1, mode="clip"),
         )
-        # Test error handling
+        # Test error handling (exclude indexed-elemwise fusion which
+        # loses bounds checking in the Numba codegen path)
+        no_fusion = get_default_mode().excluding("fuse_indexed_into_elemwise")
         with pytest.raises(IndexError):
-            X.take(indices).eval({X: x})
+            pytensor.function([X], X.take(indices), mode=no_fusion)(x)
         with pytest.raises(IndexError):
-            (2 * X.take(indices)).eval({X: x})
+            pytensor.function([X], 2 * X.take(indices), mode=no_fusion)(x)
         with pytest.raises(TypeError):
             X.take([0.0])
         indices = [[1, 0, 1], [0, 1, 1]]


### PR DESCRIPTION
## Summary

Introduce `IndexedElemwise`, an `OpFromGraph` that wraps `AdvancedSubtensor` + `Elemwise` + `AdvancedIncSubtensor` subgraphs so the Numba backend can generate a single loop with indirect indexing, avoiding materializing AdvancedSubtensor input arrays, and writing directly on the output buffer, doing the job of AdvancedIncSubtensor in the same loop, without having to loop again through the intermediate elemwise output.

Supports arbitrary-axis indexing, ND index arrays, multi-index groups, broadcast indices, repeated accumulation (inc/set modes), and multi-client outputs via Composite identity duplication.

Also included:
- Extend `FusionOptimizer` to merge independent sibling subgraphs that share inputs but have no producer-consumer edge (e.g. `f(x)` and `g(x)`)

## Motivation

In hierarchical models with mu = beta[group_idx] * x + ..., the logp+gradient graph combines indexed reads and indexed updates in the same Elemwise (the forward expands group-level parameters via advanced subtensor, and the gradient accumulates back into the source via advanced inc subtensor).

A simple example 

```python
import numpy as np
import pytensor
import pytensor.tensor as pt
from pytensor.compile.mode import get_mode

numba_mode = get_mode("NUMBA")
numba_mode_before = numba_mode.excluding("fuse_indexed_elemwise")

x = pt.vector("x")
idx = pt.vector("idx", dtype=int)
value = pt.vector("value")

y = pt.zeros(100)
out = ((x[idx] - value) ** 2).sum()
grad_wrt_x = pt.grad(out, x)
fn_before = pytensor.function([x, value, idx], [out, grad_wrt_x], mode=numba_mode_before, trust_input=True)
fn_before.dprint(print_op_info=True, print_destroy_map=True)
# Sum{axes=None} [id A] 5
#  └─ Composite{...}.0 [id B] d={0: [0]} 1
#     ├─ AdvancedSubtensor1 [id C] 0
#     │  ├─ x [id D]
#     │  └─ idx [id E]
#     └─ value [id F]
# AdvancedIncSubtensor1{inplace,inc} [id G] d={0: [0]} 4
#  ├─ Alloc [id H] 3
#  │  ├─ [0.] [id I]
#  │  └─ Shape_i{0} [id J] 2
#  │     └─ x [id D]
#  ├─ Composite{...}.1 [id B] d={0: [0]} 1
#  │  └─ ···
#  └─ idx [id E]

# Inner graphs:

# Composite{...} [id B] d={0: [0]}
#  ← sqr [id K] 'o0'
#     └─ sub [id L] 't5'
#        ├─ i0 [id M]
#        └─ i1 [id N]
#  ← mul [id O] 'o1'
#     ├─ 2.0 [id P]
#     └─ sub [id L] 't5'
#        └─ ···

fn = pytensor.function([x, value, idx], [out, grad_wrt_x], mode=numba_mode, trust_input=True)
fn.dprint(print_op_info=True, print_destroy_map=True)

# Sum{axes=None} [id A] 3
#  └─ IndexedElemwise{Composite{...}}.0 [id B] d={1: [3]} 2
#     ├─ x [id C] (indexed read (idx_0))
#     ├─ value [id D]
#     ├─ idx [id E] (idx_0)
#     └─ Alloc [id F] 1 (buf_0)
#        ├─ [0.] [id G]
#        └─ Shape_i{0} [id H] 0
#           └─ x [id C]
# IndexedElemwise{Composite{...}}.1 [id B] d={1: [3]} 2 (indexed inc (buf_0, idx_0))
#  └─ ···

# Inner graphs:

# IndexedElemwise{Composite{...}} [id B] d={1: [3]}
#  ← Composite{...}.0 [id I]
#     ├─ AdvancedSubtensor1 [id J]
#     │  ├─ *0-<Vector(float64, shape=(?,))> [id K]
#     │  └─ *2-<Vector(int64, shape=(?,))> [id L]
#     └─ *1-<Vector(float64, shape=(?,))> [id M]
#  ← AdvancedIncSubtensor1{inplace,inc} [id N] d={0: [0]}
#     ├─ *3-<Vector(float64, shape=(?,))> [id O]
#     ├─ Composite{...}.1 [id I]
#     │  └─ ···
#     └─ *2-<Vector(int64, shape=(?,))> [id L]

# Composite{...} [id I]
#  ← sqr [id P] 'o0'
#     └─ sub [id Q] 't0'
#        ├─ i0 [id R]
#        └─ i1 [id S]
#  ← mul [id T] 'o1'
#     ├─ 2.0 [id U]
#     └─ sub [id Q] 't0'
#        └─ ···

x_test = np.arange(15, dtype="float64")
idx_test = np.random.randint(15, size=(10_000,))
value_test = np.random.normal(size=idx_test.shape)

logp_before, dlogp_before = fn_before(x_test, value_test, idx_test)
logp, dlogp = fn(x_test, value_test, idx_test)
np.testing.assert_allclose(logp_before, logp)
np.testing.assert_allclose(dlogp_before, dlogp)

%timeit fn_before(x_test, value_test, idx_test)  # 29.4 μs ± 2.57 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
%timeit fn(x_test, value_test, idx_test)  # 13.8 μs ± 136 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

Next step would be to also fuse the sum directly on the elemwise, so we end up with a single loop over the data.
