### PR TITLE
System for algebraic reasoning about linear alegbra

### DIFF
--- a/pytensor/assumptions/__init__.py
+++ b/pytensor/assumptions/__init__.py
@@ -1,0 +1,32 @@
+import pytensor.assumptions.alloc
+import pytensor.assumptions.blockwise
+import pytensor.assumptions.diagonal
+import pytensor.assumptions.dimshuffle
+import pytensor.assumptions.orthogonal
+import pytensor.assumptions.positive_definite
+import pytensor.assumptions.subtensor
+import pytensor.assumptions.symmetric
+import pytensor.assumptions.triangular
+from pytensor.assumptions.core import (
+    ALL_KEYS,
+    DIAGONAL,
+    IMPLIES,
+    LOWER_TRIANGULAR,
+    ORTHOGONAL,
+    POSITIVE_DEFINITE,
+    SYMMETRIC,
+    UPPER_TRIANGULAR,
+    AssumptionFeature,
+    AssumptionKey,
+    ConflictingAssumptionsError,
+    FactState,
+    check_assumption,
+    register_assumption,
+    register_constant_inference,
+    register_implies,
+)
+from pytensor.assumptions.specify import (
+    SpecifyAssumptions,
+    assume,
+    specify_assumption_rule,
+)

--- a/pytensor/assumptions/__init__.py
+++ b/pytensor/assumptions/__init__.py
@@ -1,3 +1,6 @@
+# Import every rule module so its registrations land on the global registry that
+# ``check_assumption`` consults. The property modules pull in the shared helper
+# modules (alloc, dimshuffle, subtensor, dot, elemwise) transitively.
 import pytensor.assumptions.alloc
 import pytensor.assumptions.blockwise
 import pytensor.assumptions.diagonal
@@ -32,3 +35,54 @@ from pytensor.assumptions.specify import (
     assume,
     specify_assumption_rule,
 )
+from pytensor.graph.fg import FunctionGraph
+
+
+def summarize_assumptions(feature: AssumptionFeature, var) -> str:
+    """Return a compact ``{...}`` tag of the facts known about *var*.
+
+    Each TRUE fact appears as its ``short_name``; each FALSE fact as ``!short_name``.
+    Implied facts are pruned: a TRUE fact is dropped when a stronger fact (one that
+    implies it) is also TRUE, and a FALSE fact is dropped when a weaker fact (one it
+    implies) is also FALSE. Return ``""`` when nothing is known.
+    """
+    states = {}
+    for key in ALL_KEYS:
+        try:
+            states[key] = feature.get(var, key)
+        except ConflictingAssumptionsError:
+            states[key] = FactState.CONFLICT
+
+    tokens = []
+    for key in ALL_KEYS:
+        state = states[key]
+        label = key.short_name or key.name
+        if state is FactState.TRUE:
+            if any(
+                key in weaker and states[stronger] is FactState.TRUE
+                for stronger, weaker in IMPLIES.items()
+            ):
+                continue
+            tokens.append(label)
+        elif state is FactState.FALSE:
+            if any(states[w] is FactState.FALSE for w in IMPLIES.get(key, ())):
+                continue
+            tokens.append(f"!{label}")
+        elif state is FactState.CONFLICT:
+            tokens.append(f"{label}=CONFLICT")
+
+    return "{" + ", ".join(tokens) + "}" if tokens else ""
+
+
+def assumption_tags(outputs) -> dict:
+    """Map each variable reachable from *outputs* to its :func:`summarize_assumptions`
+    tag, omitting variables with no known facts."""
+    fgraph = FunctionGraph(outputs=list(outputs), clone=False)
+    feature = AssumptionFeature()
+    fgraph.attach_feature(feature)
+    tags = {}
+    for var in fgraph.variables:
+        tag = summarize_assumptions(feature, var)
+        if tag:
+            tags[var] = tag
+    return tags

--- a/pytensor/assumptions/__init__.py
+++ b/pytensor/assumptions/__init__.py
@@ -4,6 +4,8 @@ import pytensor.assumptions.diagonal
 import pytensor.assumptions.dimshuffle
 import pytensor.assumptions.orthogonal
 import pytensor.assumptions.positive_definite
+import pytensor.assumptions.reshape
+import pytensor.assumptions.shape
 import pytensor.assumptions.subtensor
 import pytensor.assumptions.symmetric
 import pytensor.assumptions.triangular

--- a/pytensor/assumptions/alloc.py
+++ b/pytensor/assumptions/alloc.py
@@ -1,0 +1,68 @@
+from pytensor.assumptions.core import FactState, true_if
+from pytensor.tensor.basic import (
+    NotScalarConstantError,
+    get_underlying_scalar_constant_value,
+)
+from pytensor.tensor.variable import TensorConstant
+
+
+def alloc_of_zero(key, op, feature, fgraph, node, input_states) -> list[FactState]:
+    """``Alloc`` rule for DIAGONAL / LOWER_TRIANGULAR / UPPER_TRIANGULAR: TRUE when
+    the fill value is the scalar 0 (an all-zero square matrix), FALSE when it is a
+    known non-zero scalar -- the off-diagonal entries are then non-zero, so none of
+    these properties holds.
+
+    Requires the trailing two output dims to be statically known and equal; these
+    properties apply only to square matrices. SYMMETRIC uses :func:`alloc_is_symmetric`
+    instead, since a constant fill is symmetric whatever its value.
+    """
+    out_shape = node.outputs[0].type.shape
+    if len(out_shape) < 2:
+        return [FactState.UNKNOWN]
+    m, n = out_shape[-2], out_shape[-1]
+    if m is None or n is None or m != n:
+        return [FactState.UNKNOWN]
+    try:
+        val = get_underlying_scalar_constant_value(node.inputs[0])
+    except NotScalarConstantError:
+        return [FactState.UNKNOWN]
+    return true_if(val == 0, else_false=True)
+
+
+def alloc_is_symmetric(key, op, feature, fgraph, node, input_states) -> list[FactState]:
+    """``Alloc`` rule for SYMMETRIC: a scalar fill broadcasts one value to every
+    entry, so a square output equals its transpose -- whatever the value.
+
+    A non-scalar fill (e.g. a vector broadcast across rows) is left UNKNOWN.
+    """
+    out_shape = node.outputs[0].type.shape
+    if len(out_shape) < 2:
+        return [FactState.UNKNOWN]
+    m, n = out_shape[-2], out_shape[-1]
+    if m is None or n is None or m != n:
+        return [FactState.UNKNOWN]
+    return true_if(node.inputs[0].type.ndim == 0)
+
+
+def eye_identity_rule(key, op, feature, fgraph, node, input_states) -> list[FactState]:
+    """Rule body: TRUE when an :class:`Eye` node produces the identity matrix (square, k == 0)."""
+    n, m, k = node.inputs
+    if not isinstance(k, TensorConstant):
+        return [FactState.UNKNOWN]
+    if k.data.item() != 0:
+        # Ones sit on an off-main diagonal, so this is not the identity.
+        return [FactState.FALSE]
+    if n is m:
+        return [FactState.TRUE]
+    if isinstance(n, TensorConstant) and isinstance(m, TensorConstant):
+        return true_if(n.data.item() == m.data.item(), else_false=True)
+    return [FactState.UNKNOWN]
+
+
+def alloc_diag_at_offset_zero(
+    key, op, feature, fgraph, node, input_states
+) -> list[FactState]:
+    """Rule body: TRUE when :class:`AllocDiag` places values on the main diagonal,
+    FALSE when it places them on any other diagonal (off-main entries break diagonal /
+    symmetric / PD structure regardless of the diagonal vector's values)."""
+    return [FactState.TRUE if op.offset == 0 else FactState.FALSE]

--- a/pytensor/assumptions/alloc.py
+++ b/pytensor/assumptions/alloc.py
@@ -1,5 +1,11 @@
-from pytensor.assumptions.core import FactState, true_if
+from pytensor.assumptions.core import (
+    ALL_KEYS,
+    FactState,
+    register_assumption,
+    true_if,
+)
 from pytensor.tensor.basic import (
+    Alloc,
     NotScalarConstantError,
     get_underlying_scalar_constant_value,
 )
