### PR TITLE
Add MLX dispatch for Pad

### DIFF
--- a/pytensor/link/mlx/dispatch/__init__.py
+++ b/pytensor/link/mlx/dispatch/__init__.py
@@ -13,6 +13,7 @@ import pytensor.link.mlx.dispatch.signal
 import pytensor.link.mlx.dispatch.signal.conv
 import pytensor.link.mlx.dispatch.blockwise
 import pytensor.link.mlx.dispatch.extra_ops
+import pytensor.link.mlx.dispatch.pad
 import pytensor.link.mlx.dispatch.sort
 import pytensor.link.mlx.dispatch.slinalg
 import pytensor.link.mlx.dispatch.nlinalg

--- a/pytensor/link/mlx/dispatch/pad.py
+++ b/pytensor/link/mlx/dispatch/pad.py
@@ -1,0 +1,35 @@
+import mlx.core as mx
+
+from pytensor.link.mlx.dispatch.basic import mlx_funcify
+from pytensor.tensor.pad import Pad
+
+
+@mlx_funcify.register(Pad)
+def mlx_funcify_pad(op, node, **kwargs):
+    pad_mode = op.pad_mode
+    match pad_mode:
+        case "constant":
+            _, _, constant_values = node.inputs
+            if constant_values.ndim != 0:
+                raise NotImplementedError(
+                    "MLX's 'constant' mode only accepts a scalar constant_values, "
+                    "not per-side tuples like NumPy/JAX."
+                )
+
+            def pad_fn(x, pad_width, constant_values):
+                return mx.pad(
+                    x, pad_width, mode="constant", constant_values=constant_values
+                )
+
+        case "edge":
+
+            def pad_fn(x, pad_width):
+                return mx.pad(x, pad_width, mode="edge")
+
+        case _:
+            raise NotImplementedError(
+                f"MLX does not support pad mode '{pad_mode}'. "
+                f"Supported modes are 'constant' and 'edge'."
+            )
+
+    return pad_fn

--- a/pytensor/link/mlx/dispatch/pad.py
+++ b/pytensor/link/mlx/dispatch/pad.py
@@ -7,29 +7,31 @@ from pytensor.tensor.pad import Pad
 @mlx_funcify.register(Pad)
 def mlx_funcify_pad(op, node, **kwargs):
     pad_mode = op.pad_mode
-    match pad_mode:
-        case "constant":
-            _, _, constant_values = node.inputs
-            if constant_values.ndim != 0:
-                raise NotImplementedError(
-                    "MLX's 'constant' mode only accepts a scalar constant_values, "
-                    "not per-side tuples like NumPy/JAX."
-                )
 
-            def pad_fn(x, pad_width, constant_values):
-                return mx.pad(
-                    x, pad_width, mode="constant", constant_values=constant_values
-                )
-
-        case "edge":
-
-            def pad_fn(x, pad_width):
-                return mx.pad(x, pad_width, mode="edge")
-
-        case _:
+    if pad_mode == "constant":
+        _, _, constant_values = node.inputs
+        if constant_values.ndim != 0:
             raise NotImplementedError(
-                f"MLX does not support pad mode '{pad_mode}'. "
-                f"Supported modes are 'constant' and 'edge'."
+                "MLX's 'constant' mode only accepts a scalar constant_values, "
+                "not per-side tuples like NumPy/JAX."
             )
 
-    return pad_fn
+        def pad_fn(x, pad_width, constant_values):
+            return mx.pad(
+                x, pad_width, mode="constant", constant_values=constant_values
+            )
+
+        return pad_fn
+
+    elif pad_mode == "edge":
+
+        def pad_fn(x, pad_width):
+            return mx.pad(x, pad_width, mode="edge")
+
+        return pad_fn
+
+    else:
+        raise NotImplementedError(
+            f"MLX does not support pad mode '{pad_mode}'. "
+            f"Supported modes are 'constant' and 'edge'."
+        )

--- a/pytensor/link/mlx/dispatch/pad.py
+++ b/pytensor/link/mlx/dispatch/pad.py
@@ -16,19 +16,19 @@ def mlx_funcify_pad(op, node, **kwargs):
                 "not per-side tuples like NumPy/JAX."
             )
 
-        def pad_fn(x, pad_width, constant_values):
+        def constant_pad_fn(x, pad_width, constant_values):
             return mx.pad(
                 x, pad_width, mode="constant", constant_values=constant_values
             )
 
-        return pad_fn
+        return constant_pad_fn
 
     elif pad_mode == "edge":
 
-        def pad_fn(x, pad_width):
+        def edge_pad_fn(x, pad_width):
             return mx.pad(x, pad_width, mode="edge")
 
-        return pad_fn
+        return edge_pad_fn
 
     else:
         raise NotImplementedError(

--- a/tests/link/mlx/test_pad.py
+++ b/tests/link/mlx/test_pad.py
@@ -1,0 +1,51 @@
+import numpy as np
+import pytest
+
+import pytensor.tensor as pt
+from pytensor import config
+from tests.link.mlx.test_basic import compare_mlx_and_py
+
+
+mx = pytest.importorskip("mlx.core")
+floatX = config.floatX
+RTOL = ATOL = 1e-6 if floatX.endswith("64") else 1e-3
+
+
+@pytest.mark.parametrize(
+    "mode, kwargs",
+    [
+        ("constant", {"constant_values": 0}),
+        ("edge", {}),
+    ],
+    ids=["constant_default", "edge"],
+)
+def test_mlx_pad(mode, kwargs):
+    x_pt = pt.tensor("x", shape=(3, 3))
+    x = np.random.normal(size=(3, 3))
+
+    res = pt.pad(x_pt, mode=mode, pad_width=3, **kwargs)
+
+    compare_mlx_and_py(
+        [x_pt],
+        [res],
+        [x],
+        assert_fn=lambda x, y: np.testing.assert_allclose(x, y, rtol=RTOL, atol=ATOL),
+    )
+
+
+def test_mlx_pad_unsupported_mode():
+    x_pt = pt.tensor("x", shape=(3, 3))
+    res = pt.pad(x_pt, mode="reflect", pad_width=3)
+
+    with pytest.raises(NotImplementedError, match="MLX does not support pad mode"):
+        compare_mlx_and_py([x_pt], [res], [np.ones((3, 3))])
+
+
+def test_mlx_pad_non_scalar_constant_values():
+    x_pt = pt.tensor("x", shape=(3, 3))
+    res = pt.pad(x_pt, mode="constant", pad_width=3, constant_values=(1, 2))
+
+    with pytest.raises(
+        NotImplementedError, match="only accepts a scalar constant_values"
+    ):
+        compare_mlx_and_py([x_pt], [res], [np.ones((3, 3))])


### PR DESCRIPTION
Like `ARange`, `Pad` is very limited compared to jax/numpy/pytensor. 

- Only `constant` and `edge` modes are support
- If `constant`, the constant_values must be a single scalar constant. The mlx function will accept an array but there seems to be a bug: it just takes the first item of the array and pads out with that. So might as well reject all cases.