### PR TITLE
Add dispatches for Real Op

### DIFF
--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -3929,8 +3929,7 @@ class Real(UnaryScalarOp):
 
     """
 
-    # numpy.real(float32) return a view on the inputs.
-    # nfunc_spec = ('real', 1, 1)
+    nfunc_spec = ("real", 1, 1)
 
     def impl(self, x):
         return np.real(x)

--- a/tests/tensor/test_elemwise.py
+++ b/tests/tensor/test_elemwise.py
@@ -1174,3 +1174,22 @@ def test_inplace_dtype_changed():
                 mode="fast_run",
             )
         assert fn64.maker.fgraph.outputs[0].owner.op.destroy_map == {}
+
+
+@pytest.mark.parametrize("linker", ["py", "cvm", "numba"])
+def test_nfunc_view_workaround(linker):
+    # np.real on a buffer returns a view, Elemwise python perform method works around it by making a copy
+    # Other backends shouldn't worry
+    a = pt.zvector("a")
+    b = pt.real(a)
+    c = Elemwise(ps.mul, inplace_pattern={0: 0})(b, 2.0)
+    out = c + a
+
+    mode = Mode(linker=linker, optimizer=None)
+    f = function([a], out, mode=mode, accept_inplace=True)
+
+    a_test = np.array([1 + 2j, 3 + 4j, 5 + 6j])
+    out_expected = np.real(a_test) * 2 + a_test
+
+    out_eval = f(a_test)
+    np.testing.assert_allclose(out_eval, out_expected)


### PR DESCRIPTION
We have no coverage for this Op because it doesn't have an `nfunc_name`. There was a concern that because numpy returns a view, we could end up with graph mutations that pytensor is not aware of. An example is:

```python
import pytensor.tensor as pt
x = pt.dvector('x')
out = x.real[0].set(99.0)
```

I added some checks for this specific case, it seems like everything works ok?