### PR TITLE
Fix Blockwise{ConvolveNd} static shape inference by avoiding Switch nodes

### DIFF
--- a/pytensor/link/c/cmodule.py
+++ b/pytensor/link/c/cmodule.py
@@ -2382,6 +2382,20 @@ class GCC_compiler(Compiler):
             cxxflags.append("-DMS_WIN64")
 
         if sys.platform == "darwin":
+            try:
+                import subprocess
+                sdk_path = subprocess.check_output(
+                    ["xcrun", "--show-sdk-path"], encoding="utf-8"
+                ).strip()
+                if sdk_path:
+                    # Explicitly add the SDK libc++ include path since clang may
+                    # fail to find these standard headers on macOS.
+                    cxxflags.append(f"-isysroot")
+                    cxxflags.append(sdk_path)
+                    cxxflags.append(f"-I{sdk_path}/usr/include/c++/v1")
+            except Exception:
+                pass
+
             # Use the already-loaded python symbols.
             cxxflags.extend(["-undefined", "dynamic_lookup"])
             # XCode15 introduced ld_prime linker. At the time of writing, this linker

--- a/pytensor/tensor/signal/conv.py
+++ b/pytensor/tensor/signal/conv.py
@@ -81,10 +81,18 @@ class AbstractConvolveNd:
     def infer_shape(self, fgraph, node, shapes):
         _, _, full_mode = node.inputs
         in1_shape, in2_shape, _ = shapes
-        out_shape = [
-            switch(full_mode, n + k - 1, maximum(n, k) - minimum(n, k) + 1)
-            for n, k in zip(in1_shape, in2_shape)
-        ]
+        
+        from pytensor.graph.basic import Constant
+        
+        out_shape = []
+        for n, k in zip(in1_shape, in2_shape):
+            if getattr(full_mode, "data", None) is not None:
+                if full_mode.data:
+                    out_shape.append(n + k - 1)
+                else:
+                    out_shape.append(maximum(n, k) - minimum(n, k) + 1)
+            else:
+                out_shape.append(switch(full_mode, n + k - 1, maximum(n, k) - minimum(n, k) + 1))
 
         return [out_shape]
 


### PR DESCRIPTION
Closes pymc-devs/pytensor#1988

Provides a smart patch to `AbstractConvolveNd.infer_shape` that evaluates `full_mode` if known and directly returns the arithmetic `n + k - 1`. This avoids emitting a `Switch` node which previously prevented aggressive constant folding and blocked JAX translation tracing.

(Note: This branch is based on my MacOS SDK Fix, so don't be surprised if it includes the `cmodule.py` commit as well.)