### PR TITLE
Fix failures in newer version of mypy

### DIFF
--- a/pytensor/link/numba/dispatch/random.py
+++ b/pytensor/link/numba/dispatch/random.py
@@ -424,7 +424,7 @@ def numba_funcify_RandomVariable(op: RandomVariableWithCoreShape, node, **kwargs
 
     match core_rv_fn_and_cache_key:
         case (core_rv_fn, (int() | None) as core_cache_key):
-            pass
+            pass  # type: ignore[unreachable]
         case (_core_rv_fn, invalid_core_cache_key):
             raise ValueError(
                 f"Invalid core_cache_key returned from numba_core_rv_funcify: {invalid_core_cache_key}. Must be int or None."

--- a/pytensor/tensor/einsum.py
+++ b/pytensor/tensor/einsum.py
@@ -608,11 +608,11 @@ def einsum(subscripts: str, *operands: "TensorLike", optimize=None) -> TensorVar
                 case 3:
                     # New API doesn't have index removed
                     contraction_list = []
-                    for pos, step_ein_str, _ in contraction_list_raw:  # type: ignore[misc]
+                    for pos, step_ein_str, _ in contraction_list_raw:  # type: ignore[str-unpack]
                         # e.g., 'ijp,oij->op' -> removed_str = {'i', 'j'}
-                        inp_str, out_str = step_ein_str.replace(",", "").split("->")  # type: ignore[has-type]
+                        inp_str, out_str = step_ein_str.replace(",", "").split("->")
                         removed_idx = set(inp_str) - set(out_str)
-                        contraction_list.append((pos, removed_idx, step_ein_str))  # type: ignore[has-type]
+                        contraction_list.append((pos, removed_idx, step_ein_str))  # type: ignore[arg-type]
                 case _:
                     raise ValueError("Unexpected contraction list template")
         del contraction_list_raw


### PR DESCRIPTION
Update type: ignore comments to use correct error codes for mypy 1.20:
- random.py: suppress unreachable warning in match/case
- einsum.py: replace stale misc/has-type codes with str-unpack/arg-type

CI started failing in other PRs