@@ -66,3 +72,19 @@ def alloc_diag_at_offset_zero(
     FALSE when it places them on any other diagonal (off-main entries break diagonal /
     symmetric / PD structure regardless of the diagonal vector's values)."""
     return [FactState.TRUE if op.offset == 0 else FactState.FALSE]
+
+
+def alloc_propagates_matrix_property(
+    key, op, feature, fgraph, node, input_states
+) -> list[FactState]:
+    """``Alloc`` broadcasts a value across new or expanded leading axes. When the
+    value is already matrix-shaped with non-broadcastable core axes, the alloc
+    cannot touch those axes, so the matrix property carries through unchanged."""
+    value = node.inputs[0]
+    if value.type.ndim >= 2 and not any(value.type.broadcastable[-2:]):
+        return [input_states[0]]
+    return [FactState.UNKNOWN]
+
+
+for _key in ALL_KEYS:
+    register_assumption(_key, Alloc)(alloc_propagates_matrix_property)

--- a/pytensor/assumptions/blockwise.py
+++ b/pytensor/assumptions/blockwise.py
@@ -1,0 +1,17 @@
+from pytensor.assumptions.core import (
+    ALL_KEYS,
+    infer_assumption_for_node,
+    register_assumption,
+)
+from pytensor.tensor.blockwise import Blockwise
+
+
+def _blockwise_delegate(key, op, feature, fgraph, node, input_states):
+    """Delegate assumption inference to the ``core_op`` of a Blockwise wrapper."""
+    return infer_assumption_for_node(
+        key, op.core_op, feature, fgraph, node, input_states
+    )
+
+
+for _key in ALL_KEYS:
+    register_assumption(_key, Blockwise)(_blockwise_delegate)

--- a/pytensor/assumptions/core.py
+++ b/pytensor/assumptions/core.py
@@ -1,0 +1,373 @@
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import IntFlag, auto
+from typing import Any
+
+from pytensor.graph import Apply, FunctionGraph, Op
+from pytensor.graph.features import AlreadyThere, Feature
+from pytensor.graph.traversal import walk_toposort
+from pytensor.tensor.variable import TensorConstant
+
+
+class FactState(IntFlag):
+    """Three-valued logic for assumption inference.
+
+    The three fact states are TRUE, FALSE and UNKNOWN.
+
+    UNKNOWN is the default condition, in which we cannot confirm or deny the fact.  TRUE and FALSE are definitive
+    states.  If we have evidence that a fact is both TRUE and FALSE, we get CONFLICT. In general, a CONFLICT state
+    should not be possible.
+    """
+
+    UNKNOWN = 0
+    TRUE = auto()
+    FALSE = auto()
+    CONFLICT = TRUE | FALSE
+
+    def __bool__(self) -> bool:
+        raise TypeError(
+            "FactState has no boolean value; compare against FactState.TRUE, "
+            "FactState.UNKNOWN, etc. explicitly, or use AssumptionFeature.check()."
+        )
+
+    @classmethod
+    def join(cls, left: "FactState", right: "FactState") -> "FactState":
+        """Combine two pieces of evidence about the *same* (variable, key)."""
+        return cls(left | right)
+
+
+@dataclass(frozen=True)
+class AssumptionKey:
+    """Identifies a named structural property (e.g. "diagonal" or "triangular").
+
+    ``short_name`` is an abbreviated label used by ``debugprint(print_assumptions=True)``;
+    it falls back to ``name`` when empty.
+    """
+
+    name: str
+    short_name: str = ""
+
+    def __repr__(self) -> str:
+        return self.name
+
+
+class ConflictingAssumptionsError(ValueError):
+    """Raised when joining evidence about a (variable, key) produces ``FactState.CONFLICT``.
+
+    Surfaces contradictions between user-asserted facts and inferred facts (or between
+    multiple sources of inferred facts) before they can silently corrupt downstream rewrites.
+    """
+
+
+# An inference function takes the active AssumptionKey, the Op, the current AssumptionFeature, the FunctionGraph,
+# the Apply node being analyzed, and the states of the input variables for the current key. It returns a list of
+# FactState with one entry per node output.
+InferFactFn = Callable[
+    [AssumptionKey, Op, "AssumptionFeature", FunctionGraph, Apply, list[FactState]],
+    list[FactState],
+]
+
+# The global inference registry maps (AssumptionKey, Op type) pairs to lists of inference functions.
+# Rules are tried in registration order; the first to return TRUE wins.
+ASSUMPTION_INFER_REGISTRY: dict[tuple[AssumptionKey, type], list[InferFactFn]] = {}
+
+# Registry mapping assumptions to other assumptions they imply.  For example, a "diagonal" matrix is also "symmetric"
+# and "triangular".  This is consulted after all other inference rules to derive additional facts.
+IMPLIES: dict[AssumptionKey, list[AssumptionKey]] = {}
+
+
+def register_implies(stronger: AssumptionKey, *weaker: AssumptionKey) -> None:
+    """Declare that *stronger* being TRUE implies each *weaker* key is also TRUE."""
+    IMPLIES.setdefault(stronger, []).extend(weaker)
+
+
+# Maps a key to a function that infers it directly from a literal TensorConstant's data.
+# AssumptionFeature consults this for variables with no owner, letting a property be
+# derived from raw values (e.g. recognising a constant diagonal matrix).
+ConstantInferFn = Callable[[TensorConstant], FactState]
+CONSTANT_INFER_REGISTRY: dict[AssumptionKey, ConstantInferFn] = {}
+
+
+def register_constant_inference(key: AssumptionKey, fn: ConstantInferFn) -> None:
+    """Register *fn* as the literal-constant inference for *key*."""
+    CONSTANT_INFER_REGISTRY[key] = fn
+
+
+# The canonical structural-property keys
+DIAGONAL = AssumptionKey("diagonal", short_name="diag")
+LOWER_TRIANGULAR = AssumptionKey("lower_triangular", short_name="tril")
+UPPER_TRIANGULAR = AssumptionKey("upper_triangular", short_name="triu")
+SYMMETRIC = AssumptionKey("symmetric", short_name="sym")
+POSITIVE_DEFINITE = AssumptionKey("positive_definite", short_name="pd")
+ORTHOGONAL = AssumptionKey("orthogonal", short_name="orth")
+
+ALL_KEYS = (
+    DIAGONAL,
+    LOWER_TRIANGULAR,
+    UPPER_TRIANGULAR,
+    SYMMETRIC,
+    POSITIVE_DEFINITE,
+    ORTHOGONAL,
+)
+
+# Implications about structural properties derivably from other structural properties
+register_implies(DIAGONAL, LOWER_TRIANGULAR, UPPER_TRIANGULAR, SYMMETRIC)
+register_implies(POSITIVE_DEFINITE, SYMMETRIC)
+
+
+def register_assumption(
+    key: AssumptionKey, *op_types: type
+) -> Callable[[InferFactFn], InferFactFn]:
+    """Decorator that registers an inference rule for ``(key, op_type)`` pairs.
+
+    The decorated function is called as ``fn(key, op, feature, fgraph, node, input_states)``
+    and must return a list of :class:`FactState` with one entry per node output.
+    """
+
+    def decorator(fn: InferFactFn) -> InferFactFn:
+        for op_type in op_types:
+            ASSUMPTION_INFER_REGISTRY.setdefault((key, op_type), []).append(fn)
+        return fn
+
+    return decorator
+
+
+def infer_assumption_for_node(
+    key: AssumptionKey,
+    op: Op,
+    feature: "AssumptionFeature",
+    fgraph: FunctionGraph,
+    node: Apply,
+    input_states: list[FactState],
+) -> list[FactState]:
+    """Determine the *key* fact for every output of *node*.
+
+    Walks the Op's MRO for the most specific :func:`register_assumption` rule and
+    returns the first non-UNKNOWN result. Falls back to ``UNKNOWN`` per output.
+    """
+    rules: list[InferFactFn] = []
+    for cls in type(op).__mro__:
+        fns = ASSUMPTION_INFER_REGISTRY.get((key, cls))
+        if fns is not None:
+            rules = fns
+            break
+
+    n_outputs = len(node.outputs)
+    for fn in rules:
+        output_states = fn(key, op, feature, fgraph, node, input_states)
+        if len(output_states) != n_outputs:
+            raise ValueError(
+                f"an assumption rule returned {len(output_states)} states for "
+                f"{n_outputs} outputs on node {node!r}"
+            )
+        if any(s is not FactState.UNKNOWN for s in output_states):
+            return output_states
+
+    return [FactState.UNKNOWN] * n_outputs
+
+
+class AssumptionFeature(Feature):
+    """``FunctionGraph`` feature that tracks symbolic assumptions about variables.
+
+    Assumptions (e.g. "this matrix is diagonal") are represented as ``(variable,
+    AssumptionKey) -> FactState`` mappings. Facts are inferred lazily via per-Op
+    rules registered with :func:`register_assumption`.
+
+    Attached lazily by :func:`check_assumption` on first use.
+    Results are cached and automatically refreshed when the graph changes.
+    """
+
+    __slots__ = ("_stale_vars", "_var_to_keys", "cache", "fgraph")
+
+    def on_attach(self, fgraph: Any) -> None:
+        if hasattr(fgraph, "assumption_feature"):
+            raise AlreadyThere("AssumptionFeature is already attached")
+        self.fgraph = fgraph
+        self.cache: dict[tuple[Any, AssumptionKey], FactState] = {}
+        self._var_to_keys: dict[Any, set[AssumptionKey]] = {}
+        self._stale_vars: set = set()
+        fgraph.assumption_feature = self
+
+    def on_detach(self, fgraph: Any) -> None:
+        self.cache = {}
+        self._var_to_keys = {}
+        self._stale_vars = set()
+        self.fgraph = None
+        del fgraph.assumption_feature
+
+    def on_change_input(self, fgraph, node, i, old_var, new_var, reason=None) -> None:
+        # Carry non-UNKNOWN facts from old_var to new_var, then defer downstream
+        # UNKNOWN invalidation to the next get()/check() call.
+        # CONFLICT is cached, not raised: the graph mutation has already landed,
+        # so raising here corrupts the caller's view.
+        for key in self._var_to_keys.get(old_var, ()):
+            old_state = self.cache.get((old_var, key))
+            if old_state is None or old_state is FactState.UNKNOWN:
+                continue
+            new_state = self.cache.get((new_var, key))
+            if new_state is None or new_state is FactState.UNKNOWN:
+                self.cache[(new_var, key)] = old_state
+            else:
+                self.cache[(new_var, key)] = FactState.join(old_state, new_state)
+            self._var_to_keys.setdefault(new_var, set()).add(key)
+
+        self._stale_vars.update(node.outputs)
+
+    def on_prune(self, fgraph, node, reason=None) -> None:
+        self._stale_vars.difference_update(node.outputs)
+
+    def clone(self) -> "AssumptionFeature":
+        # Cache entries are keyed on variable identity, so the cloned feature starts empty
+        # and re-derives facts from the cloned graph (assumptions attached via ``assume()``
+        # follow their variables through the clone since they live as graph nodes).
+        return AssumptionFeature()
+
+    def get(self, var: Any, key: AssumptionKey) -> FactState:
+        """Return the inferred :class:`FactState` for ``(var, key)``.
+
+        Raise :class:`ConflictingAssumptionsError` when the cached state is
+        :attr:`FactState.CONFLICT` — surfaces conflicts from substitutions or
+        owner-inferred rules at the point of query, where the graph is stable
+        and the caller can react.
+        """
+        cache_key = (var, key)
+        state = self.cache.get(cache_key)
+        if state is None or state is FactState.UNKNOWN:
+            if self._stale_vars:
+                self._drop_unknown_downstream(self._stale_vars)
+                self._stale_vars.clear()
+                # Re-check: the UNKNOWN will still be valid
+                # if the stale vars were not ancestors of var.
+                state = self.cache.get(cache_key)
+            if state is None:
+                state = self._compute(var, key)
+        if state is FactState.CONFLICT:
+            raise ConflictingAssumptionsError(
+                f"Conflicting evidence for key {key!r} on {var!r}."
+            )
+        return state
+
+    def check(self, var: Any, key: AssumptionKey) -> bool:
+        """Return ``True`` iff the assumption is definitively TRUE for ``var``."""
+        return self.get(var, key) is FactState.TRUE
+
+    def _compute(self, var: Any, key: AssumptionKey) -> FactState:
+        """Infer the fact state for ``(var, key)``, caching ancestors inputs-first.
+
+        After owner-based inference, walks the ``IMPLIES`` graph in both directions:
+          - Forward: a stronger key being TRUE makes this (weaker) key TRUE.
+          - Contrapositive: a weaker key being FALSE makes this (stronger) key FALSE.
+
+        Raise :class:`ConflictingAssumptionsError` if owner-inferred rules produce
+        ``FactState.CONFLICT``.
+        """
+
+        def deps(v: Any) -> tuple:
+            # Stop descending at cached variables — their facts (and their ancestors')
+            # are already settled for this key.
+            if (v, key) in self.cache:
+                return ()
+            owner = getattr(v, "owner", None)
+            return tuple(owner.inputs) if owner is not None else ()
+
+        for v in walk_toposort([var], deps):
+            if (v, key) in self.cache:
+                continue
+
+            # Cache UNKNOWN up front so any recursive ``self.get(v, other_key)`` triggered
+            # by the IMPLIES checks sees a placeholder instead of recursing back here.
+            self.cache[(v, key)] = FactState.UNKNOWN
+            self._var_to_keys.setdefault(v, set()).add(key)
+
+            owner = getattr(v, "owner", None)
+            if owner is not None:
+                input_states = [self.get(inp, key) for inp in owner.inputs]
+                output_states = infer_assumption_for_node(
+                    key, owner.op, self, self.fgraph, owner, input_states
+                )
+                state = output_states[owner.outputs.index(v)]
+            elif isinstance(v, TensorConstant) and key in CONSTANT_INFER_REGISTRY:
+                state = CONSTANT_INFER_REGISTRY[key](v)
+            else:
+                state = FactState.UNKNOWN
+
+            if state is FactState.UNKNOWN:
+                for stronger, weaker_list in IMPLIES.items():
+                    if key in weaker_list and self.get(v, stronger) is FactState.TRUE:
+                        state = FactState.TRUE
+                        break
+
+            if state is FactState.UNKNOWN:
+                for weaker in IMPLIES.get(key, ()):
+                    if self.get(v, weaker) is FactState.FALSE:
+                        state = FactState.FALSE
+                        break
+
+            if state is FactState.CONFLICT:
+                raise ConflictingAssumptionsError(
+                    f"Conflicting evidence for {key} on {v!r} from owner-inferred rules."
+                )
+
+            self.cache[(v, key)] = state
+
+        return self.cache[(var, key)]
+
+    def _drop_unknown_downstream(self, start_vars) -> None:
+        """Drop UNKNOWN entries for *start_vars* and downstream so they re-probe."""
+        cache = self.cache
+        var_to_keys = self._var_to_keys
+        clients = self.fgraph.clients
+        queue = deque(start_vars)
+        seen = set(start_vars)
+        while queue:
+            var = queue.popleft()
+            keys = var_to_keys.get(var)
+            if keys:
+                for key in [
+                    k for k in keys if cache.get((var, k)) is FactState.UNKNOWN
+                ]:
+                    cache.pop((var, key), None)
+                    keys.discard(key)
+                if not keys:
+                    var_to_keys.pop(var, None)
+            for client_node, _ in clients.get(var, ()):
+                for out in client_node.outputs:
+                    if out not in seen:
+                        seen.add(out)
+                        queue.append(out)
+
+
+def true_if(cond: bool, else_false: bool = False) -> list[FactState]:
+    """``[TRUE]`` when *cond* holds, ``[UNKNOWN]`` (or ``[FALSE]``) otherwise."""
+    if cond:
+        return [FactState.TRUE]
+    return [FactState.FALSE] if else_false else [FactState.UNKNOWN]
+
+
+def propagate_first(key, op, feature, fgraph, node, input_states) -> list[FactState]:
+    """Output inherits the assumption iff the first input has it."""
+    return true_if(input_states[0] is FactState.TRUE)
+
+
+def all_inputs_have_key(
+    key, op, feature, fgraph, node, input_states
+) -> list[FactState]:
+    """Output inherits the assumption iff *every* input has it."""
+    return true_if(all(s is FactState.TRUE for s in input_states))
+
+
+def check_assumption(
+    fgraph: FunctionGraph | None, var: Any, key: AssumptionKey
+) -> bool:
+    """Return True iff *key* is definitively TRUE for *var* in *fgraph*.
+
+    Lazily attaches :class:`AssumptionFeature` to *fgraph* if it is not already present.
+    """
+    if fgraph is None:
+        return False
+    feature = getattr(fgraph, "assumption_feature", None)
+    if feature is None:
+        feature = AssumptionFeature()
+        fgraph.attach_feature(feature)
+    return feature.check(var, key)

--- a/pytensor/assumptions/diagonal.py
+++ b/pytensor/assumptions/diagonal.py
@@ -1,0 +1,134 @@
+import numpy as np
+
+from pytensor.assumptions.alloc import (
+    alloc_diag_at_offset_zero,
+    alloc_of_zero,
+    eye_identity_rule,
+)
+from pytensor.assumptions.core import (
+    DIAGONAL,
+    ORTHOGONAL,
+    FactState,
+    all_inputs_have_key,
+    propagate_first,
+    register_assumption,
+    register_constant_inference,
+)
+from pytensor.assumptions.elemwise import elemwise_preserves_zero_pattern
+from pytensor.assumptions.subtensor import subtensor_propagates_matrix_property
+from pytensor.tensor.basic import Alloc, AllocDiag, Eye
+from pytensor.tensor.elemwise import DimShuffle, Elemwise
+from pytensor.tensor.linalg.constructors import BlockDiagonal
+from pytensor.tensor.linalg.decomposition.cholesky import Cholesky
+from pytensor.tensor.linalg.inverse import MatrixInverse, MatrixPinv
+from pytensor.tensor.linalg.products import KroneckerProduct
+from pytensor.tensor.math import Dot
+from pytensor.tensor.subtensor import (
+    AdvancedIncSubtensor,
+    IncSubtensor,
+    Subtensor,
+)
+from pytensor.tensor.variable import TensorConstant
+
+
+def _diagonal_from_constant(var: TensorConstant) -> FactState:
+    """Recognize a literal :class:`TensorConstant` matrix as DIAGONAL by inspecting its data.
+
+    The off-diagonal scan is O(n^2), so the result is cached on ``var.tag.is_diagonal``.
+    """
+    cached: FactState | None = getattr(var.tag, "is_diagonal", None)
+    if cached is not None:
+        return cached
+
+    data = np.asarray(var.data)
+    if data.ndim < 2:
+        # A scalar or vector is not a matrix, so it cannot be a diagonal matrix.
+        result = FactState.FALSE
+    else:
+        m, n = data.shape[-2], data.shape[-1]
+        if m != n:
+            result = FactState.FALSE
+        else:
+            eye_mask = np.eye(n, dtype=bool)
+            result = FactState.FALSE if np.any(data * ~eye_mask) else FactState.TRUE
+
+    var.tag.is_diagonal = result
+    return result
+
+
+register_constant_inference(DIAGONAL, _diagonal_from_constant)
+
+
+def indexes_diagonal(node) -> bool:
+    """True when an ``*IncSubtensor*`` node modifies only diagonal entries."""
+    op = node.op
+    if not isinstance(op, AdvancedIncSubtensor | IncSubtensor):
+        return False
+
+    # A full slice (``[:]``) over a batch axis is a no-op; drop it so the
+    # batched ``x[:, i, i]`` form is recognised, not just bare ``x[i, i]``.
+    idx_list = [p for p in op.idx_list if p != slice(None)]
+    if len(idx_list) < 2 or any(isinstance(p, slice) for p in idx_list):
+        return False
+
+    op_indices = node.inputs[2:]
+    first = op_indices[idx_list[0]]
+    return all(first is op_indices[p] for p in idx_list[1:])
+
+
+register_assumption(DIAGONAL, Eye)(eye_identity_rule)
+register_assumption(DIAGONAL, AllocDiag)(alloc_diag_at_offset_zero)
+register_assumption(DIAGONAL, Alloc)(alloc_of_zero)
+register_assumption(DIAGONAL, Cholesky)(propagate_first)
+register_assumption(DIAGONAL, BlockDiagonal)(all_inputs_have_key)
+register_assumption(DIAGONAL, MatrixInverse)(propagate_first)
+register_assumption(DIAGONAL, MatrixPinv)(propagate_first)
+register_assumption(DIAGONAL, KroneckerProduct)(all_inputs_have_key)
+register_assumption(DIAGONAL, Dot)(all_inputs_have_key)
+register_assumption(DIAGONAL, Subtensor)(subtensor_propagates_matrix_property)
+
+
+@register_assumption(DIAGONAL, Dot)
+def _dot_orthogonal_xxt(key, op, feature, fgraph, node, input_states):
+    """x @ x.T is diagonal (identity) when x is orthogonal."""
+    a, b = node.inputs
+    if (
+        feature.check(a, ORTHOGONAL)
+        and b.owner is not None
+        and isinstance(b.owner_op, DimShuffle)
+        and b.owner_op.is_matrix_transpose
+        and b.owner.inputs[0] is a
+    ):
+        return [FactState.TRUE]
+
+    return [FactState.UNKNOWN]
+
+
+@register_assumption(DIAGONAL, IncSubtensor)
+@register_assumption(DIAGONAL, AdvancedIncSubtensor)
+def _inc_subtensor(key, op, feature, fgraph, node, input_states):
+    if input_states[0] is FactState.TRUE and indexes_diagonal(node):
+        return [FactState.TRUE]
+    return [FactState.UNKNOWN]
+
+
+@register_assumption(DIAGONAL, DimShuffle)
+def _dimshuffle(key, op, feature, fgraph, node, input_states):
+    # Matrix transpose and left-expand-dims are exact diagonality bijections\
+    if op.is_transpose:
+        nd = op.input_ndim
+        if nd >= 2:
+            last_two_swapped = (*tuple(range(nd - 2)), nd - 1, nd - 2)
+            if op.new_order == last_two_swapped:
+                return [input_states[0]]
+
+    if op.is_expand_dims and op.input_ndim >= 2:
+        if op.new_order[-op.input_ndim :] == tuple(range(op.input_ndim)):
+            return [input_states[0]]
+
+    return [FactState.UNKNOWN]
+
+
+@register_assumption(DIAGONAL, Elemwise)
+def _elemwise(key, op, feature, fgraph, node, input_states):
+    return elemwise_preserves_zero_pattern(DIAGONAL, op, feature, node, input_states)

--- a/pytensor/assumptions/dimshuffle.py
+++ b/pytensor/assumptions/dimshuffle.py
@@ -1,0 +1,14 @@
+from pytensor.tensor.elemwise import DimShuffle
+
+
+def left_expand_dims_propagates_matrix_property(op) -> bool:
+    """True iff ``op`` is a ``DimShuffle`` adding new broadcast dims only on the left of a matrix.
+
+    Such a DimShuffle (e.g. ``M[None, ..., :, :]``) stacks the operand along new
+    leading batch axes without touching the trailing two axes. Every per-matrix
+    property (symmetric, PSD, triangular, orthogonal, diagonal) carries through
+    elementwise across the batch, so the output inherits the assumption.
+    """
+    return bool(
+        isinstance(op, DimShuffle) and op.is_left_expand_dims and op.input_ndim >= 2
+    )

--- a/pytensor/assumptions/dimshuffle.py
+++ b/pytensor/assumptions/dimshuffle.py
@@ -1,3 +1,4 @@
+from pytensor.assumptions.core import ALL_KEYS, FactState, register_assumption
 from pytensor.tensor.elemwise import DimShuffle
 
 
@@ -12,3 +13,21 @@ def left_expand_dims_propagates_matrix_property(op) -> bool:
     return bool(
         isinstance(op, DimShuffle) and op.is_left_expand_dims and op.input_ndim >= 2
     )
+
+
+def dimshuffle_propagates_matrix_property(
+    key, op, feature, fgraph, node, input_states
+) -> list[FactState]:
+    """A ``DimShuffle`` that only adds, drops, or permutes batch axes -- leaving
+    the trailing two axes last and in order -- forwards the matrix property.
+    Matrix transpose, which swaps the core axes, is handled per-key."""
+    input_ndim = op.input_ndim
+    if input_ndim < 2:
+        return [FactState.UNKNOWN]
+    if tuple(op.new_order[-2:]) == (input_ndim - 2, input_ndim - 1):
+        return [input_states[0]]
+    return [FactState.UNKNOWN]
+
+
+for _key in ALL_KEYS:
+    register_assumption(_key, DimShuffle)(dimshuffle_propagates_matrix_property)

--- a/pytensor/assumptions/dot.py
+++ b/pytensor/assumptions/dot.py
@@ -1,0 +1,58 @@
+from pytensor.graph.basic import Variable
+from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.elemwise import DimShuffle
+from pytensor.tensor.math import Dot
+
+
+def _are_matrix_transposes(a: Variable, b: Variable) -> bool:
+    """True iff ``a`` and ``b`` are matrix transposes of each other (in either direction)."""
+    for y, x in ((a, b), (b, a)):
+        match y.owner_op_and_inputs:
+            case (DimShuffle() as ds, inner) if ds.is_matrix_transpose and inner is x:
+                return True
+    return False
+
+
+def _matmul_inputs(var: Variable) -> tuple[Variable, Variable] | None:
+    """If ``var`` is the output of a binary matmul (``Dot`` or ``Blockwise(Dot)``),
+    return its two inputs; otherwise ``None``."""
+    owner = var.owner
+    if owner is None:
+        return None
+    op = owner.op
+    if isinstance(op, Dot) or (
+        isinstance(op, Blockwise) and isinstance(op.core_op, Dot)
+    ):
+        return owner.inputs[0], owner.inputs[1]
+    return None
+
+
+def match_congruence(node) -> Variable | None:
+    """Detect a congruence ``M @ S @ M.T`` (or ``M.T @ S @ M``) at a matmul node.
+
+    Both Python associativities are matched: ``(M @ S) @ M.T`` and
+    ``M @ (S @ M.T)``, plus their mirrors. ``M`` and ``M.T`` must appear by
+    variable identity; ``S`` is the inner matmul's other operand. The outer
+    and inner matmuls may each be a plain ``Dot`` or a ``Blockwise(Dot)``
+    (i.e. ``matmul``), since Python's ``@`` lowers to the latter.
+
+    Returns the inner ``S`` variable on a match, or ``None``. The caller
+    decides which assumption to check on ``S`` (``SYMMETRIC``, ``POSITIVE_DEFINITE``).
+    """
+    left, right = node.inputs
+
+    # Right-associative: outer(M, inner(S, M.T))  or  outer(M.T, inner(S, M))
+    inner = _matmul_inputs(right)
+    if inner is not None:
+        s, inner_right = inner
+        if _are_matrix_transposes(left, inner_right):
+            return s
+
+    # Left-associative: outer(inner(M, S), M.T)  or  outer(inner(M.T, S), M)
+    inner = _matmul_inputs(left)
+    if inner is not None:
+        inner_left, s = inner
+        if _are_matrix_transposes(inner_left, right):
+            return s
+
+    return None

--- a/pytensor/assumptions/elemwise.py
+++ b/pytensor/assumptions/elemwise.py
@@ -1,0 +1,84 @@
+from pytensor.assumptions.core import AssumptionKey, FactState, true_if
+from pytensor.scalar.basic import (
+    Add,
+    Mul,
+    Pow,
+    Sub,
+    TrueDiv,
+    UnaryScalarOp,
+)
+from pytensor.tensor.basic import (
+    NotScalarConstantError,
+    get_underlying_scalar_constant_value,
+)
+from pytensor.tensor.subtensor import _is_provably_positive
+
+
+def elemwise_preserves_zero_pattern(
+    key: AssumptionKey, op, feature, node, input_states
+) -> list[FactState]:
+    """Inference for keys whose defining property is a fixed pattern of zeros.
+
+    The output preserves *key* when:
+    - ``Mul``: at least one such input has *key* and is a non-singleton matrix.
+    - ``Add`` / ``Sub``: every such input has *key*, and at least one exists.
+    - ``TrueDiv``: the numerator has *key* and is a non-singleton matrix.
+    - ``Pow``: the base has *key*, is a non-singleton matrix, and the exponent is provably positive.
+    - Zero-preserving unary ops (e.g. ``Neg``, ``Abs``, ``Sin``, ``Sqr``):
+      output inherits *key* from the input.
+    """
+
+    def _not_singleton_matrix(var) -> bool:
+        return var.type.ndim >= 2 and not all(var.type.broadcastable[-2:])
+
+    scalar_op = op.scalar_op
+
+    if isinstance(scalar_op, Mul):
+        return true_if(
+            any(
+                feature.check(inp, key) and _not_singleton_matrix(inp)
+                for inp in node.inputs
+            )
+        )
+
+    if isinstance(scalar_op, (Add, Sub)):
+        matrix_inputs = []
+        broadcast_inputs = []
+        for inp in node.inputs:
+            if _not_singleton_matrix(inp):
+                matrix_inputs.append(inp)
+            else:
+                broadcast_inputs.append(inp)
+        if not matrix_inputs:
+            return [FactState.UNKNOWN]
+
+        # A scalar / vector / (1, 1) input broadcasts to every entry of the matrix,
+        # so it adds (or subtracts) its value at every off-diagonal position too.
+        # The zero pattern survives only if every such broadcast input is zero.
+        for inp in broadcast_inputs:
+            try:
+                val = get_underlying_scalar_constant_value(inp)
+            except NotScalarConstantError:
+                return [FactState.UNKNOWN]
+            if val != 0:
+                return [FactState.UNKNOWN]
+        return true_if(all(feature.check(inp, key) for inp in matrix_inputs))
+
+    if isinstance(scalar_op, TrueDiv):
+        numerator = node.inputs[0]
+        return true_if(
+            feature.check(numerator, key) and _not_singleton_matrix(numerator)
+        )
+
+    if isinstance(scalar_op, Pow):
+        base = node.inputs[0]
+        if not (feature.check(base, key) and _not_singleton_matrix(base)):
+            return [FactState.UNKNOWN]
+        # 0 ** p == 0 for p > 0, so a provably-positive exponent (scalar or
+        # elementwise matrix) preserves the base's zero pattern.
+        return true_if(_is_provably_positive(node.inputs[1]))
+
+    if isinstance(scalar_op, UnaryScalarOp) and scalar_op.preserves_zero:
+        return true_if(input_states[0] is FactState.TRUE)
+
+    return [FactState.UNKNOWN] * len(node.outputs)

--- a/pytensor/assumptions/orthogonal.py
+++ b/pytensor/assumptions/orthogonal.py
@@ -1,0 +1,85 @@
+from pytensor.assumptions.alloc import eye_identity_rule
+from pytensor.assumptions.core import (
+    ORTHOGONAL,
+    FactState,
+    all_inputs_have_key,
+    propagate_first,
+    register_assumption,
+)
+from pytensor.assumptions.dimshuffle import left_expand_dims_propagates_matrix_property
+from pytensor.assumptions.subtensor import subtensor_propagates_matrix_property
+from pytensor.tensor.basic import Eye
+from pytensor.tensor.elemwise import DimShuffle
+from pytensor.tensor.linalg.constructors import BlockDiagonal
+from pytensor.tensor.linalg.decomposition.eigen import Eigh
+from pytensor.tensor.linalg.decomposition.qr import QR
+from pytensor.tensor.linalg.decomposition.schur import QZ, Schur
+from pytensor.tensor.linalg.decomposition.svd import SVD
+from pytensor.tensor.linalg.inverse import MatrixInverse, MatrixPinv
+from pytensor.tensor.math import Dot
+from pytensor.tensor.subtensor import Subtensor
+
+
+register_assumption(ORTHOGONAL, Eye)(eye_identity_rule)
+register_assumption(ORTHOGONAL, MatrixInverse)(propagate_first)
+register_assumption(ORTHOGONAL, MatrixPinv)(propagate_first)
+register_assumption(ORTHOGONAL, BlockDiagonal)(all_inputs_have_key)
+register_assumption(ORTHOGONAL, Subtensor)(subtensor_propagates_matrix_property)
+# The orthogonal group is closed under matmul: (A B)ᵀ (A B) = Bᵀ AᵀA B = I.
+register_assumption(ORTHOGONAL, Dot)(all_inputs_have_key)
+
+
+@register_assumption(ORTHOGONAL, DimShuffle)
+def _dimshuffle(key, op, feature, fgraph, node, input_states):
+    """Orthogonality survives matrix transpose and left-expand-dims (batch broadcast)."""
+    if input_states[0] is not FactState.TRUE:
+        return [FactState.UNKNOWN]
+    if op.is_matrix_transpose:
+        return [FactState.TRUE]
+    if left_expand_dims_propagates_matrix_property(op):
+        return [FactState.TRUE]
+    return [FactState.UNKNOWN]
+
+
+@register_assumption(ORTHOGONAL, Schur)
+def _schur(key, op, feature, fgraph, node, input_states):
+    # Schur: A = Z @ T @ Z.T -> outputs are (T, Z); Z is orthogonal
+    return [FactState.UNKNOWN, FactState.TRUE]
+
+
+@register_assumption(ORTHOGONAL, QZ)
+def _qz(key, op, feature, fgraph, node, input_states):
+    # QZ: outputs are (AA, BB, Q, Z) or (AA, BB, alpha, beta, Q, Z)
+    n_out = len(node.outputs)
+    states = [FactState.UNKNOWN] * n_out
+    # Q and Z are always the last two outputs
+    states[-2] = FactState.TRUE
+    states[-1] = FactState.TRUE
+    return states
+
+
+@register_assumption(ORTHOGONAL, QR)
+def _qr(key, op, feature, fgraph, node, input_states):
+    # QR full mode: Q is square and orthogonal (output 0)
+    # Economic/other modes: Q has orthonormal columns but isn't square
+    n_out = len(node.outputs)
+    if op.mode == "full":
+        return [FactState.TRUE] + [FactState.UNKNOWN] * (n_out - 1)
+    return [FactState.UNKNOWN] * n_out
+
+
+@register_assumption(ORTHOGONAL, SVD)
+def _svd(key, op, feature, fgraph, node, input_states):
+    # SVD full_matrices: outputs are (U, S, V) where U and V are orthogonal
+    # Reduced: U and V have orthonormal columns/rows but aren't square
+    if not op.compute_uv:
+        return [FactState.UNKNOWN]
+    if op.full_matrices:
+        return [FactState.TRUE, FactState.UNKNOWN, FactState.TRUE]
+    return [FactState.UNKNOWN] * 3
+
+
+@register_assumption(ORTHOGONAL, Eigh)
+def _eigh(key, op, feature, fgraph, node, input_states):
+    # Eigh: outputs are (w, v) where v is the orthogonal eigenvector matrix
+    return [FactState.UNKNOWN, FactState.TRUE]

--- a/pytensor/assumptions/positive_definite.py
+++ b/pytensor/assumptions/positive_definite.py
@@ -1,0 +1,167 @@
+from pytensor.assumptions.alloc import eye_identity_rule
+from pytensor.assumptions.core import (
+    POSITIVE_DEFINITE,
+    FactState,
+    all_inputs_have_key,
+    propagate_first,
+    register_assumption,
+    true_if,
+)
+from pytensor.assumptions.dimshuffle import left_expand_dims_propagates_matrix_property
+from pytensor.assumptions.dot import match_congruence
+from pytensor.assumptions.subtensor import subtensor_propagates_matrix_property
+from pytensor.scalar.basic import Add, Conj, Mul
+from pytensor.tensor.basic import AllocDiag, Eye
+from pytensor.tensor.elemwise import DimShuffle, Elemwise
+from pytensor.tensor.linalg.constructors import BlockDiagonal
+from pytensor.tensor.linalg.inverse import MatrixInverse
+from pytensor.tensor.linalg.products import KroneckerProduct
+from pytensor.tensor.linalg.solvers.linear_control import (
+    SolveBilinearDiscreteLyapunov,
+)
+from pytensor.tensor.math import Dot
+from pytensor.tensor.subtensor import Subtensor, _is_provably_positive
+
+
+register_assumption(POSITIVE_DEFINITE, Eye)(eye_identity_rule)
+
+
+@register_assumption(POSITIVE_DEFINITE, AllocDiag)
+def _alloc_diag(key, op, feature, fgraph, node, input_states):
+    """``diag(v)`` is positive definite iff it lies on the main diagonal and every
+    element of ``v`` is provably positive."""
+    if op.offset != 0:
+        return [FactState.FALSE]
+
+    [diag_values] = node.inputs
+    return true_if(_is_provably_positive(diag_values))
+
+
+register_assumption(POSITIVE_DEFINITE, BlockDiagonal)(all_inputs_have_key)
+register_assumption(POSITIVE_DEFINITE, MatrixInverse)(propagate_first)
+register_assumption(POSITIVE_DEFINITE, KroneckerProduct)(all_inputs_have_key)
+register_assumption(POSITIVE_DEFINITE, Subtensor)(subtensor_propagates_matrix_property)
+
+
+def _is_psd_full_shape(inp, feature) -> bool:
+    """Whether ``inp`` is a known-PD matrix at full shape over the last two axes.
+
+    PD is a property of square matrices; scalar/vector inputs that broadcast into a matrix shape do not preserve
+    definiteness (e.g. ``A + c`` adds the all-ones matrix scaled by c, which is not generally PD-preserving). Only
+    inputs whose last two axes are both present (non-broadcastable) and that are themselves marked PD count.
+    """
+    if inp.type.ndim < 2:
+        return False
+    if any(inp.type.broadcastable[-2:]):
+        return False
+    return bool(feature.check(inp, POSITIVE_DEFINITE))
+
+
+@register_assumption(POSITIVE_DEFINITE, Elemwise)
+def _elemwise(key, op, feature, fgraph, node, input_states):
+    """Elementwise rules that preserve positive definiteness.
+
+    - Add: every input is a full-shape PD matrix.
+    - Mul: a provably-positive scalar times all-PD-matrix factors.
+    """
+    scalar_op = op.scalar_op
+
+    if isinstance(scalar_op, Add):
+        return true_if(all(_is_psd_full_shape(inp, feature) for inp in node.inputs))
+
+    if isinstance(scalar_op, Mul):
+        for i, inp in enumerate(node.inputs):
+            # Scaling a PD matrix by a positive scalar keeps it PD. The factor
+            # must be constant across the matrix axes (both broadcastable);
+            # per-batch variation is fine since every batch slice stays PD.
+            if not (all(inp.type.broadcastable[-2:]) and _is_provably_positive(inp)):
+                continue
+            other_inputs = [node.inputs[j] for j in range(len(node.inputs)) if j != i]
+            if other_inputs and all(
+                _is_psd_full_shape(other, feature) for other in other_inputs
+            ):
+                return [FactState.TRUE]
+        return [FactState.UNKNOWN]
+
+    return [FactState.UNKNOWN] * len(node.outputs)
+
+
+def _is_conjugate_transpose_of(y, x):
+    """Check if y is the conjugate transpose of x (x.T.conj() or x.conj().T)."""
+    match y.owner_op_and_inputs:
+        case (Elemwise(scalar_op=Conj()), y_inner):  # x.T.conj()
+            match y_inner.owner_op_and_inputs:
+                case (DimShuffle(is_left_expanded_matrix_transpose=True), inner) if (
+                    inner is x
+                ):
+                    return True
+        case (
+            DimShuffle(is_left_expanded_matrix_transpose=True),
+            y_inner,
+        ):  # x.conj().T
+            match y_inner.owner_op_and_inputs:
+                case (Elemwise(scalar_op=Conj()), inner) if inner is x:
+                    return True
+    return False
+
+
+@register_assumption(POSITIVE_DEFINITE, DimShuffle)
+def _dimshuffle(key, op, feature, fgraph, node, input_states):
+    """PSD survives matrix transpose and left-expand-dims (batch broadcast)."""
+    if input_states[0] is not FactState.TRUE:
+        return [FactState.UNKNOWN]
+    if op.is_matrix_transpose:
+        return [FactState.TRUE]
+    if left_expand_dims_propagates_matrix_property(op):
+        return [FactState.TRUE]
+    return [FactState.UNKNOWN]
+
+
+@register_assumption(POSITIVE_DEFINITE, Dot)
+def _dot(key, op, feature, fgraph, node, input_states):
+    """Detect positive semi-definite matrices from dot products.
+
+    Patterns detected:
+    - dot(x, x.T) for real matrices (and symmetric counterpart)
+    - dot(x, x.conj().T) or dot(x, x.T.conj()) for complex matrices
+
+    Technically these are semi-definite, and only positive definite if the input matrix is full rank.
+    I'm adding this to have a conversation about it. We could add an @unsafe_assumption tag that could be excluded,
+    or we could just ask users to tag their matrices in this case. But it's common enough in applications (Grahm matrices)
+    to merit some thought.
+    """
+    x, y = node.inputs
+    is_complex = x.type.dtype.startswith("complex")
+
+    for left, right in [(x, y), (y, x)]:
+        if is_complex:
+            if _is_conjugate_transpose_of(right, left):
+                return [FactState.TRUE]
+        else:
+            match right.owner_op_and_inputs:
+                case (DimShuffle(is_left_expanded_matrix_transpose=True), inner) if (
+                    inner is left
+                ):
+                    return [FactState.TRUE]
+
+    # Congruence: M @ S @ M.T (or its mirror) is PSD when S is PSD. Only valid
+    # for real matrices here -- the complex analogue requires M^H, which would
+    # need a separate Hermitian-transpose match.
+    if not is_complex:
+        s = match_congruence(node)
+        if s is not None and feature.check(s, POSITIVE_DEFINITE):
+            return [FactState.TRUE]
+
+    return [FactState.UNKNOWN]
+
+
+@register_assumption(POSITIVE_DEFINITE, SolveBilinearDiscreteLyapunov)
+def _discrete_lyapunov(key, op, feature, fgraph, node, input_states):
+    """Propagate PSD from ``Q`` to the solution ``X`` of ``A X A^T - X = Q``.
+
+    Mathematically, ``X`` is PSD when ``Q`` is PSD *and* the spectral radius of ``A``
+    is strictly less than 1; without a stability assumption on ``A`` we propagate
+    optimistically. Users with non-stable ``A`` can override with
+    ``assume(X, positive_definite=False)``.
+    """
+    return true_if(input_states[1] is FactState.TRUE)

--- a/pytensor/assumptions/reshape.py
+++ b/pytensor/assumptions/reshape.py
@@ -1,0 +1,28 @@
+from pytensor.assumptions.core import ALL_KEYS, FactState, register_assumption
+from pytensor.tensor.reshape import JoinDims, SplitDims
+
+
+def join_dims_propagates_matrix_property(
+    key, op, feature, fgraph, node, input_states
+) -> list[FactState]:
+    """``JoinDims`` merges a run of axes. The matrix property survives iff that
+    run stays clear of the trailing two (core) axes."""
+    core_start = node.inputs[0].type.ndim - 2
+    if op.start_axis + op.n_axes <= core_start:
+        return [input_states[0]]
+    return [FactState.UNKNOWN]
+
+
+def split_dims_propagates_matrix_property(
+    key, op, feature, fgraph, node, input_states
+) -> list[FactState]:
+    """``SplitDims`` splits one axis. The matrix property survives iff that axis
+    is not one of the trailing two (core) axes."""
+    if op.axis < node.inputs[0].type.ndim - 2:
+        return [input_states[0]]
+    return [FactState.UNKNOWN]
+
+
+for _key in ALL_KEYS:
+    register_assumption(_key, JoinDims)(join_dims_propagates_matrix_property)
+    register_assumption(_key, SplitDims)(split_dims_propagates_matrix_property)

--- a/pytensor/assumptions/shape.py
+++ b/pytensor/assumptions/shape.py
@@ -1,0 +1,30 @@
+from pytensor.assumptions.core import ALL_KEYS, FactState, register_assumption
+from pytensor.tensor.shape import Reshape, SpecifyShape
+
+
+def specify_shape_propagates_matrix_property(
+    key, op, feature, fgraph, node, input_states
+) -> list[FactState]:
+    """``SpecifyShape`` only annotates a shape; the value and its axes are unchanged."""
+    return [input_states[0]]
+
+
+def reshape_propagates_matrix_property(
+    key, op, feature, fgraph, node, input_states
+) -> list[FactState]:
+    """``Reshape`` preserves the matrix property iff the trailing two dimensions
+    are unchanged."""
+    in_shape = node.inputs[0].type.shape
+    out_shape = node.outputs[0].type.shape
+    if len(in_shape) < 2 or len(out_shape) < 2:
+        return [FactState.UNKNOWN]
+    in_core = in_shape[-2:]
+    out_core = out_shape[-2:]
+    if None in in_core or None in out_core or in_core != out_core:
+        return [FactState.UNKNOWN]
+    return [input_states[0]]
+
+
+for _key in ALL_KEYS:
+    register_assumption(_key, SpecifyShape)(specify_shape_propagates_matrix_property)
+    register_assumption(_key, Reshape)(reshape_propagates_matrix_property)

--- a/pytensor/assumptions/specify.py
+++ b/pytensor/assumptions/specify.py
@@ -26,6 +26,13 @@ class SpecifyAssumptions(TypeCastingOp):
             (name, FactState(state)) for name, state in sorted(assumptions.items())
         )
 
+    def __str__(self):
+        facts = ", ".join(
+            name if state is FactState.TRUE else f"!{name}"
+            for name, state in self.assumptions
+        )
+        return f"{type(self).__name__}{{{facts}}}"
+
     def make_node(self, x):
         if not isinstance(x, Variable):
             x = as_tensor_variable(x)

--- a/pytensor/assumptions/specify.py
+++ b/pytensor/assumptions/specify.py
@@ -1,0 +1,123 @@
+from collections.abc import Sequence
+
+from pytensor.assumptions.core import ALL_KEYS, FactState, register_assumption
+from pytensor.compile.ops import TypeCastingOp
+from pytensor.graph.basic import Apply, Variable
+from pytensor.tensor import TensorLike
+from pytensor.tensor.basic import as_tensor_variable
+
+
+class SpecifyAssumptions(TypeCastingOp):
+    """No-op that declares structural assumptions on a tensor for use by graph rewrites.
+
+    ``assumptions`` is a tuple of ``(name, FactState)`` pairs sorted by ``name``, where
+    ``name`` matches the name of an :class:`AssumptionKey`. Two instances with the same
+    fact set compare equal via ``__props__``, so PyTensor's graph merge collapses
+    duplicates.
+    """
+
+    __props__ = ("assumptions",)
+
+    assumptions: tuple[tuple[str, FactState], ...]
+
+    def __init__(self, assumptions: dict[str, FactState]):
+        super().__init__()
+        self.assumptions = tuple(
+            (name, FactState(state)) for name, state in sorted(assumptions.items())
+        )
+
+    def make_node(self, x):
+        if not isinstance(x, Variable):
+            x = as_tensor_variable(x)
+        out = x.type()
+        return Apply(self, [x], [out])
+
+    def infer_shape(self, fgraph, node, input_shapes):
+        return input_shapes
+
+    def pullback(
+        self, inputs, outputs, output_cotangents: Sequence[Variable]
+    ) -> list[Variable]:
+        return list(output_cotangents)
+
+
+def specify_assumption_rule(key, op, feature, fgraph, node, input_states):
+    """Report the declared state for ``key`` joined with whatever inference derived
+    from the input. The join surfaces ``ConflictingAssumptionsError`` when the user
+    asserts a state that contradicts what the system can prove (e.g. asserting
+    ``diagonal=False`` on something proved diagonal)."""
+    for name, state in op.assumptions:
+        if name == key.name:
+            return [FactState.join(state, input_states[0])]
+    return [input_states[0]]
+
+
+def assume(
+    x: TensorLike,
+    diagonal: bool | None = None,
+    lower_triangular: bool | None = None,
+    upper_triangular: bool | None = None,
+    symmetric: bool | None = None,
+    positive_definite: bool | None = None,
+    orthogonal: bool | None = None,
+):
+    """Attach structural assumptions to a symbolic tensor.
+
+    Returns a tensor identical to *x* at runtime but carrying the declared assumptions so that
+    graph rewrites can exploit them. Each keyword may be ``True`` (assert the property holds),
+    ``False`` (assert it does not hold), or ``None`` (no assertion).
+
+    Parameters
+    ----------
+    x : tensor-like
+        The input to annotate.
+    diagonal : bool, optional
+        Assert that *x* is (or is not) a diagonal matrix.
+    lower_triangular : bool, optional
+        Assert that *x* is (or is not) lower-triangular.
+    upper_triangular : bool, optional
+        Assert that *x* is (or is not) upper-triangular.
+    symmetric : bool, optional
+        Assert that *x* is (or is not) symmetric.
+    positive_definite : bool, optional
+        Assert that *x* is (or is not) positive-definite.
+    orthogonal : bool, optional
+        Assert that *x* is (or is not) orthogonal.
+
+    Returns
+    -------
+    out : TensorVariable
+        A view of *x* with the assumptions attached.
+
+    Examples
+    --------
+    >>> import pytensor.tensor as pt
+    >>> x = pt.dmatrix("x")
+    >>> x_diag = assume(x, diagonal=True)
+    >>> x_not_sym = assume(x, symmetric=False)
+    """
+    if not isinstance(x, Variable):
+        x = as_tensor_variable(x)
+
+    values = {
+        "diagonal": diagonal,
+        "lower_triangular": lower_triangular,
+        "upper_triangular": upper_triangular,
+        "symmetric": symmetric,
+        "positive_definite": positive_definite,
+        "orthogonal": orthogonal,
+    }
+    assumptions = {
+        name: FactState.TRUE if value else FactState.FALSE
+        for name, value in values.items()
+        if value is not None
+    }
+
+    if not assumptions:
+        return x
+
+    return SpecifyAssumptions(assumptions)(x)
+
+
+for _key in ALL_KEYS:
+    register_assumption(_key, SpecifyAssumptions)(specify_assumption_rule)

--- a/pytensor/assumptions/subtensor.py
+++ b/pytensor/assumptions/subtensor.py
@@ -1,4 +1,11 @@
-from pytensor.assumptions.core import FactState, true_if
+from pytensor.assumptions.core import (
+    ALL_KEYS,
+    ORTHOGONAL,
+    FactState,
+    register_assumption,
+    true_if,
+)
+from pytensor.tensor.subtensor import IncSubtensor
 
 
 def subtensor_propagates_matrix_property(
@@ -26,3 +33,43 @@ def subtensor_propagates_matrix_property(
     return true_if(
         all(idx_list[-(i + 1)] == full_slice for i in range(n_explicit_matrix_axes))
     )
+
+
+def incsubtensor_propagates_matrix_property(
+    key, op, feature, fgraph, node, input_states
+) -> list[FactState]:
+    """``IncSubtensor`` writes ``value`` into a slice of ``base``. When the index
+    leaves the trailing two (core) axes as full slices -- a batch-only write --
+    the per-matrix property forwards:
+
+    - ``set`` over the whole tensor: the output is just ``value``.
+    - ``set`` over a partial batch region: every output slice comes from ``base``
+      or ``value``, so both must carry the property.
+    - ``inc``: the written region becomes ``base + value``; the property must be
+      closed under addition -- true for every key except ``orthogonal``.
+
+    An index that reaches into the core axes is left to the per-key rules (e.g.
+    the diagonal-position write handled by ``indexes_diagonal``).
+    """
+    base_ndim = node.inputs[0].type.ndim
+    if base_ndim < 2:
+        return [FactState.UNKNOWN]
+    idx_list = op.idx_list
+    full_slice = slice(None, None, None)
+    n_core = max(0, len(idx_list) - (base_ndim - 2))
+    if n_core and not all(idx_list[-(i + 1)] == full_slice for i in range(n_core)):
+        return [FactState.UNKNOWN]
+
+    base_state, value_state = input_states[0], input_states[1]
+    if op.set_instead_of_inc:
+        if idx_list and all(idx == full_slice for idx in idx_list):
+            return [value_state]
+        return true_if(base_state is FactState.TRUE and value_state is FactState.TRUE)
+
+    if key is ORTHOGONAL:
+        return [FactState.UNKNOWN]
+    return true_if(base_state is FactState.TRUE and value_state is FactState.TRUE)
+
+
+for _key in ALL_KEYS:
+    register_assumption(_key, IncSubtensor)(incsubtensor_propagates_matrix_property)

--- a/pytensor/assumptions/subtensor.py
+++ b/pytensor/assumptions/subtensor.py
@@ -1,0 +1,28 @@
+from pytensor.assumptions.core import FactState, true_if
+
+
+def subtensor_propagates_matrix_property(
+    key, op, feature, fgraph, node, input_states
+) -> list[FactState]:
+    """Generic rule: matrix property propagates from ``input[0]`` iff the ``Subtensor``
+    leaves the trailing two matrix axes untouched.
+
+    Indexing only the leading batch axes (with scalars or slices) yields a stack
+    or single instance of the original matrices, so any per-matrix property
+    (symmetric, PSD, triangular, orthogonal, diagonal) carries through. Indexing
+    into either of the last two axes — via a non-full slice or a scalar — breaks
+    that guarantee.
+    """
+    if input_states[0] is not FactState.TRUE:
+        return [FactState.UNKNOWN]
+    input_ndim = node.inputs[0].type.ndim
+    if input_ndim < 2:
+        return [FactState.UNKNOWN]
+    idx_list = op.idx_list
+    n_explicit_matrix_axes = max(0, len(idx_list) - (input_ndim - 2))
+    if n_explicit_matrix_axes == 0:
+        return [FactState.TRUE]
+    full_slice = slice(None, None, None)
+    return true_if(
+        all(idx_list[-(i + 1)] == full_slice for i in range(n_explicit_matrix_axes))
+    )

--- a/pytensor/assumptions/symmetric.py
+++ b/pytensor/assumptions/symmetric.py
@@ -1,0 +1,118 @@
+from pytensor.assumptions.alloc import (
+    alloc_diag_at_offset_zero,
+    alloc_is_symmetric,
+    eye_identity_rule,
+)
+from pytensor.assumptions.core import (
+    SYMMETRIC,
+    FactState,
+    all_inputs_have_key,
+    propagate_first,
+    register_assumption,
+    true_if,
+)
+from pytensor.assumptions.dimshuffle import left_expand_dims_propagates_matrix_property
+from pytensor.assumptions.dot import match_congruence
+from pytensor.assumptions.subtensor import subtensor_propagates_matrix_property
+from pytensor.tensor.basic import Alloc, AllocDiag, Eye
+from pytensor.tensor.elemwise import DimShuffle, Elemwise
+from pytensor.tensor.linalg.constructors import BlockDiagonal
+from pytensor.tensor.linalg.inverse import MatrixInverse, MatrixPinv
+from pytensor.tensor.linalg.products import KroneckerProduct
+from pytensor.tensor.linalg.solvers.linear_control import (
+    SolveBilinearDiscreteLyapunov,
+)
+from pytensor.tensor.math import Dot
+from pytensor.tensor.subtensor import Subtensor
+
+
+def _preserves_symmetry_under_broadcast(inp, feature) -> bool:
+    """Whether ``inp``'s contribution to an Elemwise output is invariant under swapping the last two axes.
+
+    A 0d scalar broadcasts to a constant matrix (symmetric). A 1d vector broadcasts as a row and breaks symmetry. For
+    ndim >= 2, both trailing axes must either be jointly broadcastable (scalar in the matrix dims) or the input itself
+    must be known symmetric; a single broadcastable trailing axis (row/col vector) breaks symmetry.
+    """
+    ndim = inp.type.ndim
+    if ndim < 2:
+        return bool(ndim == 0)
+
+    last_two_bc = inp.type.broadcastable[-2:]
+    if all(last_two_bc):
+        return True
+    if any(last_two_bc):
+        return False
+    return bool(feature.check(inp, SYMMETRIC))
+
+
+register_assumption(SYMMETRIC, Eye)(eye_identity_rule)
+register_assumption(SYMMETRIC, AllocDiag)(alloc_diag_at_offset_zero)
+register_assumption(SYMMETRIC, Alloc)(alloc_is_symmetric)
+register_assumption(SYMMETRIC, BlockDiagonal)(all_inputs_have_key)
+register_assumption(SYMMETRIC, MatrixInverse)(propagate_first)
+register_assumption(SYMMETRIC, MatrixPinv)(propagate_first)
+register_assumption(SYMMETRIC, KroneckerProduct)(all_inputs_have_key)
+register_assumption(SYMMETRIC, Subtensor)(subtensor_propagates_matrix_property)
+
+
+@register_assumption(SYMMETRIC, DimShuffle)
+def _dimshuffle(key, op, feature, fgraph, node, input_states):
+    """Symmetry survives matrix transpose and left-expand-dims (batch broadcast)."""
+    if input_states[0] is not FactState.TRUE:
+        return [FactState.UNKNOWN]
+    if op.is_matrix_transpose:
+        return [FactState.TRUE]
+    if left_expand_dims_propagates_matrix_property(op):
+        return [FactState.TRUE]
+    return [FactState.UNKNOWN]
+
+
+@register_assumption(SYMMETRIC, SolveBilinearDiscreteLyapunov)
+def _discrete_lyapunov(key, op, feature, fgraph, node, input_states):
+    """The unique solution ``X`` of ``A X A^T - X = Q`` is symmetric when ``Q`` is symmetric.
+
+    Inputs are ``(A, Q)``; the output's symmetry is governed entirely by ``Q``.
+    """
+    return true_if(input_states[1] is FactState.TRUE)
+
+
+@register_assumption(SYMMETRIC, Dot)
+def _dot_congruence(key, op, feature, fgraph, node, input_states):
+    """``M @ S @ M.T`` (and the mirror ``M.T @ S @ M``) is symmetric when ``S`` is symmetric.
+
+    Matches both Python associativities so the rule fires regardless of how the
+    user parenthesized the triple product.
+    """
+    s = match_congruence(node)
+    if s is None:
+        return [FactState.UNKNOWN]
+    return true_if(feature.check(s, SYMMETRIC))
+
+
+@register_assumption(SYMMETRIC, Dot)
+def _dot_self_product(key, op, feature, fgraph, node, input_states):
+    """``A @ A`` is symmetric when ``A`` is symmetric -- ``(A A)ᵀ = Aᵀ Aᵀ = A A``.
+
+    The product of two *different* symmetric matrices is not generally symmetric,
+    so this fires only when both factors are the same variable.
+    """
+    a, b = node.inputs
+    return true_if(a is b and input_states[0] is FactState.TRUE)
+
+
+@register_assumption(SYMMETRIC, Elemwise)
+def _elemwise(key, op, feature, fgraph, node, input_states):
+    """Any elementwise op preserves symmetry when every input broadcasts to a
+    symmetric pattern: ``out[i,j] = f(*xs[i,j])`` equals ``out[j,i]`` because
+    each input contributes the same value at (i,j) and (j,i).
+    """
+    n_out = len(node.outputs)
+    if node.outputs[0].type.ndim < 2:
+        return [FactState.UNKNOWN] * n_out
+
+    state = (
+        FactState.TRUE
+        if all(_preserves_symmetry_under_broadcast(inp, feature) for inp in node.inputs)
+        else FactState.UNKNOWN
+    )
+    return [state] * n_out

--- a/pytensor/assumptions/triangular.py
+++ b/pytensor/assumptions/triangular.py
@@ -1,0 +1,167 @@
+from pytensor.assumptions.alloc import alloc_of_zero
+from pytensor.assumptions.core import (
+    LOWER_TRIANGULAR,
+    UPPER_TRIANGULAR,
+    FactState,
+    all_inputs_have_key,
+    propagate_first,
+    register_assumption,
+    true_if,
+)
+from pytensor.assumptions.dimshuffle import left_expand_dims_propagates_matrix_property
+from pytensor.assumptions.elemwise import elemwise_preserves_zero_pattern
+from pytensor.assumptions.subtensor import subtensor_propagates_matrix_property
+from pytensor.tensor.basic import Alloc, AllocDiag, Eye
+from pytensor.tensor.elemwise import DimShuffle, Elemwise
+from pytensor.tensor.linalg.constructors import BlockDiagonal
+from pytensor.tensor.linalg.decomposition.cholesky import Cholesky
+from pytensor.tensor.linalg.decomposition.lu import LU
+from pytensor.tensor.linalg.decomposition.qr import QR
+from pytensor.tensor.linalg.decomposition.schur import QZ, Schur
+from pytensor.tensor.linalg.inverse import MatrixInverse
+from pytensor.tensor.linalg.products import KroneckerProduct
+from pytensor.tensor.math import Dot
+from pytensor.tensor.subtensor import Subtensor
+from pytensor.tensor.variable import TensorConstant
+
+
+@register_assumption(LOWER_TRIANGULAR, Eye)
+def _eye_lower(key, op, feature, fgraph, node, input_states):
+    # Eye is lower triangular when its diagonal sits on or below the main one.
+    k = node.inputs[2]
+    if not isinstance(k, TensorConstant):
+        return [FactState.UNKNOWN]
+    return true_if(k.data.item() <= 0, else_false=True)
+
+
+@register_assumption(UPPER_TRIANGULAR, Eye)
+def _eye_upper(key, op, feature, fgraph, node, input_states):
+    # Eye is upper triangular when its diagonal sits on or above the main one.
+    k = node.inputs[2]
+    if not isinstance(k, TensorConstant):
+        return [FactState.UNKNOWN]
+    return true_if(k.data.item() >= 0, else_false=True)
+
+
+@register_assumption(LOWER_TRIANGULAR, AllocDiag)
+def _alloc_diag_lower(key, op, feature, fgraph, node, input_states):
+    # offset <= 0 places values on or below the main diagonal; a positive
+    # offset puts them strictly above, so the result is not lower-triangular.
+    return true_if(op.offset <= 0, else_false=True)
+
+
+@register_assumption(UPPER_TRIANGULAR, AllocDiag)
+def _alloc_diag_upper(key, op, feature, fgraph, node, input_states):
+    # offset >= 0 places values on or above the main diagonal; a negative
+    # offset puts them strictly below, so the result is not upper-triangular.
+    return true_if(op.offset >= 0, else_false=True)
+
+
+register_assumption(LOWER_TRIANGULAR, Alloc)(alloc_of_zero)
+register_assumption(UPPER_TRIANGULAR, Alloc)(alloc_of_zero)
+register_assumption(LOWER_TRIANGULAR, BlockDiagonal)(all_inputs_have_key)
+register_assumption(UPPER_TRIANGULAR, BlockDiagonal)(all_inputs_have_key)
+register_assumption(LOWER_TRIANGULAR, MatrixInverse)(propagate_first)
+register_assumption(UPPER_TRIANGULAR, MatrixInverse)(propagate_first)
+register_assumption(LOWER_TRIANGULAR, Dot)(all_inputs_have_key)
+register_assumption(UPPER_TRIANGULAR, Dot)(all_inputs_have_key)
+register_assumption(LOWER_TRIANGULAR, KroneckerProduct)(all_inputs_have_key)
+register_assumption(UPPER_TRIANGULAR, KroneckerProduct)(all_inputs_have_key)
+register_assumption(LOWER_TRIANGULAR, Subtensor)(subtensor_propagates_matrix_property)
+register_assumption(UPPER_TRIANGULAR, Subtensor)(subtensor_propagates_matrix_property)
+
+
+@register_assumption(LOWER_TRIANGULAR, Cholesky)
+def _chol_lower(key, op, feature, fgraph, node, input_states):
+    return true_if(op.lower)
+
+
+@register_assumption(UPPER_TRIANGULAR, Cholesky)
+def _chol_upper(key, op, feature, fgraph, node, input_states):
+    return true_if(not op.lower)
+
+
+@register_assumption(UPPER_TRIANGULAR, QR)
+def _qr_upper(key, op, feature, fgraph, node, input_states):
+    # R (output 1) is always upper triangular in full/economic modes
+    n_out = len(node.outputs)
+    if op.mode in ("full", "economic"):
+        states = [FactState.UNKNOWN] * n_out
+        states[1] = FactState.TRUE
+        return states
+    return [FactState.UNKNOWN] * n_out
+
+
+@register_assumption(UPPER_TRIANGULAR, Schur)
+def _schur_upper(key, op, feature, fgraph, node, input_states):
+    # T (output 0) is upper triangular only for complex Schur
+    # Real Schur gives quasi-upper-triangular (2x2 blocks)
+    if op.output == "complex":
+        return [FactState.TRUE, FactState.UNKNOWN]
+    return [FactState.UNKNOWN, FactState.UNKNOWN]
+
+
+@register_assumption(UPPER_TRIANGULAR, QZ)
+def _qz_upper(key, op, feature, fgraph, node, input_states):
+    # AA (output 0) and BB (output 1) are upper triangular
+    n_out = len(node.outputs)
+    states = [FactState.UNKNOWN] * n_out
+    states[0] = FactState.TRUE
+    states[1] = FactState.TRUE
+    return states
+
+
+@register_assumption(LOWER_TRIANGULAR, LU)
+def _lu_lower(key, op, feature, fgraph, node, input_states):
+    n_out = len(node.outputs)
+    states = [FactState.UNKNOWN] * n_out
+    if op.permute_l:
+        # outputs are (PL, U) — PL is not lower triangular
+        return states
+    elif op.p_indices:
+        # outputs are (p_indices, L, U) — L is output 1
+        states[1] = FactState.TRUE
+    else:
+        # outputs are (P, L, U) — L is output 1
+        states[1] = FactState.TRUE
+    return states
+
+
+@register_assumption(UPPER_TRIANGULAR, LU)
+def _lu_upper(key, op, feature, fgraph, node, input_states):
+    n_out = len(node.outputs)
+    states = [FactState.UNKNOWN] * n_out
+    # U is always the last output
+    states[-1] = FactState.TRUE
+    return states
+
+
+def _dimshuffle_left_expand_dims(key, op, feature, fgraph, node, input_states):
+    """Triangularity survives left-expand-dims (batch broadcast).
+
+    Matrix transpose swaps lower<->upper, so it is *not* propagated under
+    the same key.
+    """
+    if input_states[0] is not FactState.TRUE:
+        return [FactState.UNKNOWN]
+    if left_expand_dims_propagates_matrix_property(op):
+        return [FactState.TRUE]
+    return [FactState.UNKNOWN]
+
+
+register_assumption(LOWER_TRIANGULAR, DimShuffle)(_dimshuffle_left_expand_dims)
+register_assumption(UPPER_TRIANGULAR, DimShuffle)(_dimshuffle_left_expand_dims)
+
+
+@register_assumption(LOWER_TRIANGULAR, Elemwise)
+def _elemwise_lower(key, op, feature, fgraph, node, input_states):
+    return elemwise_preserves_zero_pattern(
+        LOWER_TRIANGULAR, op, feature, node, input_states
+    )
+
+
+@register_assumption(UPPER_TRIANGULAR, Elemwise)
+def _elemwise_upper(key, op, feature, fgraph, node, input_states):
+    return elemwise_preserves_zero_pattern(
+        UPPER_TRIANGULAR, op, feature, node, input_states
+    )

--- a/pytensor/printing.py
+++ b/pytensor/printing.py
@@ -192,6 +192,7 @@ def _build_label(
     print_view_map: bool,
     print_op_info: bool,
     op_information: dict,
+    assumption_tags: dict | None = None,
 ) -> str:
     """Return the formatted label string for a single `GraphNode`.
 
@@ -229,6 +230,11 @@ def _build_label(
     else:
         shape_str = ""
 
+    if assumption_tags and var in assumption_tags:
+        assumption_str = f" a={assumption_tags[var]}"
+    else:
+        assumption_str = ""
+
     if gnode.is_leaf:
         id_str = _assign_id(var, used_ids, done, id_type, var)
         if id_str:
@@ -239,7 +245,7 @@ def _build_label(
         else:
             data = ""
 
-        label = f"{var}{id_str}{type_str}{shape_str}{data}"
+        label = f"{var}{id_str}{type_str}{shape_str}{assumption_str}{data}"
 
         if print_op_info and var.owner and var.owner not in op_information:
             op_information.update(op_debug_information(var.owner.op, var.owner))
@@ -295,7 +301,10 @@ def _build_label(
     if gnode.is_inner_graph_header:
         return f"{node.op}{id_str}{destroy_map_str}{view_map_str}{topo_str}"
 
-    label = f"{node.op}{gnode.output_idx}{id_str}{type_str}{shape_str}{var_name}{destroy_map_str}{view_map_str}{topo_str}{data}"
+    label = (
+        f"{node.op}{gnode.output_idx}{id_str}{type_str}{shape_str}{assumption_str}"
+        f"{var_name}{destroy_map_str}{view_map_str}{topo_str}{data}"
+    )
 
     if print_op_info and node not in op_information:
         op_information.update(op_debug_information(node.op, node))
@@ -542,6 +551,7 @@ def debugprint(
     print_memory_map: bool = False,
     print_inner_graphs: bool | Literal["auto"] = "auto",
     print_fgraph_inputs: bool = False,
+    print_assumptions: bool = False,
 ) -> "str | TextIO | Any":  # rich.tree.Tree when file="rich"
     r"""Print a graph as text.
 
@@ -605,6 +615,11 @@ def debugprint(
         Whether to print inner graphs. Default "auto" leaves it to PyTensor discretion, or a per Op basis.
     print_fgraph_inputs
         Print the inputs of `FunctionGraph`\s.
+    print_assumptions
+        If ``True``, annotate each `Variable` that has known structural
+        assumptions with an ``a={...}`` tag, e.g. ``a={diag}`` or ``a={!sym}``.
+        Implied facts are pruned, so a diagonal matrix shows ``{diag}`` rather
+        than every property it entails.
 
     Returns
     -------
@@ -704,6 +719,15 @@ def debugprint(
         else:
             raise TypeError(f"debugprint cannot print an object type {type(obj)}")
 
+    if print_assumptions:
+        # Imported lazily: the assumptions package pulls in ``pytensor.tensor``,
+        # which imports this module.
+        from pytensor.assumptions import assumption_tags as _build_assumption_tags
+
+        assumption_tags = _build_assumption_tags(outputs_to_print)
+    else:
+        assumption_tags = None
+
     if file == "rich":
         return _build_rich_tree(
             outputs_to_print,
@@ -718,6 +742,7 @@ def debugprint(
             topo_orders=topo_orders,
             profiles=profile_list,
             storage_maps=storage_maps,
+            assumption_tags=assumption_tags,
         )
 
     inner_graph_vars: list[Variable] = []
@@ -760,6 +785,7 @@ N.B.:
             stop_on_name=stop_on_name,
             used_ids=used_ids,
             op_information=op_information,
+            assumption_tags=assumption_tags,
             parent_node=var.owner,
             print_op_info=print_op_info,
             print_destroy_map=print_destroy_map,
@@ -796,6 +822,7 @@ N.B.:
             storage_map=storage_map,
             used_ids=used_ids,
             op_information=op_information,
+            assumption_tags=assumption_tags,
             parent_node=var.owner,
             print_op_info=print_op_info,
             print_destroy_map=print_destroy_map,
@@ -876,6 +903,7 @@ N.B.:
                 inner_to_outer_inputs=inner_to_outer_inputs,
                 used_ids=used_ids,
                 op_information=op_information,
+                assumption_tags=assumption_tags,
                 parent_node=ig_var.owner,
                 print_op_info=print_op_info,
                 print_destroy_map=print_destroy_map,
@@ -899,6 +927,7 @@ N.B.:
                         inner_to_outer_inputs=inner_to_outer_inputs,
                         used_ids=used_ids,
                         op_information=op_information,
+                        assumption_tags=assumption_tags,
                         parent_node=ig_var.owner,
                         print_op_info=print_op_info,
                         print_destroy_map=print_destroy_map,
@@ -935,6 +964,7 @@ N.B.:
                     inner_to_outer_inputs=inner_to_outer_inputs,
                     used_ids=used_ids,
                     op_information=op_information,
+                    assumption_tags=assumption_tags,
                     parent_node=ig_var.owner,
                     print_op_info=print_op_info,
                     print_destroy_map=print_destroy_map,
@@ -976,6 +1006,7 @@ def _debugprint(
     print_op_info: bool = False,
     inner_graph_node: Apply | None = None,
     is_inner_graph_header: bool = False,
+    assumption_tags: dict | None = None,
 ) -> TextIO:
     r"""Print the graph represented by `var`.
 
@@ -1092,6 +1123,7 @@ def _debugprint(
             print_view_map=print_view_map,
             print_op_info=print_op_info,
             op_information=op_information,
+            assumption_tags=assumption_tags,
         )
 
         if gnode.is_repeat and not gnode.is_inner_graph_header:
@@ -1134,6 +1166,7 @@ def _build_rich_tree(
     topo_orders: list[Sequence[Apply] | None] | None = None,
     profiles: list | None = None,
     storage_maps: list | None = None,
+    assumption_tags: dict | None = None,
 ) -> Any:  # rich.tree.Tree when rich is installed
     """Build a ``rich.Tree`` for one or more output `Variable`s.
 
@@ -1234,6 +1267,7 @@ def _build_rich_tree(
                         print_view_map=print_view_map,
                         print_op_info=print_op_info,
                         op_information=op_information,
+                        assumption_tags=assumption_tags,
                     )
                 )
                 parent_tree = depth_stack[current_depth]
@@ -1258,6 +1292,7 @@ def _build_rich_tree(
                 print_view_map=print_view_map,
                 print_op_info=print_op_info,
                 op_information=op_information,
+                assumption_tags=assumption_tags,
             )
 
             label = rich.markup.escape(label)
@@ -1342,6 +1377,7 @@ def _build_rich_tree(
                             print_view_map=print_view_map,
                             print_op_info=print_op_info,
                             op_information=op_information,
+                            assumption_tags=assumption_tags,
                         )
                     )
                     parent_tree = ig_depth_stack[current_depth]
@@ -1362,6 +1398,7 @@ def _build_rich_tree(
                     print_view_map=print_view_map,
                     print_op_info=print_op_info,
                     op_information=op_information,
+                    assumption_tags=assumption_tags,
                 )
                 label = rich.markup.escape(label)
                 node_key = gnode.var.owner if gnode.var.owner is not None else gnode.var
@@ -1419,6 +1456,7 @@ def _build_rich_tree(
                                 print_view_map=print_view_map,
                                 print_op_info=print_op_info,
                                 op_information=op_information,
+                                assumption_tags=assumption_tags,
                             )
                         )
                         parent_tree = out_stack[current_depth]
@@ -1439,6 +1477,7 @@ def _build_rich_tree(
                         print_view_map=print_view_map,
                         print_op_info=print_op_info,
                         op_information=op_information,
+                        assumption_tags=assumption_tags,
                     )
                     label = rich.markup.escape(label)
                     node_key = (

--- a/pytensor/tensor/rewriting/__init__.py
+++ b/pytensor/tensor/rewriting/__init__.py
@@ -1,3 +1,4 @@
+import pytensor.tensor.rewriting.assumptions
 import pytensor.tensor.rewriting.basic
 import pytensor.tensor.rewriting.blas
 import pytensor.tensor.rewriting.blas_c

--- a/pytensor/tensor/rewriting/assumptions.py
+++ b/pytensor/tensor/rewriting/assumptions.py
@@ -1,0 +1,64 @@
+from pytensor.assumptions import ALL_KEYS, AssumptionFeature
+from pytensor.assumptions.specify import SpecifyAssumptions
+from pytensor.compile.mode import optdb
+from pytensor.graph.rewriting.basic import GraphRewriter
+
+
+_KEY_BY_NAME = {key.name: key for key in ALL_KEYS}
+
+
+class DrainSpecifyAssumptions(GraphRewriter):
+    """Drain ``SpecifyAssumptions`` declarations into the ``AssumptionFeature`` and
+    remove the marker nodes.
+
+    A ``SpecifyAssumptions`` node is an opaque view of its input, so it blocks any
+    rewrite that pattern-matches across it. Running before canonicalization, this
+    rewriter resolves every declared fact into the feature cache (where the
+    ``check_assumption`` consumers read it) and then drops the node.
+    """
+
+    def apply(self, fgraph):
+        if not any(
+            isinstance(node.op, SpecifyAssumptions) for node in fgraph.apply_nodes
+        ):
+            return None  # Fast bail out
+
+        nodes = [
+            node
+            for node in fgraph.toposort()
+            if isinstance(node.op, SpecifyAssumptions)
+        ]
+
+        assumption_feature = getattr(fgraph, "assumption_feature", None)
+        if assumption_feature is None:
+            assumption_feature = AssumptionFeature()
+            fgraph.attach_feature(assumption_feature)
+
+        replacements = {}
+        for node in nodes:
+            [out] = node.outputs
+            for name, _ in node.op.assumptions:
+                # Register the assumption by calling .get()
+                assumption_feature.get(out, _KEY_BY_NAME[name])
+            # Drain the marker: redirect its consumers to the raw input,
+            # peeling nested SpecifyAssumptions so a single replace_all
+            # collapses ``assume(assume(...))`` chains all the way down.
+            inp = node.inputs[0]
+            while inp.owner is not None and isinstance(
+                inp.owner.op, SpecifyAssumptions
+            ):
+                inp = inp.owner.inputs[0]
+            replacements[out] = inp
+
+        fgraph.replace_all(
+            tuple(replacements.items()), reason="drain_specify_assumptions"
+        )
+
+
+optdb.register(
+    "drain_specify_assumptions",
+    DrainSpecifyAssumptions(),
+    "fast_run",
+    "fast_compile",
+    position=0.8,
+)

--- a/pytensor/tensor/rewriting/linalg/decomposition.py
+++ b/pytensor/tensor/rewriting/linalg/decomposition.py
@@ -5,11 +5,15 @@ from pytensor.assumptions import (
     UPPER_TRIANGULAR,
     check_assumption,
 )
-from pytensor.graph.rewriting.basic import node_rewriter
+from pytensor.graph.rewriting.basic import copy_stack_trace, node_rewriter
 from pytensor.tensor.basic import alloc_diag
 from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.elemwise import DimShuffle
 from pytensor.tensor.linalg.decomposition.cholesky import Cholesky
+from pytensor.tensor.linalg.decomposition.eigen import Eigh, Eigvalsh
+from pytensor.tensor.linalg.decomposition.lu import LU, LUFactor
+from pytensor.tensor.linalg.decomposition.qr import QR
+from pytensor.tensor.linalg.decomposition.schur import QZ, Schur
 from pytensor.tensor.linalg.decomposition.svd import SVD, svd
 from pytensor.tensor.math import Dot
 from pytensor.tensor.rewriting.basic import (
@@ -123,3 +127,342 @@ def svd_uv_merge(fgraph, node):
                     fgraph.clients[u] or fgraph.clients[v]
                 ):
                     return [s]
+
+
+@register_canonicalize
+@register_stabilize
+@node_rewriter([blockwise_of(SVD)])
+def svd_of_diag(fgraph, node):
+    """
+    svd(D) has three return values:
+        - S = diag(sort(abs(d)))
+        - U = I
+        - V = diag(sign(sort(d)))
+
+    Where d is the diagonal of D and sort is in descending order. U and V are also permuted to match the sorted order
+    of the diagonal of D.
+    """
+    [X] = node.inputs
+
+    if not check_assumption(fgraph, X, DIAGONAL):
+        return None
+
+    diag_vals = pt.diagonal(X, axis1=-2, axis2=-1)
+
+    # Singular values are abs of diagonal, sorted descending
+    abs_diag = pt.abs(diag_vals)
+    idx = pt.argsort(-abs_diag)
+    new_s = abs_diag[idx]
+
+    if not node.op.core_op.compute_uv:
+        [s] = node.outputs
+        copy_stack_trace(s, new_s)
+        return [new_s]
+
+    n = X.shape[-1]
+    new_U = pt.eye(n)[:, idx]
+    # Vh = diag(sign(d_sorted)) @ P, where P = I[idx, :]
+    sorted_signs = pt.sign(diag_vals[idx])
+    new_Vh = alloc_diag(sorted_signs, axis1=-1, axis2=-2)[:, idx]
+    u, s, vh = node.outputs
+
+    copy_stack_trace(u, new_U)
+    copy_stack_trace(s, new_s)
+    copy_stack_trace(vh, new_Vh)
+
+    return [new_U, new_s, new_Vh]
+
+
+@register_canonicalize
+@register_stabilize
+@node_rewriter([blockwise_of(Eigh)])
+def eigh_of_diag(fgraph, node):
+    """Closed-form eigh on diagonal inputs.
+
+    - ``eigh(A)`` with ``A`` diagonal -> sort the diagonal; eigenvectors are the standard
+      basis permuted by the sort.
+    - ``eigh(A, B)`` with both diagonal -> eigenvalues are ``a / b``; eigenvectors are
+      ``e_i / sqrt(b_i)`` so they satisfy ``V^T B V = I``.
+    """
+    if len(node.inputs) == 1:
+        [X] = node.inputs
+        if not check_assumption(fgraph, X, DIAGONAL):
+            return None
+        diag_vals = pt.diagonal(X, axis1=-2, axis2=-1)
+        sort_idx = pt.argsort(diag_vals)
+        new_w = diag_vals[sort_idx]
+        new_v = pt.eye(X.shape[-1])[:, sort_idx]
+    elif len(node.inputs) == 2:
+        A, B = node.inputs
+        if not check_assumption(fgraph, A, DIAGONAL):
+            return None
+        if not check_assumption(fgraph, B, DIAGONAL):
+            return None
+        diag_a = pt.diagonal(A, axis1=-2, axis2=-1)
+        diag_b = pt.diagonal(B, axis1=-2, axis2=-1)
+        eigvals = diag_a / diag_b
+        sort_idx = pt.argsort(eigvals)
+        new_w = eigvals[sort_idx]
+        # B-orthonormal eigenvectors: column j is e_{sort_idx[j]} / sqrt(b[sort_idx[j]]).
+        new_v = pt.eye(A.shape[-1])[:, sort_idx] / pt.sqrt(diag_b[sort_idx])
+    else:
+        return None
+
+    w, v = node.outputs
+    copy_stack_trace(w, new_w)
+    copy_stack_trace(v, new_v)
+
+    return [new_w, new_v]
+
+
+@register_canonicalize
+@register_stabilize
+@node_rewriter([blockwise_of(Eigvalsh)])
+def eigvalsh_of_diag(fgraph, node):
+    """eigvalsh(D) -> sort(diagonal(D)) for diagonal D.
+
+    Also handles the generalized case eigvalsh(D, B) when both are diagonal:
+    sort(diagonal(D) / diagonal(B)).
+    """
+    if len(node.inputs) == 1:
+        [X] = node.inputs
+        if not check_assumption(fgraph, X, DIAGONAL):
+            return None
+        diag_vals = pt.diagonal(X, axis1=-2, axis2=-1)
+        new_w = pt.sort(diag_vals)
+    elif len(node.inputs) == 2:
+        X, B = node.inputs
+        if not check_assumption(fgraph, X, DIAGONAL):
+            return None
+        if not check_assumption(fgraph, B, DIAGONAL):
+            return None
+        diag_x = pt.diagonal(X, axis1=-2, axis2=-1)
+        diag_b = pt.diagonal(B, axis1=-2, axis2=-1)
+        new_w = pt.sort(diag_x / diag_b)
+    else:
+        return None
+
+    copy_stack_trace(node.outputs[0], new_w)
+    return [new_w]
+
+
+@register_canonicalize
+@register_stabilize
+@node_rewriter([blockwise_of(LU)])
+def lu_of_diag(fgraph, node):
+    """lu(D) -> (I, I, D) for diagonal D. P=I, L=I, U=D."""
+    [X] = node.inputs
+
+    if not check_assumption(fgraph, X, DIAGONAL):
+        return None
+
+    core_op = node.op.core_op
+    out_dtype = node.outputs[-1].type.dtype
+    n = X.shape[-1]
+
+    new_U = X.astype(out_dtype) if X.type.dtype != out_dtype else X
+
+    if core_op.permute_l:
+        # Returns (PL, U) — PL = I
+        new_PL = pt.eye(n, dtype=out_dtype)
+        pl, u = node.outputs
+        copy_stack_trace(pl, new_PL)
+        copy_stack_trace(u, new_U)
+        return [new_PL, new_U]
+
+    if core_op.p_indices:
+        # Returns (p_idx, L, U) — p_idx = arange(n), L = I
+        new_p = pt.arange(n, dtype="int32")
+        new_L = pt.eye(n, dtype=out_dtype)
+        p, l, u = node.outputs
+        copy_stack_trace(p, new_p)
+        copy_stack_trace(l, new_L)
+        copy_stack_trace(u, new_U)
+        return [new_p, new_L, new_U]
+
+    # Default: returns (P, L, U) — P = I, L = I
+    p_dtype = node.outputs[0].type.dtype
+    new_P = pt.eye(n, dtype=p_dtype)
+    new_L = pt.eye(n, dtype=out_dtype)
+    p, l, u = node.outputs
+    copy_stack_trace(p, new_P)
+    copy_stack_trace(l, new_L)
+    copy_stack_trace(u, new_U)
+    return [new_P, new_L, new_U]
+
+
+@register_canonicalize
+@register_stabilize
+@node_rewriter([blockwise_of(LUFactor)])
+def lu_factor_of_diag(fgraph, node):
+    """lu_factor(D) -> (D, arange(n)) for diagonal D."""
+    [X] = node.inputs
+
+    if not check_assumption(fgraph, X, DIAGONAL):
+        return None
+
+    n = X.shape[-1]
+    new_LU = X
+    new_pivots = pt.arange(n, dtype="int32")
+
+    lu_out, piv_out = node.outputs
+    copy_stack_trace(lu_out, new_LU)
+    copy_stack_trace(piv_out, new_pivots)
+    return [new_LU, new_pivots]
+
+
+@register_canonicalize
+@register_stabilize
+@node_rewriter([blockwise_of(QR)])
+def qr_of_diag(fgraph, node):
+    """qr(D) -> (diag(sign(d)), diag(|d|)) for diagonal D.
+
+    Q = diag(sign(diagonal(D))), R = diag(abs(diagonal(D))).
+    """
+    [X] = node.inputs
+
+    if not check_assumption(fgraph, X, DIAGONAL):
+        return None
+
+    core_op = node.op.core_op
+
+    out_dtype = node.outputs[0].type.dtype
+    diag_vals = pt.diagonal(X, axis1=-2, axis2=-1)
+
+    if core_op.mode == "raw":
+        # Raw returns (H, tau, R). For diagonal: H=D, tau=zeros(n), R=D
+        new_H = X.astype(out_dtype) if X.type.dtype != out_dtype else X
+        n = X.shape[-1]
+        new_tau = pt.zeros(n, dtype=out_dtype)
+        new_R = new_H
+        results = [new_H, new_tau, new_R]
+    elif core_op.mode == "r":
+        new_R = alloc_diag(pt.abs(diag_vals).astype(out_dtype), axis1=-2, axis2=-1)
+        results = [new_R]
+    else:
+        new_Q = alloc_diag(pt.sign(diag_vals).astype(out_dtype), axis1=-2, axis2=-1)
+        new_R = alloc_diag(pt.abs(diag_vals).astype(out_dtype), axis1=-2, axis2=-1)
+        results = [new_Q, new_R]
+
+    if core_op.pivoting:
+        n = X.shape[-1]
+        new_p = pt.arange(n, dtype="int32")
+        results.append(new_p)
+
+    for old, new in zip(node.outputs, results, strict=True):
+        copy_stack_trace(old, new)
+
+    return results
+
+
+@register_canonicalize
+@register_stabilize
+@node_rewriter([blockwise_of(Schur)])
+def schur_of_diag(fgraph, node):
+    """schur(D) -> (T, Z) for diagonal D.
+
+    Without sort: T=D, Z=I.
+    With sort: T=diag(d[perm]), Z=I[:, perm] where perm puts selected eigenvalues first.
+    """
+    [X] = node.inputs
+
+    if not check_assumption(fgraph, X, DIAGONAL):
+        return None
+
+    out_dtype = node.outputs[0].type.dtype
+    n = X.shape[-1]
+    diag_vals = pt.diagonal(X, axis1=-2, axis2=-1).astype(out_dtype)
+
+    match node.op.core_op.sort:
+        case None:
+            new_T = X.astype(out_dtype) if X.type.dtype != out_dtype else X
+            new_Z = pt.eye(n, dtype=out_dtype)
+        case "lhp":
+            select = diag_vals < 0
+        case "rhp":
+            select = diag_vals >= 0
+        case "iuc":
+            select = pt.abs(diag_vals) <= 1
+        case "ouc":
+            select = pt.abs(diag_vals) > 1
+
+    if node.op.core_op.sort is not None:
+        sort_idx = pt.argsort(-select.astype("int64"))
+        new_T = alloc_diag(diag_vals[sort_idx], axis1=-2, axis2=-1)
+        new_Z = pt.eye(n, dtype=out_dtype)[:, sort_idx]
+
+    T, Z = node.outputs
+    copy_stack_trace(T, new_T)
+    copy_stack_trace(Z, new_Z)
+    return [new_T, new_Z]
+
+
+@register_canonicalize
+@register_stabilize
+@node_rewriter([blockwise_of(QZ)])
+def qz_of_diag(fgraph, node):
+    """qz(A, B) -> (AA, BB, Q, Z) for diagonal A, B.
+
+    Without sort: AA=A, BB=B, Q=I, Z=I.
+    With sort: diagonals of AA, BB are permuted so selected eigenvalues come first;
+    Q=Z=permutation matrix.
+    """
+    A, B = node.inputs
+
+    if not check_assumption(fgraph, A, DIAGONAL):
+        return None
+    if not check_assumption(fgraph, B, DIAGONAL):
+        return None
+
+    core_op = node.op.core_op
+    out_dtype = node.outputs[0].type.dtype
+    n = A.shape[-1]
+
+    new_AA = A.astype(out_dtype) if A.type.dtype != out_dtype else A
+    new_BB = B.astype(out_dtype) if B.type.dtype != out_dtype else B
+
+    if core_op.sort is None:
+        new_Q = pt.eye(n, dtype=out_dtype)
+        new_Z = pt.eye(n, dtype=out_dtype)
+        diag_a = pt.diagonal(A, axis1=-2, axis2=-1)
+        diag_b = pt.diagonal(B, axis1=-2, axis2=-1)
+    else:
+        diag_a = pt.diagonal(A, axis1=-2, axis2=-1).astype(out_dtype)
+        diag_b = pt.diagonal(B, axis1=-2, axis2=-1).astype(out_dtype)
+        # Generalized eigenvalues λ_i = a_i / b_i (real diagonal case)
+        # Use pt.neq/pt.eq for elementwise zero checks (== tests identity on TensorVariables)
+        b_nonzero = pt.neq(diag_b, 0)
+        match core_op.sort:
+            case "lhp":
+                select = b_nonzero & (diag_a * diag_b < 0)
+            case "rhp":
+                select = b_nonzero & (diag_a * diag_b >= 0)
+            case "iuc":
+                select = b_nonzero & (pt.abs(diag_a) <= pt.abs(diag_b))
+            case "ouc":
+                select = (pt.eq(diag_b, 0) & pt.neq(diag_a, 0)) | (
+                    pt.abs(diag_a) > pt.abs(diag_b)
+                )
+
+        sort_idx = pt.argsort(-select.astype("int64"))
+        new_AA = alloc_diag(diag_a[sort_idx], axis1=-2, axis2=-1)
+        new_BB = alloc_diag(diag_b[sort_idx], axis1=-2, axis2=-1)
+        # Q = Z = permutation matrix: Q.T @ diag(a) @ Z = diag(a[perm])
+        perm = pt.eye(n, dtype=out_dtype)[:, sort_idx]
+        new_Q = perm
+        new_Z = perm
+        diag_a = diag_a[sort_idx]
+        diag_b = diag_b[sort_idx]
+
+    if core_op.return_eigenvalues:
+        alpha_dtype = node.outputs[2].type.dtype
+        new_alpha = diag_a.astype(alpha_dtype)
+        new_beta = diag_b.astype(out_dtype)
+        results = [new_AA, new_BB, new_alpha, new_beta, new_Q, new_Z]
+    else:
+        results = [new_AA, new_BB, new_Q, new_Z]
+
+    for old, new in zip(node.outputs, results, strict=True):
+        copy_stack_trace(old, new)
+
+    return results

--- a/pytensor/tensor/rewriting/linalg/decomposition.py
+++ b/pytensor/tensor/rewriting/linalg/decomposition.py
@@ -2,6 +2,7 @@ from pytensor import tensor as pt
 from pytensor.assumptions import (
     DIAGONAL,
     LOWER_TRIANGULAR,
+    SYMMETRIC,
     UPPER_TRIANGULAR,
     check_assumption,
 )
@@ -10,7 +11,7 @@ from pytensor.tensor.basic import alloc_diag
 from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.elemwise import DimShuffle
 from pytensor.tensor.linalg.decomposition.cholesky import Cholesky
-from pytensor.tensor.linalg.decomposition.eigen import Eigh, Eigvalsh
+from pytensor.tensor.linalg.decomposition.eigen import Eig, Eigh, Eigvalsh, eigh
 from pytensor.tensor.linalg.decomposition.lu import LU, LUFactor
 from pytensor.tensor.linalg.decomposition.qr import QR
 from pytensor.tensor.linalg.decomposition.schur import QZ, Schur
@@ -171,6 +172,31 @@ def svd_of_diag(fgraph, node):
     copy_stack_trace(vh, new_Vh)
 
     return [new_U, new_s, new_Vh]
+
+
+@register_canonicalize
+@register_stabilize
+@node_rewriter([blockwise_of(Eig)])
+def eig_to_eigh(fgraph, node):
+    """Replace eig(X) with eigh(X) when X is symmetric.
+
+    eigh is faster (~2x), returns real outputs, and supports gradients.
+    """
+    [X] = node.inputs
+    # Eigh is a subclass of Eig, so this tracker also matches Eigh — skip it
+    if isinstance(node.op.core_op, Eigh):
+        return None
+    if not check_assumption(fgraph, X, SYMMETRIC):
+        return None
+
+    w, v = eigh(X)
+    # Eig returns complex, Eigh returns real — cast to match original types
+    old_w, old_v = node.outputs
+    w = w.astype(old_w.type.dtype)
+    v = v.astype(old_v.type.dtype)
+    copy_stack_trace(old_w, w)
+    copy_stack_trace(old_v, v)
+    return [w, v]
 
 
 @register_canonicalize

--- a/pytensor/tensor/rewriting/linalg/decomposition.py
+++ b/pytensor/tensor/rewriting/linalg/decomposition.py
@@ -1,7 +1,12 @@
 from pytensor import tensor as pt
-from pytensor.graph import Constant
+from pytensor.assumptions import (
+    DIAGONAL,
+    LOWER_TRIANGULAR,
+    UPPER_TRIANGULAR,
+    check_assumption,
+)
 from pytensor.graph.rewriting.basic import node_rewriter
-from pytensor.tensor.basic import AllocDiag, Eye
+from pytensor.tensor.basic import alloc_diag
 from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.elemwise import DimShuffle
 from pytensor.tensor.linalg.decomposition.cholesky import Cholesky
@@ -13,7 +18,6 @@ from pytensor.tensor.rewriting.basic import (
     register_stabilize,
 )
 from pytensor.tensor.rewriting.blockwise import blockwise_of
-from pytensor.tensor.rewriting.linalg.utils import is_eye_mul
 
 
 @register_canonicalize
@@ -25,63 +29,50 @@ def cholesky_ldotlt(fgraph, node):
     or cholesky(dot(U.T, U), upper=True) = U where U is upper triangular.
 
     Also works with matmul.
-
-    This utilizes a boolean `lower_triangular` or `upper_triangular` tag on matrices.
     """
     A = node.inputs[0]
     lower = node.op.core_op.lower
 
     match A.owner_op_and_inputs:
         case (Blockwise(Dot()) | Dot(), l, r):
-            lower_triangular = getattr(l.tag, "lower_triangular", False)
-            match (lower_triangular, r.owner_op_and_inputs):
-                # cholesky(dot(L,L.T)) case
-                case (
-                    True,
-                    (DimShuffle(is_left_expanded_matrix_transpose=True), l_T),
-                ) if l_T == l:
-                    return [l] if lower else [r]
+            if getattr(l.tag, "lower_triangular", False) or check_assumption(
+                fgraph, l, LOWER_TRIANGULAR
+            ):
+                match r.owner_op_and_inputs:
+                    # cholesky(dot(L,L.T)) case
+                    case (
+                        DimShuffle(is_left_expanded_matrix_transpose=True),
+                        l_T,
+                    ) if l_T == l:
+                        return [l] if lower else [r]
 
-            upper_triangular = getattr(r.tag, "upper_triangular", False)
-            match (upper_triangular, l.owner_op_and_inputs):
-                # cholesky(dot(U.T,U)) case
-                case (
-                    True,
-                    (DimShuffle(is_left_expanded_matrix_transpose=True), r_T),
-                ) if r_T == r:
-                    return [l] if lower else [r]
+            if getattr(r.tag, "upper_triangular", False) or check_assumption(
+                fgraph, r, UPPER_TRIANGULAR
+            ):
+                match l.owner_op_and_inputs:
+                    # cholesky(dot(U.T,U)) case
+                    case (
+                        DimShuffle(is_left_expanded_matrix_transpose=True),
+                        r_T,
+                    ) if r_T == r:
+                        return [l] if lower else [r]
 
 
 @register_canonicalize
 @register_stabilize
 @node_rewriter([blockwise_of(Cholesky)])
 def cholesky_of_diag(fgraph, node):
+    """cholesky(D) -> diag(sqrt(diagonal(D))) for diagonal D."""
     [X] = node.inputs
 
-    # Check if input is a (1, 1) matrix
     if all(X.type.broadcastable[-2:]):
         return [pt.sqrt(X)]
 
-    match X.owner_op_and_inputs:
-        # Check whether input to Cholesky is Eye and the 1's are on main diagonal
-        case (Eye(), _, _, Constant(0)):
-            return [X]
-        case (AllocDiag(offset=0, axis1=axis1, axis2=axis2), diag_input):
-            ndim = diag_input.ndim
-            if axis1 == ndim - 1 and axis2 == ndim:
-                return [pt.diag(diag_input**0.5)]
+    if not check_assumption(fgraph, X, DIAGONAL):
+        return None
 
-    # Check if the input is an elemwise multiply with identity matrix -- this also results in a diagonal matrix
-    match is_eye_mul(X):
-        case (eye_input, non_eye_input):
-            # Now, we can simply return the matrix consisting of sqrt values of the original diagonal elements
-            # For a matrix, we have to first extract the diagonal (non-zero values) and then only use those
-            if non_eye_input.type.broadcastable[-2:] == (False, False):
-                non_eye_input = non_eye_input.diagonal(axis1=-1, axis2=-2)
-                if eye_input.type.ndim > 2:
-                    non_eye_input = pt.shape_padaxis(non_eye_input, -2)
-
-            return [eye_input * (non_eye_input**0.5)]
+    diag_vals = pt.sqrt(pt.diagonal(X, axis1=-2, axis2=-1))
+    return [alloc_diag(diag_vals, axis1=-2, axis2=-1)]
 
 
 @register_canonicalize

--- a/pytensor/tensor/rewriting/linalg/inverse.py
+++ b/pytensor/tensor/rewriting/linalg/inverse.py
@@ -1,10 +1,11 @@
 from pytensor import tensor as pt
-from pytensor.graph import Apply, Constant, FunctionGraph
+from pytensor.assumptions import DIAGONAL, check_assumption
+from pytensor.graph import Apply, FunctionGraph
 from pytensor.graph.rewriting.basic import (
     node_rewriter,
 )
 from pytensor.graph.rewriting.unify import OpPattern
-from pytensor.tensor.basic import AllocDiag, Eye
+from pytensor.tensor.basic import alloc_diag
 from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.elemwise import DimShuffle
 from pytensor.tensor.linalg.constructors import BlockDiagonal, block_diag
@@ -19,7 +20,11 @@ from pytensor.tensor.rewriting.basic import (
     register_stabilize,
 )
 from pytensor.tensor.rewriting.blockwise import blockwise_of
-from pytensor.tensor.rewriting.linalg.utils import MATRIX_INVERSE_OPS, is_eye_mul
+from pytensor.tensor.rewriting.linalg.utils import (
+    ASSUME_A_OF_TRANSPOSE,
+    MATRIX_INVERSE_OPS,
+    get_assume_a,
+)
 
 
 @register_canonicalize
@@ -35,24 +40,20 @@ def transpose_of_inv(fgraph, node):
 @register_stabilize
 @node_rewriter([Dot])
 def inv_to_solve(fgraph, node):
-    """
-    This utilizes a boolean `symmetric` tag on the matrices.
-
-    TODO: Exploit other assumptions like 'triangular' and 'psd'
-    TODO: Handle expand_dims / matrix transpose between inv and dot
-    """
+    """Replace inv(X) @ b with solve(X, b) and b @ inv(X) with solve(X.T, b.T).T."""
     l, r = node.inputs
+
     match l.owner_op_and_inputs:
         case (Blockwise(MatrixInverse()), X):
-            assume_a = "sym" if getattr(X.tag, "symmetric", False) else "gen"
-            return [solve(X, r, assume_a=assume_a)]
+            return [solve(X, r, assume_a=get_assume_a(fgraph, X))]
 
     match r.owner_op_and_inputs:
         case (Blockwise(MatrixInverse()), X):
-            if getattr(X.tag, "symmetric", False):
-                return [solve(X, (l.mT), assume_a="sym").mT]
-            else:
-                return [solve((X.mT), (l.mT)).mT]
+            assume_a = get_assume_a(fgraph, X)
+            # X.mT == X for sym/pos, so reuse X and skip an unnecessary transpose.
+            if assume_a in ("sym", "pos"):
+                return [solve(X, l.mT, assume_a=assume_a).mT]
+            return [solve(X.mT, l.mT, assume_a=ASSUME_A_OF_TRANSPOSE[assume_a]).mT]
 
     return None
 
@@ -62,9 +63,11 @@ def inv_to_solve(fgraph, node):
 @node_rewriter([blockwise_of(MATRIX_INVERSE_OPS)])
 def inv_of_inv(fgraph, node):
     """
-    This rewrite takes advantage of the fact that if there are two consecutive inverse operations (inv(inv(input))), we get back our original input without having to compute inverse once.
+    This rewrite takes advantage of the fact that if there are two consecutive inverse operations (inv(inv(input))),
+    we get back our original input without having to compute inverse once.
 
-    Here, we check for direct inverse operations (inv/pinv)  and allows for any combination of these "inverse" nodes to be simply rewritten.
+    Here, we check for direct inverse operations (inv/pinv)  and allows for any combination of these "inverse" nodes to
+    be simply rewritten.
 
     Parameters
     ----------
@@ -88,42 +91,14 @@ def inv_of_inv(fgraph, node):
 @register_stabilize
 @node_rewriter([blockwise_of(MATRIX_INVERSE_OPS)])
 def inv_of_diag_to_diag_reciprocal(fgraph, node):
-    """
-     This rewrite takes advantage of the fact that for a diagonal matrix, the inverse is a diagonal matrix with the new diagonal entries as reciprocals of the original diagonal elements.
-     This function deals with diagonal matrix arising from the multiplicaton of eye with a scalar/vector/matrix
-
-    Parameters
-    ----------
-    fgraph: FunctionGraph
-        Function graph being optimized
-    node: Apply
-        Node of the function graph to be optimized
-
-    Returns
-    -------
-    list of Variable, optional
-        List of optimized variables, or None if no optimization was performed
-    """
+    """inv(D) -> AllocDiag(1 / diagonal(D)) for diagonal D."""
     inp = node.inputs[0]
 
-    # Check for diagonal constructors first
-    match inp.owner_op_and_inputs:
-        case (Eye(), _, _, Constant(0)):
-            return [inp]
-        case (AllocDiag(offset=0, axis1=axis1, axis2=axis2), inv_input):
-            ndim = inv_input.type.ndim
-            if axis1 == ndim - 1 and axis2 == ndim:
-                return [pt.diag(1 / inv_input)]
+    if not check_assumption(fgraph, inp, DIAGONAL):
+        return None
 
-    # Check if the input is an elemwise multiply with identity matrix -- this also results in a diagonal matrix
-    match is_eye_mul(inp):
-        case (eye_term, non_eye_term):
-            # For a matrix, we have to first extract the diagonal (non-zero values) and then only use those
-            if non_eye_term.type.broadcastable[-2:] == (False, False):
-                non_eye_diag = non_eye_term.diagonal(axis1=-1, axis2=-2)
-                non_eye_term = pt.shape_padaxis(non_eye_diag, -2)
-
-            return [eye_term / non_eye_term]
+    diag_vals = pt.diagonal(inp, axis1=-2, axis2=-1)
+    return [alloc_diag(1 / diag_vals, axis1=-2, axis2=-1)]
 
 
 @register_specialize
@@ -159,5 +134,5 @@ def lift_linalg_of_expanded_matrices(fgraph: FunctionGraph, node: Apply):
     match y.owner_op_and_inputs:
         case (Blockwise(BlockDiagonal()), *inner_matrices):
             return [block_diag(*(outer_op(m) for m in inner_matrices))]
-        case (KroneckerProduct(), *inner_matrices):
-            return [kron(*(outer_op(m) for m in inner_matrices))]
+        case (KroneckerProduct(), *inner_matrices):  # type: ignore[unreachable, unused-ignore]
+            return [kron(*(outer_op(m) for m in inner_matrices))]  # type: ignore[unreachable, unused-ignore]

--- a/pytensor/tensor/rewriting/linalg/inverse.py
+++ b/pytensor/tensor/rewriting/linalg/inverse.py
@@ -1,5 +1,5 @@
 from pytensor import tensor as pt
-from pytensor.assumptions import DIAGONAL, check_assumption
+from pytensor.assumptions import DIAGONAL, ORTHOGONAL, check_assumption
 from pytensor.graph import Apply, FunctionGraph
 from pytensor.graph.rewriting.basic import (
     node_rewriter,
@@ -85,6 +85,17 @@ def inv_of_inv(fgraph, node):
     match node.inputs[0].owner_op_and_inputs:
         case (Blockwise(MatrixInverse() | MatrixPinv()), X):
             return [X]
+
+
+@register_canonicalize
+@register_stabilize
+@node_rewriter([blockwise_of(MATRIX_INVERSE_OPS)])
+def inv_of_orthogonal_to_transpose(fgraph, node):
+    """inv(Q) -> Q.T when Q is orthogonal."""
+    [X] = node.inputs
+    if not check_assumption(fgraph, X, ORTHOGONAL):
+        return None
+    return [X.mT]
 
 
 @register_canonicalize

--- a/pytensor/tensor/rewriting/linalg/products.py
+++ b/pytensor/tensor/rewriting/linalg/products.py
@@ -1,15 +1,16 @@
 from pytensor import tensor as pt
-from pytensor.assumptions import DIAGONAL, check_assumption
+from pytensor.assumptions import DIAGONAL, ORTHOGONAL, check_assumption
 from pytensor.graph.rewriting.basic import (
     copy_stack_trace,
     node_rewriter,
 )
 from pytensor.tensor.basic import ExtractDiag, alloc_diag, concatenate, diag
 from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.elemwise import DimShuffle
 from pytensor.tensor.linalg.constructors import BlockDiagonal
 from pytensor.tensor.linalg.products import Expm, KroneckerProduct
 from pytensor.tensor.linalg.summary import det
-from pytensor.tensor.math import outer, prod
+from pytensor.tensor.math import Dot, outer, prod
 from pytensor.tensor.rewriting.basic import (
     register_canonicalize,
     register_stabilize,
@@ -193,3 +194,33 @@ def expm_of_diag(fgraph, node):
     new_out = alloc_diag(diag_vals, axis1=-2, axis2=-1)
     copy_stack_trace(node.outputs[0], new_out)
     return [new_out]
+
+
+@register_canonicalize
+@register_stabilize
+@node_rewriter([Dot, blockwise_of(Dot)])
+def orthogonal_dot_transpose_to_eye(fgraph, node):
+    """Replace X @ X.T -> eye and X.T @ X -> eye when X is orthogonal."""
+    a, b = node.inputs
+    if not check_assumption(fgraph, a, ORTHOGONAL) or not check_assumption(
+        fgraph, b, ORTHOGONAL
+    ):
+        return None
+
+    # X @ X.T case
+    match b.owner_op_and_inputs:
+        case (DimShuffle(is_matrix_transpose=True), b_inner) if b_inner is a:
+            result = pt.eye(a.shape[-2], dtype=a.type.dtype)
+            if a.type.ndim > 2:
+                result = pt.broadcast_to(result, (*a.shape[:-2], *result.shape[-2:]))
+            copy_stack_trace(node.outputs[0], result)
+            return [result]
+
+    # X.T @ X case
+    match a.owner_op_and_inputs:
+        case (DimShuffle(is_matrix_transpose=True), a_inner) if a_inner is b:
+            result = pt.eye(b.shape[-1], dtype=b.type.dtype)
+            if b.type.ndim > 2:
+                result = pt.broadcast_to(result, (*b.shape[:-2], *result.shape[-2:]))
+            copy_stack_trace(node.outputs[0], result)
+            return [result]

--- a/pytensor/tensor/rewriting/linalg/products.py
+++ b/pytensor/tensor/rewriting/linalg/products.py
@@ -1,17 +1,20 @@
+from pytensor import tensor as pt
+from pytensor.assumptions import DIAGONAL, check_assumption
 from pytensor.graph.rewriting.basic import (
     copy_stack_trace,
     node_rewriter,
 )
-from pytensor.tensor.basic import ExtractDiag, concatenate, diag
+from pytensor.tensor.basic import ExtractDiag, alloc_diag, concatenate, diag
 from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.linalg.constructors import BlockDiagonal
-from pytensor.tensor.linalg.products import KroneckerProduct
+from pytensor.tensor.linalg.products import Expm, KroneckerProduct
 from pytensor.tensor.linalg.summary import det
 from pytensor.tensor.math import outer, prod
 from pytensor.tensor.rewriting.basic import (
     register_canonicalize,
     register_stabilize,
 )
+from pytensor.tensor.rewriting.blockwise import blockwise_of
 
 
 @register_canonicalize
@@ -152,3 +155,41 @@ def det_of_kronecker(fgraph, node):
                 [dets[i] ** (prod_sizes / sizes[i]) for i in range(2)], axis=-1
             )
             return [det_final]
+
+
+@register_canonicalize
+@register_stabilize
+@node_rewriter([KroneckerProduct])
+def kron_of_diagonal_to_diagonal(fgraph, node):
+    """kron(D1, D2) -> alloc_diag(outer_product) when both inputs are diagonal."""
+    a, b = node.inputs
+
+    if not (
+        check_assumption(fgraph, a, DIAGONAL) and check_assumption(fgraph, b, DIAGONAL)
+    ):
+        return None
+
+    diag_a = pt.diagonal(a, axis1=-2, axis2=-1)
+    diag_b = pt.diagonal(b, axis1=-2, axis2=-1)
+
+    kron_diag = pt.join_dims(diag_a[..., :, None] * diag_b[..., None, :], start_axis=-2)
+    return [alloc_diag(kron_diag, axis1=-2, axis2=-1)]
+
+
+@register_canonicalize
+@register_stabilize
+@node_rewriter([blockwise_of(Expm)])
+def expm_of_diag(fgraph, node):
+    """expm(D) -> diag(exp(diagonal(D))) for diagonal D."""
+    [X] = node.inputs
+
+    if all(X.type.broadcastable[-2:]):
+        return [pt.exp(X)]
+
+    if not check_assumption(fgraph, X, DIAGONAL):
+        return None
+
+    diag_vals = pt.exp(pt.diagonal(X, axis1=-2, axis2=-1))
+    new_out = alloc_diag(diag_vals, axis1=-2, axis2=-1)
+    copy_stack_trace(node.outputs[0], new_out)
+    return [new_out]

--- a/pytensor/tensor/rewriting/linalg/solvers.py
+++ b/pytensor/tensor/rewriting/linalg/solvers.py
@@ -2,6 +2,8 @@ from collections.abc import Container
 from copy import copy
 
 from pytensor import tensor as pt
+from pytensor.assumptions import check_assumption
+from pytensor.assumptions.positive_definite import POSITIVE_DEFINITE
 from pytensor.compile import optdb
 from pytensor.graph import Constant, graph_inputs
 from pytensor.graph.rewriting.basic import (
@@ -109,18 +111,64 @@ def batched_vector_b_solve_to_matrix_b_solve(fgraph, node):
 @register_stabilize
 @node_rewriter([blockwise_of(OpPattern(Solve, b_ndim=2))])
 def psd_solve_to_chol_solve(fgraph, node):
-    """
-    This utilizes the Solve assume_a flag or a boolean `psd` tag on matrices.
-    """
+    """Rewrite solve(A, b) → triangular solves via Cholesky when A is positive-definite."""
     assume_a = node.op.core_op.assume_a
-    A, b = node.inputs  # result is the solution to Ax=b
-    if assume_a == "pos" or getattr(A.tag, "psd", None) is True:
+    A, b = node.inputs
+    if (
+        assume_a == "pos"
+        or getattr(A.tag, "psd", None) is True
+        or check_assumption(fgraph, A, POSITIVE_DEFINITE)
+    ):
         L = cholesky(A)
-        # N.B. this can be further reduced to cho_solve Op
-        #     if no other Op makes use of the L matrix
         Li_b = solve_triangular(L, b, lower=True, b_ndim=2)
         x = solve_triangular((L.mT), Li_b, lower=False, b_ndim=2)
         return [x]
+
+
+@register_specialize
+@node_rewriter([blockwise_of(SolveTriangular)])
+def paired_triangular_solves_to_cho_solve(fgraph, node):
+    """Fuse paired triangular solves from Cholesky into a single cho_solve.
+
+    solve_triangular(L.T, solve_triangular(L, b), lower=False) -> cho_solve((L, True), b)
+    """
+    core_op = node.op.core_op
+
+    # We're looking for the outer solve: solve_triangular(L.T, ..., lower=False)
+    if core_op.lower:
+        return None
+
+    L_T, inner_result = node.inputs
+
+    # Check L.T is a matrix transpose of a Cholesky factor
+    match L_T.owner_op_and_inputs:
+        case (DimShuffle(is_left_expanded_matrix_transpose=True), L):
+            pass
+        case _:
+            return None
+
+    # L must be output of a Cholesky(lower=True)
+    match L.owner_op:
+        case Blockwise(Cholesky(lower=True)):
+            pass
+        case _:
+            return None
+
+    # inner_result must be solve_triangular(L, b, lower=True)
+    match inner_result.owner_op_and_inputs:
+        case (Blockwise(SolveTriangular(lower=True)), inner_L, b):
+            pass
+        case _:
+            return None
+
+    # inner_L must be the same Cholesky output as L
+    if inner_L is not L:
+        return None
+
+    b_ndim = core_op.b_ndim
+    new_out = cho_solve((L, True), b, b_ndim=b_ndim)
+    copy_stack_trace(node.outputs[0], new_out)
+    return [new_out]
 
 
 @register_stabilize
@@ -321,7 +369,7 @@ def _split_decomp_and_solve_steps(
             case (DimShuffle(is_left_expand_dims=True), root_a):  # type: ignore[misc]
                 transposed = False
             case (DimShuffle(is_left_expanded_matrix_transpose=True), root_a):  # type: ignore[misc]
-                transposed = True
+                transposed = True  # type: ignore[unreachable, unused-ignore]
 
         return root_a, transposed
 

--- a/pytensor/tensor/rewriting/linalg/solvers.py
+++ b/pytensor/tensor/rewriting/linalg/solvers.py
@@ -22,7 +22,7 @@ from pytensor.tensor.linalg.decomposition.cholesky import Cholesky, cholesky
 from pytensor.tensor.linalg.decomposition.lu import lu_factor
 from pytensor.tensor.linalg.inverse import MatrixInverse
 from pytensor.tensor.linalg.solvers.core import SolveBase
-from pytensor.tensor.linalg.solvers.general import Solve, lu_solve
+from pytensor.tensor.linalg.solvers.general import Solve, lu_solve, solve
 from pytensor.tensor.linalg.solvers.linear_control import (
     SolveBilinearDiscreteLyapunov,
     SolveSylvester,
@@ -40,6 +40,7 @@ from pytensor.tensor.rewriting.basic import (
     register_stabilize,
 )
 from pytensor.tensor.rewriting.blockwise import blockwise_of
+from pytensor.tensor.rewriting.linalg.utils import get_assume_a
 from pytensor.tensor.variable import TensorVariable
 
 
@@ -170,6 +171,28 @@ def paired_triangular_solves_to_cho_solve(fgraph, node):
     new_out = cho_solve((L, True), b, b_ndim=b_ndim)
     copy_stack_trace(node.outputs[0], new_out)
     return [new_out]
+
+
+@register_stabilize
+@register_canonicalize
+@node_rewriter([blockwise_of(OpPattern(Solve, assume_a="gen"))])
+def generic_solve_to_structured_form(fgraph, node):
+    """Upgrade solve(A, b, assume_a='gen') based on known structure of A.
+
+    Priority order (most specialized first):
+    - LOWER_TRIANGULAR -> solve_triangular(lower=True)
+    - UPPER_TRIANGULAR -> solve_triangular(lower=False)
+    - POSITIVE_DEFINITE -> solve(assume_a='pos')
+    - SYMMETRIC → solve(assume_a='sym')
+    """
+    b_ndim = node.op.core_op.b_ndim
+    A, b = node.inputs
+
+    assume_a = get_assume_a(fgraph, A)
+    if assume_a == "gen":
+        return None
+
+    return [solve(A, b, assume_a=assume_a, b_ndim=b_ndim)]
 
 
 @register_stabilize

--- a/pytensor/tensor/rewriting/linalg/solvers.py
+++ b/pytensor/tensor/rewriting/linalg/solvers.py
@@ -2,7 +2,7 @@ from collections.abc import Container
 from copy import copy
 
 from pytensor import tensor as pt
-from pytensor.assumptions import check_assumption
+from pytensor.assumptions import DIAGONAL, check_assumption
 from pytensor.assumptions.positive_definite import POSITIVE_DEFINITE
 from pytensor.compile import optdb
 from pytensor.graph import Constant, graph_inputs
@@ -25,6 +25,7 @@ from pytensor.tensor.linalg.solvers.core import SolveBase
 from pytensor.tensor.linalg.solvers.general import Solve, lu_solve
 from pytensor.tensor.linalg.solvers.linear_control import (
     SolveBilinearDiscreteLyapunov,
+    SolveSylvester,
     solve_discrete_lyapunov,
 )
 from pytensor.tensor.linalg.solvers.psd import CholeskySolve, cho_solve
@@ -232,6 +233,47 @@ def solve_of_inv_to_matmul(fgraph, node):
 @register_canonicalize
 @register_stabilize
 @node_rewriter([blockwise_of(SolveBase)])
+def diagonal_solve_to_division(fgraph, node):
+    """Replace solve(D, b) with b / diagonal(D) when D is known diagonal."""
+    a, b = node.inputs
+
+    # Scalar case already handled by scalar_solve_to_division
+    if all(a.type.broadcastable[-2:]):
+        return None
+
+    if not check_assumption(fgraph, a, DIAGONAL):
+        return None
+
+    core_op = node.op.core_op
+    b_ndim = core_op.b_ndim
+    a_diag = pt.diagonal(a, axis1=-2, axis2=-1)
+
+    match core_op:
+        case SolveTriangular(unit_diagonal=True):
+            # Unit diagonal means diag is all ones; solve is identity
+            return [b]
+        case Solve() | SolveTriangular():
+            if b_ndim == 1:
+                new_out = b / a_diag
+            else:
+                new_out = b / a_diag[..., :, None]
+        case CholeskySolve():
+            # D is the Cholesky factor; D @ D.T = diag(d^2) for diagonal D
+            if b_ndim == 1:
+                new_out = b / a_diag**2
+            else:
+                new_out = b / (a_diag**2)[..., :, None]
+        case _:
+            return None
+
+    old_out = node.outputs[0]
+    copy_stack_trace(old_out, new_out)
+    return [new_out]
+
+
+@register_canonicalize
+@register_stabilize
+@node_rewriter([blockwise_of(SolveBase)])
 def block_diag_solve_to_block_diag_solves(fgraph, node):
     """Push ``solve(block_diag(A_1, ..., A_n), b)`` into per-block solves.
 
@@ -306,6 +348,32 @@ def block_diag_solve_to_block_diag_solves(fgraph, node):
 
     new_out = pt.concatenate(per_block_solutions, axis=split_axis)
     copy_stack_trace(node.outputs[0], new_out)
+    return [new_out]
+
+
+@register_canonicalize
+@register_stabilize
+@node_rewriter([blockwise_of(SolveSylvester)])
+def solve_sylvester_of_diag(fgraph, node):
+    """Replace solve_sylvester(A, B, C) with C / (a[:, None] + b[None, :]) when both A, B are diagonal.
+
+    The Sylvester equation A @ X + X @ B = C, when A = diag(a) and B = diag(b),
+    reduces to X_ij = C_ij / (a_i + b_j).
+    """
+    A, B, C = node.inputs
+
+    if not check_assumption(fgraph, A, DIAGONAL):
+        return None
+    if not check_assumption(fgraph, B, DIAGONAL):
+        return None
+
+    a = pt.diagonal(A, axis1=-2, axis2=-1)
+    b = pt.diagonal(B, axis1=-2, axis2=-1)
+
+    new_out = C / (a[..., :, None] + b[..., None, :])
+
+    old_out = node.outputs[0]
+    copy_stack_trace(old_out, new_out)
     return [new_out]
 
 

--- a/pytensor/tensor/rewriting/linalg/solvers.py
+++ b/pytensor/tensor/rewriting/linalg/solvers.py
@@ -2,7 +2,7 @@ from collections.abc import Container
 from copy import copy
 
 from pytensor import tensor as pt
-from pytensor.assumptions import DIAGONAL, check_assumption
+from pytensor.assumptions import DIAGONAL, ORTHOGONAL, check_assumption
 from pytensor.assumptions.positive_definite import POSITIVE_DEFINITE
 from pytensor.compile import optdb
 from pytensor.graph import Constant, graph_inputs
@@ -371,6 +371,27 @@ def block_diag_solve_to_block_diag_solves(fgraph, node):
 
     new_out = pt.concatenate(per_block_solutions, axis=split_axis)
     copy_stack_trace(node.outputs[0], new_out)
+    return [new_out]
+
+
+@register_canonicalize
+@register_stabilize
+@node_rewriter([blockwise_of(SolveBase)])
+def orthogonal_solve_to_transpose_matmul(fgraph, node):
+    """Replace solve(Q, b) with Q.T @ b when Q is orthogonal."""
+    A, b = node.inputs
+
+    if not check_assumption(fgraph, A, ORTHOGONAL):
+        return None
+
+    b_ndim = node.op.core_op.b_ndim
+    if b_ndim == 1:
+        new_out = (A.mT @ b[..., :, None])[..., 0]
+    else:
+        new_out = A.mT @ b
+
+    old_out = node.outputs[0]
+    copy_stack_trace(old_out, new_out)
     return [new_out]
 
 

--- a/pytensor/tensor/rewriting/linalg/summary.py
+++ b/pytensor/tensor/rewriting/linalg/summary.py
@@ -1,12 +1,13 @@
 import numpy as np
 
 from pytensor import tensor as pt
+from pytensor.assumptions import DIAGONAL, check_assumption
 from pytensor.graph.rewriting.basic import (
     copy_stack_trace,
     node_rewriter,
 )
 from pytensor.scalar.basic import Abs, Exp, Log, Sign, Sqr
-from pytensor.tensor.basic import AllocDiag, ones
+from pytensor.tensor.basic import ones
 from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.linalg.decomposition.cholesky import Cholesky
@@ -20,7 +21,7 @@ from pytensor.tensor.rewriting.basic import (
     register_specialize,
     register_stabilize,
 )
-from pytensor.tensor.rewriting.linalg.utils import is_eye_mul, matrix_diagonal_product
+from pytensor.tensor.rewriting.linalg.utils import matrix_diagonal_product
 
 
 @register_stabilize
@@ -174,55 +175,15 @@ def det_of_factorized_matrix(fgraph, node):
 @register_stabilize("shape_unsafe")
 @node_rewriter([det])
 def det_of_diag(fgraph, node):
-    """
-     This rewrite takes advantage of the fact that for a diagonal matrix, the determinant value is the product of its
-     diagonal elements.
-
-    The presence of a diagonal matrix is detected by inspecting the graph. This rewrite can identify diagonal matrices
-    that arise as the result of elementwise multiplication with an identity matrix. Specialized computation is used to
-    make this rewrite as efficient as possible, depending on whether the multiplication was with a scalar,
-    vector or a matrix.
-
-    Parameters
-    ----------
-    fgraph: FunctionGraph
-        Function graph being optimized
-    node: Apply
-        Node of the function graph to be optimized
-
-    Returns
-    -------
-    list of Variable, optional
-        List of optimized variables, or None if no optimization was performed
-    """
+    """det(D) -> prod(diagonal(D)) for diagonal D."""
     inp = node.inputs[0]
 
-    match inp.owner_op_and_inputs:
-        # Check for use of pt.diag first
-        case (AllocDiag(offset=0, axis1=axis1, axis2=axis2), diag_input):
-            ndim = diag_input.ndim
-            if axis1 == ndim - 1 and axis2 == ndim:
-                return [diag_input.prod(axis=-1)]
+    if not check_assumption(fgraph, inp, DIAGONAL):
+        return None
 
-    # Check if the input is an elemwise multiply with identity matrix -- this also results in a diagonal matrix
-    match is_eye_mul(inp):
-        case (eye_term, non_eye_term):
-            # Checking if original x was scalar/vector/matrix
-            match non_eye_term.type.broadcastable[-2:]:
-                case (True, True):
-                    # For scalar
-                    det_val = (
-                        non_eye_term.squeeze(axis=(-1, -2)) ** (eye_term.shape[-1])
-                    )
-                case (False, False):
-                    # For Matrix
-                    det_val = non_eye_term.diagonal(axis1=-1, axis2=-2).prod(axis=-1)
-                case _:
-                    # For vector
-                    det_val = non_eye_term.prod(axis=(-1, -2))
-
-            det_val = det_val.astype(node.outputs[0].type.dtype)
-            return [det_val]
+    det_val = pt.diagonal(inp, axis1=-2, axis2=-1).prod(axis=-1)
+    det_val = det_val.astype(node.outputs[0].type.dtype)
+    return [det_val]
 
 
 @register_specialize

--- a/pytensor/tensor/rewriting/linalg/summary.py
+++ b/pytensor/tensor/rewriting/linalg/summary.py
@@ -1,7 +1,11 @@
 import numpy as np
 
 from pytensor import tensor as pt
-from pytensor.assumptions import DIAGONAL, check_assumption
+from pytensor.assumptions import (
+    LOWER_TRIANGULAR,
+    UPPER_TRIANGULAR,
+    check_assumption,
+)
 from pytensor.graph.rewriting.basic import (
     copy_stack_trace,
     node_rewriter,
@@ -174,15 +178,17 @@ def det_of_factorized_matrix(fgraph, node):
 @register_canonicalize("shape_unsafe")
 @register_stabilize("shape_unsafe")
 @node_rewriter([det])
-def det_of_diag(fgraph, node):
-    """det(D) -> prod(diagonal(D)) for diagonal D."""
+def det_of_triangular(fgraph, node):
+    """det(T) -> prod(diagonal(T)) when T is triangular (incl. diagonal)."""
     inp = node.inputs[0]
 
-    if not check_assumption(fgraph, inp, DIAGONAL):
+    if not (
+        check_assumption(fgraph, inp, LOWER_TRIANGULAR)
+        or check_assumption(fgraph, inp, UPPER_TRIANGULAR)
+    ):
         return None
 
-    det_val = pt.diagonal(inp, axis1=-2, axis2=-1).prod(axis=-1)
-    det_val = det_val.astype(node.outputs[0].type.dtype)
+    det_val = matrix_diagonal_product(inp).astype(node.outputs[0].type.dtype)
     return [det_val]
 
 

--- a/pytensor/tensor/rewriting/linalg/utils.py
+++ b/pytensor/tensor/rewriting/linalg/utils.py
@@ -1,6 +1,13 @@
 import logging
 
 from pytensor import tensor as pt
+from pytensor.assumptions import (
+    LOWER_TRIANGULAR,
+    POSITIVE_DEFINITE,
+    SYMMETRIC,
+    UPPER_TRIANGULAR,
+    check_assumption,
+)
 from pytensor.graph import Constant
 from pytensor.graph.rewriting.basic import node_rewriter
 from pytensor.graph.rewriting.unify import OpPattern
@@ -25,9 +32,38 @@ logger = logging.getLogger(__name__)
 
 MATRIX_INVERSE_OPS = (MatrixInverse, MatrixPinv)
 
+# Mapping of ``solve``'s ``assume_a`` for ``A`` to the one valid for ``A.mT``: triangular
+# flips direction, sym/pos/gen are preserved (since A.mT == A for sym/pos).
+ASSUME_A_OF_TRANSPOSE = {
+    "lower triangular": "upper triangular",
+    "upper triangular": "lower triangular",
+    "pos": "pos",
+    "sym": "sym",
+    "gen": "gen",
+}
+
 
 def matrix_diagonal_product(x):
     return pt.prod(diagonal(x, axis1=-2, axis2=-1), axis=-1)
+
+
+def get_assume_a(fgraph, A):
+    """Return the most-specific ``solve`` ``assume_a`` for ``A`` from tags and assumptions."""
+    if getattr(A.tag, "lower_triangular", False) or check_assumption(
+        fgraph, A, LOWER_TRIANGULAR
+    ):
+        return "lower triangular"
+    if getattr(A.tag, "upper_triangular", False) or check_assumption(
+        fgraph, A, UPPER_TRIANGULAR
+    ):
+        return "upper triangular"
+    if getattr(A.tag, "psd", None) is True or check_assumption(
+        fgraph, A, POSITIVE_DEFINITE
+    ):
+        return "pos"
+    if getattr(A.tag, "symmetric", False) or check_assumption(fgraph, A, SYMMETRIC):
+        return "sym"
+    return "gen"
 
 
 def is_matrix_transpose(x: TensorVariable) -> bool:
@@ -80,5 +116,5 @@ def is_eye_mul(x) -> None | tuple[TensorVariable, TensorVariable]:
 @node_rewriter([OpPattern(DimShuffle, is_left_expanded_matrix_transpose=True)])
 def useless_symmetric_transpose(fgraph, node):
     x = node.inputs[0]
-    if getattr(x.tag, "symmetric", False):
+    if getattr(x.tag, "symmetric", False) or check_assumption(fgraph, x, SYMMETRIC):
         return [atleast_Nd(x, n=node.outputs[0].type.ndim)]

--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -9,6 +9,7 @@ import numpy as np
 
 import pytensor.scalar.basic as ps
 import pytensor.scalar.math as ps_math
+from pytensor.assumptions import DIAGONAL, check_assumption
 from pytensor.graph.basic import Constant, Variable
 from pytensor.graph.rewriting.basic import (
     NodeRewriter,
@@ -24,10 +25,12 @@ from pytensor.tensor.basic import (
     Join,
     MakeVector,
     alloc,
+    alloc_diag,
     as_tensor_variable,
     atleast_Nd,
     cast,
     constant,
+    diagonal,
     expand_dims,
     get_underlying_scalar_constant_value,
     moveaxis,
@@ -263,6 +266,42 @@ def local_lift_transpose_through_dot(fgraph, node):
     ret = atleast_Nd(ret, n=replaced_client.type.ndim)
 
     return {replaced_client: ret}
+
+
+@register_canonicalize
+@register_stabilize
+@node_rewriter([_matmul, Dot])
+def dot_diag_to_elemwise(fgraph, node):
+    """Replace matmul with a diagonal operand by elementwise scaling.
+
+    dot(D1, D2) -> alloc_diag(diagonal(D1) * diagonal(D2))   (both diagonal)
+    dot(D, X) -> diagonal(D)[..., :, None] * X   (row scaling)
+    dot(X, D) -> X * diagonal(D)[..., None, :]   (column scaling)
+    """
+    a, b = node.inputs
+    old_out = node.outputs[0]
+
+    a_is_diag = check_assumption(fgraph, a, DIAGONAL)
+    b_is_diag = check_assumption(fgraph, b, DIAGONAL)
+
+    if a_is_diag and b_is_diag:
+        a_diag = diagonal(a, axis1=-2, axis2=-1)
+        b_diag = diagonal(b, axis1=-2, axis2=-1)
+        new_out = alloc_diag(a_diag * b_diag, axis1=-2, axis2=-1)
+        copy_stack_trace(old_out, new_out)
+        return [new_out]
+
+    if a_is_diag:
+        a_diag = diagonal(a, axis1=-2, axis2=-1)
+        new_out = a_diag[..., :, None] * b
+        copy_stack_trace(old_out, new_out)
+        return [new_out]
+
+    if b_is_diag:
+        b_diag = diagonal(b, axis1=-2, axis2=-1)
+        new_out = a * b_diag[..., None, :]
+        copy_stack_trace(old_out, new_out)
+        return [new_out]
 
 
 def _batched_matmul_to_core_matmul(fgraph, node, allow_reshape: bool):

--- a/pytensor/tensor/subtensor.py
+++ b/pytensor/tensor/subtensor.py
@@ -239,50 +239,76 @@ def as_index_literal(
     raise NotScalarConstantError()
 
 
-def _is_provably_non_negative(var) -> bool:
-    """``True`` when ``var`` can be statically shown to be non-negative.
+def _is_provably_positive(var, strict: bool = True) -> bool:
+    """``True`` when ``var`` can be statically shown to be positive.
+
+    With ``strict=True`` this proves :math:`var > 0`; with ``strict=False`` it
+    proves :math:`var \\geq 0`.
 
     Recognized cases:
 
-    - Python ``int`` / ``np.integer`` ``>= 0``.
-    - ``TensorConstant`` / ``ScalarConstant`` whose data is all ``>= 0``
-      (cached via ``tag.is_non_negative``).
-    - Unsigned-integer dtype.
-    - ``Shape`` / ``Shape_i`` outputs.
-    - ``MakeVector`` of provably non-negative inputs.
+    - Python ``int`` / ``np.integer``.
+    - ``TensorConstant`` / ``ScalarConstant`` whose data clears the bound
+      (cached via ``tag.is_positive`` or ``tag.is_non_negative``).
+    - ``MakeVector`` of provably positive inputs.
     - View / shape-permutation ops — ``Subtensor``, ``ScalarFromTensor``,
       ``TensorFromScalar``, ``DimShuffle`` — recurse to their input.
-    - ``Cast`` of a provably non-negative input.
-    - ``minimum(a, b)`` when both ``a`` and ``b`` are non-negative.
-    - ``maximum(a, b)`` when at least one of ``a``, ``b`` is non-negative.
+    - ``minimum(a, b)`` when both ``a`` and ``b`` are positive.
+    - ``maximum(a, b)`` when at least one of ``a``, ``b`` is positive.
+
+    Three further cases prove non-negativity but not strict positivity, so they
+    are recognized only when ``strict=False``:
+
+    - Unsigned-integer dtype (a ``uint`` may be 0).
+    - ``Shape`` / ``Shape_i`` outputs (a dimension may be 0).
+    - ``Cast`` of a non-negative input (a float :math:`0 < x < 1` truncates to 0).
+
+    Parameters
+    ----------
+    var : Variable or int
+        The value to test.
+    strict : bool
+        Prove :math:`> 0` when ``True``, :math:`\\geq 0` when ``False``. Default
+        ``True``.
     """
+    tag_name = "is_positive" if strict else "is_non_negative"
+
     if isinstance(var, int | np.integer):
-        return bool(var >= 0)
-    if var.type.dtype.startswith("uint"):
+        return bool(var > 0) if strict else bool(var >= 0)
+    if not strict and var.type.dtype.startswith("uint"):
         return True
     if isinstance(var, Constant):
-        cached: bool | None = getattr(var.tag, "is_non_negative", None)
+        cached: bool | None = getattr(var.tag, tag_name, None)
         if cached is not None:
             return cached
-        result = bool((np.asarray(var.data) >= 0).all())
-        var.tag.is_non_negative = result
+        data = np.asarray(var.data)
+        result = bool((data > 0).all()) if strict else bool((data >= 0).all())
+        setattr(var.tag, tag_name, result)
         return result
     op = var.owner_op
-    if isinstance(op, Shape | Shape_i):
+    if not strict and isinstance(op, Shape | Shape_i):
         return True
     if isinstance(op, MakeVector):
-        return all(_is_provably_non_negative(i) for i in var.owner.inputs)
+        return all(_is_provably_positive(i, strict) for i in var.owner.inputs)
     if isinstance(op, Subtensor | ScalarFromTensor | TensorFromScalar | DimShuffle):
-        return _is_provably_non_negative(var.owner.inputs[0])
+        return _is_provably_positive(var.owner.inputs[0], strict)
     if isinstance(op, Elemwise):
         scalar_op = op.scalar_op
-        if isinstance(scalar_op, Cast):
-            return _is_provably_non_negative(var.owner.inputs[0])
+        if not strict and isinstance(scalar_op, Cast):
+            return _is_provably_positive(var.owner.inputs[0], strict)
         if isinstance(scalar_op, ScalarMinimum):
-            return all(_is_provably_non_negative(i) for i in var.owner.inputs)
+            return all(_is_provably_positive(i, strict) for i in var.owner.inputs)
         if isinstance(scalar_op, ScalarMaximum):
-            return any(_is_provably_non_negative(i) for i in var.owner.inputs)
+            return any(_is_provably_positive(i, strict) for i in var.owner.inputs)
     return False
+
+
+def _is_provably_non_negative(var) -> bool:
+    """``True`` when ``var`` can be statically shown to be non-negative (:math:`\\geq 0`).
+
+    Thin wrapper over :func:`_is_provably_positive` with ``strict=False``.
+    """
+    return _is_provably_positive(var, strict=False)
 
 
 def get_idx_list(inputs, idx_list):

--- a/tests/assumptions/conftest.py
+++ b/tests/assumptions/conftest.py
@@ -1,0 +1,28 @@
+import copy
+
+import pytest
+
+from pytensor.assumptions import AssumptionFeature
+from pytensor.assumptions import core as _assumptions_core
+from pytensor.graph.fg import FunctionGraph
+
+
+@pytest.fixture(autouse=True)
+def _snapshot_assumption_registries():
+    """Restore module-global assumption registries after each test."""
+    infer_snapshot = copy.deepcopy(_assumptions_core.ASSUMPTION_INFER_REGISTRY)
+    implies_snapshot = copy.deepcopy(_assumptions_core.IMPLIES)
+    try:
+        yield
+    finally:
+        _assumptions_core.ASSUMPTION_INFER_REGISTRY.clear()
+        _assumptions_core.ASSUMPTION_INFER_REGISTRY.update(infer_snapshot)
+        _assumptions_core.IMPLIES.clear()
+        _assumptions_core.IMPLIES.update(implies_snapshot)
+
+
+def make_fgraph(*outputs, **kwargs):
+    fg = FunctionGraph(outputs=outputs, clone=False, **kwargs)
+    af = AssumptionFeature()
+    fg.attach_feature(af)
+    return fg, af

--- a/tests/assumptions/test_alloc.py
+++ b/tests/assumptions/test_alloc.py
@@ -5,10 +5,12 @@ from pytensor.assumptions import (
     ALL_KEYS,
     DIAGONAL,
     LOWER_TRIANGULAR,
+    POSITIVE_DEFINITE,
     SYMMETRIC,
     UPPER_TRIANGULAR,
     FactState,
 )
+from pytensor.assumptions.specify import assume
 from tests.assumptions.conftest import make_fgraph
 
 
@@ -35,7 +37,7 @@ def test_eye_non_identity_is_false(eye_args):
 def test_eye_symbolic_same_shape_is_identity():
     n = pt.iscalar("n")
     e = pt.eye(n, n, 0)
-    _, af = make_fgraph(e, inputs=[n])
+    _, af = make_fgraph(e)
     assert af.check(e, DIAGONAL)
 
 
@@ -43,7 +45,7 @@ def test_eye_symbolic_different_shapes_is_unknown():
     n = pt.iscalar("n")
     m = pt.iscalar("m")
     e = pt.eye(n, m, 0)
-    _, af = make_fgraph(e, inputs=[n, m])
+    _, af = make_fgraph(e)
     assert af.get(e, DIAGONAL) == FactState.UNKNOWN
 
 
@@ -53,7 +55,7 @@ def test_eye_symbolic_different_shapes_is_unknown():
 def test_alloc_diag_properties(key):
     v = pt.vector("v", shape=(5,))
     d = pt.diag(v)
-    _, af = make_fgraph(d, inputs=[v])
+    _, af = make_fgraph(d)
     assert af.check(d, key)
 
 
@@ -66,7 +68,7 @@ def test_zeros_matrix_is_diagonal():
 def test_ones_matrix_is_not_diagonal():
     o = pt.ones((5, 5))
     _, af = make_fgraph(o)
-    assert af.get(o, DIAGONAL) == FactState.UNKNOWN
+    assert af.get(o, DIAGONAL) == FactState.FALSE
 
 
 @pytest.mark.parametrize(
@@ -85,3 +87,27 @@ def test_nonsquare_zeros_matrix_is_not_matrix_property(key):
     z = pt.zeros((3, 4))
     _, af = make_fgraph(z)
     assert af.get(z, key) == FactState.UNKNOWN
+
+
+def test_alloc_broadcast_matrix_value_forwards_property():
+    m = pt.matrix("m", shape=(4, 4))
+    m_pd = assume(m, positive_definite=True)
+    y = pt.alloc(m_pd, 3, 4, 4)
+    _, af = make_fgraph(y)
+    assert af.check(y, POSITIVE_DEFINITE)
+
+
+def test_alloc_broadcast_scalar_value_is_symmetric():
+    """A square Alloc of a scalar fill is symmetric -- every entry equals that
+    one value -- whether or not the value is statically known."""
+    s = pt.scalar("s")
+    y = pt.alloc(s, 4, 4)
+    _, af = make_fgraph(y)
+    assert af.check(y, SYMMETRIC)
+
+
+def test_alloc_broadcast_vector_value_is_unknown():
+    v = pt.vector("v", shape=(4,))
+    y = pt.alloc(v, 4, 4)
+    _, af = make_fgraph(y)
+    assert af.get(y, SYMMETRIC) == FactState.UNKNOWN

--- a/tests/assumptions/test_alloc.py
+++ b/tests/assumptions/test_alloc.py
@@ -1,0 +1,87 @@
+import pytest
+
+import pytensor.tensor as pt
+from pytensor.assumptions import (
+    ALL_KEYS,
+    DIAGONAL,
+    LOWER_TRIANGULAR,
+    SYMMETRIC,
+    UPPER_TRIANGULAR,
+    FactState,
+)
+from tests.assumptions.conftest import make_fgraph
+
+
+def test_eye_identity_has_all_properties():
+    e = pt.eye(5)
+    _, af = make_fgraph(e)
+    for key in ALL_KEYS:
+        assert af.check(e, key), f"Eye should be {key}"
+
+
+@pytest.mark.parametrize(
+    "eye_args",
+    [
+        pytest.param(dict(n=5, k=1), id="offset"),
+        pytest.param(dict(n=5, m=3), id="rectangular"),
+    ],
+)
+def test_eye_non_identity_is_false(eye_args):
+    e = pt.eye(**eye_args)
+    _, af = make_fgraph(e)
+    assert af.get(e, DIAGONAL) == FactState.FALSE
+
+
+def test_eye_symbolic_same_shape_is_identity():
+    n = pt.iscalar("n")
+    e = pt.eye(n, n, 0)
+    _, af = make_fgraph(e, inputs=[n])
+    assert af.check(e, DIAGONAL)
+
+
+def test_eye_symbolic_different_shapes_is_unknown():
+    n = pt.iscalar("n")
+    m = pt.iscalar("m")
+    e = pt.eye(n, m, 0)
+    _, af = make_fgraph(e, inputs=[n, m])
+    assert af.get(e, DIAGONAL) == FactState.UNKNOWN
+
+
+@pytest.mark.parametrize(
+    "key", [DIAGONAL, SYMMETRIC, LOWER_TRIANGULAR, UPPER_TRIANGULAR]
+)
+def test_alloc_diag_properties(key):
+    v = pt.vector("v", shape=(5,))
+    d = pt.diag(v)
+    _, af = make_fgraph(d, inputs=[v])
+    assert af.check(d, key)
+
+
+def test_zeros_matrix_is_diagonal():
+    z = pt.zeros((5, 5))
+    _, af = make_fgraph(z)
+    assert af.check(z, DIAGONAL)
+
+
+def test_ones_matrix_is_not_diagonal():
+    o = pt.ones((5, 5))
+    _, af = make_fgraph(o)
+    assert af.get(o, DIAGONAL) == FactState.UNKNOWN
+
+
+@pytest.mark.parametrize(
+    "key", [DIAGONAL, SYMMETRIC, LOWER_TRIANGULAR, UPPER_TRIANGULAR]
+)
+def test_zeros_vector_is_not_matrix_property(key):
+    z = pt.zeros((5,))
+    _, af = make_fgraph(z)
+    assert af.get(z, key) == FactState.UNKNOWN
+
+
+@pytest.mark.parametrize(
+    "key", [DIAGONAL, SYMMETRIC, LOWER_TRIANGULAR, UPPER_TRIANGULAR]
+)
+def test_nonsquare_zeros_matrix_is_not_matrix_property(key):
+    z = pt.zeros((3, 4))
+    _, af = make_fgraph(z)
+    assert af.get(z, key) == FactState.UNKNOWN

--- a/tests/assumptions/test_blockwise.py
+++ b/tests/assumptions/test_blockwise.py
@@ -1,0 +1,44 @@
+import pytest
+
+import pytensor.tensor as pt
+from pytensor.assumptions import (
+    DIAGONAL,
+    LOWER_TRIANGULAR,
+    SYMMETRIC,
+    UPPER_TRIANGULAR,
+)
+from pytensor.assumptions.specify import assume
+from pytensor.tensor.basic import alloc_diag
+from pytensor.tensor.blockwise import Blockwise
+from tests.assumptions.conftest import make_fgraph
+
+
+def test_blockwise_cholesky_is_lower_triangular():
+    x = pt.tensor("x", shape=(5, 3, 3))
+    L = pt.linalg.cholesky(x, lower=True)
+    _, af = make_fgraph(L)
+    assert af.check(L, LOWER_TRIANGULAR)
+
+
+def test_blockwise_diagonal_propagation():
+    x = pt.tensor("x", shape=(5, 3, 3))
+    x_diag = assume(x, diagonal=True)
+    L = pt.linalg.cholesky(x_diag, lower=True)
+    _, af = make_fgraph(L)
+    assert af.check(L, DIAGONAL)
+
+
+@pytest.mark.parametrize(
+    "key", [DIAGONAL, SYMMETRIC, LOWER_TRIANGULAR, UPPER_TRIANGULAR]
+)
+def test_blockwise_alloc_diag_properties(key):
+    v_core = pt.vector("v", shape=(3,))
+    d_core = alloc_diag(v_core, offset=0, axis1=0, axis2=1)
+
+    bw = Blockwise(d_core.owner.op, signature="(n)->(n,n)")
+    v_batch = pt.matrix("v_batch", shape=(5, 3))
+    result = bw(v_batch)
+
+    _, af = make_fgraph(result)
+
+    assert af.check(result, key)

--- a/tests/assumptions/test_core.py
+++ b/tests/assumptions/test_core.py
@@ -1,0 +1,211 @@
+import pytest
+
+import pytensor.tensor as pt
+from pytensor.assumptions import (
+    DIAGONAL,
+    LOWER_TRIANGULAR,
+    POSITIVE_DEFINITE,
+    SYMMETRIC,
+    UPPER_TRIANGULAR,
+    AssumptionFeature,
+    AssumptionKey,
+    ConflictingAssumptionsError,
+    FactState,
+    register_assumption,
+)
+from pytensor.assumptions.specify import assume
+from pytensor.graph.basic import Apply
+from pytensor.graph.fg import FunctionGraph
+from pytensor.graph.op import Op
+from pytensor.tensor.basic import Eye
+from pytensor.tensor.type import TensorType
+from tests.assumptions.conftest import make_fgraph
+
+
+@pytest.mark.parametrize(
+    "left, right, expected",
+    [
+        (FactState.UNKNOWN, FactState.UNKNOWN, FactState.UNKNOWN),
+        (FactState.TRUE, FactState.UNKNOWN, FactState.TRUE),
+        (FactState.FALSE, FactState.UNKNOWN, FactState.FALSE),
+        (FactState.TRUE, FactState.FALSE, FactState.CONFLICT),
+    ],
+    ids=["unknown+unknown", "true+unknown", "false+unknown", "true+false"],
+)
+def test_fact_state_join(left, right, expected):
+    assert FactState.join(left, right) == expected
+
+
+@pytest.mark.parametrize(
+    "state",
+    [FactState.TRUE, FactState.UNKNOWN, FactState.FALSE, FactState.CONFLICT],
+)
+def test_fact_state_has_no_bool(state):
+    with pytest.raises(TypeError, match="FactState has no boolean value"):
+        bool(state)
+
+
+def test_double_attach_keeps_single_feature():
+    x = pt.matrix("x")
+    fg = FunctionGraph([x], [x], clone=False)
+    fg.attach_feature(AssumptionFeature())
+    fg.attach_feature(AssumptionFeature())
+    assert sum(isinstance(f, AssumptionFeature) for f in fg._features) == 1
+
+
+def test_bare_input_is_unknown():
+    x = pt.matrix("x")
+    _, af = make_fgraph(x)
+    assert af.get(x, DIAGONAL) == FactState.UNKNOWN
+
+
+def test_custom_op_via_register_assumption():
+    class AlwaysSymmetricOp(Op):
+        __props__ = ()
+
+        def make_node(self, x):
+            return Apply(self, [x], [TensorType(dtype=x.dtype, shape=(None, None))()])
+
+        def perform(self, node, inputs, outputs):
+            outputs[0][0] = inputs[0]
+
+    @register_assumption(SYMMETRIC, AlwaysSymmetricOp)
+    def _always_symmetric(key, op, feature, fgraph, node, input_states):
+        return [FactState.TRUE]
+
+    x = pt.matrix("x")
+    y = AlwaysSymmetricOp()(x)
+    _, af = make_fgraph(y)
+    assert af.check(y, SYMMETRIC)
+    assert af.get(y, DIAGONAL) == FactState.UNKNOWN
+
+
+def test_register_custom_assumption_key():
+    INVERTIBLE = AssumptionKey("invertible")
+
+    @register_assumption(INVERTIBLE, Eye)
+    def _eye_invertible(key, op, feature, fgraph, node, input_states):
+        return [FactState.TRUE]
+
+    e = pt.eye(5)
+    _, af = make_fgraph(e)
+    assert af.check(e, INVERTIBLE)
+
+
+@pytest.mark.parametrize(
+    "stronger, weaker",
+    [
+        (DIAGONAL, SYMMETRIC),
+        (DIAGONAL, LOWER_TRIANGULAR),
+        (DIAGONAL, UPPER_TRIANGULAR),
+        (POSITIVE_DEFINITE, SYMMETRIC),
+    ],
+)
+def test_implication(stronger, weaker):
+    x = pt.matrix("x", shape=(3, 3))
+    x_asserted = assume(x, **{stronger.name: True})
+    _, af = make_fgraph(x_asserted)
+    assert af.check(x_asserted, weaker)
+
+
+@pytest.mark.parametrize(
+    "stronger, weaker",
+    [
+        (DIAGONAL, SYMMETRIC),
+        (DIAGONAL, LOWER_TRIANGULAR),
+        (DIAGONAL, UPPER_TRIANGULAR),
+        (POSITIVE_DEFINITE, SYMMETRIC),
+    ],
+)
+def test_contrapositive_implication(stronger, weaker):
+    """``weaker = FALSE`` forces ``stronger = FALSE`` (contrapositive of the implication)."""
+    x = pt.matrix("x", shape=(3, 3))
+    x_asserted = assume(x, **{weaker.name: False})
+    _, af = make_fgraph(x_asserted)
+    assert af.get(x_asserted, weaker) is FactState.FALSE
+    assert af.get(x_asserted, stronger) is FactState.FALSE
+
+
+def test_symmetric_does_not_imply_diagonal():
+    x = pt.matrix("x", shape=(3, 3))
+    x_sym = assume(x, symmetric=True)
+    _, af = make_fgraph(x_sym)
+    assert not af.check(x_sym, DIAGONAL)
+
+
+def test_deep_graph_no_recursion_error():
+    x = pt.eye(5)
+    for _ in range(2000):
+        x = x * 1.0
+    _, af = make_fgraph(x)
+    assert af.check(x, DIAGONAL)
+
+
+def test_replace_propagates_true_fact_to_new_var():
+    """``fg.replace`` carries a TRUE fact from the old var onto the new one, and
+    the downstream TRUE survives."""
+    v = pt.vector("v", shape=(5,))
+    d_old = pt.diag(v)
+    y = pt.sin(d_old)
+    fg, af = make_fgraph(y)
+    assert af.check(d_old, DIAGONAL)
+    assert af.check(y, DIAGONAL)
+
+    d_new = pt.diag(v)
+    fg.replace(d_old, d_new, reason="replace")
+    assert af.get(d_new, DIAGONAL) is FactState.TRUE
+    assert af.get(y, DIAGONAL) is FactState.TRUE
+
+
+def test_replace_reprobes_downstream_unknown():
+    """A downstream UNKNOWN is dropped after ``replace`` so it re-probes and picks
+    up the richer ancestor."""
+    v = pt.vector("v", shape=(5,))
+    x_opaque = pt.matrix("x_opaque", shape=(5, 5))
+    y = pt.sin(x_opaque)
+    fg, af = make_fgraph(y, inputs=[x_opaque, v])
+    assert af.get(y, DIAGONAL) is FactState.UNKNOWN
+
+    fg.replace(x_opaque, pt.diag(v), reason="replace")
+    assert af.check(y, DIAGONAL)
+
+
+def test_replace_unknown_does_not_override_new_inference():
+    """An UNKNOWN cached on the old var must not mask the new var's own inference."""
+    v = pt.vector("v", shape=(5,))
+    x = pt.matrix("x", shape=(5, 5))
+    fg, af = make_fgraph(pt.sin(x), inputs=[x, v])
+    assert af.get(x, DIAGONAL) is FactState.UNKNOWN
+
+    d = pt.diag(v)
+    fg.replace(x, d, reason="replace")
+    assert af.check(d, DIAGONAL)
+
+
+def test_conflict_during_substitution_does_not_corrupt_graph():
+    """A conflicting substitution must not raise from ``on_change_input``.
+
+    ``fg.change_node_input`` mutates ``node.inputs[i]`` and ``clients`` *before*
+    firing feature callbacks, so raising from ``on_change_input`` leaves the graph
+    half-updated while the caller's ``except`` reads the substitution as rejected.
+    The substitution should land cleanly; the conflict is cached and surfaces on
+    the next ``feature.get(new_var, key)``.
+    """
+    v = pt.vector("v", shape=(5,))
+    x = pt.matrix("x", shape=(5, 5))
+    old_true = pt.diag(v)
+    new_false = assume(x, diagonal=False)
+    sink = pt.sin(old_true)
+
+    fg, af = make_fgraph(sink, inputs=[v, x])
+    assert af.get(old_true, DIAGONAL) is FactState.TRUE
+    assert af.get(new_false, DIAGONAL) is FactState.FALSE
+
+    fg.replace(old_true, new_false, reason="conflict")
+
+    assert sink.owner.inputs[0] is new_false
+    assert fg.clients[old_true] == []
+    assert (sink.owner, 0) in fg.clients[new_false]
+
+    with pytest.raises(ConflictingAssumptionsError):
+        af.get(new_false, DIAGONAL)

--- a/tests/assumptions/test_diagonal.py
+++ b/tests/assumptions/test_diagonal.py
@@ -5,6 +5,8 @@ import pytensor.tensor as pt
 from pytensor.assumptions import DIAGONAL, FactState
 from pytensor.assumptions.specify import assume
 from pytensor.graph import rewrite_graph
+from pytensor.graph.fg import FunctionGraph
+from pytensor.tensor.math import Dot
 from tests.assumptions.conftest import make_fgraph
 
 
@@ -54,6 +56,18 @@ def test_constant_sub_matrix_ndim_is_false(data):
     c = pt.constant(data)
     _, af = make_fgraph(c)
     assert af.get(c, DIAGONAL) == FactState.FALSE
+
+
+def test_dot_of_constant_eye_reduces():
+    """End-to-end: ``Dot(Constant(eye), x)`` reduces via ``dot_diag_to_elemwise``
+    once the Constant-DIAGONAL inference recovers the structural property that
+    constant-folding stripped from the original ``Eye`` Op."""
+    x = pt.matrix("x", shape=(5, 1))
+    y = pt.constant(np.eye(5)) @ x
+    fg = FunctionGraph([x], [y], clone=True)
+    rewrite_graph(fg, include=("canonicalize",))
+    # Reduces to leaf -- no Dot remains.
+    assert not any(isinstance(n.op, Dot) for n in fg.toposort())
 
 
 def test_cholesky_of_diagonal_is_diagonal():

--- a/tests/assumptions/test_diagonal.py
+++ b/tests/assumptions/test_diagonal.py
@@ -1,0 +1,243 @@
+import numpy as np
+import pytest
+
+import pytensor.tensor as pt
+from pytensor.assumptions import DIAGONAL, FactState
+from pytensor.assumptions.specify import assume
+from pytensor.graph import rewrite_graph
+from tests.assumptions.conftest import make_fgraph
+
+
+def test_constant_identity_matrix_is_diagonal():
+    """A literal Constant identity matrix is recognized as DIAGONAL via the
+    Constant-data inference path. Reaches this case after constant-folding
+    or ``scan_inline_invariant_constants`` collapses an ``Eye`` into a bare
+    ``Constant``."""
+    c = pt.constant(np.eye(5))
+    _, af = make_fgraph(c)
+    assert af.check(c, DIAGONAL)
+
+
+def test_constant_non_diagonal_matrix_is_false():
+    c = pt.constant(np.ones((5, 5)))
+    _, af = make_fgraph(c)
+    assert af.get(c, DIAGONAL) == FactState.FALSE
+
+
+def test_constant_batched_diagonal_matrix_is_diagonal():
+    data = np.broadcast_to(np.eye(4), (3, 4, 4)).copy()
+    c = pt.constant(data)
+    _, af = make_fgraph(c)
+    assert af.check(c, DIAGONAL)
+
+
+def test_constant_batched_partial_diagonal_is_false():
+    """If any batch slice has off-diagonal entries, the whole tensor is NOT DIAGONAL."""
+    data = np.broadcast_to(np.eye(4), (3, 4, 4)).copy()
+    data[1, 0, 1] = 1.0
+    c = pt.constant(data)
+    _, af = make_fgraph(c)
+    assert af.get(c, DIAGONAL) == FactState.FALSE
+
+
+def test_constant_nonsquare_matrix_is_false():
+    c = pt.constant(np.zeros((4, 5)))
+    _, af = make_fgraph(c)
+    assert af.get(c, DIAGONAL) == FactState.FALSE
+
+
+@pytest.mark.parametrize(
+    "data", [np.arange(5), np.array(3.0)], ids=["1d_vector", "0d_scalar"]
+)
+def test_constant_sub_matrix_ndim_is_false(data):
+    """A scalar or vector is not a matrix, so it is not a diagonal matrix."""
+    c = pt.constant(data)
+    _, af = make_fgraph(c)
+    assert af.get(c, DIAGONAL) == FactState.FALSE
+
+
+def test_cholesky_of_diagonal_is_diagonal():
+    v = pt.vector("v", shape=(3,))
+    L = pt.linalg.cholesky(pt.diag(v), lower=True)
+    _, af = make_fgraph(L)
+    assert af.check(L, DIAGONAL)
+
+
+def test_inv_propagates_diagonal():
+    x = pt.matrix("x", shape=(3, 3))
+    x_diag = assume(x, diagonal=True)
+    inv_x = pt.linalg.inv(x_diag)
+    _, af = make_fgraph(inv_x)
+    assert af.check(inv_x, DIAGONAL)
+
+
+def test_pinv_propagates_diagonal():
+    x = pt.matrix("x", shape=(3, 3))
+    x_diag = assume(x, diagonal=True)
+    px = pt.linalg.pinv(x_diag)
+    _, af = make_fgraph(px)
+    assert af.check(px, DIAGONAL)
+
+
+def test_block_diag_of_diagonal_blocks_is_diagonal():
+    bd = pt.linalg.block_diag(pt.eye(3), pt.eye(4))
+    _, af = make_fgraph(bd)
+    assert af.check(bd, DIAGONAL)
+
+
+def test_block_diag_of_generic_blocks_is_unknown():
+    x = pt.matrix("x", shape=(3, 3))
+    y = pt.matrix("y", shape=(4, 4))
+    bd = pt.linalg.block_diag(x, y)
+    _, af = make_fgraph(bd)
+    assert af.get(bd, DIAGONAL) == FactState.UNKNOWN
+
+
+def test_kron_of_eyes_is_diagonal():
+    k = pt.linalg.kron(pt.eye(3), pt.eye(4))
+    _, af = make_fgraph(k)
+    assert af.check(k, DIAGONAL)
+
+
+def test_kron_with_generic_input_not_diagonal():
+    x = pt.matrix("x", shape=(3, 3))
+    k = pt.linalg.kron(x, pt.eye(4))
+    _, af = make_fgraph(k)
+    assert af.get(k, DIAGONAL) == FactState.UNKNOWN
+
+
+def test_matmul_diagonal_diagonal_is_diagonal():
+    y = pt.eye(5) @ pt.diag(pt.ones(5))
+    _, af = make_fgraph(y)
+    assert af.check(y, DIAGONAL)
+
+
+def test_matmul_diagonal_generic_is_unknown():
+    x = pt.matrix("x", shape=(5, 5))
+    y = pt.eye(5) @ x
+    _, af = make_fgraph(y)
+    assert af.get(y, DIAGONAL) == FactState.UNKNOWN
+
+
+def test_dot_orthogonal_xxt_is_diagonal():
+    x = pt.dmatrix("x")
+    x_orth = assume(x, orthogonal=True)
+    y = pt.dot(x_orth, x_orth.T)
+    _, af = make_fgraph(y)
+    assert af.check(y, DIAGONAL)
+
+
+class TestSubtensorDiagonalPreservation:
+    def test_set_diagonal_entries(self):
+        d = pt.eye(5)
+        idx = pt.arange(5)
+        v = pt.vector("v", shape=(5,))
+        y = pt.set_subtensor(d[idx, idx], v)
+        _, af = make_fgraph(y)
+        assert af.check(y, DIAGONAL)
+
+    def test_inc_diagonal_entries(self):
+        d = pt.eye(5)
+        idx = pt.arange(5)
+        v = pt.vector("v", shape=(5,))
+        y = pt.inc_subtensor(d[idx, idx], v)
+        _, af = make_fgraph(y)
+        assert af.check(y, DIAGONAL)
+
+    def test_set_scalar_diagonal_entry(self):
+        d = pt.eye(5)
+        i = pt.iscalar("i")
+        y = rewrite_graph(pt.set_subtensor(d[i, i], 1.0), include=["merge"])
+        _, af = make_fgraph(y)
+        assert af.check(y, DIAGONAL)
+
+    def test_set_batched_diagonal_entries(self):
+        x = pt.tensor("x", shape=(3, 5, 5))
+        idx = pt.arange(5)
+        v = pt.matrix("v", shape=(3, 5))
+        y = pt.set_subtensor(assume(x, diagonal=True)[:, idx, idx], v)
+        _, af = make_fgraph(y)
+        assert af.check(y, DIAGONAL)
+
+    def test_set_off_diagonal_entries_is_unknown(self):
+        d = pt.eye(5)
+        v = pt.vector("v", shape=(5,))
+        y = pt.set_subtensor(d[pt.arange(5), pt.arange(1, 6)], v)
+        _, af = make_fgraph(y)
+        assert af.get(y, DIAGONAL) == FactState.UNKNOWN
+
+    def test_non_diagonal_base_is_unknown(self):
+        x = pt.matrix("x", shape=(5, 5))
+        v = pt.vector("v", shape=(5,))
+        y = pt.set_subtensor(x[pt.arange(5), pt.arange(5)], v)
+        _, af = make_fgraph(y)
+        assert af.get(y, DIAGONAL) == FactState.UNKNOWN
+
+
+def test_transpose_preserves_diagonal():
+    e = pt.eye(5)
+    _, af = make_fgraph(e.T)
+    assert af.check(e.T, DIAGONAL)
+
+
+def test_expand_dims_preserves_diagonal():
+    e = pt.eye(5)
+    e3d = e.dimshuffle("x", 0, 1)
+    _, af = make_fgraph(e3d)
+    assert af.check(e3d, DIAGONAL)
+
+
+def test_transpose_of_generic_matrix_is_unknown():
+    x = pt.matrix("x", shape=(3, 3))
+    xT = x.T
+    _, af = make_fgraph(xT)
+    assert af.get(xT, DIAGONAL) == FactState.UNKNOWN
+
+
+class TestElemwiseAssumptions:
+    def test_mul_diagonal_by_anything_is_diagonal(self):
+        x = pt.matrix("x", shape=(5, 5))
+        y = pt.eye(5) * x
+        _, af = make_fgraph(y)
+        assert af.check(y, DIAGONAL)
+
+    def test_add_diagonal_plus_diagonal(self):
+        y = pt.eye(5) + pt.diag(pt.ones(5))
+        _, af = make_fgraph(y)
+        assert af.check(y, DIAGONAL)
+
+    def test_add_diagonal_plus_generic_is_unknown(self):
+        x = pt.matrix("x", shape=(5, 5))
+        y = pt.eye(5) + x
+        _, af = make_fgraph(y)
+        assert not af.check(y, DIAGONAL)
+
+    def test_sub_diagonal_minus_diagonal(self):
+        y = pt.eye(5) - pt.diag(pt.ones(5))
+        _, af = make_fgraph(y)
+        assert af.check(y, DIAGONAL)
+
+    def test_truediv_diagonal_over_anything_is_diagonal(self):
+        x = pt.matrix("x", shape=(5, 5))
+        y = pt.eye(5) / x
+        _, af = make_fgraph(y)
+        assert af.check(y, DIAGONAL)
+
+    def test_truediv_anything_over_diagonal_is_unknown(self):
+        x = pt.matrix("x", shape=(5, 5))
+        y = x / pt.eye(5)
+        _, af = make_fgraph(y)
+        assert not af.check(y, DIAGONAL)
+
+    @pytest.mark.parametrize(
+        "transform",
+        [
+            pytest.param(lambda d: -d, id="neg"),
+            pytest.param(lambda d: abs(d), id="abs"),
+            pytest.param(lambda d: d**2, id="pow2"),
+        ],
+    )
+    def test_zero_preserving_unary_preserves_diagonal(self, transform):
+        y = transform(pt.eye(5))
+        _, af = make_fgraph(y)
+        assert af.check(y, DIAGONAL)

--- a/tests/assumptions/test_dimshuffle.py
+++ b/tests/assumptions/test_dimshuffle.py
@@ -24,7 +24,7 @@ class TestLeftExpandDimsPropagation:
         x = pt.matrix("x", shape=(4, 4))
         x_tagged = assume(x, **{key.name: True})
         y = x_tagged[None, :, :]
-        _, af = make_fgraph(y, inputs=[x])
+        _, af = make_fgraph(y)
         assert af.check(y, key)
 
     @pytest.mark.parametrize(
@@ -35,7 +35,7 @@ class TestLeftExpandDimsPropagation:
         x = pt.matrix("x", shape=(4, 4))
         x_tagged = assume(x, **{key.name: True})
         y = x_tagged[None, None, :, :]
-        _, af = make_fgraph(y, inputs=[x])
+        _, af = make_fgraph(y)
         assert af.check(y, key)
 
     def test_triangular_transpose_does_not_propagate(self):
@@ -44,7 +44,7 @@ class TestLeftExpandDimsPropagation:
         x = pt.matrix("x", shape=(4, 4))
         x_lower = assume(x, lower_triangular=True)
         y = x_lower.T
-        _, af = make_fgraph(y, inputs=[x])
+        _, af = make_fgraph(y)
         assert af.get(y, LOWER_TRIANGULAR) == FactState.UNKNOWN
 
     def test_right_expand_dims_does_not_propagate(self):
@@ -52,5 +52,21 @@ class TestLeftExpandDimsPropagation:
         x = pt.matrix("x", shape=(4, 4))
         x_sym = assume(x, symmetric=True)
         y = x_sym[:, :, None]
-        _, af = make_fgraph(y, inputs=[x])
+        _, af = make_fgraph(y)
         assert af.get(y, SYMMETRIC) == FactState.UNKNOWN
+
+
+def test_permute_batch_axes_forwards_property():
+    x = pt.tensor("x", shape=(2, 3, 4, 4))
+    x_orth = assume(x, orthogonal=True)
+    y = x_orth.dimshuffle(1, 0, 2, 3)
+    _, af = make_fgraph(y)
+    assert af.check(y, ORTHOGONAL)
+
+
+def test_moving_core_axis_does_not_propagate():
+    x = pt.tensor("x", shape=(2, 3, 4, 4))
+    x_sym = assume(x, symmetric=True)
+    y = x_sym.dimshuffle(0, 2, 1, 3)
+    _, af = make_fgraph(y)
+    assert af.get(y, SYMMETRIC) == FactState.UNKNOWN

--- a/tests/assumptions/test_dimshuffle.py
+++ b/tests/assumptions/test_dimshuffle.py
@@ -1,0 +1,56 @@
+import pytest
+
+import pytensor.tensor as pt
+from pytensor.assumptions import (
+    LOWER_TRIANGULAR,
+    ORTHOGONAL,
+    POSITIVE_DEFINITE,
+    SYMMETRIC,
+    UPPER_TRIANGULAR,
+    FactState,
+)
+from pytensor.assumptions.specify import assume
+from tests.assumptions.conftest import make_fgraph
+
+
+class TestLeftExpandDimsPropagation:
+    """Adding new broadcast dims on the left of a tagged matrix preserves the assumption."""
+
+    @pytest.mark.parametrize(
+        "key",
+        [SYMMETRIC, POSITIVE_DEFINITE, ORTHOGONAL, LOWER_TRIANGULAR, UPPER_TRIANGULAR],
+    )
+    def test_single_left_axis(self, key):
+        x = pt.matrix("x", shape=(4, 4))
+        x_tagged = assume(x, **{key.name: True})
+        y = x_tagged[None, :, :]
+        _, af = make_fgraph(y, inputs=[x])
+        assert af.check(y, key)
+
+    @pytest.mark.parametrize(
+        "key",
+        [SYMMETRIC, POSITIVE_DEFINITE, ORTHOGONAL, LOWER_TRIANGULAR, UPPER_TRIANGULAR],
+    )
+    def test_multiple_left_axes(self, key):
+        x = pt.matrix("x", shape=(4, 4))
+        x_tagged = assume(x, **{key.name: True})
+        y = x_tagged[None, None, :, :]
+        _, af = make_fgraph(y, inputs=[x])
+        assert af.check(y, key)
+
+    def test_triangular_transpose_does_not_propagate(self):
+        """Transpose swaps the triangle, so a lower-triangular matrix is no longer
+        known to be lower-triangular."""
+        x = pt.matrix("x", shape=(4, 4))
+        x_lower = assume(x, lower_triangular=True)
+        y = x_lower.T
+        _, af = make_fgraph(y, inputs=[x])
+        assert af.get(y, LOWER_TRIANGULAR) == FactState.UNKNOWN
+
+    def test_right_expand_dims_does_not_propagate(self):
+        """Adding a broadcast dim on the right shifts the matrix axes; the property is lost."""
+        x = pt.matrix("x", shape=(4, 4))
+        x_sym = assume(x, symmetric=True)
+        y = x_sym[:, :, None]
+        _, af = make_fgraph(y, inputs=[x])
+        assert af.get(y, SYMMETRIC) == FactState.UNKNOWN

--- a/tests/assumptions/test_dot.py
+++ b/tests/assumptions/test_dot.py
@@ -1,0 +1,55 @@
+import pytest
+
+import pytensor.tensor as pt
+from pytensor.assumptions import POSITIVE_DEFINITE, SYMMETRIC, FactState
+from pytensor.assumptions.specify import assume
+from tests.assumptions.conftest import make_fgraph
+
+
+class TestCongruenceMatmul:
+    """Tests for ``M @ S @ M.T`` -> symmetric/PSD when ``S`` is symmetric/PSD."""
+
+    @pytest.mark.parametrize("key", [SYMMETRIC, POSITIVE_DEFINITE])
+    def test_left_associative(self, key):
+        m = pt.matrix("m", shape=(4, 3))
+        s = pt.matrix("s", shape=(3, 3))
+        s_tagged = assume(s, **{key.name: True})
+        y = (m @ s_tagged) @ m.T
+        _, af = make_fgraph(y)
+        assert af.check(y, key)
+
+    @pytest.mark.parametrize("key", [SYMMETRIC, POSITIVE_DEFINITE])
+    def test_right_associative(self, key):
+        m = pt.matrix("m", shape=(4, 3))
+        s = pt.matrix("s", shape=(3, 3))
+        s_tagged = assume(s, **{key.name: True})
+        y = m @ (s_tagged @ m.T)
+        _, af = make_fgraph(y)
+        assert af.check(y, key)
+
+    @pytest.mark.parametrize("key", [SYMMETRIC, POSITIVE_DEFINITE])
+    def test_mirror_mtsm(self, key):
+        """``M.T @ S @ M`` is also a congruence."""
+        m = pt.matrix("m", shape=(3, 4))
+        s = pt.matrix("s", shape=(3, 3))
+        s_tagged = assume(s, **{key.name: True})
+        y = m.T @ s_tagged @ m
+        _, af = make_fgraph(y)
+        assert af.check(y, key)
+
+    @pytest.mark.parametrize("key", [SYMMETRIC, POSITIVE_DEFINITE])
+    def test_inner_not_tagged_is_unknown(self, key):
+        m = pt.matrix("m", shape=(4, 3))
+        s = pt.matrix("s", shape=(3, 3))
+        y = m @ s @ m.T
+        _, af = make_fgraph(y)
+        assert af.get(y, key) == FactState.UNKNOWN
+
+    def test_psd_implies_symmetric_via_congruence(self):
+        m = pt.matrix("m", shape=(4, 3))
+        s = pt.matrix("s", shape=(3, 3))
+        s_psd = assume(s, positive_definite=True)
+        y = m @ s_psd @ m.T
+        _, af = make_fgraph(y)
+        assert af.check(y, POSITIVE_DEFINITE)
+        assert af.check(y, SYMMETRIC)

--- a/tests/assumptions/test_elemwise.py
+++ b/tests/assumptions/test_elemwise.py
@@ -1,0 +1,17 @@
+import numpy as np
+import pytest
+
+import pytensor.tensor as pt
+from pytensor.assumptions import DIAGONAL, LOWER_TRIANGULAR, UPPER_TRIANGULAR, FactState
+from tests.assumptions.conftest import make_fgraph
+
+
+@pytest.mark.parametrize("key", [DIAGONAL, LOWER_TRIANGULAR, UPPER_TRIANGULAR])
+def test_add_broadcast_nonzero_scalar_breaks_zero_pattern(key):
+    diag_like = pt.alloc(np.float64(0), 5, 5)
+    add_with_nonzero = pt.constant(np.array([[1.0]])) + diag_like
+    add_with_zero = pt.constant(np.array([[0.0]])) + diag_like
+
+    _, af = make_fgraph(add_with_nonzero, add_with_zero)
+    assert af.get(add_with_nonzero, key) == FactState.UNKNOWN
+    assert af.check(add_with_zero, key)

--- a/tests/assumptions/test_orthogonal.py
+++ b/tests/assumptions/test_orthogonal.py
@@ -1,0 +1,94 @@
+import pytest
+
+import pytensor.tensor as pt
+from pytensor.assumptions import ORTHOGONAL, FactState
+from pytensor.assumptions.specify import assume
+from tests.assumptions.conftest import make_fgraph
+
+
+def test_block_diag_of_orthogonal_blocks_is_orthogonal():
+    # Mirrors a structural-time-series transition matrix: identity for the level
+    # component, a 2x2 rotation for a cycle component (orthogonal by construction).
+    theta = pt.scalar("theta")
+    cycle = pt.stack(
+        [
+            pt.stack([pt.cos(theta), pt.sin(theta)]),
+            pt.stack([-pt.sin(theta), pt.cos(theta)]),
+        ]
+    )
+    cycle = assume(cycle, orthogonal=True)
+    T = pt.linalg.block_diag(pt.eye(3), cycle)
+    _, af = make_fgraph(T)
+    assert af.check(T, ORTHOGONAL)
+
+
+def test_block_diag_with_one_non_orthogonal_block_is_unknown():
+    x = pt.matrix("x", shape=(3, 3))
+    bd = pt.linalg.block_diag(pt.eye(3), x)
+    _, af = make_fgraph(bd)
+    assert af.get(bd, ORTHOGONAL) == FactState.UNKNOWN
+
+
+def test_qr_full_mode_q_is_orthogonal():
+    x = pt.matrix("x", shape=(3, 3))
+    Q, R = pt.linalg.qr(x, mode="full")
+    _, af = make_fgraph(Q, R)
+    assert af.check(Q, ORTHOGONAL)
+    assert af.get(R, ORTHOGONAL) == FactState.UNKNOWN
+
+
+@pytest.mark.parametrize("mode", ["economic", "reduced"])
+def test_qr_reduced_mode_q_is_not_claimed_orthogonal(mode):
+    # In economic/reduced mode Q has orthonormal columns but is not square,
+    # so orthogonality is not claimed.
+    x = pt.matrix("x", shape=(5, 3))
+    Q, R = pt.linalg.qr(x, mode=mode)
+    _, af = make_fgraph(Q, R)
+    assert af.get(Q, ORTHOGONAL) == FactState.UNKNOWN
+    assert af.get(R, ORTHOGONAL) == FactState.UNKNOWN
+
+
+def test_svd_full_matrices_u_and_v_are_orthogonal():
+    x = pt.matrix("x", shape=(3, 3))
+    U, S, V = pt.linalg.svd(x, full_matrices=True, compute_uv=True)
+    _, af = make_fgraph(U, S, V)
+    assert af.check(U, ORTHOGONAL)
+    assert af.check(V, ORTHOGONAL)
+    assert af.get(S, ORTHOGONAL) == FactState.UNKNOWN
+
+
+def test_svd_reduced_u_and_v_are_not_claimed_orthogonal():
+    # With full_matrices=False, U and V have orthonormal columns/rows but are
+    # not square, so orthogonality is not claimed.
+    x = pt.matrix("x", shape=(5, 3))
+    U, S, V = pt.linalg.svd(x, full_matrices=False, compute_uv=True)
+    _, af = make_fgraph(U, S, V)
+    assert af.get(U, ORTHOGONAL) == FactState.UNKNOWN
+    assert af.get(V, ORTHOGONAL) == FactState.UNKNOWN
+
+
+def test_eigh_eigenvectors_are_orthogonal():
+    x = pt.matrix("x", shape=(3, 3))
+    w, v = pt.linalg.eigh(x)
+    _, af = make_fgraph(w, v)
+    assert af.check(v, ORTHOGONAL)
+    assert af.get(w, ORTHOGONAL) == FactState.UNKNOWN
+
+
+def test_schur_z_is_orthogonal():
+    x = pt.matrix("x", shape=(3, 3))
+    T, Z = pt.linalg.schur(x)
+    _, af = make_fgraph(T, Z)
+    assert af.check(Z, ORTHOGONAL)
+    assert af.get(T, ORTHOGONAL) == FactState.UNKNOWN
+
+
+def test_qz_q_and_z_are_orthogonal():
+    a = pt.matrix("a", shape=(3, 3))
+    b = pt.matrix("b", shape=(3, 3))
+    AA, BB, Q, Z = pt.linalg.qz(a, b)
+    _, af = make_fgraph(AA, BB, Q, Z)
+    assert af.check(Q, ORTHOGONAL)
+    assert af.check(Z, ORTHOGONAL)
+    assert af.get(AA, ORTHOGONAL) == FactState.UNKNOWN
+    assert af.get(BB, ORTHOGONAL) == FactState.UNKNOWN

--- a/tests/assumptions/test_positive_definite.py
+++ b/tests/assumptions/test_positive_definite.py
@@ -1,0 +1,183 @@
+import pytest
+
+import pytensor.tensor as pt
+from pytensor.assumptions import POSITIVE_DEFINITE, SYMMETRIC, FactState
+from pytensor.assumptions.specify import assume
+from tests.assumptions.conftest import make_fgraph
+
+
+def test_inv_propagates_positive_definite():
+    x = pt.matrix("x", shape=(3, 3))
+    x_psd = assume(x, positive_definite=True)
+    inv_x = pt.linalg.inv(x_psd)
+    _, af = make_fgraph(inv_x)
+    assert af.check(inv_x, POSITIVE_DEFINITE)
+
+
+def test_kron_of_eyes_is_positive_definite():
+    k = pt.linalg.kron(pt.eye(3), pt.eye(4))
+    _, af = make_fgraph(k)
+    assert af.check(k, POSITIVE_DEFINITE)
+
+
+def test_dot_xxt_is_psd_and_symmetric():
+    x = pt.matrix("x")
+    gram = pt.dot(x, x.T)
+    _, af = make_fgraph(gram)
+    assert af.check(gram, POSITIVE_DEFINITE)
+    assert af.check(gram, SYMMETRIC)
+
+
+def test_dot_xtx_is_psd_and_symmetric():
+    x = pt.matrix("x")
+    gram = pt.dot(x.T, x)
+    _, af = make_fgraph(gram)
+    assert af.check(gram, POSITIVE_DEFINITE)
+    assert af.check(gram, SYMMETRIC)
+
+
+@pytest.mark.parametrize(
+    "hermitian_transpose",
+    [
+        pytest.param(lambda x: x.conj().T, id="conj_then_T"),
+        pytest.param(lambda x: x.T.conj(), id="T_then_conj"),
+    ],
+)
+def test_dot_xxH_complex_is_psd(hermitian_transpose):
+    x = pt.cmatrix("x")
+    gram = pt.dot(x, hermitian_transpose(x))
+    _, af = make_fgraph(gram)
+    assert af.check(gram, POSITIVE_DEFINITE)
+
+
+class TestKalmanPSDPropagation:
+    """End-to-end PSD propagation through patterns Kalman filters generate.
+
+    Each piece relies on a rule already in the assumptions system; this class
+    pins them down together so the ``cholesky``-friendly chain stays intact.
+    """
+
+    def test_psd_plus_psd(self):
+        x = pt.matrix("x", shape=(4, 4))
+        y = pt.matrix("y", shape=(4, 4))
+        x_psd = assume(x, positive_definite=True)
+        y_psd = assume(y, positive_definite=True)
+        s = x_psd + y_psd
+        _, af = make_fgraph(s)
+        assert af.check(s, POSITIVE_DEFINITE)
+
+    def test_inv_psd(self):
+        x = pt.matrix("x", shape=(4, 4))
+        x_psd = assume(x, positive_definite=True)
+        s = pt.linalg.inv(x_psd)
+        _, af = make_fgraph(s)
+        assert af.check(s, POSITIVE_DEFINITE)
+
+    def test_kalman_predict(self):
+        """``T @ P @ T.T + Q`` is PSD when ``P`` and ``Q`` are PSD."""
+        T = pt.matrix("T", shape=(4, 4))
+        P = pt.matrix("P", shape=(4, 4))
+        Q = pt.matrix("Q", shape=(4, 4))
+        P_psd = assume(P, positive_definite=True)
+        Q_psd = assume(Q, positive_definite=True)
+        P_next = T @ P_psd @ T.T + Q_psd
+        _, af = make_fgraph(P_next)
+        assert af.check(P_next, POSITIVE_DEFINITE)
+
+    def test_joseph_form(self):
+        """``(I - K @ H) @ P @ (I - K @ H).T + K @ R @ K.T`` is PSD when ``P``, ``R`` are PSD.
+
+        Each summand is a congruence on a PSD matrix, then ``+`` of two PSDs.
+        """
+        I = pt.eye(4)
+        K = pt.matrix("K", shape=(4, 2))
+        H = pt.matrix("H", shape=(2, 4))
+        P = pt.matrix("P", shape=(4, 4))
+        R = pt.matrix("R", shape=(2, 2))
+        P_psd = assume(P, positive_definite=True)
+        R_psd = assume(R, positive_definite=True)
+        IKH = I - K @ H
+        P_update = IKH @ P_psd @ IKH.T + K @ R_psd @ K.T
+        _, af = make_fgraph(P_update)
+        assert af.check(P_update, POSITIVE_DEFINITE)
+
+
+def test_discrete_lyapunov_propagates_positive_definite():
+    a = pt.matrix("a", shape=(3, 3))
+    q = pt.matrix("q", shape=(3, 3))
+    q_psd = assume(q, positive_definite=True)
+    x = pt.linalg.solve_discrete_lyapunov(a, q_psd, method="bilinear")
+    _, af = make_fgraph(x)
+    assert af.check(x, POSITIVE_DEFINITE)
+
+
+def test_discrete_lyapunov_untagged_is_unknown_positive_definite():
+    a = pt.matrix("a", shape=(3, 3))
+    q = pt.matrix("q", shape=(3, 3))
+    x = pt.linalg.solve_discrete_lyapunov(a, q, method="bilinear")
+    _, af = make_fgraph(x)
+    assert af.get(x, POSITIVE_DEFINITE) == FactState.UNKNOWN
+
+
+class TestPSDElemwiseAssumptions:
+    @staticmethod
+    def _psd(name, shape=(5, 5)):
+        x = pt.tensor(name, shape=shape)
+        return assume(x, positive_definite=True), x
+
+    def test_add_pd_plus_pd(self):
+        a, _ = self._psd("a")
+        b, _ = self._psd("b")
+        z = a + b
+        _, af = make_fgraph(z)
+        assert af.check(z, POSITIVE_DEFINITE)
+
+    @pytest.mark.parametrize(
+        "scale, expected",
+        [
+            pytest.param(2.5, True, id="positive"),
+            pytest.param(-1.0, False, id="negative"),
+            pytest.param(0.0, False, id="zero"),
+        ],
+    )
+    def test_scalar_times_pd(self, scale, expected):
+        a, _ = self._psd("a")
+        z = scale * a
+        _, af = make_fgraph(z)
+        assert af.check(z, POSITIVE_DEFINITE) is expected
+
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            pytest.param((), id="0d_scalar"),
+            pytest.param((1, 1), id="1x1_matrix"),
+            pytest.param((5, 1), id="col_vector"),
+            pytest.param((5, 5), id="generic_matrix"),
+        ],
+    )
+    def test_add_pd_plus_other_is_unknown(self, shape):
+        a, _ = self._psd("a")
+        y = pt.tensor("y", shape=shape)
+        z = a + y
+        _, af = make_fgraph(z)
+        assert not af.check(z, POSITIVE_DEFINITE)
+
+    def test_batched_pd_plus_pd(self):
+        a, _ = self._psd("a", shape=(4, 5, 5))
+        b, _ = self._psd("b", shape=(4, 5, 5))
+        z = a + b
+        _, af = make_fgraph(z)
+        assert af.check(z, POSITIVE_DEFINITE)
+
+    def test_unrelated_elemwise_is_unknown(self):
+        a, _ = self._psd("a")
+        z = -a
+        _, af = make_fgraph(z)
+        assert not af.check(z, POSITIVE_DEFINITE)
+
+    def test_mul_of_only_positive_scalars_is_not_pd(self):
+        # Mul of a single positive scalar (no matrix factor) should not be claimed PD —
+        # the result is a 0d scalar, not a matrix.
+        z = pt.constant(2.0) * pt.constant(3.0)
+        _, af = make_fgraph(z)
+        assert not af.check(z, POSITIVE_DEFINITE)

--- a/tests/assumptions/test_reshape.py
+++ b/tests/assumptions/test_reshape.py
@@ -1,0 +1,42 @@
+import pytensor.tensor as pt
+from pytensor.assumptions import (
+    LOWER_TRIANGULAR,
+    SYMMETRIC,
+    UPPER_TRIANGULAR,
+    FactState,
+)
+from pytensor.assumptions.specify import assume
+from pytensor.tensor.reshape import join_dims, split_dims
+from tests.assumptions.conftest import make_fgraph
+
+
+def test_join_dims_clear_of_core_forwards_property():
+    x = pt.tensor("x", shape=(2, 3, 4, 4))
+    x_lower = assume(x, lower_triangular=True)
+    y = join_dims(x_lower, start_axis=0, n_axes=2)
+    _, af = make_fgraph(y)
+    assert af.check(y, LOWER_TRIANGULAR)
+
+
+def test_join_dims_reaching_core_axis_is_unknown():
+    x = pt.tensor("x", shape=(2, 3, 4, 4))
+    x_sym = assume(x, symmetric=True)
+    y = join_dims(x_sym, start_axis=1, n_axes=2)
+    _, af = make_fgraph(y)
+    assert af.get(y, SYMMETRIC) == FactState.UNKNOWN
+
+
+def test_split_dims_batch_axis_forwards_property():
+    x = pt.tensor("x", shape=(6, 4, 4))
+    x_upper = assume(x, upper_triangular=True)
+    y = split_dims(x_upper, shape=(2, 3), axis=0)
+    _, af = make_fgraph(y)
+    assert af.check(y, UPPER_TRIANGULAR)
+
+
+def test_split_dims_core_axis_is_unknown():
+    x = pt.tensor("x", shape=(5, 6, 4))
+    x_sym = assume(x, symmetric=True)
+    y = split_dims(x_sym, shape=(2, 3), axis=1)
+    _, af = make_fgraph(y)
+    assert af.get(y, SYMMETRIC) == FactState.UNKNOWN

--- a/tests/assumptions/test_shape.py
+++ b/tests/assumptions/test_shape.py
@@ -1,0 +1,37 @@
+import pytensor.tensor as pt
+from pytensor.assumptions import DIAGONAL, SYMMETRIC, FactState
+from pytensor.assumptions.specify import assume
+from tests.assumptions.conftest import make_fgraph
+
+
+def test_specify_shape_forwards_property():
+    x = pt.matrix("x", shape=(4, 4))
+    x_diag = assume(x, diagonal=True)
+    y = pt.specify_shape(x_diag, (4, 4))
+    _, af = make_fgraph(y)
+    assert af.check(y, DIAGONAL)
+
+
+def test_reshape_rechunk_batch_axes_forwards_property():
+    x = pt.tensor("x", shape=(6, 4, 4))
+    x_sym = assume(x, symmetric=True)
+    y = pt.reshape(x_sym, (2, 3, 4, 4))
+    _, af = make_fgraph(y)
+    assert af.check(y, SYMMETRIC)
+
+
+def test_reshape_changing_trailing_dims_is_unknown():
+    x = pt.matrix("x", shape=(4, 4))
+    x_sym = assume(x, symmetric=True)
+    y = pt.reshape(x_sym, (2, 8))
+    _, af = make_fgraph(y)
+    assert af.get(y, SYMMETRIC) == FactState.UNKNOWN
+
+
+def test_reshape_unknown_trailing_dim_is_unknown():
+    """A statically-unknown trailing dim cannot be confirmed unchanged."""
+    x = pt.tensor("x", shape=(6, 4, None))
+    x_sym = assume(x, symmetric=True)
+    y = pt.reshape(x_sym, (2, 3, 4, x.shape[2]))
+    _, af = make_fgraph(y)
+    assert af.get(y, SYMMETRIC) == FactState.UNKNOWN

--- a/tests/assumptions/test_specify.py
+++ b/tests/assumptions/test_specify.py
@@ -1,0 +1,88 @@
+import pytest
+
+import pytensor.tensor as pt
+from pytensor.assumptions import (
+    DIAGONAL,
+    LOWER_TRIANGULAR,
+    ORTHOGONAL,
+    POSITIVE_DEFINITE,
+    SYMMETRIC,
+    UPPER_TRIANGULAR,
+    ConflictingAssumptionsError,
+    FactState,
+)
+from pytensor.assumptions.specify import SpecifyAssumptions, assume
+from tests.assumptions.conftest import make_fgraph
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        DIAGONAL,
+        LOWER_TRIANGULAR,
+        UPPER_TRIANGULAR,
+        SYMMETRIC,
+        POSITIVE_DEFINITE,
+        ORTHOGONAL,
+    ],
+    ids=lambda k: k.name,
+)
+def test_assume_records_false_assertions(key):
+    x = pt.matrix("x", shape=(3, 3))
+    x_not = assume(x, **{key.name: False})
+    _, af = make_fgraph(x_not)
+    assert af.get(x_not, key) is FactState.FALSE
+
+
+def test_assume_multiple_true_kwargs():
+    x = pt.matrix("x", shape=(3, 3))
+    x_both = assume(x, diagonal=True, positive_definite=True)
+    _, af = make_fgraph(x_both)
+    assert af.check(x_both, DIAGONAL)
+    assert af.check(x_both, POSITIVE_DEFINITE)
+    assert af.check(x_both, SYMMETRIC)
+
+
+def test_assume_mixed_true_and_false_kwargs():
+    x = pt.matrix("x", shape=(3, 3))
+    x_mix = assume(x, diagonal=True, orthogonal=False)
+    _, af = make_fgraph(x_mix)
+    assert af.check(x_mix, DIAGONAL)
+    assert af.get(x_mix, ORTHOGONAL) is FactState.FALSE
+
+
+def test_assume_chained_combines_facts():
+    x = pt.matrix("x", shape=(3, 3))
+    chained = assume(assume(x, diagonal=True), positive_definite=True)
+    _, af = make_fgraph(chained)
+    assert af.check(chained, DIAGONAL)
+    assert af.check(chained, POSITIVE_DEFINITE)
+
+
+def test_specify_assumptions_op_equal_for_same_facts():
+    a = SpecifyAssumptions({"diagonal": FactState.TRUE, "symmetric": FactState.FALSE})
+    b = SpecifyAssumptions({"symmetric": FactState.FALSE, "diagonal": FactState.TRUE})
+    assert a == b
+    assert hash(a) == hash(b)
+
+
+def test_assume_none_kwarg_passes_through():
+    x = pt.matrix("x", shape=(3, 3))
+    x_diag = assume(x, diagonal=True, symmetric=None)
+    _, af = make_fgraph(x_diag)
+    assert af.check(x_diag, DIAGONAL)
+    # SYMMETRIC is recovered via the DIAGONAL -> SYMMETRIC implication, not asserted directly.
+    assert af.check(x_diag, SYMMETRIC)
+
+
+def test_assume_no_kwargs_returns_input_unchanged():
+    x = pt.matrix("x")
+    assert assume(x) is x
+
+
+def test_assume_conflict_with_inferred_fact_raises():
+    e = pt.eye(5)
+    e_not_diag = assume(e, diagonal=False)
+    _, af = make_fgraph(e_not_diag)
+    with pytest.raises(ConflictingAssumptionsError):
+        af.get(e_not_diag, DIAGONAL)

--- a/tests/assumptions/test_subtensor.py
+++ b/tests/assumptions/test_subtensor.py
@@ -1,0 +1,61 @@
+import pytest
+
+import pytensor.tensor as pt
+from pytensor.assumptions import (
+    ALL_KEYS,
+    POSITIVE_DEFINITE,
+    SYMMETRIC,
+    FactState,
+)
+from pytensor.assumptions.specify import assume
+from tests.assumptions.conftest import make_fgraph
+
+
+class TestSubtensorMatrixPropertyPropagation:
+    """A ``Subtensor`` that leaves the trailing two axes alone preserves matrix properties."""
+
+    @pytest.mark.parametrize("key", ALL_KEYS)
+    def test_scalar_index_strips_leading_axis(self, key):
+        x = pt.tensor3("x", shape=(5, 4, 4))
+        x_tagged = assume(x, **{key.name: True})
+        y = x_tagged[2]
+        _, af = make_fgraph(y, inputs=[x])
+        assert af.check(y, key)
+
+    @pytest.mark.parametrize("key", ALL_KEYS)
+    def test_explicit_full_slices(self, key):
+        x = pt.tensor3("x", shape=(5, 4, 4))
+        x_tagged = assume(x, **{key.name: True})
+        y = x_tagged[2, :, :]
+        _, af = make_fgraph(y, inputs=[x])
+        assert af.check(y, key)
+
+    @pytest.mark.parametrize("key", ALL_KEYS)
+    def test_partial_slice_on_batch_axis(self, key):
+        x = pt.tensor3("x", shape=(5, 4, 4))
+        x_tagged = assume(x, **{key.name: True})
+        y = x_tagged[1:3]
+        _, af = make_fgraph(y, inputs=[x])
+        assert af.check(y, key)
+
+    def test_indexing_a_matrix_axis_breaks_property(self):
+        x = pt.tensor3("x", shape=(5, 4, 4))
+        x_sym = assume(x, symmetric=True)
+        y = x_sym[2, :, 0]
+        _, af = make_fgraph(y, inputs=[x])
+        assert af.get(y, SYMMETRIC) == FactState.UNKNOWN
+
+    def test_subtensor_after_expand_dims(self):
+        """The user-reported pattern: ``Subtensor[i, :, :](ExpandDims[0](X))``.
+
+        After expand_dims promotes the matrix to ``(1, n, n)``, indexing the
+        leading axis recovers the original matrix; the property must survive
+        the round trip.
+        """
+        x = pt.matrix("x", shape=(4, 4))
+        x_psd = assume(x, positive_definite=True)
+        x_3d = x_psd[None, :, :]
+        y = x_3d[0]
+        _, af = make_fgraph(y, inputs=[x])
+        assert af.check(y, POSITIVE_DEFINITE)
+        assert af.check(y, SYMMETRIC)

--- a/tests/assumptions/test_subtensor.py
+++ b/tests/assumptions/test_subtensor.py
@@ -3,6 +3,9 @@ import pytest
 import pytensor.tensor as pt
 from pytensor.assumptions import (
     ALL_KEYS,
+    DIAGONAL,
+    LOWER_TRIANGULAR,
+    ORTHOGONAL,
     POSITIVE_DEFINITE,
     SYMMETRIC,
     FactState,
@@ -19,7 +22,7 @@ class TestSubtensorMatrixPropertyPropagation:
         x = pt.tensor3("x", shape=(5, 4, 4))
         x_tagged = assume(x, **{key.name: True})
         y = x_tagged[2]
-        _, af = make_fgraph(y, inputs=[x])
+        _, af = make_fgraph(y)
         assert af.check(y, key)
 
     @pytest.mark.parametrize("key", ALL_KEYS)
@@ -27,7 +30,7 @@ class TestSubtensorMatrixPropertyPropagation:
         x = pt.tensor3("x", shape=(5, 4, 4))
         x_tagged = assume(x, **{key.name: True})
         y = x_tagged[2, :, :]
-        _, af = make_fgraph(y, inputs=[x])
+        _, af = make_fgraph(y)
         assert af.check(y, key)
 
     @pytest.mark.parametrize("key", ALL_KEYS)
@@ -35,14 +38,14 @@ class TestSubtensorMatrixPropertyPropagation:
         x = pt.tensor3("x", shape=(5, 4, 4))
         x_tagged = assume(x, **{key.name: True})
         y = x_tagged[1:3]
-        _, af = make_fgraph(y, inputs=[x])
+        _, af = make_fgraph(y)
         assert af.check(y, key)
 
     def test_indexing_a_matrix_axis_breaks_property(self):
         x = pt.tensor3("x", shape=(5, 4, 4))
         x_sym = assume(x, symmetric=True)
         y = x_sym[2, :, 0]
-        _, af = make_fgraph(y, inputs=[x])
+        _, af = make_fgraph(y)
         assert af.get(y, SYMMETRIC) == FactState.UNKNOWN
 
     def test_subtensor_after_expand_dims(self):
@@ -56,6 +59,74 @@ class TestSubtensorMatrixPropertyPropagation:
         x_psd = assume(x, positive_definite=True)
         x_3d = x_psd[None, :, :]
         y = x_3d[0]
-        _, af = make_fgraph(y, inputs=[x])
+        _, af = make_fgraph(y)
         assert af.check(y, POSITIVE_DEFINITE)
         assert af.check(y, SYMMETRIC)
+
+
+def test_incsubtensor_full_slice_set_forwards_value():
+    base = pt.tensor3("base", shape=(5, 4, 4))
+    value = pt.tensor3("value", shape=(5, 4, 4))
+    value_diag = assume(value, diagonal=True)
+    y = pt.set_subtensor(base[:], value_diag)
+    _, af = make_fgraph(y)
+    assert af.check(y, DIAGONAL)
+
+
+def test_incsubtensor_partial_batch_set_with_both_tagged_forwards():
+    base = pt.tensor3("base", shape=(5, 4, 4))
+    value = pt.tensor3("value", shape=(2, 4, 4))
+    base_sym = assume(base, symmetric=True)
+    value_sym = assume(value, symmetric=True)
+    y = pt.set_subtensor(base_sym[1:3], value_sym)
+    _, af = make_fgraph(y)
+    assert af.check(y, SYMMETRIC)
+
+
+def test_incsubtensor_partial_batch_set_with_untagged_base_is_unknown():
+    base = pt.tensor3("base", shape=(5, 4, 4))
+    value = pt.tensor3("value", shape=(2, 4, 4))
+    value_orth = assume(value, orthogonal=True)
+    y = pt.set_subtensor(base[1:3], value_orth)
+    _, af = make_fgraph(y)
+    assert af.get(y, ORTHOGONAL) == FactState.UNKNOWN
+
+
+def test_incsubtensor_partial_batch_inc_with_both_tagged_forwards():
+    base = pt.tensor3("base", shape=(5, 4, 4))
+    value = pt.tensor3("value", shape=(2, 4, 4))
+    base_pd = assume(base, positive_definite=True)
+    value_pd = assume(value, positive_definite=True)
+    y = pt.inc_subtensor(base_pd[1:3], value_pd)
+    _, af = make_fgraph(y)
+    assert af.check(y, POSITIVE_DEFINITE)
+
+
+def test_incsubtensor_partial_batch_inc_with_untagged_base_is_unknown():
+    base = pt.tensor3("base", shape=(5, 4, 4))
+    value = pt.tensor3("value", shape=(2, 4, 4))
+    value_lower = assume(value, lower_triangular=True)
+    y = pt.inc_subtensor(base[1:3], value_lower)
+    _, af = make_fgraph(y)
+    assert af.get(y, LOWER_TRIANGULAR) == FactState.UNKNOWN
+
+
+def test_incsubtensor_batch_inc_orthogonal_is_unknown():
+    """Orthogonality is not closed under addition, so ``inc`` never forwards it"""
+    base = pt.tensor3("base", shape=(5, 4, 4))
+    value = pt.tensor3("value", shape=(2, 4, 4))
+    base_orth = assume(base, orthogonal=True)
+    value_orth = assume(value, orthogonal=True)
+    y = pt.inc_subtensor(base_orth[1:3], value_orth)
+    _, af = make_fgraph(y)
+    assert af.get(y, ORTHOGONAL) == FactState.UNKNOWN
+
+
+def test_incsubtensor_index_reaching_core_axis_is_unknown():
+    base = pt.tensor3("base", shape=(5, 4, 4))
+    value = pt.tensor3("value", shape=(2, 4, 2))
+    base_sym = assume(base, symmetric=True)
+    value_sym = assume(value, symmetric=True)
+    y = pt.set_subtensor(base_sym[1:3, :, 0:2], value_sym)
+    _, af = make_fgraph(y)
+    assert af.get(y, SYMMETRIC) == FactState.UNKNOWN

--- a/tests/assumptions/test_symmetric.py
+++ b/tests/assumptions/test_symmetric.py
@@ -1,0 +1,114 @@
+import pytest
+
+import pytensor.tensor as pt
+from pytensor.assumptions import SYMMETRIC, FactState
+from pytensor.assumptions.specify import assume
+from tests.assumptions.conftest import make_fgraph
+
+
+def test_inv_propagates_symmetric():
+    x = pt.matrix("x", shape=(3, 3))
+    x_sym = assume(x, symmetric=True)
+    inv_x = pt.linalg.inv(x_sym)
+    _, af = make_fgraph(inv_x)
+    assert af.check(inv_x, SYMMETRIC)
+
+
+def test_pinv_propagates_symmetric():
+    x = pt.matrix("x", shape=(3, 3))
+    x_sym = assume(x, symmetric=True)
+    px = pt.linalg.pinv(x_sym)
+    _, af = make_fgraph(px)
+    assert af.check(px, SYMMETRIC)
+
+
+def test_kron_of_eyes_is_symmetric():
+    k = pt.linalg.kron(pt.eye(3), pt.eye(4))
+    _, af = make_fgraph(k)
+    assert af.check(k, SYMMETRIC)
+
+
+def test_discrete_lyapunov_propagates_symmetric():
+    a = pt.matrix("a", shape=(3, 3))
+    q = pt.matrix("q", shape=(3, 3))
+    q_sym = assume(q, symmetric=True)
+    x = pt.linalg.solve_discrete_lyapunov(a, q_sym, method="bilinear")
+    _, af = make_fgraph(x)
+    assert af.check(x, SYMMETRIC)
+
+
+def test_discrete_lyapunov_untagged_is_unknown_symmetric():
+    a = pt.matrix("a", shape=(3, 3))
+    q = pt.matrix("q", shape=(3, 3))
+    x = pt.linalg.solve_discrete_lyapunov(a, q, method="bilinear")
+    _, af = make_fgraph(x)
+    assert af.get(x, SYMMETRIC) == FactState.UNKNOWN
+
+
+class TestSymmetricElemwiseAssumptions:
+    @staticmethod
+    def _sym(name, shape=(5, 5)):
+        x = pt.tensor(name, shape=shape)
+        return assume(x, symmetric=True), x
+
+    @pytest.mark.parametrize(
+        "binop",
+        [
+            pytest.param(lambda a, b: a + b, id="add"),
+            pytest.param(lambda a, b: a - b, id="sub"),
+            pytest.param(lambda a, b: a * b, id="mul"),
+            pytest.param(lambda a, b: a / b, id="truediv"),
+            pytest.param(lambda a, b: a**b, id="pow"),
+        ],
+    )
+    def test_binop_of_symmetric_is_symmetric(self, binop):
+        a, _ = self._sym("a")
+        b, _ = self._sym("b")
+        z = binop(a, b)
+        _, af = make_fgraph(z)
+        assert af.check(z, SYMMETRIC)
+
+    @pytest.mark.parametrize(
+        "unop",
+        [
+            pytest.param(lambda a: -a, id="neg"),
+            pytest.param(lambda a: pt.exp(a), id="exp"),
+            pytest.param(abs, id="abs"),
+        ],
+    )
+    def test_unop_of_symmetric_is_symmetric(self, unop):
+        a, _ = self._sym("a")
+        z = unop(a)
+        _, af = make_fgraph(z)
+        assert af.check(z, SYMMETRIC)
+
+    @pytest.mark.parametrize(
+        "shape, expected",
+        [
+            pytest.param((), True, id="0d_scalar"),
+            pytest.param((1, 1), True, id="1x1_matrix"),
+            pytest.param((5,), False, id="1d_vector"),
+            pytest.param((5, 1), False, id="col_vector"),
+            pytest.param((1, 5), False, id="row_vector"),
+            pytest.param((5, 5), False, id="generic_matrix"),
+        ],
+    )
+    def test_add_symmetric_plus_other(self, shape, expected):
+        a, _ = self._sym("a")
+        y = pt.tensor("y", shape=shape)
+        z = a + y
+        _, af = make_fgraph(z)
+        assert af.check(z, SYMMETRIC) is expected
+
+    def test_batched_symmetric_add(self):
+        a, _ = self._sym("a", shape=(4, 5, 5))
+        b, _ = self._sym("b", shape=(4, 5, 5))
+        z = a + b
+        _, af = make_fgraph(z)
+        assert af.check(z, SYMMETRIC)
+
+    def test_scalar_only_elemwise_is_unknown(self):
+        s = pt.scalar("s")
+        z = s + s
+        _, af = make_fgraph(z)
+        assert not af.check(z, SYMMETRIC)

--- a/tests/assumptions/test_triangular.py
+++ b/tests/assumptions/test_triangular.py
@@ -1,0 +1,168 @@
+import pytest
+
+import pytensor.tensor as pt
+from pytensor.assumptions import (
+    DIAGONAL,
+    LOWER_TRIANGULAR,
+    UPPER_TRIANGULAR,
+    FactState,
+)
+from pytensor.assumptions.specify import assume
+from pytensor.tensor.basic import alloc_diag
+from tests.assumptions.conftest import make_fgraph
+
+
+@pytest.mark.parametrize(
+    "offset, lower, upper, diagonal",
+    [
+        (0, FactState.TRUE, FactState.TRUE, FactState.TRUE),
+        (1, FactState.FALSE, FactState.TRUE, FactState.FALSE),
+        (-1, FactState.TRUE, FactState.FALSE, FactState.FALSE),
+        (2, FactState.FALSE, FactState.TRUE, FactState.FALSE),
+        (-2, FactState.TRUE, FactState.FALSE, FactState.FALSE),
+    ],
+)
+def test_alloc_diag_offset_triangular(offset, lower, upper, diagonal):
+    v = pt.vector("v", shape=(5,))
+    d = alloc_diag(v, offset=offset, axis1=0, axis2=1)
+    _, af = make_fgraph(d)
+    assert af.get(d, LOWER_TRIANGULAR) == lower
+    assert af.get(d, UPPER_TRIANGULAR) == upper
+    assert af.get(d, DIAGONAL) == diagonal
+
+
+@pytest.mark.parametrize(
+    "lower, expected_true, expected_false",
+    [
+        (True, LOWER_TRIANGULAR, UPPER_TRIANGULAR),
+        (False, UPPER_TRIANGULAR, LOWER_TRIANGULAR),
+    ],
+)
+def test_cholesky_triangularity(lower, expected_true, expected_false):
+    x = pt.matrix("x", shape=(3, 3))
+    L = pt.linalg.cholesky(x, lower=lower)
+    _, af = make_fgraph(L)
+    assert af.check(L, expected_true)
+    assert not af.check(L, expected_false)
+
+
+def test_inv_propagates_lower_triangular():
+    x = pt.matrix("x", shape=(3, 3))
+    x_lower = assume(x, lower_triangular=True)
+    inv_x = pt.linalg.inv(x_lower)
+    _, af = make_fgraph(inv_x)
+    assert af.check(inv_x, LOWER_TRIANGULAR)
+
+
+@pytest.mark.parametrize("key", [LOWER_TRIANGULAR, UPPER_TRIANGULAR])
+def test_kron_of_eyes_is_triangular(key):
+    k = pt.linalg.kron(pt.eye(3), pt.eye(4))
+    _, af = make_fgraph(k)
+    assert af.check(k, key)
+
+
+@pytest.mark.parametrize(
+    "eye_args, lower, upper",
+    [
+        pytest.param((5, 5, 0), FactState.TRUE, FactState.TRUE, id="identity"),
+        pytest.param((5, 5, -1), FactState.TRUE, FactState.FALSE, id="subdiagonal"),
+        pytest.param((5, 5, 2), FactState.FALSE, FactState.TRUE, id="superdiagonal"),
+        pytest.param((5, 3, 0), FactState.TRUE, FactState.TRUE, id="nonsquare"),
+    ],
+)
+def test_eye_triangularity_follows_offset(eye_args, lower, upper):
+    """Eye is lower-triangular iff its diagonal sits on or below the main one,
+    upper-triangular iff on or above -- regardless of whether it is square."""
+    e = pt.eye(*eye_args)
+    _, af = make_fgraph(e)
+    assert af.get(e, LOWER_TRIANGULAR) == lower
+    assert af.get(e, UPPER_TRIANGULAR) == upper
+
+
+def test_eye_symbolic_offset_is_unknown():
+    k = pt.iscalar("k")
+    e = pt.eye(5, 5, k)
+    _, af = make_fgraph(e)
+    assert af.get(e, LOWER_TRIANGULAR) == FactState.UNKNOWN
+    assert af.get(e, UPPER_TRIANGULAR) == FactState.UNKNOWN
+
+
+class TestTriangularElemwiseAssumptions:
+    @pytest.mark.parametrize("key", [LOWER_TRIANGULAR, UPPER_TRIANGULAR])
+    @pytest.mark.parametrize(
+        "build, expected",
+        [
+            pytest.param(lambda a, b: a + b, True, id="add"),
+            pytest.param(lambda a, b: a - b, True, id="sub"),
+            pytest.param(lambda a, b: a * b, True, id="mul"),
+            pytest.param(lambda a, b: 2.0 * a, True, id="scalar_mul"),
+            pytest.param(lambda a, b: -a, True, id="neg"),
+            pytest.param(lambda a, b: a**3, True, id="pow_const"),
+            pytest.param(lambda a, b: pt.exp(a), False, id="non_zero_preserving_unary"),
+        ],
+    )
+    def test_elemwise_propagation(self, key, build, expected):
+        kwarg = {key.name: True}
+        x = pt.matrix("x", shape=(5, 5))
+        y = pt.matrix("y", shape=(5, 5))
+        a = assume(x, **kwarg)
+        b = assume(y, **kwarg)
+        z = build(a, b)
+        _, af = make_fgraph(z)
+        assert af.check(z, key) is expected
+
+
+@pytest.mark.parametrize("mode", ["full", "economic"])
+def test_qr_r_is_upper_triangular(mode):
+    x = pt.matrix("x", shape=(3, 3))
+    Q, R = pt.linalg.qr(x, mode=mode)
+    _, af = make_fgraph(Q, R)
+    assert af.check(R, UPPER_TRIANGULAR)
+    assert af.get(R, LOWER_TRIANGULAR) == FactState.UNKNOWN
+    assert af.get(Q, UPPER_TRIANGULAR) == FactState.UNKNOWN
+
+
+@pytest.mark.parametrize(
+    "output, expected",
+    [("complex", True), ("real", False)],
+)
+def test_schur_t_is_upper_triangular_only_for_complex(output, expected):
+    # Complex Schur form is upper-triangular; real Schur form is only
+    # quasi-upper-triangular (2x2 blocks), so it is not claimed.
+    x = pt.matrix("x", shape=(3, 3))
+    T, Z = pt.linalg.schur(x, output=output)
+    _, af = make_fgraph(T, Z)
+    assert af.check(T, UPPER_TRIANGULAR) is expected
+    assert af.get(Z, UPPER_TRIANGULAR) == FactState.UNKNOWN
+
+
+def test_qz_aa_and_bb_are_upper_triangular():
+    a = pt.matrix("a", shape=(3, 3))
+    b = pt.matrix("b", shape=(3, 3))
+    AA, BB, Q, Z = pt.linalg.qz(a, b)
+    _, af = make_fgraph(AA, BB, Q, Z)
+    assert af.check(AA, UPPER_TRIANGULAR)
+    assert af.check(BB, UPPER_TRIANGULAR)
+    assert af.get(Q, UPPER_TRIANGULAR) == FactState.UNKNOWN
+    assert af.get(Z, UPPER_TRIANGULAR) == FactState.UNKNOWN
+
+
+def test_lu_l_is_lower_and_u_is_upper_triangular():
+    x = pt.matrix("x", shape=(3, 3))
+    P, L, U = pt.linalg.lu(x)
+    _, af = make_fgraph(P, L, U)
+    assert af.check(L, LOWER_TRIANGULAR)
+    assert af.check(U, UPPER_TRIANGULAR)
+    assert af.get(L, UPPER_TRIANGULAR) == FactState.UNKNOWN
+    assert af.get(U, LOWER_TRIANGULAR) == FactState.UNKNOWN
+    assert af.get(P, LOWER_TRIANGULAR) == FactState.UNKNOWN
+
+
+def test_lu_permute_l_pl_is_not_lower_triangular():
+    # With permute_l=True the outputs are (PL, U); PL is the product of a
+    # permutation and a unit-lower-triangular matrix, so it is not claimed.
+    x = pt.matrix("x", shape=(3, 3))
+    PL, U = pt.linalg.lu(x, permute_l=True)
+    _, af = make_fgraph(PL, U)
+    assert af.get(PL, LOWER_TRIANGULAR) == FactState.UNKNOWN
+    assert af.check(U, UPPER_TRIANGULAR)

--- a/tests/link/c/test_basic.py
+++ b/tests/link/c/test_basic.py
@@ -255,8 +255,11 @@ def test_clinker_literal_cache():
     )
 
     orientationi = np.array([59.36276866, 1.06116353, 0.93797339], dtype=config.floatX)
+    shared_literal = np.array(
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]], dtype=config.floatX
+    )
 
-    for out1 in [A - input1[0] * np.identity(3), input1[0] * np.identity(3)]:
+    for out1 in [A - input1[0] * shared_literal, input1[0] * shared_literal]:
         benchmark = function(
             inputs=[A, input1], outputs=[out1], on_unused_input="ignore", mode=mode
         )

--- a/tests/tensor/rewriting/linalg/test_decomposition.py
+++ b/tests/tensor/rewriting/linalg/test_decomposition.py
@@ -17,6 +17,7 @@ from pytensor.tensor.basic import alloc_diag
 from pytensor.tensor.blockwise import Blockwise, BlockwiseWithCoreShape
 from pytensor.tensor.elemwise import DimShuffle
 from pytensor.tensor.linalg.decomposition.cholesky import Cholesky, cholesky
+from pytensor.tensor.linalg.decomposition.eigen import eigh
 from pytensor.tensor.linalg.decomposition.lu import lu, lu_factor
 from pytensor.tensor.linalg.decomposition.qr import qr
 from pytensor.tensor.linalg.decomposition.schur import QZ, Schur, qz, schur
@@ -631,3 +632,17 @@ def test_qz_of_diag_sort(sort, return_eigenvalues):
 
     np.testing.assert_allclose(Q_val @ AA_val @ Z_val.T, np.diag(a_val), atol=1e-12)
     np.testing.assert_allclose(Q_val @ BB_val @ Z_val.T, np.diag(b_val), atol=1e-12)
+
+
+def test_eig_to_eigh():
+    x = pt.dmatrix("x", shape=(5, 5))
+    x_sym = assume(x, symmetric=True)
+    w, v = pt.linalg.eig(x_sym)
+
+    rewrites = ("canonicalize", "ShapeOpt")
+    w_r, v_r = rewrite_graph([w, v], include=rewrites)
+
+    w_expected, v_expected = eigh(x_sym)
+    w_expected = w_expected.astype("complex128")
+    v_expected = v_expected.astype("complex128")
+    assert_equal_computations([w_r, v_r], [w_expected, v_expected])

--- a/tests/tensor/rewriting/linalg/test_decomposition.py
+++ b/tests/tensor/rewriting/linalg/test_decomposition.py
@@ -9,14 +9,21 @@ import pytensor
 from pytensor import tensor as pt
 from pytensor.assumptions.specify import assume
 from pytensor.compile import get_default_mode
+from pytensor.compile.mode import get_mode
 from pytensor.configdefaults import config
+from pytensor.graph.rewriting.utils import rewrite_graph
 from pytensor.tensor import swapaxes
+from pytensor.tensor.basic import alloc_diag
 from pytensor.tensor.blockwise import Blockwise, BlockwiseWithCoreShape
 from pytensor.tensor.elemwise import DimShuffle
 from pytensor.tensor.linalg.decomposition.cholesky import Cholesky, cholesky
+from pytensor.tensor.linalg.decomposition.lu import lu, lu_factor
+from pytensor.tensor.linalg.decomposition.qr import qr
+from pytensor.tensor.linalg.decomposition.schur import QZ, Schur, qz, schur
 from pytensor.tensor.linalg.decomposition.svd import SVD, svd
 from pytensor.tensor.math import dot, matmul
 from pytensor.tensor.type import tensor
+from tests.unittest_tools import assert_equal_computations
 
 
 @pytest.mark.parametrize("tag", ("lower", "upper", None))
@@ -264,3 +271,363 @@ def test_cholesky_of_diag_not_applied():
     f_rewritten = pytensor.function([x], z_cholesky, mode="FAST_RUN")
     nodes = f_rewritten.maker.fgraph.apply_nodes
     assert any(isinstance(node.op, Cholesky) for node in nodes)
+
+
+@pytest.mark.parametrize(
+    "make_diag",
+    [
+        pytest.param(lambda d: pt.diag(d), id="alloc_diag"),
+        pytest.param(lambda d: pt.eye(5) * d, id="eye_mul"),
+    ],
+)
+def test_eigh_of_diag(make_diag):
+    d = pt.dvector("d", shape=(5,))
+    D = make_diag(d)
+    w, v = pt.linalg.eigh(D)
+
+    # Needs ShapeOpt to rewrite away shape graph used to build Eye for v rewrite;
+    # specialize fires the extract_diag short-circuits the lift depends on.
+    passes = ("canonicalize", "stabilize", "specialize", "ShapeOpt")
+    rewritten = rewrite_graph([w, v], include=passes)
+
+    idx = pt.argsort(d)
+    expected_w = d[idx]
+    expected_v = pt.as_tensor(np.eye(5))[:, idx]
+    expected = rewrite_graph([expected_w, expected_v], include=passes)
+
+    assert_equal_computations(rewritten, expected)
+
+
+def test_eigh_generalized_of_diag_correctness():
+    # Numerical correctness of the generalized eigh-of-diag rewrite: V^T B V = I and
+    # A V = B V diag(w).
+    a_vals = np.array([4.0, 1.0, 9.0, 2.0, 5.0])
+    b_vals = np.array([1.0, 2.0, 4.0, 1.0, 0.5])
+    a = pt.dvector("a", shape=(5,))
+    b = pt.dvector("b", shape=(5,))
+    A = pt.diag(a)
+    B = pt.diag(b)
+    w, v = pt.linalg.eigh(A, B)
+    fn = pytensor.function([a, b], [w, v])
+    w_val, v_val = fn(a_vals, b_vals)
+    expected_eigvals = np.sort(a_vals / b_vals)
+    np.testing.assert_allclose(w_val, expected_eigvals)
+    A_np = np.diag(a_vals)
+    B_np = np.diag(b_vals)
+    np.testing.assert_allclose(v_val.T @ B_np @ v_val, np.eye(5), atol=1e-10)
+    np.testing.assert_allclose(A_np @ v_val, B_np @ v_val * w_val, atol=1e-10)
+
+
+@pytest.mark.parametrize(
+    "make_diag, include_b",
+    [
+        (lambda d: pt.diag(d), True),
+        (lambda d: pt.eye(5) * d, False),
+    ],
+    ids=["alloc_diag_with_b", "eye_mul_no_b"],
+)
+def test_eigvalsh_of_diag(make_diag, include_b):
+    d = pt.dvector("d", shape=(5,))
+    D = make_diag(d)
+
+    if include_b:
+        b = pt.dvector("b", shape=(5,))
+        B = make_diag(b)
+    else:
+        B = None
+
+    w = pt.linalg.eigvalsh(D, B)
+
+    expected = pt.sort(d) if not include_b else pt.sort(d / b)
+    rewritten = rewrite_graph(w, include=("canonicalize", "stabilize", "specialize"))
+
+    assert_equal_computations([rewritten], [expected])
+
+
+@pytest.mark.parametrize(
+    "make_diag, compute_uv",
+    [(lambda d: pt.diag(d), True), (lambda d: pt.eye(5) * d, False)],
+    ids=["alloc_diag_with_uv", "eye_mul_no_uv"],
+)
+def test_svd_of_diag(make_diag, compute_uv):
+    d = pt.dvector("d", shape=(5,))
+    D = make_diag(d)
+    out = svd(D, compute_uv=compute_uv)
+    if not compute_uv:
+        out = [out]
+
+    passes = ("canonicalize", "stabilize", "specialize", "ShapeOpt")
+    rewritten = rewrite_graph(out, include=passes)
+
+    abs_d = pt.abs(d)
+    idx = pt.argsort(-abs_d)
+
+    if compute_uv:
+        expected_s = abs_d[idx]
+        expected_u = pt.as_tensor(np.eye(5))[:, idx]
+        sorted_signs = pt.sign(d[idx])
+        expected_vh = alloc_diag(sorted_signs, axis1=-1, axis2=-2)[:, idx]
+        expected = rewrite_graph([expected_u, expected_s, expected_vh], include=passes)
+    else:
+        expected = rewrite_graph([abs_d[idx]], include=passes)
+
+    assert_equal_computations(rewritten, expected)
+
+
+@pytest.mark.parametrize(
+    "make_diag, permute_l, p_indices",
+    [
+        pytest.param(lambda d: pt.diag(d), False, False, id="alloc_diag_default"),
+        pytest.param(lambda d: pt.diag(d), True, False, id="alloc_diag_permute_l"),
+    ],
+)
+def test_lu_of_diag(make_diag, permute_l, p_indices):
+    n = 5
+    d = pt.dvector("d", shape=(n,))
+    D = make_diag(d)
+    diag_idx = np.diag_indices(n)
+    n_64 = np.array(n, dtype="int64")
+    simplified_D = pt.zeros((n_64, n_64))[diag_idx].set(d)
+
+    out = lu(D, permute_l=permute_l, p_indices=p_indices)
+    rewritten = rewrite_graph(
+        out, include=("canonicalize", "stabilize", "specialize", "ShapeOpt")
+    )
+    if permute_l:
+        expected_PL = pt.as_tensor(np.eye(n, dtype="float64"))
+        expected = [expected_PL, simplified_D]
+
+    elif p_indices:
+        expected_p = pt.as_tensor(np.arange(n, dtype="int32"))
+        expected_L = pt.as_tensor(np.eye(n, dtype="float64"))
+        expected = [expected_p, expected_L, simplified_D]
+
+    else:
+        expected_P = pt.as_tensor(np.eye(n, dtype="float64"))
+        expected_L = pt.as_tensor(np.eye(n, dtype="float64"))
+        expected = [expected_P, expected_L, simplified_D]
+
+    assert_equal_computations(rewritten, expected)
+
+
+def test_lu_factor_of_diag():
+    n = 5
+    d = pt.dvector("d", shape=(n,))
+    D = pt.diag(d)
+    diag_idx = np.diag_indices(n)
+    n_64 = np.array(n, dtype="int64")
+    simplified_D = pt.zeros((n_64, n_64))[diag_idx].set(d)
+
+    lu_out, piv_out = lu_factor(D)
+    rewritten = rewrite_graph(
+        [lu_out, piv_out],
+        include=("canonicalize", "stabilize", "specialize", "ShapeOpt"),
+    )
+
+    expected_pivots = pt.as_tensor(np.arange(n, dtype="int32"))
+    expected = [simplified_D, expected_pivots]
+
+    assert_equal_computations(rewritten, expected)
+
+
+@pytest.mark.parametrize(
+    "make_diag, mode, pivoting",
+    [
+        pytest.param(lambda d: pt.diag(d), "full", False, id="alloc_diag_full"),
+        pytest.param(lambda d: pt.eye(5) * d, "r", False, id="eye_mul_r"),
+        pytest.param(
+            lambda d: pt.diag(d), "economic", True, id="alloc_diag_economic_pivot"
+        ),
+        pytest.param(lambda d: pt.diag(d), "raw", False, id="alloc_diag_raw"),
+    ],
+)
+def test_qr_of_diag(make_diag, mode, pivoting):
+    n = 5
+    d = pt.dvector("d", shape=(n,))
+    D = make_diag(d)
+    diag_idx = np.diag_indices(n)
+    n_64 = np.array(n, dtype="int64")
+
+    out = qr(D, mode=mode, pivoting=pivoting)
+    if not isinstance(out, list | tuple):
+        out = [out]
+    passes = ("canonicalize", "stabilize", "specialize", "ShapeOpt")
+    rewritten = rewrite_graph(out, include=passes)
+
+    def diag_of(vals):
+        return pt.zeros((n_64, n_64))[diag_idx].set(vals)
+
+    expected_R = diag_of(pt.abs(d))
+
+    if mode == "raw":
+        simplified_D = diag_of(d)
+        expected_tau = pt.alloc(np.float64(0.0), n_64)
+        expected = [simplified_D, expected_tau, simplified_D]
+    elif mode == "r":
+        expected = [expected_R]
+    else:
+        expected_Q = diag_of(pt.sign(d))
+        expected = [expected_Q, expected_R]
+
+    if pivoting:
+        expected.append(pt.as_tensor(np.arange(n, dtype="int32")))
+
+    assert_equal_computations(rewritten, expected)
+
+
+@pytest.mark.parametrize(
+    "make_diag",
+    [
+        pytest.param(lambda d: pt.diag(d), id="alloc_diag"),
+    ],
+)
+def test_schur_of_diag(make_diag):
+    n = 5
+    d = pt.dvector("d", shape=(n,))
+    D = make_diag(d)
+    diag_idx = np.diag_indices(n)
+    n_64 = np.array(n, dtype="int64")
+
+    T, Z = schur(D)
+    passes = ("canonicalize", "stabilize", "specialize", "ShapeOpt")
+    rewritten = rewrite_graph([T, Z], include=passes)
+
+    simplified_D = pt.zeros((n_64, n_64))[diag_idx].set(d)
+    expected = [simplified_D, pt.as_tensor(np.eye(n, dtype="float64"))]
+    assert_equal_computations(rewritten, expected)
+
+
+@pytest.mark.parametrize("sort", ["lhp", "rhp", "iuc", "ouc"])
+def test_schur_of_diag_sort(sort):
+    n = 5
+    rng = np.random.default_rng(sum(map(ord, "schur_of_diag_sort")))
+    d_var = pt.dvector("d", shape=(n,))
+    D = pt.diag(d_var)
+    T, Z = schur(D, sort=sort)
+
+    mode = get_mode("FAST_RUN")
+    f = pytensor.function([d_var], [T, Z], mode=mode)
+    f_no_rewrite = pytensor.function(
+        [d_var], [T, Z], mode=mode.excluding("schur_of_diag")
+    )
+
+    assert not any(
+        isinstance(node.op, Blockwise | BlockwiseWithCoreShape)
+        and isinstance(node.op.core_op, Schur)
+        for node in f.maker.fgraph.apply_nodes
+    )
+
+    d_val = rng.uniform(-2, 2, n)
+    T_val, Z_val = f(d_val)
+    T_ref, _ = f_no_rewrite(d_val)
+
+    # Order within each sort group (selected / non-selected) is not uniquely
+    # determined, so compare sorted diagonals instead of element-wise.
+    np.testing.assert_allclose(
+        np.sort(np.diag(T_val)), np.sort(np.diag(T_ref)), atol=1e-12
+    )
+    np.testing.assert_allclose(Z_val @ T_val @ Z_val.T, np.diag(d_val), atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "make_diag, return_eigenvalues",
+    [
+        pytest.param(lambda d: pt.diag(d), False, id="alloc_diag_no_eigs"),
+        pytest.param(lambda d: pt.diag(d), True, id="alloc_diag_with_eigs"),
+    ],
+)
+def test_qz_of_diag(make_diag, return_eigenvalues):
+    n = 5
+    a = pt.dvector("a", shape=(n,))
+    b = pt.dvector("b", shape=(n,))
+    A = make_diag(a)
+    B = make_diag(b)
+    diag_idx = np.diag_indices(n)
+    n_64 = np.array(n, dtype="int64")
+
+    out = qz(A, B, return_eigenvalues=return_eigenvalues)
+    passes = ("canonicalize", "stabilize", "specialize", "ShapeOpt")
+    rewritten = rewrite_graph(list(out), include=passes)
+
+    def diag_of(vals):
+        return pt.zeros((n_64, n_64))[diag_idx].set(vals)
+
+    expected_I = pt.as_tensor(np.eye(n, dtype="float64"))
+
+    if return_eigenvalues:
+        expected = [
+            diag_of(a),
+            diag_of(b),
+            a.astype("complex128"),
+            b,
+            expected_I,
+            expected_I,
+        ]
+    else:
+        expected = [diag_of(a), diag_of(b), expected_I, expected_I]
+
+    assert_equal_computations(rewritten, expected)
+
+
+@pytest.mark.parametrize(
+    "sort, return_eigenvalues",
+    [
+        pytest.param("lhp", False, id="lhp"),
+        pytest.param("rhp", False, id="rhp"),
+        pytest.param("iuc", False, id="iuc"),
+        pytest.param("ouc", True, id="ouc_with_eigs"),
+    ],
+)
+def test_qz_of_diag_sort(sort, return_eigenvalues):
+    n = 5
+    rng = np.random.default_rng(42)
+    a_var = pt.dvector("a", shape=(n,))
+    b_var = pt.dvector("b", shape=(n,))
+    A = pt.diag(a_var)
+    B = pt.diag(b_var)
+
+    out = qz(A, B, sort=sort, return_eigenvalues=return_eigenvalues)
+    mode = get_mode("FAST_RUN")
+    f = pytensor.function([a_var, b_var], list(out), mode=mode)
+    f_no_rewrite = pytensor.function(
+        [a_var, b_var], list(out), mode=mode.excluding("qz_of_diag")
+    )
+
+    assert not any(
+        isinstance(node.op, Blockwise | BlockwiseWithCoreShape)
+        and isinstance(node.op.core_op, QZ)
+        for node in f.maker.fgraph.apply_nodes
+    )
+
+    a_val = rng.uniform(-2, 2, n)
+    b_val = rng.uniform(0.5, 2, n)
+    result = f(a_val, b_val)
+    ref = f_no_rewrite(a_val, b_val)
+
+    if return_eigenvalues:
+        AA_val, BB_val, alpha_val, beta_val, Q_val, Z_val = result
+        AA_ref, BB_ref, alpha_ref, beta_ref, *_ = ref
+        # Order within each sort group is not uniquely determined, so compare
+        # sorted diagonals / eigenvalue arrays instead of element-wise.
+        np.testing.assert_allclose(
+            np.sort(np.diag(AA_val)), np.sort(np.diag(AA_ref)), atol=1e-12
+        )
+        np.testing.assert_allclose(
+            np.sort(np.diag(BB_val)), np.sort(np.diag(BB_ref)), atol=1e-12
+        )
+        np.testing.assert_allclose(
+            np.sort(np.abs(alpha_val)), np.sort(np.abs(alpha_ref)), atol=1e-12
+        )
+        np.testing.assert_allclose(np.sort(beta_val), np.sort(beta_ref), atol=1e-12)
+    else:
+        AA_val, BB_val, Q_val, Z_val = result
+        AA_ref, BB_ref, *_ = ref
+        np.testing.assert_allclose(
+            np.sort(np.diag(AA_val)), np.sort(np.diag(AA_ref)), atol=1e-12
+        )
+        np.testing.assert_allclose(
+            np.sort(np.diag(BB_val)), np.sort(np.diag(BB_ref)), atol=1e-12
+        )
+
+    np.testing.assert_allclose(Q_val @ AA_val @ Z_val.T, np.diag(a_val), atol=1e-12)
+    np.testing.assert_allclose(Q_val @ BB_val @ Z_val.T, np.diag(b_val), atol=1e-12)

--- a/tests/tensor/rewriting/linalg/test_decomposition.py
+++ b/tests/tensor/rewriting/linalg/test_decomposition.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_allclose
 
 import pytensor
 from pytensor import tensor as pt
+from pytensor.assumptions.specify import assume
 from pytensor.compile import get_default_mode
 from pytensor.configdefaults import config
 from pytensor.tensor import swapaxes
@@ -28,15 +29,19 @@ def test_cholesky_ldotlt(tag, cholesky_form, product, op):
 
     ndim = 2 if op == dot else 3
     A = tensor("L", shape=(None,) * ndim)
-    if tag:
-        setattr(A.tag, tag + "_triangular", True)
+    if tag == "lower":
+        A_with_assumption = assume(A, lower_triangular=True)
+    elif tag == "upper":
+        A_with_assumption = assume(A, upper_triangular=True)
+    else:
+        A_with_assumption = A
 
     if product == "lower":
-        M = op(A, swapaxes(A, -1, -2))
+        M = op(A_with_assumption, swapaxes(A_with_assumption, -1, -2))
     elif product == "upper":
-        M = op(swapaxes(A, -1, -2), A)
+        M = op(swapaxes(A_with_assumption, -1, -2), A_with_assumption)
     else:
-        M = A
+        M = A_with_assumption
 
     C = cholesky(M, lower=(cholesky_form == "lower"))
     f = pytensor.function([A], C, mode=get_default_mode().including("cholesky_ldotlt"))

--- a/tests/tensor/rewriting/linalg/test_inverse.py
+++ b/tests/tensor/rewriting/linalg/test_inverse.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_allclose
 import pytensor
 from pytensor import function
 from pytensor import tensor as pt
+from pytensor.assumptions.specify import assume
 from pytensor.compile import get_default_mode
 from pytensor.configdefaults import config
 from pytensor.graph.replace import clone_replace
@@ -21,6 +22,7 @@ from pytensor.tensor.rewriting.linalg.inverse import inv_to_solve
 from pytensor.tensor.type import dmatrix, matrix, vector
 from tests import unittest_tools as utt
 from tests.test_rop import break_op
+from tests.unittest_tools import assert_equal_computations
 
 
 def test_matrix_inverse_pushforward_pullback():
@@ -245,3 +247,15 @@ def test_lift_linalg_of_expanded_matrices(constructor, f_op, f, g_op, g):
     test_vals = [x @ np.swapaxes(x, -1, -2) for x in test_vals]
 
     np.testing.assert_allclose(f1(*test_vals), f2(*test_vals), atol=1e-8)
+
+
+def test_inv_of_orthogonal_to_transpose():
+    n = 5
+    rewrites = ("canonicalize", "stabilize", "ShapeOpt")
+
+    x = pt.dmatrix("x", shape=(n, n))
+    x_orth = assume(x, orthogonal=True)
+    out = pt.linalg.inv(x_orth)
+    rewritten = rewrite_graph(out, include=rewrites)
+    expected = rewrite_graph(x_orth.mT, include=rewrites)
+    assert_equal_computations([rewritten], [expected])

--- a/tests/tensor/rewriting/linalg/test_products.py
+++ b/tests/tensor/rewriting/linalg/test_products.py
@@ -303,3 +303,28 @@ def test_kron_of_diagonal_to_diagonal():
         da_batch_val, db_batch_val
     )
     assert_allclose(f_batch(da_batch_val, db_batch_val), expected_batch)
+
+
+def test_orthogonal_dot_transpose_to_eye():
+    n = 5
+    rewrites = ("canonicalize", "specialize", "ShapeOpt")
+
+    # 2D: X @ X.T -> eye
+    x = pt.dmatrix("x", shape=(n, n))
+    x_orth = assume(x, orthogonal=True)
+    out_xxt = pt.dot(x_orth, x_orth.T)
+    rewritten_xxt = rewrite_graph(out_xxt, include=rewrites)
+    expected = pt.as_tensor(np.eye(n, dtype=config.floatX))
+    assert_equal_computations([rewritten_xxt], [expected])
+
+    # Batched: X @ X.T -> broadcast_to(eye, batch_shape)
+    x_batch = pt.dtensor3("x_batch", shape=(3, n, n))
+    x_batch_orth = assume(x_batch, orthogonal=True)
+    out_batch = x_batch_orth @ pt.moveaxis(x_batch_orth, -1, -2)
+    rewritten_batch = rewrite_graph(out_batch, include=rewrites)
+
+    n64 = np.array(n, dtype="int64")
+    b64 = np.array(3, dtype="int64")
+    expected_batch = pt.alloc(np.eye(n, dtype=config.floatX), b64, n64, n64)
+
+    assert_equal_computations([rewritten_batch], [expected_batch])

--- a/tests/tensor/rewriting/linalg/test_products.py
+++ b/tests/tensor/rewriting/linalg/test_products.py
@@ -1,14 +1,18 @@
 import numpy as np
+import pytest
 import scipy.linalg
 from numpy.testing import assert_allclose
 
 from pytensor import function
 from pytensor import tensor as pt
+from pytensor.assumptions.specify import assume
 from pytensor.configdefaults import config
 from pytensor.graph import FunctionGraph, ancestors
 from pytensor.graph.rewriting.utils import rewrite_graph
+from pytensor.tensor.basic import alloc_diag
 from pytensor.tensor.linalg.constructors import BlockDiagonal
 from pytensor.tensor.linalg.products import KroneckerProduct
+from tests.unittest_tools import assert_equal_computations
 
 
 def test_nested_blockdiag_fusion():
@@ -236,3 +240,66 @@ def test_slogdet_kronecker_rewrite():
         atol=1e-3 if config.floatX == "float32" else 1e-8,
         rtol=1e-3 if config.floatX == "float32" else 1e-8,
     )
+
+
+@pytest.mark.parametrize(
+    "make_diag",
+    [
+        pytest.param(lambda d: pt.diag(d), id="alloc_diag"),
+        pytest.param(lambda d: pt.eye(5) * d, id="eye_mul"),
+    ],
+)
+def test_expm_of_diag(make_diag):
+    d = pt.dvector("d", shape=(5,))
+    D = make_diag(d)
+    out = pt.linalg.expm(D)
+
+    passes = ("canonicalize", "stabilize", "specialize")
+    rewritten = rewrite_graph(out, include=passes)
+    expected = rewrite_graph(alloc_diag(pt.exp(d), axis1=-2, axis2=-1), include=passes)
+    assert_equal_computations([rewritten], [expected])
+
+
+def test_kron_of_diagonal_to_diagonal():
+    da = pt.tensor("da", shape=(3, 3))
+    db = pt.tensor("db", shape=(4, 4))
+    A = assume(da, diagonal=True)
+    B = assume(db, diagonal=True)
+
+    out = pt.linalg.kron(A, B)
+    f = function([da, db], out, mode="FAST_RUN")
+
+    nodes_batch = f.maker.fgraph.apply_nodes
+    assert not any(isinstance(node.op, KroneckerProduct) for node in nodes_batch)
+
+    rng = np.random.default_rng()
+
+    da_test = np.diag(rng.normal(size=(3,)))
+    db_test = np.diag(rng.normal(size=(4,)))
+    expected = np.kron(da_test, db_test)
+    assert_allclose(f(da_test, db_test), expected)
+
+    # Batched case
+    da_batch = pt.tensor("da_batch", shape=(2, 3, 3))
+    db_batch = pt.tensor("db_batch", shape=(2, 4, 4))
+    A_batch = assume(da_batch, diagonal=True)
+    B_batch = assume(db_batch, diagonal=True)
+
+    signature = "(m,m),(n,n)->(mn,mn)"
+    kron_batched = pt.vectorize(lambda a, b: pt.linalg.kron(a, b), signature=signature)
+    out_batch = kron_batched(A_batch, B_batch)
+    f_batch = function([da_batch, db_batch], out_batch)
+
+    nodes_batch = f_batch.maker.fgraph.apply_nodes
+    assert not any(isinstance(node.op, KroneckerProduct) for node in nodes_batch)
+
+    a_diags = np.random.normal(size=(2, 3))
+    b_diags = np.random.normal(size=(2, 4))
+    vec_diag = np.vectorize(np.diag, signature="(n)->(n,n)")
+    da_batch_val = vec_diag(a_diags)
+    db_batch_val = vec_diag(b_diags)
+
+    expected_batch = np.vectorize(np.kron, signature=signature)(
+        da_batch_val, db_batch_val
+    )
+    assert_allclose(f_batch(da_batch_val, db_batch_val), expected_batch)

--- a/tests/tensor/rewriting/linalg/test_solvers.py
+++ b/tests/tensor/rewriting/linalg/test_solvers.py
@@ -19,6 +19,9 @@ from pytensor.tensor.linalg.decomposition.cholesky import Cholesky, cholesky
 from pytensor.tensor.linalg.decomposition.lu import LUFactor
 from pytensor.tensor.linalg.solvers.core import SolveBase
 from pytensor.tensor.linalg.solvers.general import Solve, solve
+from pytensor.tensor.linalg.solvers.linear_control import (
+    solve_sylvester,
+)
 from pytensor.tensor.linalg.solvers.psd import CholeskySolve, cho_solve
 from pytensor.tensor.linalg.solvers.triangular import SolveTriangular, solve_triangular
 from pytensor.tensor.linalg.solvers.tridiagonal import (
@@ -558,3 +561,91 @@ def test_block_diag_solve_pushdown_both_sides_block_diag():
         scipy.linalg.block_diag(B1_v, B2_v),
     )
     assert_allclose(f(A1_v, A2_v, B1_v, B2_v), expected, atol=1e-10)
+
+
+class TestDiagonalSolveToDivision:
+    @pytest.mark.parametrize("b_ndim", [1, 2], ids=lambda x: f"b_ndim={x}")
+    @pytest.mark.parametrize(
+        "make_diag",
+        [
+            pytest.param(lambda d: pt.diag(d), id="alloc_diag"),
+            pytest.param(lambda d: pt.eye(5) * d, id="eye_mul"),
+        ],
+    )
+    def test_solve_diag(self, b_ndim, make_diag):
+        d = pt.dvector("d", shape=(5,))
+        b = pt.tensor("b", shape=(5,) if b_ndim == 1 else (5, 3), dtype="float64")
+        D = make_diag(d)
+        out = solve(D, b, b_ndim=b_ndim)
+
+        rewritten = rewrite_graph(
+            out, include=("canonicalize", "stabilize", "specialize")
+        )
+        expected = b / d if b_ndim == 1 else b / d[..., :, None]
+
+        assert_equal_computations([rewritten], [expected])
+
+    @pytest.mark.parametrize("b_ndim", [1, 2], ids=lambda x: f"b_ndim={x}")
+    def test_solve_triangular_diag(self, b_ndim):
+        d = pt.dvector("d")
+        b = pt.tensor("b", shape=(5,) if b_ndim == 1 else (5, 3), dtype="float64")
+        D = pt.diag(d)
+        out = solve_triangular(D, b, lower=True, b_ndim=b_ndim)
+
+        rewritten = rewrite_graph(
+            out, include=("canonicalize", "stabilize", "specialize")
+        )
+        expected = b / d if b_ndim == 1 else b / d[..., :, None]
+
+        assert_equal_computations([rewritten], [expected])
+
+    @pytest.mark.parametrize("b_ndim", [1, 2], ids=lambda x: f"b_ndim={x}")
+    def test_solve_triangular_unit_diag(self, b_ndim):
+        d = pt.dvector("d")
+        b = pt.tensor("b", shape=(5,) if b_ndim == 1 else (5, 3), dtype="float64")
+        D = pt.diag(d)
+        out = solve_triangular(D, b, lower=True, unit_diagonal=True, b_ndim=b_ndim)
+
+        rewritten = rewrite_graph(
+            out, include=("canonicalize", "stabilize", "specialize")
+        )
+
+        assert_equal_computations([rewritten], [b])
+
+    @pytest.mark.parametrize("b_ndim", [1, 2], ids=lambda x: f"b_ndim={x}")
+    def test_cho_solve_diag(self, b_ndim):
+        d = pt.dvector("d", shape=(5,))
+        b = pt.tensor("b", shape=(5,) if b_ndim == 1 else (5, 3), dtype="float64")
+        L = pt.diag(d)
+        out = cho_solve((L, True), b, b_ndim=b_ndim)
+
+        rewritten = rewrite_graph(
+            out, include=("canonicalize", "stabilize", "specialize")
+        )
+        expected = b / pt.square(d) if b_ndim == 1 else b / pt.square(d[..., :, None])
+
+        assert_equal_computations([rewritten], [expected])
+
+
+@pytest.mark.parametrize(
+    "make_diag",
+    [
+        pytest.param(lambda d: pt.diag(d), id="alloc_diag"),
+        pytest.param(lambda d: pt.eye(5) * d, id="eye_mul"),
+    ],
+)
+def test_solve_sylvester_both_diag(make_diag):
+    n = 5
+    a = pt.dvector("a", shape=(n,))
+    b = pt.dvector("b", shape=(n,))
+    C = pt.dmatrix("C", shape=(n, n))
+
+    A = make_diag(a)
+    B = make_diag(b)
+    X = solve_sylvester(A, B, C)
+
+    passes = ("canonicalize", "stabilize", "specialize")
+    rewritten = rewrite_graph(X, include=passes)
+    expected = rewrite_graph(C / (a[:, None] + b[None, :]), include=passes)
+
+    assert_equal_computations([rewritten], [expected])

--- a/tests/tensor/rewriting/linalg/test_solvers.py
+++ b/tests/tensor/rewriting/linalg/test_solvers.py
@@ -6,6 +6,7 @@ from numpy.testing import assert_allclose
 import pytensor
 from pytensor import function, scan
 from pytensor import tensor as pt
+from pytensor.assumptions.specify import assume
 from pytensor.compile import get_default_mode
 from pytensor.configdefaults import config
 from pytensor.gradient import grad
@@ -74,30 +75,34 @@ def test_generic_solve_to_solve_triangular():
 
 
 def test_psd_solve_with_chol():
-    X = matrix("X")
-    X.tag.psd = True
-    X_inv = pt.linalg.solve(X, pt.identity_like(X))
+    """Test that solve(A, b) with PSD A gets rewritten to cholesky + cho_solve."""
+    A = matrix("A")
+    b = matrix("b")
+    A_psd = assume(A, positive_definite=True)
+    out = pt.linalg.solve(A_psd, b)
 
-    f = pytensor.function([X], X_inv, mode="FAST_RUN")
+    rewritten = rewrite_graph(out, include=("canonicalize", "stabilize", "specialize"))
 
-    nodes = f.maker.fgraph.apply_nodes
+    L = cholesky(A_psd)
+    expected = cho_solve((L, True), b, b_ndim=2)
 
-    assert not any(isinstance(node.op, Solve) for node in nodes)
-    assert any(isinstance(node.op, Cholesky) for node in nodes)
-    assert any(isinstance(node.op, SolveTriangular) for node in nodes)
+    assert_equal_computations([rewritten], [expected])
 
-    # Numeric test
-    rng = np.random.default_rng(sum(map(ord, "test_psd_solve_with_chol")))
 
-    L = rng.normal(size=(5, 5)).astype(config.floatX)
-    X_psd = L @ L.T
-    X_psd_inv = f(X_psd)
-    assert_allclose(
-        X_psd_inv,
-        np.linalg.inv(X_psd),
-        atol=1e-4 if config.floatX == "float32" else 1e-8,
-        rtol=1e-4 if config.floatX == "float32" else 1e-8,
-    )
+def test_paired_triangular_solves_to_cho_solve():
+    """Test that paired triangular solves from Cholesky get fused into cho_solve."""
+    A = matrix("A")
+    b = matrix("b")
+
+    # Manually create the pattern: solve_triangular(L.T, solve_triangular(L, b))
+    L = pt.linalg.cholesky(A, lower=True)
+    Li_b = pt.linalg.solve_triangular(L, b, lower=True, b_ndim=2)
+    x = pt.linalg.solve_triangular(L.mT, Li_b, lower=False, b_ndim=2)
+
+    rewritten = rewrite_graph(x, include=("canonicalize", "stabilize", "specialize"))
+    expected = cho_solve((L, True), b, b_ndim=2)
+
+    assert_equal_computations([rewritten], [expected])
 
 
 class TestBatchedVectorBSolveToMatrixBSolve:

--- a/tests/tensor/rewriting/linalg/test_solvers.py
+++ b/tests/tensor/rewriting/linalg/test_solvers.py
@@ -649,3 +649,16 @@ def test_solve_sylvester_both_diag(make_diag):
     expected = rewrite_graph(C / (a[:, None] + b[None, :]), include=passes)
 
     assert_equal_computations([rewritten], [expected])
+
+
+def test_orthogonal_solve_to_transpose_matmul():
+    n = 5
+    rewrites = ("canonicalize", "stabilize", "ShapeOpt")
+
+    Q = pt.dmatrix("Q", shape=(n, n))
+    Q_orth = assume(Q, orthogonal=True)
+    b = pt.dmatrix("b", shape=(n, 3))
+    out = solve(Q_orth, b)
+    rewritten = rewrite_graph(out, include=rewrites)
+    expected = rewrite_graph(Q_orth.mT @ b, include=rewrites)
+    assert_equal_computations([rewritten], [expected])

--- a/tests/tensor/rewriting/linalg/test_summary.py
+++ b/tests/tensor/rewriting/linalg/test_summary.py
@@ -4,6 +4,7 @@ from numpy.testing import assert_allclose
 
 from pytensor import function
 from pytensor import tensor as pt
+from pytensor.assumptions.specify import assume
 from pytensor.configdefaults import config
 from pytensor.graph import rewrite_graph
 from pytensor.tensor.linalg.decomposition import lu, qr, svd
@@ -115,6 +116,38 @@ def test_dont_apply_det_of_diag_from_scalar_eye():
     assert_allclose(
         det_val,
         rewritten_val,
+        atol=1e-3 if config.floatX == "float32" else 1e-8,
+        rtol=1e-3 if config.floatX == "float32" else 1e-8,
+    )
+
+
+@pytest.mark.parametrize(
+    "side, shape",
+    [
+        pytest.param("lower_triangular", (5, 5), id="lower"),
+        pytest.param("upper_triangular", (5, 5), id="upper"),
+        pytest.param("lower_triangular", (3, 5, 5), id="batched_lower"),
+    ],
+)
+def test_det_of_triangular(side, shape):
+    x = pt.tensor("x", shape=shape)
+    y = pt.linalg.det(assume(x, **{side: True}))
+
+    f = function([x], y, mode="FAST_RUN")
+    nodes = f.maker.fgraph.apply_nodes
+    assert not any(
+        isinstance(node.op, Det) or isinstance(getattr(node.op, "core_op", None), Det)
+        for node in nodes
+    )
+
+    rng = np.random.default_rng(0)
+    tri = np.tril if side == "lower_triangular" else np.triu
+    x_test = tri(rng.normal(size=shape)).astype(config.floatX)
+    expected = np.linalg.det(x_test)
+
+    assert_allclose(
+        expected,
+        f(x_test),
         atol=1e-3 if config.floatX == "float32" else 1e-8,
         rtol=1e-3 if config.floatX == "float32" else 1e-8,
     )

--- a/tests/tensor/rewriting/test_assumptions.py
+++ b/tests/tensor/rewriting/test_assumptions.py
@@ -1,0 +1,74 @@
+import pytest
+
+import pytensor.tensor as pt
+from pytensor.assumptions import (
+    DIAGONAL,
+    POSITIVE_DEFINITE,
+    ConflictingAssumptionsError,
+    FactState,
+)
+from pytensor.assumptions.specify import assume
+from pytensor.graph.fg import FunctionGraph
+from pytensor.tensor.rewriting.assumptions import DrainSpecifyAssumptions
+from tests.unittest_tools import assert_equal_computations
+
+
+def _drain(*outputs):
+    """Build a ``FunctionGraph`` in place and apply only the drain rewriter."""
+    fgraph = FunctionGraph(outputs=list(outputs), clone=False)
+    DrainSpecifyAssumptions().rewrite(fgraph)
+    return fgraph
+
+
+def test_unshared_marker_is_drained():
+    x = pt.matrix("x", shape=(3, 3))
+    fgraph = _drain(pt.linalg.inv(assume(x, diagonal=True)))
+    assert_equal_computations(fgraph.outputs, [pt.linalg.inv(x)])
+    assert fgraph.assumption_feature.check(x, DIAGONAL)
+
+
+def test_marker_with_multiple_clients_is_drained():
+    x = pt.matrix("x", shape=(3, 3))
+    x_diag = assume(x, diagonal=True)
+    fgraph = _drain(pt.linalg.inv(x_diag), pt.linalg.inv(x_diag.T))
+    assert_equal_computations(fgraph.outputs, [pt.linalg.inv(x), pt.linalg.inv(x.T)])
+
+
+@pytest.mark.parametrize("declared", [True, False], ids=["true", "false"])
+def test_assertion_state_survives_drain(declared):
+    x = pt.matrix("x", shape=(3, 3))
+    fgraph = _drain(assume(x, diagonal=declared))
+    assert_equal_computations(fgraph.outputs, [x])
+    expected = FactState.TRUE if declared else FactState.FALSE
+    assert fgraph.assumption_feature.get(x, DIAGONAL) is expected
+
+
+def test_nested_assume_fully_drained():
+    z = pt.matrix("z", shape=(3, 3))
+    out = assume(assume(z, diagonal=True), positive_definite=True)
+    fgraph = _drain(out)
+    assert_equal_computations(fgraph.outputs, [z])
+    feature = fgraph.assumption_feature
+    assert feature.check(z, DIAGONAL)
+    assert feature.check(z, POSITIVE_DEFINITE)
+
+
+def test_aliased_input_drains_marker():
+    """Assumptions are per-variable: the marker is drained even when the input
+    has other clients."""
+    y = pt.matrix("y", shape=(3, 3))
+    fgraph = _drain(
+        pt.linalg.inv(assume(y, diagonal=True)),
+        pt.linalg.inv(y),
+    )
+    assert_equal_computations(
+        fgraph.outputs,
+        [pt.linalg.inv(y), pt.linalg.inv(y)],
+    )
+    assert fgraph.assumption_feature.check(y, DIAGONAL)
+
+
+def test_conflicting_assertion_raises_during_drain():
+    eye_not_diag = assume(pt.eye(3), diagonal=False)
+    with pytest.raises(ConflictingAssumptionsError):
+        _drain(eye_not_diag)

--- a/tests/tensor/rewriting/test_math.py
+++ b/tests/tensor/rewriting/test_math.py
@@ -4913,6 +4913,86 @@ def test_local_dot_to_mul_unspecified_length_1():
     )
 
 
+class TestDotDiagToElemwise:
+    @pytest.mark.parametrize(
+        "make_diag",
+        [
+            pytest.param(lambda d: pt.diag(d), id="alloc_diag"),
+            pytest.param(lambda d: pt.eye(5) * d, id="eye_mul"),
+        ],
+    )
+    def test_left_diag_matrix(self, make_diag):
+        d = dvector("d", shape=(5,))
+        X = dmatrix("X", shape=(5, 3))
+        D = make_diag(d)
+        out = D @ X
+
+        rewritten = rewrite_graph(
+            out, include=("canonicalize", "stabilize", "specialize")
+        )
+        expected = d[:, None] * X
+        assert_equal_computations([rewritten], [expected])
+
+    @pytest.mark.parametrize(
+        "make_diag",
+        [
+            pytest.param(lambda d: pt.diag(d), id="alloc_diag"),
+            pytest.param(lambda d: pt.eye(5) * d, id="eye_mul"),
+        ],
+    )
+    def test_left_diag_vector(self, make_diag):
+        d = dvector("d", shape=(5,))
+        x = dvector("x", shape=(5,))
+        D = make_diag(d)
+        out = D @ x
+
+        rewritten = rewrite_graph(
+            out, include=("canonicalize", "stabilize", "specialize")
+        )
+        expected = d * x
+        assert_equal_computations([rewritten], [expected])
+
+    @pytest.mark.parametrize(
+        "make_diag",
+        [
+            pytest.param(lambda d: pt.diag(d), id="alloc_diag"),
+            pytest.param(lambda d: pt.eye(5) * d, id="eye_mul"),
+        ],
+    )
+    def test_right_diag_matrix(self, make_diag):
+        d = dvector("d", shape=(5,))
+        X = dmatrix("X", shape=(3, 5))
+        D = make_diag(d)
+        out = X @ D
+
+        rewritten = rewrite_graph(
+            out, include=("canonicalize", "stabilize", "specialize")
+        )
+        expected = X * d[None, :]
+        assert_equal_computations([rewritten], [expected])
+
+    @pytest.mark.parametrize(
+        "make_diag",
+        [
+            pytest.param(lambda d: pt.diag(d), id="alloc_diag"),
+            pytest.param(lambda d: pt.eye(5) * d, id="eye_mul"),
+        ],
+    )
+    def test_both_diag(self, make_diag):
+        d1 = dvector("d1", shape=(5,))
+        d2 = dvector("d2", shape=(5,))
+        D1 = make_diag(d1)
+        D2 = make_diag(d2)
+        out = D1 @ D2
+
+        passes = ("canonicalize", "stabilize", "specialize")
+        rewritten = rewrite_graph(out, include=passes)
+        expected = rewrite_graph(
+            pt.basic.alloc_diag(d1 * d2, axis1=-2, axis2=-1), include=passes
+        )
+        assert_equal_computations([rewritten], [expected])
+
+
 class TestBlockDiagDotToDotBlockDiag:
     @pytest.mark.parametrize("left_multiply", [True, False], ids=["left", "right"])
     @pytest.mark.parametrize(

--- a/tests/tensor/rewriting/test_subtensor.py
+++ b/tests/tensor/rewriting/test_subtensor.py
@@ -2732,7 +2732,13 @@ def test_cholesky_unconstrain_grad(exp_before_materialize):
         ExtractDiag,
     )
     n_idx = sum(1 for n in f.maker.fgraph.toposort() if isinstance(n.op, idx_types))
-    assert n_idx == 6
+    # The ``BlasOpt`` rewrites lower ``L @ L.T`` to ``Gemm``; the gradient then
+    # fuses the diagonal-gradient term into a ``Gemm`` operand, materializing one
+    # extra set-subtensor. A linker that cannot use them lists ``BlasOpt`` in
+    # ``incompatible_rewrites`` (e.g. the numba linker), keeping the plain ``Dot``
+    # lowering with that term as a vector. Both lowerings are correct.
+    blas_rewrites_run = "BlasOpt" not in f.maker.mode.linker.incompatible_rewrites
+    assert n_idx == (7 if blas_rewrites_run else 6)
 
     x = np.array([1.0, 0.5, 2.0, 0.3, 0.1, 1.5])
     # Expected values were computed once by running ``f(x)``.

--- a/tests/tensor/test_subtensor.py
+++ b/tests/tensor/test_subtensor.py
@@ -25,7 +25,7 @@ from pytensor.scalar.basic import as_scalar, int16
 from pytensor.tensor import as_tensor, constant, get_vector_length, ivector, vectorize
 from pytensor.tensor.blockwise import Blockwise, BlockwiseWithCoreShape
 from pytensor.tensor.elemwise import DimShuffle
-from pytensor.tensor.math import exp, isinf, lt, switch
+from pytensor.tensor.math import exp, isinf, lt, maximum, minimum, switch
 from pytensor.tensor.math import sum as pt_sum
 from pytensor.tensor.shape import specify_broadcastable, specify_shape
 from pytensor.tensor.subtensor import (
@@ -35,6 +35,8 @@ from pytensor.tensor.subtensor import (
     AdvancedSubtensor1,
     IncSubtensor,
     Subtensor,
+    _is_provably_non_negative,
+    _is_provably_positive,
     advanced_inc_subtensor,
     advanced_inc_subtensor1,
     advanced_set_subtensor,
@@ -102,6 +104,67 @@ def test_as_index_literal():
 
     res = as_index_literal(np.newaxis)
     assert res is np.newaxis
+
+
+class TestProvablyPositive:
+    @pytest.mark.parametrize(
+        "data, strict, expected",
+        [
+            ([1.0, 2.0], True, True),
+            ([1.0, 2.0], False, True),
+            ([0.0, 2.0], True, False),
+            ([0.0, 2.0], False, True),
+            ([-1.0, 2.0], True, False),
+            ([-1.0, 2.0], False, False),
+        ],
+        ids=[
+            "all-positive-strict",
+            "all-positive-loose",
+            "zero-fails-strict",
+            "zero-passes-loose",
+            "negative-fails-strict",
+            "negative-fails-loose",
+        ],
+    )
+    def test_constant_data_respects_strictness(self, data, strict, expected):
+        assert (
+            _is_provably_positive(constant(np.array(data)), strict=strict) is expected
+        )
+
+    @pytest.mark.parametrize(
+        "make_var",
+        [
+            pytest.param(lambda: vector("v", dtype="uint8"), id="uint-dtype"),
+            pytest.param(lambda: matrix("m").shape[0], id="shape-dim"),
+            pytest.param(lambda: constant(np.array([0.5])).astype("int64"), id="cast"),
+        ],
+    )
+    def test_proves_non_negative_but_not_strict_positive(self, make_var):
+        """A uint value, a shape dimension, and a cast can each equal zero, so
+        they establish ``>= 0`` but never strict ``> 0``."""
+        var = make_var()
+        assert _is_provably_non_negative(var) is True
+        assert _is_provably_positive(var, strict=True) is False
+
+    @pytest.mark.parametrize(
+        "expr, strict, expected",
+        [
+            (minimum(2, 3), True, True),
+            (minimum(2, 0), True, False),
+            (minimum(2, 0), False, True),
+            (maximum(5, -10), True, True),
+            (maximum(-1, -10), True, False),
+        ],
+        ids=[
+            "min-needs-all-positive",
+            "min-zero-fails-strict",
+            "min-zero-passes-loose",
+            "max-needs-any-positive",
+            "max-none-positive",
+        ],
+    )
+    def test_recurses_through_min_and_max(self, expr, strict, expected):
+        assert _is_provably_positive(expr, strict=strict) is expected
 
 
 class TestGetCanonicalFormSlice:

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -13,6 +13,7 @@ import pytest
 
 import pytensor
 from pytensor import config
+from pytensor.assumptions import assume
 from pytensor.compile.builders import OpFromGraph
 from pytensor.compile.debug.profiling import ProfileStats
 from pytensor.compile.mode import get_mode
@@ -31,6 +32,7 @@ from pytensor.printing import (
     pydotprint,
 )
 from pytensor.tensor import as_tensor_variable
+from pytensor.tensor.linalg import inv
 from pytensor.tensor.type import dmatrix, dvector, matrix
 from tests.graph.utils import MyInnerGraphOp, MyOp, MyVariable
 
@@ -333,6 +335,75 @@ def test_debugprint():
     assert [l.strip() for l in s.split("\n")] == [
         l.strip() for l in exp_res.split("\n")
     ]
+
+
+def test_debugprint_assumptions():
+    x = matrix("x")
+    out = inv(assume(x, diagonal=True))
+
+    s = StringIO()
+    debugprint(out, file=s, print_assumptions=True)
+    reference = dedent(
+        r"""
+        Blockwise{MatrixInverse, (m,m)->(m,m)} [id A] a={diag}
+         └─ SpecifyAssumptions{diagonal} [id B] a={diag}
+            └─ x [id C]
+        """
+    ).lstrip()
+    assert s.getvalue() == reference
+
+    # The flag is off by default, so no a={...} tag is printed.
+    s = StringIO()
+    debugprint(out, file=s)
+    assert "a={" not in s.getvalue()
+
+
+def test_debugprint_assumptions_prunes_implied_facts():
+    # positive_definite implies symmetric; only the strongest fact is shown.
+    x = matrix("x")
+    s = StringIO()
+    debugprint(assume(x, positive_definite=True), file=s, print_assumptions=True)
+    reference = dedent(
+        r"""
+        SpecifyAssumptions{positive_definite} [id A] a={pd}
+         └─ x [id B]
+        """
+    ).lstrip()
+    assert s.getvalue() == reference
+
+
+def test_debugprint_assumptions_negation_and_multiple():
+    x = matrix("x")
+
+    s = StringIO()
+    debugprint(assume(x, symmetric=False), file=s, print_assumptions=True)
+    assert (
+        s.getvalue()
+        == dedent(
+            r"""
+        SpecifyAssumptions{!symmetric} [id A] a={!sym}
+         └─ x [id B]
+        """
+        ).lstrip()
+    )
+
+    # Two independent facts survive propagation through ``inv``.
+    s = StringIO()
+    debugprint(
+        inv(assume(x, diagonal=True, orthogonal=True)),
+        file=s,
+        print_assumptions=True,
+    )
+    assert (
+        s.getvalue()
+        == dedent(
+            r"""
+        Blockwise{MatrixInverse, (m,m)->(m,m)} [id A] a={diag, orth}
+         └─ SpecifyAssumptions{diagonal, orthogonal} [id B] a={diag, orth}
+            └─ x [id C]
+        """
+        ).lstrip()
+    )
 
 
 def test_debugprint_id_type():


### PR DESCRIPTION
This PR is a proposal for a typing system for linear algebra primitives. The purpose is to enable graph-wide reasoning about the kinds of matrices, so that we can rewrite to efficient computational forms.

## Current State

We currently have several linear algebra rewrites and plan to add more. These are tracked in https://github.com/pymc-devs/pytensor/issues/573. This is important because linear algebra is 1) ubiquotous, 2) expensive, and 3) inscrutiable. Pytensor's static graph representation and rewrite system is well positioned to provide users help writing the best possible programs involving heavy linear algebra, if only we can figure out what is going on.

Consider the motivating case of `solve(A, b)`, when `A = pt.diag(pt.arange(100_000))`. This is an O(n^3) operation that will call out to specialized routines. But there is no need for this. Since A is diagonal, we can write this as an elementwise division `b / pt.extract_diag(A)`. 

How do we decide to do this? We:
- Track the `Solve` `Op`
- Check if either input "seems diagonal"
- If so, do the rewrite

What seems diagonal? We assume an input is diagonal if it was created by `pt.eye` or `pt.diag`. Users cannot specify themselves whether input data is diagonal. If an `Op` get inbetween the known "diagonalish" `Op` and the `Solve`, we cannot detect diagonality. For example, we cannot rewrite `solve(A * 3, b)`, because now the first input is `Elemwise(Mul)(A, 3)`. Multiplication is diagonal-preserving (because it is zero-preserving), but since the known diagonal op is now buried inside the Elemwise, we're out of luck.

## Proposal

My proposal is to reason about algebraic properties of matrices the same way we reason about shapes. For shapes, we attach a `ShapeFeature` to `FunctionGraphs`. Each `Op` has an `infer_shape` method that explains how the static shape propagates. Likewise, I propose an `AssumptionFeature`. `Ops` do not have `infer_assumption` methods. That would be too messy. Instead, we have a central `ASSUMPTION_INFER_REGISTRY` with keys `(Op, AssumptionKey )` and values `InferFactFn`. 

- An `AssumptionKey` is just a marker class corresponding to an algebraic fact about a matrix, like `DIAGONAL`, `LOWER_TRIANGULAR`, `ORTHOGONAL`, `POSITIVE`, `SEMIDEFINITE`, and so on.
- An `InferFactFn` has the following signature:

```py
def infer_diagonal(op: Op, assumption_feature: AssumptionFeature, fgraph: FunctionGraph, node: Apply, input_facts: list[FactState]) -> list[FactState]:
```

Like other symbolic operations, the `InferFactFunction` takes an Op (plus global information about the graph it lives in, `fgraph` and `assumption_feature`), and information about its inputs (the list of `FactStates`) and returns a list of information about its outputs.

A `FactState` is a three-valued logic for assumption inference. The possible values are `UNKNOWN`, `TRUE`, or `FALSE`. A fourth state, `CONFLICT`, exists, but should never arise. 

All facts about all Ops are assumed to be `UNKNOWN` unless we can prove otherwise. Proof comes from each Op's registered `InferFactFunction`s. The `AssumptionFeature` is responsible for gathering all the rules of fact propagation. An example of a simple fact is that all `Eye` `Ops` are `DIAGONAL`, provided it is 1) square and 2) offset of zero:

```py
def true_if(cond: bool) -> list[FactState]:
    """``[TRUE]`` when *cond* holds, ``[UNKNOWN]`` otherwise."""
    return [FactState.TRUE] if cond else [FactState.UNKNOWN]

def eye_is_identity(node) -> bool:
    """True when an :class:`Eye` node produces the identity matrix (square, k == 0)."""
    n, m, k = node.inputs
    if not (isinstance(k, Constant) and k.data.item() == 0):
        return False
    if n is m:
        return True
    if isinstance(n, Constant) and isinstance(m, Constant):
        return n.data.item() == m.data.item()
    return False

@register_assumption(DIAGONAL, Eye)
def _eye(op, feature, fgraph, node, input_states):
    return true_if(eye_is_identity(node))
```

In a program, we can use the `AssumptionFeature.get(x, AssumptionKey)` to query about the state of a `Variable`. Here, we ask "is x diagonal?". Obviously it is:

```py
import pytensor.tensor as pt
from pytensor.graph.fg import FunctionGraph
from pytensor.tensor.assumptions import AssumptionFeature, DIAGONAL
x = pt.eye(5)
fg = FunctionGraph([], [x])
af = AssumptionFeature()
fg.attach_feature(af)

af.get(x, DIAGONAL) # <FactState.TRUE: 1>
```

Where this becomes powerful is by accumulating `InferFactFunction`s. Many `Ops` preserve diagonality, like `Cholesky` or `Inverse`. We can use information about the inputs to these `Ops` to propogate fact information through the graph:

```py
@register_assumption(DIAGONAL, Cholesky)
def _cholesky(op, feature, fgraph, node, input_states):
    return true_if(input_states[0])

@register_assumption(DIAGONAL, MatrixInverse)
def _inv(op, feature, fgraph, node, input_states):
    return true_if(input_states[0])
```

Now we don't lose information about `x` in deeper graphs, and are free to do more rewrites:

```py
x = pt.eye(5)
y = pt.linalg.cholesky(x)
z = pt.linalg.inv(y)

fg = FunctionGraph([z], [x])
af = AssumptionFeature()
fg.attach_feature(af)

af.get(y, DIAGONAL) # <FactState.TRUE: 1>
af.get(z, DIAGONAL) # <FactState.TRUE: 1>
```

Of course can also reason conditionally. An `IncSubtensor` might be diagonal-preserving if we can prove that we're setting a value on the diagonal of the matrix. Otherwise we fall back to `UNKNOWN`:

```py
from pytensor.tensor.subtensor import IncSubtensor

x = pt.eye(5)
i, j = pt.iscalars('i', 'j')
y = x[i, j].inc(3) # Cannot prove i != j at runtime, so UNKNOWN
z = x[i, i].inc(3) # i == i provable, so this is diagonal-preserving
fg = FunctionGraph([y, z], [x])
af = AssumptionFeature()
fg.attach_feature(af)

af.get(y, DIAGONAL) #<FactState.UNKNOWN: 0>
af.get(z, DIAGONAL) #<FactState.TRUE: 1>
```

Facts can also imply other facts. `DIAGONAL` matrices are also symmetrical. These general relationships can be registered and encoded as well. Continuing the example above:

```py
from pytensor.tensor.assumptions import SYMMETRIC
af.get(z, SYMMETRIC) # <FactState.TRUE: 1>
```

Finally, users can specify facts about matrices using `pt.specify_assumptions`, the same way they are able to specify shapes. 

```py
x = pt.specify_assumptions(pt.dmatrix('x'), diagonal=True)
fg = FunctionGraph([x], [x])
af = AssumptionFeature()
fg.attach_feature(af)

af.get(x, DIAGONAL) # <FactState.TRUE: 1>
```

## Benefits for rewriting:

- `FactStates` are trivial to check. We can check any fact about any Variable in 5 lines:

```py
def _is_diagonal(var, fgraph):
    """Check if *var* is diagonal using the AssumptionFeature."""

    af = getattr(fgraph, "assumption_feature", None)
    if af is None:
        af = AssumptionFeature()
        fgraph.attach_feature(af)

    return af.check(var, DIAGONAL)
```

- We can reason globally about the graph
As noted above, information flows through the graph. As long as we have good coverage of fact rules for Ops, we can make statements about Variables at all levels of computation

- `InferFactFunction`s are lightweight and easy to write
It is trivial to add new `InferFactFunction`s. LLMs can bang them out. They require only local reasoning about the `Op` and its immediate inputs. 

- `FactStates` allow non-trivial combinations of rewrites
One example I hit while working on this was a rewrite for `DirectSolveLyapunov` given diagonal inputs. Because there is a rule that `kron` preserves diagonality if both inputs are diagonal, the chain of rewrites from `solve_discrete_lyapunov(diag(a), Q) -> Q.ravel() / (1 - outer(a, a).ravel())` is discovered by the rewrite system via:

- `rewrite_kron_diag_to_diag_outer: kron(diag(a), diag(b)) → diag(outer(a, b).ravel())`
- `rewrite_solve_diag_to_division: solve(diag(x), b) → b / x`

The key is that after the first rewrite produces a diagonal matrix (via alloc_diag), the assumption system recognizes it as diagonal (via AllocDiag being registered with DIAGONAL), and then the second rewrite kicks in.

## Non-Goals
The purpose of this system is not to introduce an complete, closed algebra over all types. That is impossible. The goal is also not to complete the project of German romanticism. That is also impossible.  

- There should never be any "global state" (no Wolfram `Assuming`). Assumptions live on FunctionGraphs. There is never a need to to deal with global context, logical combinations, relational assumptions. 
- We are not trying to be smart or figure out as much as possible. On the contrary, we want to be very dumb. The Assumptions should be maximally conservative, and fall back to UNKNOWN whenever there is runtime ambiguity. 
- Assumption logic lives separately from all other machinery. No other part of Pytensor needs to know anything about them. Evaluation logic does not check assumptions. Perform methods don't dispatch on the `FactState` of the `Node`. We check during rewrites and that's it.
- We do not aspire to provide Maple-style conditional dispatches. If we don't know, we just don't know. There is no `LinearAlgebra[IsDefinite]`. No symbolic conditionals as part of the core API.
- We are not and cannot be a theorm prover. We do not present assumptions to the user as a tool for this. Assumptions are primarily an inner-api, and rewrite-focused.

