### PR TITLE
Correct nit_sot shapes for scan with n_steps=0 (or raise)

### DIFF
--- a/doc/extending/creating_an_op.rst
+++ b/doc/extending/creating_an_op.rst
@@ -763,8 +763,8 @@ If you want to see it fail, you can implement an incorrect gradient
 Testing the pushforward
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The class :class:`RopLopChecker` defines the methods
-:meth:`RopLopChecker.check_mat_rop_lop`, :meth:`RopLopChecker.check_rop_lop` and :meth:`RopLopChecker.check_nondiff_rop`.
+The class :class:`PushforwardPullbackChecker` defines the methods
+:meth:`PushforwardPullbackChecker.check_mat_pushforward_pullback`, :meth:`PushforwardPullbackChecker.check_pushforward_pullback` and :meth:`PushforwardPullbackChecker.check_nondiff_pushforward`.
 These allow to test the implementation of the :meth:`pushforward` method of a particular :class:`Op`.
 
 For instance, to verify the :meth:`pushforward` method of the ``DoubleOp``, you can use this:
@@ -773,12 +773,12 @@ For instance, to verify the :meth:`pushforward` method of the ``DoubleOp``, you 
 
    import numpy
    import tests
-   from tests.test_rop import RopLopChecker
+   from tests.test_rop import PushforwardPullbackChecker
 
-   class TestDoubleOpRop(RopLopChecker):
+   class TestDoubleOpPushforward(PushforwardPullbackChecker):
 
-       def test_double_rop(self):
-           self.check_rop_lop(DoubleOp()(self.x), self.in_shape)
+       def test_double_pushforward(self):
+           self.check_pushforward_pullback(DoubleOp()(self.x), self.in_shape)
 
 
 Running Your Tests

--- a/doc/extending/creating_an_op.rst
+++ b/doc/extending/creating_an_op.rst
@@ -74,20 +74,12 @@ possibilities you may encounter or need.  For that refer to
         def perform(self, node: Apply, inputs_storage: list[Any], output_storage: list[list[Any]]) -> None:
             pass
 
-        # Defines the symbolic expression for the L-operator based on the input and output variables
-        # and the output gradient variables. Optional.
-        def L_op(self, inputs: list[Variable], outputs: list[Variable], output_grads: list[Variable]) -> list[Variable]:
+        # Defines the vector-Jacobian product (pullback/reverse-mode AD). Optional.
+        def pullback(self, inputs: list[Variable], outputs: list[Variable], cotangents: list[Variable]) -> list[Variable]:
             pass
 
-        # Equivalent to L_op, but with a "technically"-bad name and without outputs provided.
-        # It exists for historical reasons. Optional.
-        def grad(self, inputs: list[Variable], output_grads: list[Variable]) -> list[Variable]:
-            # Same as self.L_op(inputs, self(inputs), output_grads)
-            pass
-
-        # Defines the symbolic expression for the R-operator based on the input variables
-        # and eval_point variables. Optional.
-        def R_op(self, inputs: list[Variable], eval_points: list[Variable | None]) -> list[Variable | None]:
+        # Defines the Jacobian-vector product (pushforward/forward-mode AD). Optional.
+        def pushforward(self, inputs: list[Variable], outputs: list[Variable], tangents: list[Variable]) -> list[Variable]:
             pass
 
         # Defines the symbolic expression for the output shape based on the input shapes
@@ -182,36 +174,42 @@ This could be helpful if one only needs the shape of the output instead of the
 actual outputs, which can be useful, for instance, for rewriting
 procedures.
 
-:meth:`L_op`
-^^^^^^^^^^^^^^^
+:meth:`pullback`
+^^^^^^^^^^^^^^^^^^^
 
-The :meth:`L_op` method is required if you want to differentiate some cost
-whose expression includes your :class:`Op`. The gradient is
-specified symbolically in this method. It takes three arguments ``inputs``, ``outputs`` and
-``output_gradients``, which are both lists of :ref:`variable`\s, and
-those must be operated on using PyTensor's symbolic language. The :meth:`L_op`
-method must return a list containing one :ref:`variable` for each
-input. Each returned :ref:`variable` represents the gradient with respect
-to that input computed based on the symbolic gradients with respect
-to each output.
+The :meth:`pullback` method is required if you want to differentiate some cost
+whose expression includes your :class:`Op`. It implements the vector-Jacobian
+product (VJP) for reverse-mode automatic differentiation.
+
+It takes three arguments ``inputs``, ``outputs`` and ``cotangents``, which are
+all lists of :ref:`variable`\s that must be operated on using PyTensor's
+symbolic language. The :meth:`pullback` method must return a list containing
+one :ref:`variable` for each input. Each returned :ref:`variable` represents
+the cotangent (gradient) with respect to that input computed based on the
+symbolic cotangents with respect to each output.
 
 If the output is not differentiable with respect to an input then
-this method should be defined to return a variable of type :class:`NullType`
-for that input. Likewise, if you have not implemented the gradient
-computation for some input, you may return a variable of type
-:class:`NullType` for that input. Please refer to :meth:`L_op` for a more detailed
-view.
+this method should return a variable of type :class:`DisconnectedType`
+for that input. If the gradient is not implemented or undefined for some
+input, return a variable of type :class:`NullType` for that input
+(see :func:`pytensor.gradient.grad_not_implemented` and
+:func:`pytensor.gradient.grad_undefined`).
 
-:meth:`R_op`
-^^^^^^^^^^^^^^^
-The :meth:`R_op` method is needed if you want :func:`pytensor.gradient.Rop` to
-work with your :class:`Op`.
+:meth:`pushforward`
+^^^^^^^^^^^^^^^^^^^^^^
 
-This function implements the application of the R-operator on the
-function represented by your :class:`Op`. Let's assume that function is :math:`f`,
-with input :math:`x`, applying the R-operator means computing the
-Jacobian of :math:`f` and right-multiplying it by :math:`v`, the evaluation
-point, namely: :math:`\frac{\partial f}{\partial x} v`.
+The :meth:`pushforward` method is needed if you want :func:`pytensor.gradient.pushforward` to
+work with your :class:`Op` with the non-default ``use_op_pushforward=True`` argument.
+It implements the Jacobian-vector product (JVP) for forward-mode automatic
+differentiation.
+
+Given a function :math:`f` with input :math:`x`, the pushforward computes
+:math:`J \dot{x}` where :math:`J = \frac{\partial f}{\partial x}` is the
+Jacobian and :math:`\dot{x}` are the tangent vectors. It takes ``inputs``,
+``outputs``, and ``tangents`` as arguments. Tangent entries of type
+:class:`DisconnectedType` indicate that the corresponding input is not being
+differentiated. ``None`` must not be used to indicate disconnected entries;
+use :class:`DisconnectedType` variables instead.
 
 
 Example: :class:`Op` definition
@@ -253,22 +251,21 @@ Example: :class:`Op` definition
             # The output shape is the same as the input shape
             return input_shapes
 
-        def L_op(self, inputs: list[TensorVariable], outputs: list[TensorVariable], output_grads: list[TensorVariable]):
-            # Symbolic expression for the gradient
+        def pullback(self, inputs: list[TensorVariable], outputs: list[TensorVariable], cotangents: list[TensorVariable]):
+            # Symbolic expression for the vector-Jacobian product
             # For this Op, the inputs and outputs aren't part of the expression
-            # output_grads[0] is a TensorVariable!
-            return [output_grads[0] * 2]
+            # cotangents[0] is a TensorVariable!
+            return [cotangents[0] * 2]
 
-        def R_op(self, inputs: list[TensorVariable], eval_points: list[TensorVariable | None]) -> list[TensorVariable] | None:
-            # R_op can receive None as eval_points.
-            # That means there is no differentiable path through that input
-            # If this imply that you cannot compute some outputs,
-            # return None for those.
-            if eval_points[0] is None:
-                return None
-            # For this Op, the R_op is the same as the L_op
-            outputs = self(inputs)
-            return self.L_op(inputs, outputs, eval_points)
+        def pushforward(self, inputs: list[TensorVariable], outputs: list[TensorVariable], tangents: list[TensorVariable]):
+            from pytensor.gradient import DisconnectedType, disconnected_type
+
+            # pushforward receives DisconnectedType for non-differentiable inputs.
+            # If this means you cannot compute some outputs, return disconnected_type() for those.
+            if isinstance(tangents[0].type, DisconnectedType):
+                return [disconnected_type()]
+            # For this Op, the Jacobian-vector product is symmetric
+            return [tangents[0] * 2]
 
     doubleOp1 = DoubleOp1()
 
@@ -486,8 +483,8 @@ Furthermore, this :class:`Op` will work with batched dimensions, meaning we can 
 To achieve this behavior we cannot use `itypes` and `otypes` as those encode specific number of dimensions.
 Instead we will have to define the `make_node` method.
 
-We need to be careful in the :meth:`L_op` method, as one of output gradients may be disconnected from the cost, in which case we should ignore its contribution.
-If both outputs are disconnected PyTensor will not bother calling the :meth:`L_op` method, so we don't need to worry about that case.
+We need to be careful in the :meth:`pullback` method, as one of output cotangents may be disconnected from the cost, in which case we should ignore its contribution.
+If both outputs are disconnected PyTensor will not bother calling the :meth:`pullback` method, so we don't need to worry about that case.
 
 .. testcode::
 
@@ -534,23 +531,23 @@ If both outputs are disconnected PyTensor will not bother calling the :meth:`L_o
             out2_shape = y_shapes[:-1]
             return [out1_shape, out2_shape]
 
-        def L_op(self, inputs, outputs, output_grads):
+        def pullback(self, inputs, outputs, cotangents):
             x, y = inputs
-            out1_grad, out2_grad = output_grads
+            out1_ct, out2_ct = cotangents
 
-            if isinstance(out1_grad.type, DisconnectedType):
-                x_grad = disconnected_type()
+            if isinstance(out1_ct.type, DisconnectedType):
+                x_ct = disconnected_type()
             else:
-                # Transpose the last two dimensions of the output gradient
-                x_grad = pt.swapaxes(out1_grad, -1, -2)
+                # Transpose the last two dimensions of the output cotangent
+                x_ct = pt.swapaxes(out1_ct, -1, -2)
 
-            if isinstance(out2_grad.type, DisconnectedType):
-                y_grad = disconnected_type()
+            if isinstance(out2_ct.type, DisconnectedType):
+                y_ct = disconnected_type()
             else:
-                # Broadcast the output gradient to the same shape as y
-                y_grad = pt.broadcast_to(pt.expand_dims(out2_grad, -1), y.shape)
+                # Broadcast the output cotangent to the same shape as y
+                y_ct = pt.broadcast_to(pt.expand_dims(out2_ct, -1), y.shape)
 
-            return [x_grad, y_grad]
+            return [x_ct, y_ct]
 
 Let's test the `Op` evaluation:
 
@@ -659,8 +656,8 @@ that are added to the codebase, to be used with ``pytest``.
 
 Here we mention those that can be used to test the implementation of:
   :meth:`infer_shape`
-  :meth:`L_op`
-  :meth:`R_op`
+  :meth:`pullback`
+  :meth:`pushforward`
 
 
 Basic Tests
@@ -763,14 +760,14 @@ If you want to see it fail, you can implement an incorrect gradient
                 rng = rng,
             )
 
-Testing the Rop
-^^^^^^^^^^^^^^^
+Testing the pushforward
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The class :class:`RopLopChecker` defines the methods
 :meth:`RopLopChecker.check_mat_rop_lop`, :meth:`RopLopChecker.check_rop_lop` and :meth:`RopLopChecker.check_nondiff_rop`.
-These allow to test the implementation of the :meth:`R_op` method of a particular :class:`Op`.
+These allow to test the implementation of the :meth:`pushforward` method of a particular :class:`Op`.
 
-For instance, to verify the :meth:`R_op` method of the ``DoubleOp``, you can use this:
+For instance, to verify the :meth:`pushforward` method of the ``DoubleOp``, you can use this:
 
 .. testcode:: tests
 
@@ -798,7 +795,7 @@ Modify and execute to compute: ``x * y``.
 
 Modify and execute the example to return two outputs: ``x + y`` and `jx - yj`.
 
-You can omit the :meth:`Rop` functions. Try to implement the testing apparatus described above.
+You can omit the :meth:`pushforward` method. Try to implement the testing apparatus described above.
 
 :download:`Solution<extending_pytensor_solution_1.py>`
 
@@ -830,7 +827,7 @@ It takes an optional :meth:`infer_shape` parameter that must have this signature
 
 .. note::
 
-    As no L_op is defined, this means you won't be able to
+    As no pullback is defined, this means you won't be able to
     differentiate paths that include this :class:`Op`.
 
 .. note::

--- a/doc/extending/op.rst
+++ b/doc/extending/op.rst
@@ -244,21 +244,28 @@ Optional methods or attributes
 If you want your :class:`Op` to work with :func:`pytensor.gradient.grad` you also
 need to implement the functions described below.
 
-Gradient
-========
+Automatic Differentiation
+=========================
 
-These are the function required to work with :func:`pytensor.gradient.grad`.
+These are the functions required to work with :func:`pytensor.gradient.grad`
+and :func:`pytensor.gradient.pushforward`.
 
-.. function:: grad(inputs, output_gradients)
+.. function:: pullback(inputs, outputs, cotangents)
 
-  If the :class:`Op` being defined is differentiable, its gradient may be
-  specified symbolically in this method. Both ``inputs`` and
-  ``output_gradients`` are lists of symbolic PyTensor :class:`Variable`\s and
-  those must be operated on using PyTensor's symbolic language. The :meth:`Op.grad`
-  method must return a list containing one :class:`Variable` for each
-  input. Each returned :class:`Variable` represents the gradient with respect
-  to that input computed based on the symbolic gradients with respect
-  to each output.
+  Implements the vector-Jacobian product (VJP) for reverse-mode automatic
+  differentiation. This is the primary method for gradient computation.
+
+  Given a function :math:`f` with inputs :math:`x` and outputs :math:`y = f(x)`,
+  the pullback computes :math:`\bar{x} = \bar{y} J` where
+  :math:`J = \frac{\partial f}{\partial x}` is the Jacobian and
+  :math:`\bar{y}` are the cotangent (row) vectors (upstream gradients).
+
+  Both ``inputs``, ``outputs``, and ``cotangents`` are lists of symbolic PyTensor
+  :class:`Variable`\s and those must be operated on using PyTensor's symbolic
+  language. The :meth:`Op.pullback` method must return a list containing one
+  :class:`Variable` for each input. Each returned :class:`Variable` represents
+  the cotangent with respect to that input computed based on the symbolic
+  cotangents with respect to each output.
 
   If the output is not differentiable with respect to an input then
   this method should be defined to return a variable of type :class:`NullType`
@@ -269,108 +276,50 @@ These are the function required to work with :func:`pytensor.gradient.grad`.
   :func:`pytensor.gradient.grad_undefined` and
   :func:`pytensor.gradient.grad_not_implemented`, respectively.
 
-  If an element of ``output_gradient`` is of type
+  If an element of ``cotangents`` is of type
   :class:`pytensor.gradient.DisconnectedType`, it means that the cost is not a
   function of this output. If any of the :class:`Op`'s inputs participate in
-  the computation of only disconnected outputs, then :meth:`Op.grad` should
+  the computation of only disconnected outputs, then :meth:`Op.pullback` should
   return :class:`DisconnectedType` variables for those inputs.
 
-  If the :meth:`Op.grad` method is not defined, then PyTensor assumes it has been
+  If :meth:`Op.pullback` is not defined, then PyTensor assumes it has been
   forgotten.  Symbolic differentiation will fail on a graph that
   includes this :class:`Op`.
 
-  It must be understood that the :meth:`Op.grad` method is not meant to
-  return the gradient of the :class:`Op`'s output. :func:`pytensor.grad` computes
-  gradients; :meth:`Op.grad` is a helper function that computes terms that
-  appear in gradients.
-
   If an :class:`Op` has a single vector-valued output ``y`` and a single
-  vector-valued input ``x``, then the :meth:`Op.grad` method will be passed ``x`` and a
-  second vector ``z``. Define ``J`` to be the Jacobian of ``y`` with respect to
-  ``x``. The :meth:`Op.grad` method should return ``dot(J.T,z)``. When
-  :func:`pytensor.grad` calls the :meth:`Op.grad` method, it will set ``z`` to be the
-  gradient of the cost ``C`` with respect to ``y``. If this :class:`Op` is the only :class:`Op`
-  that acts on ``x``, then ``dot(J.T,z)`` is the gradient of C with respect to
-  ``x``.  If there are other :class:`Op`\s that act on ``x``, :func:`pytensor.grad` will
-  have to add up the terms of ``x``'s gradient contributed by the other
-  :meth:`Op.grad` method.
-
-  In practice, an :class:`Op`'s input and output are rarely implemented as
-  single vectors.  Even if an :class:`Op`'s output consists of a list
-  containing a scalar, a sparse matrix, and a 4D tensor, you can think
-  of these objects as being formed by rearranging a vector. Likewise
-  for the input. In this view, the values computed by the :meth:`Op.grad` method
-  still represent a Jacobian-vector product.
+  vector-valued input ``x``, then :meth:`Op.pullback` will be passed ``x``,
+  ``y``, and a cotangent vector ``z``. Define ``J`` to be the Jacobian of ``y``
+  with respect to ``x``. The method should return ``dot(z, J)``. When
+  :func:`pytensor.grad` calls :meth:`Op.pullback`, it will set ``z`` to be the
+  gradient of the cost ``C`` with respect to ``y``. If this :class:`Op` is the only
+  :class:`Op` that acts on ``x``, then ``dot(z, J)`` is the gradient of C with
+  respect to ``x``. If there are other :class:`Op`\s that act on ``x``,
+  :func:`pytensor.grad` will add up the terms of ``x``'s gradient contributed
+  by each :meth:`Op.pullback`.
 
   In practice, it is probably not a good idea to explicitly construct
   the Jacobian, which might be very large and very sparse. However,
-  the returned value should be equal to the Jacobian-vector product.
-
-  So long as you implement this product correctly, you need not
-  understand what :func:`pytensor.gradient.grad` is doing, but for the curious the
-  mathematical justification is as follows:
-
-  In essence, the :meth:`Op.grad` method must simply implement through symbolic
-  :class:`Variable`\s and operations the chain rule of differential
-  calculus. The chain rule is the mathematical procedure that allows
-  one to calculate the total derivative :math:`\frac{d C}{d x}` of the
-  final scalar symbolic `Variable` ``C`` with respect to a primitive
-  symbolic :class:`Variable` x found in the list ``inputs``.  The :meth:`Op.grad` method
-  does this using ``output_gradients`` which provides the total
-  derivative :math:`\frac{d C}{d f}` of ``C`` with respect to a symbolic
-  :class:`Variable` that is returned by the `Op` (this is provided in
-  ``output_gradients``), as well as the knowledge of the total
-  derivative :math:`\frac{d f}{d x}` of the latter with respect to the
-  primitive :class:`Variable` (this has to be computed).
-
-  In mathematics, the total derivative of a scalar variable :math:`C` with
-  respect to a vector of scalar variables :math:`x`, i.e. the gradient, is
-  customarily represented as the row vector of the partial
-  derivatives, whereas the total derivative of a vector of scalar
-  variables :math:`f` with respect to another :math:`x`, is customarily
-  represented by the matrix of the partial derivatives, i.e. the
-  Jacobian matrix. In this convenient setting, the chain rule
-  says that the gradient of the final scalar variable :math:`C` with
-  respect to the primitive scalar variables in :math:`x` through those in
-  :math:`f` is simply given by the matrix product:
-  :math:`\frac{d C}{d x} = \frac{d C}{d f} * \frac{d f}{d x}`.
-
-  Here, the chain rule must be implemented in a similar but slightly
-  more complex setting: PyTensor provides in the list
-  ``output_gradients`` one gradient for each of the :class:`Variable`\s returned
-  by the `Op`. Where :math:`f` is one such particular :class:`Variable`, the
-  corresponding gradient found in ``output_gradients`` and
-  representing :math:`\frac{d C}{d f}` is provided with a shape
-  similar to :math:`f` and thus not necessarily as a row vector of scalars.
-  Furthermore, for each :class:`Variable` :math:`x` of the :class:`Op`'s list of input variables
-  ``inputs``, the returned gradient representing :math:`\frac{d C}{d
-  x}` must have a shape similar to that of :class:`Variable` x.
-
-  If the output list of the :class:`Op` is :math:`[f_1, ... f_n]`, then the
-  list ``output_gradients`` is :math:`[grad_{f_1}(C), grad_{f_2}(C),
-  ... , grad_{f_n}(C)]`.  If ``inputs`` consists of the list
-  :math:`[x_1, ..., x_m]`, then `Op.grad` should return the list
-  :math:`[grad_{x_1}(C), grad_{x_2}(C), ..., grad_{x_m}(C)]`, where
-  :math:`(grad_{y}(Z))_i = \frac{\partial Z}{\partial y_i}` (and
-  :math:`i` can stand for multiple dimensions).
-
-  In other words, :meth:`Op.grad` does not return :math:`\frac{d f_i}{d
-  x_j}`, but instead the appropriate dot product specified by the
-  chain rule: :math:`\frac{d C}{d x_j} = \frac{d C}{d f_i} \cdot
-  \frac{d f_i}{d x_j}`.  Both the partial differentiation and the
-  multiplication have to be performed by :meth:`Op.grad`.
+  the returned value should be equal to the vector-Jacobian product.
+  Note that an :class:`Op`'s inputs and outputs may include scalars,
+  matrices, sparse arrays, or higher-dimensional tensors — not just vectors.
+  The VJP contract still applies: conceptually, each of these can be viewed
+  as a vector that has been reshaped into a tensor. The returned cotangent
+  for each input must have the same shape as that input, and each incoming
+  cotangent in ``cotangents`` will have the same shape as the corresponding
+  output.
 
   PyTensor currently imposes the following constraints on the values
-  returned by the :meth:`Op.grad` method:
+  returned by the :meth:`Op.pullback` method:
 
   1) They must be :class:`Variable` instances.
   2) When they are types that have dtypes, they must never have an integer dtype.
 
-  The output gradients passed *to* :meth:`Op.grad` will also obey these constraints.
+  The output cotangents passed *to* :meth:`Op.pullback` will also obey these
+  constraints.
 
   Integers are a tricky subject. Integers are the main reason for
   having :class:`DisconnectedType`, :class:`NullType` or zero gradient. When you have an
-  integer as an argument to your :meth:`Op.grad` method, recall the definition of
+  integer as an argument to your :meth:`Op.pullback` method, recall the definition of
   a derivative to help you decide what value to return:
 
   :math:`\frac{d f}{d x} = \lim_{\epsilon \rightarrow 0} (f(x+\epsilon)-f(x))/\epsilon`.
@@ -410,7 +359,7 @@ These are the function required to work with :func:`pytensor.gradient.grad`.
 
   1) :math:`f(x,y)` is a dot product between :math:`x` and :math:`y`. :math:`x` and :math:`y` are integers.
      Since the output is also an integer, :math:`f` is a step function.
-     Its gradient is zero almost everywhere, so :meth:`Op.grad` should return
+     Its gradient is zero almost everywhere, so :meth:`Op.pullback` should return
      zeros in the shape of :math:`x` and :math:`y`.
   2) :math:`f(x,y)` is a dot product between :math:`x` and :math:`y`. :math:`x`
      is floating point and :math:`y` is an integer.  In this case the output is
@@ -423,7 +372,7 @@ These are the function required to work with :func:`pytensor.gradient.grad`.
      along a fractional axis?  The gradient with respect to :math:`x` is 0,
      because :math:`f(x+\epsilon, y) = f(x)` almost everywhere.
   4) :math:`f(x,y)` is a vector with :math:`y` elements, each of which taking on
-     the value :math:`x` The :meth:`Op.grad` method should return
+     the value :math:`x` The :meth:`Op.pullback` method should return
      :class:`DisconnectedType` for :math:`y`, because the elements of :math:`f`
      don't depend on :math:`y`. Only the shape of :math:`f` depends on
      :math:`y`. You probably also want to implement a connection_pattern method to encode this.
@@ -432,6 +381,29 @@ These are the function required to work with :func:`pytensor.gradient.grad`.
      g(y) = 0.5 g(f(x))`, then the gradient with respect to :math:`y` will be 0.5,
      even if :math:`y` is an integer. However, the gradient with respect to :math:`x` will be
      0, because the output of :math:`f` is integer-valued.
+
+.. function:: pushforward(inputs, outputs, tangents)
+
+  Implements the Jacobian-vector product (JVP) for forward-mode automatic
+  differentiation.
+
+  Given a function :math:`f` with inputs :math:`x` and outputs :math:`y = f(x)`,
+  the pushforward computes :math:`\dot{y} = J \dot{x}` where
+  :math:`J = \frac{\partial f}{\partial x}` is the Jacobian and
+  :math:`\dot{x}` are the tangent vectors.
+
+  ``inputs`` are the symbolic variables corresponding to the input values,
+  ``outputs`` are the symbolic variables corresponding to the output values,
+  and ``tangents`` are the symbolic variables corresponding to the tangent
+  vectors to right-multiply the Jacobian with. Tangent entries of type
+  :class:`DisconnectedType` indicate that the corresponding input is not being
+  differentiated.
+
+  The method must return the same number of outputs as there are outputs of
+  the :class:`Op`. For each output, the result is the Jacobian of that output
+  with respect to the inputs, right-multiplied by the tangent vector. Return
+  a variable of type :class:`DisconnectedType` for outputs that are disconnected
+  from all inputs.
 
 .. function:: connection_pattern(node):
 
@@ -477,32 +449,4 @@ These are the function required to work with :func:`pytensor.gradient.grad`.
   :func:`pytensor.gradient.grad` returns an expression, that expression will be
   numerically correct.
 
-.. function:: R_op(inputs, eval_points)
-
-   Optional, to work with :func:`pytensor.gradient.R_op`.
-
-   This function implements the application of the R-operator on the
-   function represented by your :class:`Op`. Let assume that function is :math:`f`,
-   with input :math:`x`, applying the R-operator means computing the
-   Jacobian of :math:`f` and right-multiplying it by :math:`v`, the evaluation
-   point, namely: :math:`\frac{\partial f}{\partial x} v`.
-
-   ``inputs`` are the symbolic variables corresponding to the value of
-   the input where you want to evaluate the Jacobian, and ``eval_points``
-   are the symbolic variables corresponding to the value you want to
-   right multiply the Jacobian with.
-
-   Same conventions as for the :meth:`Op.grad` method hold. If your :class:`Op`
-   is not differentiable, you can return None. Note that in contrast to the
-   method :meth:`Op.grad`, for :meth:`Op.R_op` you need to return the
-   same number of outputs as there are outputs of the :class:`Op`. You can think
-   of it in the following terms. You have all your inputs concatenated
-   into a single vector :math:`x`. You do the same with the evaluation
-   points (which are as many as inputs and of the shame shape) and obtain
-   another vector :math:`v`. For each output, you reshape it into a vector,
-   compute the Jacobian of that vector with respect to :math:`x` and
-   multiply it by :math:`v`. As a last step you reshape each of these
-   vectors you obtained for each outputs (that have the same shape as
-   the outputs) back to their corresponding shapes and return them as the
-   output of the :meth:`Op.R_op` method.
 

--- a/doc/gallery/autodiff/vector_jacobian_product.ipynb
+++ b/doc/gallery/autodiff/vector_jacobian_product.ipynb
@@ -13,7 +13,7 @@
    "id": "ff301ea1be9ef0a6",
    "metadata": {},
    "source": [
-    "At the core of autodiff is the vector-Jacobian product (VJP), or in PyTensor's archaic terminology, the L-Operator (because the vector is on the left). The Jacobian is the matrix (or tensor) of all first-order partial derivatives. Let us completely ignore what the vector means, and think how do we go about computing the product of a general vector with the Jacobian matrix?"
+    "At the core of autodiff is the vector-Jacobian product (VJP), also known as the pullback. The Jacobian is the matrix (or tensor) of all first-order partial derivatives. Let us completely ignore what the vector means, and think how do we go about computing the product of a general vector with the Jacobian matrix?"
    ]
   },
   {
@@ -29,7 +29,7 @@
    "outputs": [],
    "source": [
     "import pytensor.tensor as pt\n",
-    "from pytensor.gradient import Lop, jacobian as jacobian_raw\n",
+    "from pytensor.gradient import pullback, jacobian as jacobian_raw\n",
     "from pytensor.graph import rewrite_graph\n",
     "import numpy as np"
    ]
@@ -193,7 +193,7 @@
     "\\end{pmatrix}\n",
     "$$\n",
     "\n",
-    "It is unnecessary to compute the whole Jacobian matrix, and then perform a vector-matrix multiplication. The `Lop` returns the smart computations directly:"
+    "It is unnecessary to compute the whole Jacobian matrix, and then perform a vector-matrix multiplication. The pullback returns the smart computations directly:"
    ]
   },
   {
@@ -219,7 +219,7 @@
    ],
    "source": [
     "v = pt.vector(\"v\")\n",
-    "vjp_log = Lop(log_x, wrt=x, eval_points=v)\n",
+    "vjp_log = pullback(log_x, wrt=x, cotangents=v)\n",
     "simplify_print(vjp_log)"
    ]
   },
@@ -428,7 +428,7 @@
    ],
    "source": [
     "v = pt.vector(\"v\")\n",
-    "vjp_cumsum = Lop(cumsum_x, x, v)\n",
+    "vjp_cumsum = pullback(cumsum_x, x, v)\n",
     "simplify_print(vjp_cumsum)"
    ]
   },
@@ -642,7 +642,7 @@
    ],
    "source": [
     "v = pt.vector(\"v\", shape=(4,))\n",
-    "vjp_convolution = Lop(convolution_xy, y, v)\n",
+    "vjp_convolution = pullback(convolution_xy, y, v)\n",
     "simplify_print(vjp_convolution)"
    ]
   },
@@ -849,7 +849,7 @@
    "id": "0e39d268-12c3-463f-9ec7-e8b48bbd95d4",
    "metadata": {},
    "source": [
-    "To recreate the outcome of `Lop`, we ravel the `V` matrix, multiply it with the Jacobian defined on the raveled function, and reshape the result to the original input shape."
+    "To recreate the outcome of the pullback, we ravel the `V` matrix, multiply it with the Jacobian defined on the raveled function, and reshape the result to the original input shape."
    ]
   },
   {
@@ -887,7 +887,7 @@
     "\n",
     "What's more, after the reshape, we end up with a simple transposition of the original `V` matrix!\n",
     "\n",
-    "Unsurprisingly, `Lop` takes the direct shortcut:"
+    "Unsurprisingly, the pullback takes the direct shortcut:"
    ]
   },
   {
@@ -916,7 +916,7 @@
     }
    ],
    "source": [
-    "Lop(transpose_A, A, V).dprint()"
+    "pullback(transpose_A, A, V).dprint()"
    ]
   },
   {
@@ -932,7 +932,7 @@
    "id": "4f92c6a4-27d2-4854-8b66-038eca62ebb7",
    "metadata": {},
    "source": [
-    "It is time to reveal the meaning of the mysterious vector (or reshaped tensor) `v`. In the context ouf auto-diff, it is the vector that accumulates the partial derivatives of intermediate computations. If you chain the VJP for each operation in your graph you obtain reverse-mode autodiff. \n",
+    "It is time to reveal the meaning of the mysterious vector (or reshaped tensor) `v`. In the context of auto-diff, it is the cotangent vector that accumulates the partial derivatives of intermediate computations. If you chain the pullback for each operation in your graph you obtain reverse-mode autodiff.\n",
     "\n",
     "Let's look at a simple example with the operations we discussed already:"
    ]
@@ -983,7 +983,7 @@
    "source": [
     "You may recognize the gradient components from the examples above. The gradient simplifies to `cumsum(ones_like(x))[::-1] / x`\n",
     "\n",
-    "We can build the same graph manually, by chaining two `Lop` calls and setting the initial `grad_vec` to `ones` with the right shape."
+    "We can build the same graph manually, by chaining two pullback calls and setting the initial cotangent vector to `ones` with the right shape."
    ]
   },
   {
@@ -1010,7 +1010,7 @@
    ],
    "source": [
     "grad_vec = pt.ones_like(cumsum_log_x)\n",
-    "grad_out_wrt_x = Lop(log_x, x, Lop(cumsum_log_x, log_x, grad_vec))\n",
+    "grad_out_wrt_x = pullback(log_x, x, pullback(cumsum_log_x, log_x, grad_vec))\n",
     "simplify_print(grad_out_wrt_x)"
    ]
   },
@@ -1019,7 +1019,7 @@
    "id": "a2e9e121-7363-41f9-9c1d-d6792db36bcc",
    "metadata": {},
    "source": [
-    "Similarly, forward-mode autodiff makes use of the R-Operator (Rop) or Jacobian-vector product (JVP) to accumulate the partial derivations from inputs to outputs."
+    "Similarly, forward-mode autodiff makes use of the pushforward (also known as the Jacobian-vector product, or JVP) to accumulate the partial derivatives from inputs to outputs."
    ]
   },
   {

--- a/doc/internal/metadocumentation.rst
+++ b/doc/internal/metadocumentation.rst
@@ -61,11 +61,11 @@ For example::
 
 Link to the generated doc of a class this way::
 
-    :class:`RopLop_checker`
+    :class:`PushforwardPullbackChecker`
 
 For example::
 
-    The class :class:`RopLop_checker`, give the functions
+    The class :class:`PushforwardPullbackChecker`, give the functions
 
 
 However, if the link target is ambiguous, Sphinx will generate warning or errors.

--- a/doc/tutorial/gradients.rst
+++ b/doc/tutorial/gradients.rst
@@ -144,17 +144,17 @@ matrix which corresponds to the Jacobian.
 Using automatic vectorization
 -----------------------------
 An alternative way to build the Jacobian is to vectorize the graph that computes a single row or colum of the jacobian
-We can use `Lop` or `Rop` (more about it below) to obtain the row or column of the jacobian and `vectorize_graph`
+We can use `pullback` or `pushforward` (more about it below) to obtain the row or column of the jacobian and `vectorize_graph`
 to vectorize it to the full jacobian matrix.
 
 >>> import pytensor
 >>> import pytensor.tensor as pt
->>> from pytensor.gradient import Lop
+>>> from pytensor.gradient import pullback
 >>> from pytensor.graph import vectorize_graph
 >>> x = pt.dvector('x')
 >>> y = x ** 2
 >>> row_cotangent = pt.dvector("row_cotangent")  # Helper variable, it will be replaced during vectorization
->>> J_row = Lop(y, x, row_cotangent)
+>>> J_row = pullback(y, x, row_cotangent)
 >>> J = vectorize_graph(J_row, replace={row_cotangent: pt.eye(x.size)})
 >>> f = pytensor.function([x], J)
 >>> f([4, 4])
@@ -207,16 +207,16 @@ in practice, implementing such optimizations in a generic manner is extremely
 difficult. Therefore, we provide special functions dedicated to these tasks.
 
 
-R-operator
-----------
+Pushforward (Jacobian-vector product)
+-------------------------------------
 
-The **R operator** is built to evaluate the product between a Jacobian and a
+The **pushforward** evaluates the product between a Jacobian and a
 vector, namely :math:`\frac{\partial f(x)}{\partial x} v`. The formulation
 can be extended even for :math:`x` being a matrix, or a tensor in general, case in
 which also the Jacobian becomes a tensor and the product becomes some kind
 of tensor product. Because in practice we end up needing to compute such
 expressions in terms of weight matrices, PyTensor supports this more generic
-form of the operation. In order to evaluate the R-operation of
+form of the operation. In order to evaluate the pushforward of
 expression ``y``, with respect to ``x``, multiplying the Jacobian with ``V``
 you need to do something similar to this:
 
@@ -224,40 +224,40 @@ you need to do something similar to this:
 >>> V = pt.dmatrix('V')
 >>> x = pt.dvector('x')
 >>> y = pt.dot(x, W)
->>> JV = pytensor.gradient.Rop(y, W, V)
+>>> JV = pytensor.gradient.pushforward(y, W, V)
 >>> f = pytensor.function([W, V, x], JV)
 >>> f([[1, 1], [1, 1]], [[2, 2], [2, 2]], [0,1])
 array([ 2.,  2.])
 
-By default, the R-operator is implemented as a double application of the L_operator
+By default, the pushforward is implemented as a double application of the pullback
 (see `reference <https://j-towns.github.io/2017/06/12/A-new-trick.html>`_).
-In most cases this should be as performant as a specialized implementation of the R-operator.
+In most cases this should be as performant as a specialized implementation of the pushforward.
 However, PyTensor may sometimes fail to prune dead branches or fuse common expressions within composite operators,
-such as Scan and OpFromGraph, that would be more easily avoidable in a direct implentation of the R-operator.
+such as Scan and OpFromGraph, that would be more easily avoidable in a direct implentation of the pushforward.
 
-When this is a concern, it is possible to force `Rop` to use the specialized `Op.R_op` methods by passing
-`use_op_rop_implementation=True`. Note that this will fail if the graph contains `Op`s that don't implement this method.
+When this is a concern, it is possible to force `pushforward` to use the specialized `Op.pushforward` methods by passing
+`use_op_pushforward=True`. Note that this will fail if the graph contains `Op`s that don't implement this method.
 
 
->>> JV = pytensor.gradient.Rop(y, W, V, use_op_rop_implementation=True)
+>>> JV = pytensor.gradient.pushforward(y, W, V, use_op_pushforward=True)
 >>> f = pytensor.function([W, V, x], JV)
 >>> f([[1, 1], [1, 1]], [[2, 2], [2, 2]], [0,1])
 array([ 2.,  2.])
 
 
-L-operator
-----------
+Pullback (vector-Jacobian product)
+----------------------------------
 
-In similitude to the R-operator, the **L-operator** would compute a row vector times
+The **pullback** computes a row vector times
 the Jacobian. The mathematical formula would be :math:`v \frac{\partial
-f(x)}{\partial x}`. The L-operator is also supported for generic tensors
+f(x)}{\partial x}`. The pullback is also supported for generic tensors
 (not only for vectors). Similarly, it can be implemented as follows:
 
 >>> W = pt.dmatrix('W')
 >>> v = pt.dvector('v')
 >>> x = pt.dvector('x')
 >>> y = pt.dot(x, W)
->>> VJ = pytensor.gradient.Lop(y, W, v)
+>>> VJ = pytensor.gradient.pullback(y, W, v)
 >>> f = pytensor.function([v,x], VJ)
 >>> f([2, 2], [0, 1])
 array([[ 0.,  0.],
@@ -265,12 +265,12 @@ array([[ 0.,  0.],
 
 .. note::
 
-    ``v``, the point of evaluation, differs between the L-operator and the R-operator.
-    For the L-operator, the point of evaluation needs to have the same shape
-    as the output, whereas for the R-operator this point should
+    The cotangent/tangent vectors differ between the pullback and the pushforward.
+    For the pullback, the cotangent vectors need to have the same shape
+    as the output, whereas for the pushforward the tangent vectors should
     have the same shape as the input parameter. Furthermore, the results of these two
-    operations differ. The result of the L-operator is of the same shape
-    as the input parameter, while the result of the R-operator has a shape similar
+    operations differ. The result of the pullback is of the same shape
+    as the input parameter, while the result of the pushforward has a shape similar
     to that of the output.
 
 
@@ -294,13 +294,13 @@ Hence, we suggest profiling the methods before using either one of the two:
 array([ 4.,  4.])
 
 
-or, making use of the R-operator:
+or, making use of the pushforward:
 
 >>> x = pt.dvector('x')
 >>> v = pt.dvector('v')
 >>> y = pt.sum(x ** 2)
 >>> gy = pt.grad(y, x)
->>> Hv = pytensor.gradient.Rop(gy, x, v)
+>>> Hv = pytensor.gradient.pushforward(gy, x, v)
 >>> f = pytensor.function([x, v], Hv)
 >>> f([4, 4], [2, 2])
 array([ 4.,  4.])

--- a/pytensor/__init__.py
+++ b/pytensor/__init__.py
@@ -24,7 +24,7 @@ from pytensor.compile import (
 )
 from pytensor.compile.maker import function
 from pytensor.compile.mode import get_mode
-from pytensor.gradient import Lop, Rop, grad
+from pytensor.gradient import Lop, Rop, grad, pullback, pushforward
 from pytensor.printing import debugprint as dprint
 
 from pytensor.ifelse import ifelse

--- a/pytensor/breakpoint.py
+++ b/pytensor/breakpoint.py
@@ -141,7 +141,7 @@ class PdbBreakpoint(Op):
             for i in range(len(output_storage)):
                 output_storage[i][0] = inputs[i + 1]
 
-    def grad(self, inputs, output_gradients):
+    def pullback(self, inputs, outputs, output_gradients):
         return [disconnected_type(), *output_gradients]
 
     def infer_shape(self, fgraph, inputs, input_shapes):

--- a/pytensor/compile/builders.py
+++ b/pytensor/compile/builders.py
@@ -13,7 +13,7 @@ from typing import cast
 from pytensor.compile.maker import function
 from pytensor.compile.rebuild import rebuild_collect_shared
 from pytensor.compile.sharedvalue import SharedVariable
-from pytensor.gradient import DisconnectedType, Rop, disconnected_type, grad
+from pytensor.gradient import DisconnectedType, disconnected_type, grad, pushforward
 from pytensor.graph.basic import (
     Apply,
     Constant,
@@ -235,7 +235,11 @@ class OpFromGraph(Op, HasInnerGraph):
             return z * 2
 
 
-        op = OpFromGraph([x, y, z], [e], lop_overrides=[None, rescale_dy, None])
+        op = OpFromGraph(
+            [x, y, z],
+            [e],
+            pullback=[None, rescale_dy, None],
+        )
         e2 = op(x, y, z)
         dx, dy, dz = grad(e2, [x, y, z])
         fn = function([x, y, z], [dx, dy, dz])
@@ -249,8 +253,10 @@ class OpFromGraph(Op, HasInnerGraph):
         outputs: list[Variable],
         *,
         inline: bool = False,
-        lop_overrides: Callable | list | OpFromGraph | None = None,
-        rop_overrides: Callable | list | OpFromGraph | None = None,
+        pullback: Callable | OpFromGraph | None = None,
+        pushforward: Callable | OpFromGraph | None = None,
+        lop_overrides: Callable | OpFromGraph | None = None,
+        rop_overrides: Callable | OpFromGraph | None = None,
         connection_pattern: list[list[bool]] | None = None,
         strict: bool = False,
         name: str | None = None,
@@ -267,32 +273,54 @@ class OpFromGraph(Op, HasInnerGraph):
         inline : bool, optional
             If True, the Op's inner graph is inlined during compilation. If False (default), a
             pre-compiled function is used instead.
-        lop_overrides : callable or OpFromGraph or list or None, optional
-            Override for the L_op method.
+        pullback
+            Overrides the :meth:`Op.pullback` (vector-Jacobian product) method.
 
-            - None: use the default L_op result.
-            - OpFromGraph: should accept ``(inputs, outputs, output_grads)`` with the same types
-              as the inner graph.
-            - callable: should take three args ``(inputs, outputs, output_grads)``, each a list of
-              Variable, and return a list of Variable.
-            - list: one entry per input. Each entry is None (use default), a DisconnectedType or
-              NullType Variable, or a callable returning a single Variable.
-        rop_overrides : callable or OpFromGraph or list or None, optional
-            Override for the R_op method.
+            ``None``: Do not override, use the default :meth:`Op.pullback` result
 
-            - None: use the default R_op result.
-            - OpFromGraph: should accept ``(inputs, eval_points)`` with the same types as the
-              inner graph inputs.
-            - callable: should take two args ``(inputs, eval_points)``, each a list of Variable,
-              and return a list of Variable.
-            - list: one entry per output. Each entry is None (use default), a DisconnectedType or
-              NullType Variable, or a callable returning a single Variable.
+            `OpFromGraph`: Override with another `OpFromGraph`, should
+            accept inputs as the same order and types of ``inputs``,
+            ``outputs`` and ``cotangents`` arguments as one would specify in
+            :meth:`Op.pullback`.
+
+            `callable`: Should take three args: ``inputs``, ``outputs`` and ``cotangents``.
+            Each argument is expected to be a list of :class:`Variable`.
+            Must return list of :class:`Variable`.
+
+            ``list``: Each `OpFromGraph`/callable must return a single
+            :class:`Variable`. Each list element corresponds to gradient of
+            a specific input, length of list must be equal to number of inputs.
+
+        pushforward
+            Overrides the :meth:`Op.pushforward` (Jacobian-vector product) method.
+
+            ``None``: Do not override, use the default :meth:`Op.pushforward` result
+
+            `OpFromGraph`: Override with another `OpFromGraph`, should
+            accept inputs as the same order and types of ``inputs`` and ``tangents``
+            arguments as one would specify in :meth:`Op.pushforward`.
+
+            `callable`: Should take two args: ``inputs`` and ``tangents``.
+            Each argument is expected to be a list of :class:`Variable`.  Must
+            return list of :class:`Variable`.
+
+            ``list``:
+            Each :class:`OpFromGraph`/callable must return a single
+            :class:`Variable <pytensor.graph.basic.Variable>`. Each list element
+            corresponds to a specific output of :meth:`Op.pushforward`, length of list
+            must be equal to number of outputs.
 
             .. warning::
 
-                R_op overrides are ignored when ``pytensor.gradient.Rop`` is called with
-                ``use_op_rop_implementation=False`` (the default). In that case the L_op is used
-                twice to obtain a mathematically equivalent R_op.
+                pushforward is ignored when ``pytensor.gradient.pushforward`` is called with
+                ``use_op_pushforward=False`` (the default). In that case the pullback is used
+                twice to obtain a mathematically equivalent pushforward.
+
+        lop_overrides
+            .. deprecated:: Use ``pullback`` instead.
+
+        rop_overrides
+            .. deprecated:: Use ``pushforward`` instead.
         connection_pattern : list of list of bool, optional
             If provided, used as the connection pattern for this Op. Each inner list has one bool
             per output, and the outer list has one entry per input.
@@ -344,10 +372,28 @@ class OpFromGraph(Op, HasInnerGraph):
         self.input_types = [inp.type for inp in inputs]
         self.output_types = [out.type for out in outputs]
 
-        self.lop_overrides = lop_overrides
-        self.rop_overrides = rop_overrides
-        # Dictionary where we cache OpFromGraph that represent the L_op
-        # A distinct OpFromGraph is needed to represent each pattern of output_grads connection
+        if lop_overrides is not None:
+            if pullback is not None:
+                raise ValueError("lop_overrides and pullback are mutually exclusive")
+            warnings.warn(
+                "lop_overrides is deprecated in favor of pullback.",
+                FutureWarning,
+            )
+            pullback = lop_overrides
+
+        if rop_overrides is not None:
+            if pushforward is not None:
+                raise ValueError("rop_overrides and pushforward are mutually exclusive")
+            warnings.warn(
+                "rop_overrides is deprecated in favor of pushforward.",
+                FutureWarning,
+            )
+            pushforward = rop_overrides
+
+        self.pullback_overrides = pullback
+        self.pushforward_overrides = pushforward
+        # Dictionary where we cache OpFromGraph that represent the pullback
+        # A distinct OpFromGraph is needed to represent each pattern of cotangents connection
         # It also returns a tuple that indicates which input_gradients are disconnected
         self._lop_op_cache: dict[tuple[bool, ...], Callable] = {}
         self._rop_op_cache: Callable | None = None
@@ -409,8 +455,8 @@ class OpFromGraph(Op, HasInnerGraph):
         if self._frozen_lop is not None or self._frozen_rop is not None:
             return
 
-        lop = self.lop_overrides
-        rop = self.rop_overrides
+        lop = self.pullback_overrides
+        rop = self.pushforward_overrides
         if lop is None and rop is None:
             return
 
@@ -511,11 +557,11 @@ class OpFromGraph(Op, HasInnerGraph):
         outputs = op_overrides(*callable_args)
         if not isinstance(outputs, list):
             raise TypeError(
-                f"Lop/Rop overriding function should return a list, got {type(outputs)}"
+                f"pullback/pushforward overriding function should return a list, got {type(outputs)}"
             )
         if len(outputs) != nout:
             raise ValueError(
-                f"Lop/Rop overriding function {self.rop_overrides} should return "
+                f"pullback/pushforward overriding function {self.pushforward_overrides} should return "
                 f"a list of {nout} outputs, got {len(outputs)}"
             )
         return outputs
@@ -523,8 +569,8 @@ class OpFromGraph(Op, HasInnerGraph):
     def _build_and_cache_lop_op(
         self, disconnected_output_grads: tuple[bool, ...]
     ) -> Callable:
-        """converts lop_overrides from user supplied form to type(self) instance,
-        specialized for the pattern of disconnected_output_grads
+        """Converts pullback_overrides from user supplied form to type(self) instance,
+        specialized for the pattern of disconnected_output_grads.
 
         Results are cached in self._lop_op_cache
         """
@@ -537,12 +583,12 @@ class OpFromGraph(Op, HasInnerGraph):
         inner_outputs = self.inner_outputs
         nin = len(inner_inputs)
         nout = len(inner_outputs)
-        lop_overrides = self.lop_overrides
+        pullback_overrides = self.pullback_overrides
 
-        if isinstance(lop_overrides, OpFromGraph):
-            self._lop_op_cache[disconnected_output_grads] = lop_overrides
-            lop_overrides.kwargs["on_unused_input"] = "ignore"
-            return lop_overrides
+        if isinstance(pullback_overrides, OpFromGraph):
+            self._lop_op_cache[disconnected_output_grads] = pullback_overrides
+            pullback_overrides.kwargs["on_unused_input"] = "ignore"
+            return pullback_overrides
 
         # We try to compute the gradient with respect to connected outputs only
         connected_inner_outputs = [
@@ -579,10 +625,10 @@ class OpFromGraph(Op, HasInnerGraph):
         )
 
         # we need to convert _lop_op into an OfG instance
-        if lop_overrides is None:
+        if pullback_overrides is None:
             input_grads = fn_grad(wrt=inner_inputs)
-        elif isinstance(lop_overrides, list):
-            custom_input_grads = lop_overrides
+        elif isinstance(pullback_overrides, list):
+            custom_input_grads = pullback_overrides
             if len(custom_input_grads) != nin:
                 raise ValueError(
                     f"Need to override {nin} gradients, got {len(custom_input_grads)}",
@@ -600,7 +646,9 @@ class OpFromGraph(Op, HasInnerGraph):
                 default_input_grads, custom_input_grads, callable_args
             )
         else:
-            input_grads = self._call_custom_override(lop_overrides, callable_args, nin)
+            input_grads = self._call_custom_override(
+                pullback_overrides, callable_args, nin
+            )
 
         # Filter out disconnected/null input generated from the inner graph grad
         # We append them in the outer wrapper function below
@@ -650,7 +698,7 @@ class OpFromGraph(Op, HasInnerGraph):
         return wrapper
 
     def _build_and_cache_rop_op(self):
-        """Converts rop_overrides from user supplied form to type(self) instance.
+        """Converts pushforward_overrides from user supplied form to type(self) instance.
 
         Results are cached in self._rop_op_cache
         """
@@ -660,31 +708,31 @@ class OpFromGraph(Op, HasInnerGraph):
         inner_inputs = self.inner_inputs
         inner_outputs = self.inner_outputs
         nout = len(inner_outputs)
-        rop_overrides = self.rop_overrides
+        pushforward_overrides = self.pushforward_overrides
 
-        if isinstance(rop_overrides, OpFromGraph):
-            self._rop_op_cache = rop_overrides
-            return rop_overrides
+        if isinstance(pushforward_overrides, OpFromGraph):
+            self._rop_op_cache = pushforward_overrides
+            return pushforward_overrides
 
         eval_points = [inp_t() for inp_t in self.input_types]
-        fn_rop = partial(
-            Rop,
+        fn_pf = partial(
+            pushforward,
             wrt=inner_inputs,
-            eval_points=eval_points,
-            use_op_rop_implementation=True,
+            tangents=eval_points,
+            use_op_pushforward=True,
         )
 
         callable_args = (inner_inputs, eval_points)
-        if rop_overrides is None:
-            output_grads = fn_rop(f=inner_outputs)
-        elif isinstance(rop_overrides, list):
-            custom_output_grads = rop_overrides
+        if pushforward_overrides is None:
+            output_grads = fn_pf(f=inner_outputs)
+        elif isinstance(pushforward_overrides, list):
+            custom_output_grads = pushforward_overrides
             if len(custom_output_grads) != nout:
                 raise ValueError(
-                    f"Need to override {int(nout)} Rop, got {len(custom_output_grads)}",
+                    f"Need to override {int(nout)} pushforward, got {len(custom_output_grads)}",
                     custom_output_grads,
                 )
-            # get outputs that does not have Rop override
+            # get outputs that don't have pushforward override
             f = [
                 output
                 for output, custom_output_grad in zip(
@@ -692,13 +740,13 @@ class OpFromGraph(Op, HasInnerGraph):
                 )
                 if custom_output_grad is None
             ]
-            default_output_grads = fn_rop(f=f) if f else []
+            default_output_grads = fn_pf(f=f) if f else []
             output_grads = self._combine_list_overrides(
                 default_output_grads, custom_output_grads, callable_args
             )
         else:
             output_grads = self._call_custom_override(
-                rop_overrides, callable_args, nout
+                pushforward_overrides, callable_args, nout
             )
 
         # Filter out disconnected output gradients
@@ -716,13 +764,12 @@ class OpFromGraph(Op, HasInnerGraph):
         )
 
         # Return a wrapper that combines connected and disconnected output gradients
-        def wrapper(*inputs: Variable, **kwargs) -> list[Variable | None]:
+        def wrapper(*inputs: Variable, **kwargs) -> list[Variable]:
             connected_output_grads = iter(rop_op(*inputs, **kwargs))
             all_output_grads = []
             for out_grad in output_grads:
                 if isinstance(out_grad.type, DisconnectedType):
-                    # R_Op does not have DisconnectedType yet, None should be used instead
-                    all_output_grads.append(None)
+                    all_output_grads.append(disconnected_type())
                 elif isinstance(out_grad.type, NullType):
                     all_output_grads.append(out_grad)
                 else:
@@ -732,14 +779,14 @@ class OpFromGraph(Op, HasInnerGraph):
         self._rop_op_cache = wrapper
         return wrapper
 
-    def L_op(self, inputs, outputs, output_grads):
+    def pullback(self, inputs, outputs, output_grads):
         disconnected_output_grads = tuple(
             isinstance(og.type, DisconnectedType) for og in output_grads
         )
         lop_op = self._build_and_cache_lop_op(disconnected_output_grads)
         return lop_op(*inputs, *outputs, *output_grads, return_list=True)
 
-    def R_op(self, inputs, eval_points):
+    def pushforward(self, inputs, outputs, eval_points):
         rop_op = self._build_and_cache_rop_op()
         return rop_op(*inputs, *eval_points, return_list=True)
 
@@ -806,8 +853,8 @@ class OpFromGraph(Op, HasInnerGraph):
                 inputs=new_inner_inputs,
                 outputs=new_inner_outputs,
                 inline=self.is_inline,
-                lop_overrides=self.lop_overrides,
-                rop_overrides=self.rop_overrides,
+                pullback=self.pullback_overrides,
+                pushforward=self.pushforward_overrides,
                 connection_pattern=self._connection_pattern,
                 name=self.name,
                 destroy_map=self.destroy_map,

--- a/pytensor/compile/builders.py
+++ b/pytensor/compile/builders.py
@@ -250,7 +250,6 @@ class OpFromGraph(Op, HasInnerGraph):
         *,
         inline: bool = False,
         lop_overrides: Callable | list | OpFromGraph | None = None,
-        grad_overrides: Callable | list | OpFromGraph | None = None,
         rop_overrides: Callable | list | OpFromGraph | None = None,
         connection_pattern: list[list[bool]] | None = None,
         strict: bool = False,
@@ -269,7 +268,7 @@ class OpFromGraph(Op, HasInnerGraph):
             If True, the Op's inner graph is inlined during compilation. If False (default), a
             pre-compiled function is used instead.
         lop_overrides : callable or OpFromGraph or list or None, optional
-            Override for the L_op method. Mutually exclusive with ``grad_overrides``.
+            Override for the L_op method.
 
             - None: use the default L_op result.
             - OpFromGraph: should accept ``(inputs, outputs, output_grads)`` with the same types
@@ -278,10 +277,6 @@ class OpFromGraph(Op, HasInnerGraph):
               Variable, and return a list of Variable.
             - list: one entry per input. Each entry is None (use default), a DisconnectedType or
               NullType Variable, or a callable returning a single Variable.
-        grad_overrides : callable or OpFromGraph or list or None, optional
-            Deprecated in favor of ``lop_overrides``. Same as ``lop_overrides`` but the callable
-            signature is ``(inputs, output_grads)`` (no ``outputs`` argument). Mutually exclusive
-            with ``lop_overrides``.
         rop_overrides : callable or OpFromGraph or list or None, optional
             Override for the R_op method.
 
@@ -349,31 +344,8 @@ class OpFromGraph(Op, HasInnerGraph):
         self.input_types = [inp.type for inp in inputs]
         self.output_types = [out.type for out in outputs]
 
-        for override in (lop_overrides, grad_overrides, rop_overrides):
-            if override == "default":
-                raise ValueError(
-                    "'default' is no longer a valid value for overrides. Use None instead."
-                )
-            if isinstance(override, Variable):
-                raise TypeError(
-                    "Variables are no longer valid types for overrides. Return them in a list for each output instead"
-                )
-
         self.lop_overrides = lop_overrides
-        self.grad_overrides = grad_overrides
         self.rop_overrides = rop_overrides
-
-        self._lop_op_interface = True
-        if grad_overrides is not None:
-            if lop_overrides is not None:
-                raise ValueError(
-                    "lop_overrides and grad_overrides are mutually exclusive"
-                )
-            warnings.warn(
-                "grad_overrides is deprecated in favor of lop_overrides. Using it will lead to an error in the future.",
-                FutureWarning,
-            )
-            self._lop_op_interface = False
         # Dictionary where we cache OpFromGraph that represent the L_op
         # A distinct OpFromGraph is needed to represent each pattern of output_grads connection
         # It also returns a tuple that indicates which input_gradients are disconnected
@@ -437,7 +409,7 @@ class OpFromGraph(Op, HasInnerGraph):
         if self._frozen_lop is not None or self._frozen_rop is not None:
             return
 
-        lop = self.lop_overrides if self._lop_op_interface else self.grad_overrides
+        lop = self.lop_overrides
         rop = self.rop_overrides
         if lop is None and rop is None:
             return
@@ -450,14 +422,9 @@ class OpFromGraph(Op, HasInnerGraph):
                     dummy_inputs = [t() for t in self.input_types]
                     dummy_outputs = [t() for t in self.output_types]
                     dummy_output_grads = [t() for t in self.output_types]
-                    if self._lop_op_interface:
-                        return dummy_inputs + dummy_outputs + dummy_output_grads, (
-                            dummy_inputs,
-                            dummy_outputs,
-                            dummy_output_grads,
-                        )
-                    return dummy_inputs + dummy_output_grads, (
+                    return dummy_inputs + dummy_outputs + dummy_output_grads, (
                         dummy_inputs,
+                        dummy_outputs,
                         dummy_output_grads,
                     )
 
@@ -556,7 +523,7 @@ class OpFromGraph(Op, HasInnerGraph):
     def _build_and_cache_lop_op(
         self, disconnected_output_grads: tuple[bool, ...]
     ) -> Callable:
-        """converts lop_overrides (or grad_overrides) from user supplied form to type(self) instance,
+        """converts lop_overrides from user supplied form to type(self) instance,
         specialized for the pattern of disconnected_output_grads
 
         Results are cached in self._lop_op_cache
@@ -570,21 +537,12 @@ class OpFromGraph(Op, HasInnerGraph):
         inner_outputs = self.inner_outputs
         nin = len(inner_inputs)
         nout = len(inner_outputs)
-        lop_overrides = (
-            self.lop_overrides if self._lop_op_interface else self.grad_overrides
-        )
+        lop_overrides = self.lop_overrides
 
         if isinstance(lop_overrides, OpFromGraph):
-            if self._lop_op_interface:
-                self._lop_op_cache[disconnected_output_grads] = lop_overrides
-                lop_overrides.kwargs["on_unused_input"] = "ignore"
-                return lop_overrides
-
-            else:
-                # We need to add a wrapper for the different input signature
-                # TODO: Remove this once the grad interface is gone
-                def lop_overrides(inps, grads):
-                    return self.grad_overrides(*inps, *grads)
+            self._lop_op_cache[disconnected_output_grads] = lop_overrides
+            lop_overrides.kwargs["on_unused_input"] = "ignore"
+            return lop_overrides
 
         # We try to compute the gradient with respect to connected outputs only
         connected_inner_outputs = [
@@ -614,14 +572,11 @@ class OpFromGraph(Op, HasInnerGraph):
             ),
         )
 
-        if self._lop_op_interface:
-            callable_args = (
-                inner_inputs,
-                connected_inner_outputs,
-                connected_output_grads,
-            )
-        else:
-            callable_args = (inner_inputs, connected_output_grads)
+        callable_args = (
+            inner_inputs,
+            connected_inner_outputs,
+            connected_output_grads,
+        )
 
         # we need to convert _lop_op into an OfG instance
         if lop_overrides is None:
@@ -852,7 +807,6 @@ class OpFromGraph(Op, HasInnerGraph):
                 outputs=new_inner_outputs,
                 inline=self.is_inline,
                 lop_overrides=self.lop_overrides,
-                grad_overrides=self.grad_overrides,
                 rop_overrides=self.rop_overrides,
                 connection_pattern=self._connection_pattern,
                 name=self.name,

--- a/pytensor/compile/mode.py
+++ b/pytensor/compile/mode.py
@@ -311,7 +311,7 @@ class Mode:
         if linker is None:
             linker = config.linker
         if isinstance(linker, str) and linker == "auto":
-            linker = "cvm" if config.cxx else "vm"
+            linker = "numba"
         if isinstance(optimizer, str) and optimizer == "default":
             optimizer = config.optimizer
 

--- a/pytensor/compile/ops.py
+++ b/pytensor/compile/ops.py
@@ -93,7 +93,7 @@ class ViewOp(TypeCastingOp):
     def infer_shape(self, fgraph, node, input_shapes):
         return input_shapes
 
-    def grad(self, args, g_outs):
+    def pullback(self, args, outputs, g_outs):
         return g_outs
 
 

--- a/pytensor/gradient.py
+++ b/pytensor/gradient.py
@@ -2302,12 +2302,12 @@ def _is_zero(x):
 
 
 class ZeroGrad(ViewOp):
-    def grad(self, args, g_outs):
+    def pullback(self, args, outputs, g_outs):
         return [g_out.zeros_like() for g_out in g_outs]
 
-    def R_op(self, inputs, eval_points):
-        if eval_points[0] is None:
-            return [None]
+    def pushforward(self, inputs, outputs, eval_points):
+        if isinstance(eval_points[0].type, DisconnectedType):
+            return [disconnected_type()]
 
         return pytensor.tensor.zeros(1)
 
@@ -2340,11 +2340,11 @@ def zero_grad(x):
 
 
 class UndefinedGrad(ViewOp):
-    def grad(self, args, g_outs):
+    def pullback(self, args, outputs, g_outs):
         return [grad_undefined(self, i, arg) for i, arg in enumerate(args)]
 
-    def R_op(self, inputs, eval_points):
-        return [None]
+    def pushforward(self, inputs, outputs, eval_points):
+        return [disconnected_type()]
 
     def connection_pattern(self, node):
         return [[True]]
@@ -2378,11 +2378,11 @@ def undefined_grad(x):
 
 
 class DisconnectedGrad(ViewOp):
-    def grad(self, args, g_outs):
+    def pullback(self, args, outputs, g_outs):
         return [disconnected_type() for g_out in g_outs]
 
-    def R_op(self, inputs, eval_points):
-        return [None]
+    def pushforward(self, inputs, outputs, eval_points):
+        return [disconnected_type()]
 
     def connection_pattern(self, node):
         return [[False]]
@@ -2433,7 +2433,7 @@ class GradClip(ViewOp):
         if not self.clip_upper_bound >= self.clip_lower_bound:
             raise ValueError("`clip_upper_bound` should be >= `clip_lower_bound`")
 
-    def grad(self, args, g_outs):
+    def pullback(self, args, outputs, g_outs):
         return [
             pytensor.tensor.clip(g_out, self.clip_lower_bound, self.clip_upper_bound)
             for g_out in g_outs
@@ -2476,7 +2476,7 @@ class GradScale(ViewOp):
     def __init__(self, multiplier):
         self.multiplier = multiplier
 
-    def grad(self, args, g_outs):
+    def pullback(self, args, outputs, g_outs):
         return [self.multiplier * g_out for g_out in g_outs]
 
 

--- a/pytensor/gradient.py
+++ b/pytensor/gradient.py
@@ -24,6 +24,25 @@ if TYPE_CHECKING:
 V = TypeVar("V", bound=Variable | None)
 
 
+def _match_tangent_dtype(var: Variable, tangent: Variable) -> Variable:
+    """Cast a tangent/cotangent to match the dtype of the variable it corresponds to.
+
+    Float variables get their tangent cast to the same float dtype (to avoid
+    unnecessary precision upcasting). Integer/discrete variables are left alone,
+    since their tangents are legitimately float-valued.
+    """
+    var_dt = getattr(var.type, "dtype", None)
+    tangent_dt = getattr(tangent.type, "dtype", None)
+    if (
+        var_dt is not None
+        and tangent_dt is not None
+        and var_dt != tangent_dt
+        and var_dt not in pytensor.scalar.basic.discrete_dtypes
+    ):
+        tangent = tangent.astype(var_dt)  # type: ignore[attr-defined]
+    return tangent
+
+
 # TODO: Refactor this so that it's not a global variable
 grad_time: float = 0.0
 
@@ -148,7 +167,7 @@ def pushforward_through_pullback(
     disconnected_outputs: Literal["ignore", "warn", "raise"] = "raise",
     return_disconnected: Literal["none", "zero", "disconnected"] = "zero",
 ) -> Sequence[Variable | None]:
-    """Compute the pushforward (Rop) through two applications of a pullback (Lop) operation.
+    """Compute the push-forward through two applications of a pull-back operation.
 
     References
     ----------
@@ -161,44 +180,41 @@ def pushforward_through_pullback(
     # To avoid trouble we use .zeros_like() instead of .type(), which does not create a new root variable.
     cotangents = [out.zeros_like(dtype=config.floatX) for out in outputs]  # type: ignore
 
-    input_cotangents = Lop(
+    input_cotangents = pullback(
         f=outputs,
         wrt=inputs,
-        eval_points=cotangents,
+        cotangents=cotangents,
         disconnected_inputs=disconnected_outputs,
         return_disconnected="zero",
     )
 
-    return Lop(
+    return pullback(
         f=input_cotangents,  # type: ignore
         wrt=cotangents,
-        eval_points=tangents,
+        cotangents=tangents,
         disconnected_inputs="ignore",
         return_disconnected=return_disconnected,
     )
 
 
-def _rop_legacy(
+def _pushforward_direct(
     f: Sequence[Variable],
     wrt: Sequence[Variable],
-    eval_points: Sequence[Variable],
+    tangents: Sequence[Variable],
     disconnected_outputs: Literal["ignore", "warn", "raise"] = "raise",
     return_disconnected: Literal["none", "zero", "disconnected"] = "zero",
 ) -> Sequence[Variable | None]:
-    """Computes the R-operator applied to `f` with respect to `wrt` at `eval_points`.
-
-    Mathematically this stands for the Jacobian of `f` right multiplied by the
-    `eval_points`.
+    """Compute the push-forward by directly calling :meth:`Op.pushforward` on each node.
 
     Parameters
     ----------
     f
-        The outputs of the computational graph to which the R-operator is
+        The outputs of the computational graph to which the push-forward is
         applied.
     wrt
-        Variables for which the R-operator of `f` is computed.
-    eval_points
-        Points at which to evaluate each of the variables in `wrt`.
+        Variables for which the push-forward of `f` is computed.
+    tangents
+        Tangent vectors, one for each variable in `wrt`.
     disconnected_outputs
         Defines the behaviour if some of the variables in `f`
         have no dependency on any of the variable in `wrt` (or if
@@ -218,11 +234,8 @@ def _rop_legacy(
     Returns
     -------
     :class:`~pytensor.graph.basic.Variable` or list/tuple of Variables
-        A symbolic expression such obeying
-        ``R_op[i] = sum_j (d f[i] / d wrt[j]) eval_point[j]``,
-        where the indices in that expression are magic multidimensional
-        indices that specify both the position within a list and all
-        coordinates of the tensor elements.
+        A symbolic expression for the Jacobian-vector product
+        ``Jvp[i] = sum_j (d f[i] / d wrt[j]) tangents[j]``.
         If `f` is a list/tuple, then return a list/tuple with the results.
     """
 
@@ -237,61 +250,42 @@ def _rop_legacy(
         op = node.op
         inputs = node.inputs
 
-        # Compute the evaluation points corresponding to each of the
+        # Compute the tangents corresponding to each of the
         # inputs of the node
-        local_eval_points = []
+        local_tangents = []
         for inp in inputs:
             if inp in wrt:
-                local_eval_points.append(eval_points[wrt.index(inp)])
+                local_tangents.append(tangents[wrt.index(inp)])
             elif inp.owner is None:
                 try:
-                    local_eval_points.append(inp.zeros_like())
+                    local_tangents.append(inp.zeros_like())
                 except Exception:
-                    # None should be used for non-differentiable
-                    # arguments, like for example random states
-                    local_eval_points.append(None)
+                    local_tangents.append(disconnected_type())
             elif inp.owner in seen_nodes:
-                local_eval_points.append(
+                local_tangents.append(
                     seen_nodes[inp.owner][inp.owner.outputs.index(inp)]
                 )
 
             else:
-                # We actually need to compute the R_op for this node
+                # We actually need to compute the pushforward for this node
 
                 _traverse(inp.owner)
-                local_eval_points.append(
+                local_tangents.append(
                     seen_nodes[inp.owner][inp.owner.outputs.index(inp)]
                 )
-        same_type_eval_points = []
-        for x, y in zip(inputs, local_eval_points, strict=True):
-            if y is not None:
+        matched_tangents = []
+        for x, y in zip(inputs, local_tangents, strict=True):
+            if not isinstance(y.type, DisconnectedType):
                 if not isinstance(x, Variable):
                     x = pytensor.tensor.as_tensor_variable(x)
                 if not isinstance(y, Variable):
                     y = pytensor.tensor.as_tensor_variable(y)
-                try:
-                    y = x.type.filter_variable(y)
-                except TypeError:
-                    # This is a hack
-                    # Originally both grad and Rop were written
-                    # with the assumption that a variable and the
-                    # gradient wrt that variable would have the same
-                    # dtype. This was a bad assumption because the
-                    # gradient wrt an integer can take on non-integer
-                    # values.
-                    # grad is now fixed, but Rop is not, so when grad
-                    # does the right thing and violates this assumption
-                    # we have to make it be wrong for Rop to keep working
-                    # Rop should eventually be upgraded to handle integers
-                    # correctly, the same as grad
-                    y = pytensor.tensor.cast(y, x.type.dtype)
-                    y = x.type.filter_variable(y)
-                assert x.type.in_same_class(y.type)
-                same_type_eval_points.append(y)
+                y = _match_tangent_dtype(x, y)
+                matched_tangents.append(y)
             else:
-                same_type_eval_points.append(y)
+                matched_tangents.append(y)
 
-        seen_nodes[node] = op.R_op(node.inputs, same_type_eval_points)
+        seen_nodes[node] = op.pushforward(node.inputs, node.outputs, matched_tangents)
 
     # end _traverse
 
@@ -302,13 +296,13 @@ def _rop_legacy(
     rval: list[Variable | None] = []
     for out in f:
         if out in wrt:
-            rval.append(eval_points[wrt.index(out)])
-        elif (
-            seen_nodes.get(out.owner, None) is None
-            or seen_nodes[out.owner][out.owner.outputs.index(out)] is None
+            rval.append(tangents[wrt.index(out)])
+        elif seen_nodes.get(out.owner, None) is None or isinstance(
+            seen_nodes[out.owner][out.owner.outputs.index(out)].type,
+            DisconnectedType,
         ):
             message = (
-                "Rop method was asked to compute the gradient "
+                "pushforward was asked to compute the Jacobian-vector product "
                 "with respect to a variable that is not part of "
                 "the computational graph of variables in wrt, or is "
                 f"used only by a non-differentiable operator: {out}"
@@ -344,36 +338,37 @@ def _rop_legacy(
     return rval
 
 
-def Rop(
+def pushforward(
     f: Variable | Sequence[Variable],
     wrt: Variable | Sequence[Variable],
-    eval_points: Variable | Sequence[Variable],
+    tangents: Variable | Sequence[Variable],
     disconnected_outputs: Literal["ignore", "warn", "raise"] = "raise",
     return_disconnected: Literal["none", "zero", "disconnected"] = "zero",
-    use_op_rop_implementation: bool = False,
+    use_op_pushforward: bool = False,
 ) -> Variable | None | Sequence[Variable | None]:
-    """Computes the R-operator applied to `f` with respect to `wrt` at `eval_points`.
+    """Compute the push-forward (Jacobian-vector product) of `f` with respect to `wrt` at `tangents`.
 
-    Mathematically this stands for the Jacobian of `f` right multiplied by the
-    `eval_points`.
+    Mathematically this computes the Jacobian of `f` right-multiplied by the
+    `tangents`.
 
-    By default, the R-operator is implemented as a double application of the L_operator [1]_.
-    In most cases this should be as performant as a specialized implementation of the R-operator.
+    By default, the push-forward is implemented as a double application of pullback [1]_.
+    In most cases this should be as performant as a specialized implementation.
     However, PyTensor may sometimes fail to prune dead branches or fuse common expressions within composite operators,
-    such as Scan and OpFromGraph, that would be more easily avoidable in a direct implentation of the R-operator.
+    such as Scan and OpFromGraph, that would be more easily avoidable in a direct implementation.
 
-    When this is a concern, it is possible to force `Rop` to use the specialized `Op.R_op` methods by passing
-    `use_op_rop_implementation=True`. Note that this will fail if the graph contains `Op`s that don't implement this method.
+    When this is a concern, it is possible to force ``pushforward`` to use the specialized :meth:`Op.pushforward`
+    methods by passing ``use_op_pushforward=True``. Note that this will fail if the graph contains Ops
+    that don't implement this method.
 
     Parameters
     ----------
     f
-        The outputs of the computational graph to which the R-operator is
+        The outputs of the computational graph to which the push-forward is
         applied.
     wrt
-        Variables for which the R-operator of `f` is computed.
-    eval_points
-        Points at which to evaluate each of the variables in `wrt`.
+        Variables for which the push-forward of `f` is computed.
+    tangents
+        Tangent vectors, one for each variable in `wrt`.
     disconnected_outputs
         Defines the behaviour if some of the variables in `f`
         have no dependency on any of the variable in `wrt` (or if
@@ -389,19 +384,17 @@ def Rop(
         - ``'none'`` : If ``wrt[i]`` is disconnected, return value ``i`` will be
           ``None``
         - ``'disconnected'`` : returns variables of type `DisconnectedType`
-    use_op_lop_implementation: bool, default=True
-        If `True`, we obtain Rop via double application of Lop.
-        If `False`, the legacy Rop implementation is used. The number of graphs that support this form
-        is much more restricted, and the generated graphs may be less optimized.
+    use_op_pushforward : bool, default=False
+        If ``False``, we obtain the push-forward via double application of pullback.
+        If ``True``, the :meth:`Op.pushforward` implementation is used directly.
+        The number of graphs that support this form is more restricted, and the generated
+        graphs may be less optimized.
 
     Returns
     -------
     :class:`~pytensor.graph.basic.Variable` or list/tuple of Variables
-        A symbolic expression such obeying
-        ``R_op[i] = sum_j (d f[i] / d wrt[j]) eval_point[j]``,
-        where the indices in that expression are magic multidimensional
-        indices that specify both the position within a list and all
-        coordinates of the tensor elements.
+        A symbolic expression for the Jacobian-vector product
+        ``Jvp[i] = sum_j (d f[i] / d wrt[j]) tangents[j]``.
         If `f` is a list/tuple, then return a list/tuple with the results.
 
     References
@@ -415,40 +408,40 @@ def Rop(
     else:
         _wrt = [pytensor.tensor.as_tensor_variable(x) for x in wrt]
 
-    if not isinstance(eval_points, list | tuple):
-        _eval_points: list[Variable] = [pytensor.tensor.as_tensor_variable(eval_points)]
+    if not isinstance(tangents, list | tuple):
+        _tangents: list[Variable] = [pytensor.tensor.as_tensor_variable(tangents)]
     else:
-        _eval_points = [pytensor.tensor.as_tensor_variable(x) for x in eval_points]
+        _tangents = [pytensor.tensor.as_tensor_variable(x) for x in tangents]
 
     if not isinstance(f, list | tuple):
         _f: list[Variable] = [pytensor.tensor.as_tensor_variable(f)]
     else:
         _f = [pytensor.tensor.as_tensor_variable(x) for x in f]
 
-    if len(_wrt) != len(_eval_points):
-        raise ValueError("`wrt` must be the same length as `eval_points`.")
+    if len(_wrt) != len(_tangents):
+        raise ValueError("`wrt` must be the same length as `tangents`.")
 
     # Check that each element of wrt corresponds to an element
-    # of eval_points with the same dimensionality.
-    for i, (wrt_elem, eval_point) in enumerate(zip(_wrt, _eval_points, strict=True)):
+    # of tangents with the same dimensionality.
+    for i, (wrt_elem, tangent) in enumerate(zip(_wrt, _tangents, strict=True)):
         try:
-            if wrt_elem.type.ndim != eval_point.type.ndim:
+            if wrt_elem.type.ndim != tangent.type.ndim:
                 raise ValueError(
-                    f"Elements {i} of `wrt` and `eval_point` have mismatched dimensionalities: "
-                    f"{wrt_elem.type.ndim} and {eval_point.type.ndim}"
+                    f"Elements {i} of `wrt` and `tangents` have mismatched dimensionalities: "
+                    f"{wrt_elem.type.ndim} and {tangent.type.ndim}"
                 )
         except AttributeError:
-            # wrt_elem and eval_point don't always have ndim like random type
+            # wrt_elem and tangent don't always have ndim like random type
             # Tensor, Sparse have the ndim attribute
             pass
 
-    if use_op_rop_implementation:
-        rval = _rop_legacy(
-            _f, _wrt, _eval_points, disconnected_outputs, return_disconnected
+    if use_op_pushforward:
+        rval = _pushforward_direct(
+            _f, _wrt, _tangents, disconnected_outputs, return_disconnected
         )
     else:
         rval = pushforward_through_pullback(
-            _f, _wrt, _eval_points, disconnected_outputs, return_disconnected
+            _f, _wrt, _tangents, disconnected_outputs, return_disconnected
         )
 
     using_list = isinstance(f, list)
@@ -456,28 +449,28 @@ def Rop(
     return as_list_or_tuple(using_list, using_tuple, rval)
 
 
-def Lop(
+def pullback(
     f: Variable | Sequence[Variable],
     wrt: Variable | Sequence[Variable],
-    eval_points: Variable | Sequence[Variable],
+    cotangents: Variable | Sequence[Variable],
     consider_constant: Sequence[Variable] | None = None,
     disconnected_inputs: Literal["ignore", "warn", "raise"] = "raise",
     return_disconnected: Literal["none", "zero", "disconnected"] = "zero",
 ) -> Variable | None | Sequence[Variable | None]:
-    """Computes the L-operator applied to `f` with respect to `wrt` at `eval_points`.
+    """Compute the pull-back (vector-Jacobian product) of `f` with respect to `wrt` at `cotangents`.
 
-    Mathematically this stands for the Jacobian of `f` with respect to `wrt`
-    left muliplied by the `eval_points`.
+    Mathematically this computes the Jacobian of `f` with respect to `wrt`
+    left-multiplied by the `cotangents`.
 
     Parameters
     ----------
     f
-        The outputs of the computational graph to which the L-operator is
+        The outputs of the computational graph to which the pull-back is
         applied.
     wrt
-        Variables for which the L-operator of `f` is computed.
-    eval_points
-        Points at which to evaluate each of the variables in `wrt`.
+        Variables for which the pull-back of `f` is computed.
+    cotangents
+        Cotangent vectors, one for each output in `f`.
     consider_constant
         See `grad`.
     disconnected_inputs
@@ -486,26 +479,23 @@ def Lop(
     Returns
     -------
     :class:`~pytensor.graph.basic.Variable` or list/tuple of Variables
-        A symbolic expression satisfying
-        ``L_op[i] = sum_i (d f[i] / d wrt[j]) eval_point[i]``
-        where the indices in that expression are magic multidimensional
-        indices that specify both the position within a list and all
-        coordinates of the tensor elements.
+        A symbolic expression for the vector-Jacobian product
+        ``vJp[j] = sum_i cotangents[i] (d f[i] / d wrt[j])``.
         If `f` is a list/tuple, then return a list/tuple with the results.
     """
     from pytensor.tensor import as_tensor_variable
 
-    if not isinstance(eval_points, Sequence):
-        eval_points = [eval_points]
-    _eval_points = [
-        x if isinstance(x, Variable) else as_tensor_variable(x) for x in eval_points
+    if not isinstance(cotangents, Sequence):
+        cotangents = [cotangents]
+    _cotangents = [
+        x if isinstance(x, Variable) else as_tensor_variable(x) for x in cotangents
     ]
 
     if not isinstance(f, Sequence):
         f = [f]
     _f = [x if isinstance(x, Variable) else as_tensor_variable(x) for x in f]
 
-    grads = list(_eval_points)
+    grads = list(_cotangents)
 
     using_list = isinstance(wrt, list)
     using_tuple = isinstance(wrt, tuple)
@@ -526,6 +516,52 @@ def Lop(
     )
 
     return as_list_or_tuple(using_list, using_tuple, ret)
+
+
+def Rop(
+    f,
+    wrt,
+    eval_points,
+    disconnected_outputs="raise",
+    return_disconnected="zero",
+    use_op_rop_implementation=False,
+):
+    """.. deprecated:: Use :func:`pushforward` instead."""
+    warnings.warn(
+        "Rop is deprecated, use pushforward instead.",
+        FutureWarning,
+    )
+    return pushforward(
+        f,
+        wrt,
+        tangents=eval_points,
+        disconnected_outputs=disconnected_outputs,
+        return_disconnected=return_disconnected,
+        use_op_pushforward=use_op_rop_implementation,
+    )
+
+
+def Lop(
+    f,
+    wrt,
+    eval_points,
+    consider_constant=None,
+    disconnected_inputs="raise",
+    return_disconnected="zero",
+):
+    """.. deprecated:: Use :func:`pullback` instead."""
+    warnings.warn(
+        "Lop is deprecated, use pullback instead.",
+        FutureWarning,
+    )
+    return pullback(
+        f,
+        wrt,
+        cotangents=eval_points,
+        consider_constant=consider_constant,
+        disconnected_inputs=disconnected_inputs,
+        return_disconnected=return_disconnected,
+    )
 
 
 @overload
@@ -1266,18 +1302,10 @@ def _populate_grad_dict(var_to_app_to_idx, grad_dict, wrt, cost_name=None):
                 # gradients.
                 # DO NOT force integer variables to have integer dtype.
                 # This is a violation of the op contract.
-                new_output_grads = []
-                for o, og in zip(node.outputs, output_grads, strict=True):
-                    o_dt = getattr(o.type, "dtype", None)
-                    og_dt = getattr(og.type, "dtype", None)
-                    if (
-                        o_dt not in pytensor.tensor.type.discrete_dtypes
-                        and og_dt
-                        and o_dt != og_dt
-                    ):
-                        new_output_grads.append(og.astype(o_dt))
-                    else:
-                        new_output_grads.append(og)
+                new_output_grads = [
+                    _match_tangent_dtype(o, og)
+                    for o, og in zip(node.outputs, output_grads, strict=True)
+                ]
 
                 # Make sure that, if new_output_grads[i] has a floating point
                 # dtype, it is the same dtype as outputs[i]
@@ -1296,11 +1324,11 @@ def _populate_grad_dict(var_to_app_to_idx, grad_dict, wrt, cost_name=None):
                     for ng in new_output_grads
                 )
 
-                input_grads = node.op.L_op(inputs, node.outputs, new_output_grads)
+                input_grads = node.op.pullback(inputs, node.outputs, new_output_grads)
 
                 if input_grads is None:
                     raise TypeError(
-                        f"{node.op}.grad returned NoneType, expected iterable."
+                        f"{node.op}.pullback returned NoneType, expected iterable."
                     )
 
                 if len(input_grads) != len(inputs):
@@ -2039,7 +2067,9 @@ def jacobian(
     elif vectorize:
         expression_flat = expression.ravel()
         row_tangent = _float_ones_like(expression_flat).type("row_tangent")
-        jacobian_single_rows = Lop(expression.ravel(), wrt, row_tangent, **grad_kwargs)
+        jacobian_single_rows = pullback(
+            expression.ravel(), wrt, row_tangent, **grad_kwargs
+        )
 
         n_rows = expression_flat.size
         jacobian_matrices = vectorize_graph(

--- a/pytensor/graph/op.py
+++ b/pytensor/graph/op.py
@@ -1,3 +1,4 @@
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from typing import (
@@ -235,10 +236,117 @@ class Op(MetaObject):
     # just to self.add_tag_trace
     add_tag_trace = staticmethod(add_tag_trace)
 
+    def pullback(
+        self,
+        inputs: Sequence[Variable],
+        outputs: Sequence[Variable],
+        cotangents: Sequence[Variable],
+    ) -> list[Variable]:
+        r"""Construct a graph for the vector-Jacobian product (pullback).
+
+        Given a function :math:`f` implemented by this `Op` with inputs :math:`x`
+        and outputs :math:`y = f(x)`, the pullback computes :math:`\bar{x} = \bar{y}^T J`
+        where :math:`J` is the Jacobian :math:`\frac{\partial f}{\partial x}` and
+        :math:`\bar{y}` are the cotangent vectors (upstream gradients).
+
+        This is the core method for reverse-mode automatic differentiation.
+
+        If the output is not differentiable with respect to an input,
+        return a variable of type `DisconnectedType` for that input. If the
+        gradient is not implemented for some input, return a variable of type
+        `NullType` (see :func:`pytensor.gradient.grad_not_implemented` and
+        :func:`pytensor.gradient.grad_undefined`).
+
+        Parameters
+        ----------
+        inputs : Sequence[Variable]
+            The input variables of the `Apply` node using this `Op`.
+        outputs : Sequence[Variable]
+            The output variables of the `Apply` node using this `Op`.
+        cotangents : Sequence[Variable]
+            The cotangent vectors (gradients w.r.t. each output).
+
+        Returns
+        -------
+        input_cotangents : list of Variable
+            The cotangent vectors w.r.t. each input. One `Variable` per input.
+
+        """
+        # Fall back to deprecated L_op/grad if overridden by subclass
+        if type(self).L_op is not Op.L_op or type(self).grad is not Op.grad:
+            warnings.warn(
+                f"{type(self).__name__} should implement `pullback` instead of "
+                f"`L_op`/`grad`. Direct `L_op`/`grad` implementations are deprecated "
+                f"and will stop being called in a future version.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            return self.L_op(inputs, outputs, cotangents)
+        raise NotImplementedError(f"pullback not implemented for {self}")
+
+    def pushforward(
+        self,
+        inputs: Sequence[Variable],
+        outputs: Sequence[Variable],
+        tangents: Sequence[Variable],
+    ) -> list[Variable]:
+        r"""Construct a graph for the Jacobian-vector product (pushforward).
+
+        Given a function :math:`f` implemented by this `Op` with inputs :math:`x`
+        and outputs :math:`y = f(x)`, the pushforward computes :math:`\dot{y} = J \dot{x}`
+        where :math:`J` is the Jacobian :math:`\frac{\partial f}{\partial x}` and
+        :math:`\dot{x}` are the tangent vectors.
+
+        This is the core method for forward-mode automatic differentiation.
+
+        If an output is not differentiable with respect to any input, return a
+        variable of type `DisconnectedType` for that output. Unlike the legacy
+        `R_op` method, `pushforward` must never use ``None`` to indicate
+        disconnected outputs.
+
+        Parameters
+        ----------
+        inputs : Sequence[Variable]
+            The input variables of the `Apply` node using this `Op`.
+        outputs : Sequence[Variable]
+            The output variables of the `Apply` node using this `Op`.
+        tangents : Sequence[Variable]
+            The tangent vectors. One per input. A variable of `DisconnectedType`
+            indicates that the corresponding input is not being differentiated.
+
+        Returns
+        -------
+        output_tangents : list of Variable
+            The tangent vectors w.r.t. each output. One `Variable` per output.
+
+        """
+        from pytensor.gradient import DisconnectedType, disconnected_type
+
+        # Fall back to deprecated R_op if overridden by subclass
+        if type(self).R_op is not Op.R_op:
+            warnings.warn(
+                f"{type(self).__name__} should implement `pushforward` instead of "
+                f"`R_op`. Direct `R_op` implementations are deprecated "
+                f"and will stop being called in a future version.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            # Convert DisconnectedType tangents to None for R_op compatibility
+            eval_points: list[Variable | None] = [
+                None if isinstance(t.type, DisconnectedType) else t for t in tangents
+            ]
+            result = self.R_op(inputs, eval_points)
+            # Convert None returns to DisconnectedType
+            return [disconnected_type() if r is None else r for r in result]
+        raise NotImplementedError(f"pushforward not implemented for {self}")
+
     def grad(
         self, inputs: Sequence[Variable], output_grads: Sequence[Variable]
     ) -> list[Variable]:
         r"""Construct a graph for the gradient with respect to each input variable.
+
+        .. deprecated::
+            Implement :meth:`pullback` instead.
 
         Each returned `Variable` represents the gradient with respect to that
         input computed based on the symbolic gradients with respect to each
@@ -275,7 +383,7 @@ class Op(MetaObject):
 
         References
         ----------
-        .. [1] Giles, Mike. 2008. “An Extended Collection of Matrix Derivative Results for Forward and Reverse Mode Automatic Differentiation.”
+        .. [1] Giles, Mike. 2008. "An Extended Collection of Matrix Derivative Results for Forward and Reverse Mode Automatic Differentiation."
 
         """
         raise NotImplementedError(f"grad not implemented for Op {self}")
@@ -288,14 +396,13 @@ class Op(MetaObject):
     ) -> list[Variable]:
         r"""Construct a graph for the L-operator.
 
+        .. deprecated::
+            Implement :meth:`pullback` instead.
+
         The L-operator computes a row vector times the Jacobian.
 
-        This method dispatches to :meth:`Op.grad` by default.  In one sense,
-        this method provides the original outputs when they're needed to
-        compute the return value, whereas `Op.grad` doesn't.
-
-        See `Op.grad` for a mathematical explanation of the inputs and outputs
-        of this method.
+        This method dispatches to :meth:`pullback` if overridden by a
+        subclass, otherwise falls back to :meth:`Op.grad`.
 
         Parameters
         ----------
@@ -307,14 +414,20 @@ class Op(MetaObject):
             The gradients with respect to each `Variable` in `inputs`.
 
         """
+        if type(self).pullback is not Op.pullback:
+            return self.pullback(inputs, outputs, output_grads)
         return self.grad(inputs, output_grads)
 
     def R_op(
-        self, inputs: list[Variable], eval_points: Variable | list[Variable]
+        self, inputs: Sequence[Variable], eval_points: Sequence[Variable | None]
     ) -> list[Variable]:
         r"""Construct a graph for the R-operator.
 
-        This method is primarily used by `Rop`.
+        .. deprecated::
+            Implement :meth:`pushforward` instead.
+
+        This method is primarily used by `Rop`. It dispatches to
+        :meth:`pushforward` if overridden by a subclass.
 
         Parameters
         ----------
@@ -330,6 +443,15 @@ class Op(MetaObject):
         ``rval[i]`` should be ``Rop(f=f_i(inputs), wrt=inputs, eval_points=eval_points)``.
 
         """
+        from pytensor.gradient import DisconnectedType, disconnected_type
+
+        if type(self).pushforward is not Op.pushforward:
+            outputs = self.make_node(*inputs).outputs
+            # Convert None eval_points to DisconnectedType for pushforward
+            tangents = [disconnected_type() if ep is None else ep for ep in eval_points]
+            result = self.pushforward(inputs, outputs, tangents)
+            # Convert DisconnectedType back to None for R_op callers
+            return [None if isinstance(r.type, DisconnectedType) else r for r in result]  # type: ignore[misc]
         raise NotImplementedError()
 
     @abstractmethod

--- a/pytensor/ifelse.py
+++ b/pytensor/ifelse.py
@@ -241,10 +241,10 @@ class IfElse(_NoPythonOp):
             output_vars,
         )
 
-    def R_op(self, inputs, eval_points):
+    def pushforward(self, inputs, outputs, eval_points):
         return self(inputs[0], *eval_points[1:], return_list=True)
 
-    def grad(self, ins, grads):
+    def pullback(self, ins, outputs, grads):
         condition = ins[0]
         inputs_true_branch = ins[1:][: self.n_outs]
         inputs_false_branch = ins[1:][self.n_outs :]

--- a/pytensor/link/jax/ops.py
+++ b/pytensor/link/jax/ops.py
@@ -135,7 +135,7 @@ class JAXOp(Op):
             return outputs[0]
         return outputs
 
-    def grad(self, inputs, output_gradients):
+    def pullback(self, inputs, outputs, output_gradients):
         """Compute gradients using JAX's vector-Jacobian product (VJP)."""
         import jax
 

--- a/pytensor/link/numba/dispatch/scan.py
+++ b/pytensor/link/numba/dispatch/scan.py
@@ -457,12 +457,24 @@ def numba_funcify_Scan(op: Scan, node, **kwargs):
         for s, d in zip(inner_out_to_outer_in_stmts, inner_output_names, strict=True)
     )
 
+    if op.nit_sot_core_shapes() is None and op.info.n_nit_sot > 0:
+        n_steps_zero_guard = (
+            "    if n_steps == 0:\n"
+            '        raise ValueError("Scan has nit_sot outputs with unknown static shapes '
+            "and n_steps=0. The output core shapes cannot be determined without "
+            'executing the inner function.")'
+        )
+    else:
+        n_steps_zero_guard = ""
+
     scan_op_src = f"""
 def scan({", ".join(outer_in_names)}):
 
 {indent(input_storage_block, " " * 4)}
 
 {indent(input_temp_0d_storage_block, " " * 4)}
+
+{n_steps_zero_guard}
 
     i = 0
     cond = np.array(False)

--- a/pytensor/link/numba/dispatch/typed_list.py
+++ b/pytensor/link/numba/dispatch/typed_list.py
@@ -72,6 +72,8 @@ def list_all_equal(x, y):
         def all_equal(x, y):
             return (
                 x.shape == y.shape
+                and len(x.data) == len(y.data)
+                and len(x.indices) == len(y.indices)
                 and (x.data == y.data).all()
                 and (x.indptr == y.indptr).all()
                 and (x.indices == y.indices).all()

--- a/pytensor/printing.py
+++ b/pytensor/printing.py
@@ -805,10 +805,10 @@ class Print(Op):
         xout[0] = xin
         self.global_fn(self, xin)
 
-    def grad(self, input, output_gradients):
+    def pullback(self, input, outputs, output_gradients):
         return output_gradients
 
-    def R_op(self, inputs, eval_points):
+    def pushforward(self, inputs, outputs, eval_points):
         return list(eval_points)
 
     def __setstate__(self, dct):

--- a/pytensor/raise_op.py
+++ b/pytensor/raise_op.py
@@ -88,7 +88,7 @@ class CheckAndRaise(COp):
         if not all(conds):
             raise self.exc_type(self.msg)
 
-    def grad(self, input, output_gradients):
+    def pullback(self, input, outputs, output_gradients):
         return [
             *output_gradients,
             *(disconnected_type() for _ in range(len(input) - 1)),

--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -25,7 +25,7 @@ from pytensor.configdefaults import config
 from pytensor.gradient import disconnected_type, grad_undefined
 from pytensor.graph.basic import Apply, Constant, Variable
 from pytensor.graph.fg import FrozenFunctionGraph
-from pytensor.graph.op import HasInnerGraph
+from pytensor.graph.op import HasInnerGraph, Op
 from pytensor.graph.traversal import applys_between
 from pytensor.graph.type import HasDataType, HasShape
 from pytensor.graph.utils import MetaObject, MethodNotDefined
@@ -1254,11 +1254,13 @@ class ScalarOp(COp):
     def impl(self, *inputs):
         raise MethodNotDefined("impl", type(self), self.__class__.__name__)
 
-    def grad(self, inputs, output_gradients):
-        raise MethodNotDefined("grad", type(self), self.__class__.__name__)
-
-    def L_op(self, inputs, outputs, output_gradients):
-        return self.grad(inputs, output_gradients)
+    def pullback(self, inputs, outputs, output_gradients):
+        # Fall back to deprecated L_op/grad if overridden by subclass
+        if type(self).L_op is not Op.L_op:
+            return type(self).L_op(self, inputs, outputs, output_gradients)
+        if type(self).grad is not Op.grad:
+            return self.grad(inputs, output_gradients)
+        raise MethodNotDefined("pullback", type(self), self.__class__.__name__)
 
     def __eq__(self, other):
         return type(self) is type(other) and getattr(
@@ -1391,7 +1393,7 @@ class LogicalComparison(BinaryScalarOp):
     def output_types(self, *input_dtypes):
         return [bool] if getattr(self, "bool", False) else [int8]
 
-    def L_op(self, inputs, outputs, output_gradients):
+    def pullback(self, inputs, outputs, output_gradients):
         x, y = inputs
         assert outputs[0].type == bool
         return [
@@ -1427,7 +1429,7 @@ class FixedLogicalComparison(UnaryScalarOp):
     def output_types(self, *input_dtypes):
         return [bool] if getattr(self, "bool", False) else [int8]
 
-    def L_op(self, inputs, outputs, output_gradients):
+    def pullback(self, inputs, outputs, output_gradients):
         (x,) = inputs
         assert outputs[0].type == bool
         return [x.zeros_like(dtype=config.floatX)]
@@ -1626,7 +1628,7 @@ class Switch(ScalarOp):
         (z,) = outputs
         return f"{z} = {cond} ? {ift} : {iff};"
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (cond, ift, iff) = inputs
         (gz,) = gout
         first_part = switch(cond, gz, 0.0)
@@ -1665,7 +1667,7 @@ class UnaryBitOp(UnaryScalarOp):
                 )
         return upcast_out(*input_types[0])
 
-    def grad(self, inputs, output_gradients):
+    def pullback(self, inputs, outputs, output_gradients):
         return [inputs[0].zeros_like(dtype=config.floatX)]
 
 
@@ -1683,7 +1685,7 @@ class BinaryBitOp(BinaryScalarOp):
                 )
         return upcast_out(*input_types[0])
 
-    def grad(self, inputs, output_gradients):
+    def pullback(self, inputs, outputs, output_gradients):
         a, b = inputs
         return [
             a.zeros_like(dtype=config.floatX),
@@ -1788,7 +1790,7 @@ class Maximum(BinaryScalarOp):
         # Test for both y>x and x>=y to detect NaN
         return f'{z} = (({y})>({x})? ({y}): (({x})>=({y})? ({x}): nan("")));'
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x, y) = inputs
         (gz,) = gout
         if gz.type in complex_types:
@@ -1834,7 +1836,7 @@ class Minimum(BinaryScalarOp):
             raise NotImplementedError()
         return f'{z} = (({y})<({x})? ({y}): (({x})<=({y})? ({x}): nan("")));'
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x, y) = inputs
         (gz,) = gout
         if gz.type in complex_types:
@@ -1882,7 +1884,7 @@ class Add(ScalarOp):
         else:
             return z + " = " + op.join(inputs) + ";"
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (gz,) = gout
         if gz.type in complex_types:
             raise NotImplementedError()
@@ -1924,7 +1926,7 @@ class Mul(ScalarOp):
         else:
             return z + " = " + op.join(inputs) + ";"
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (gz,) = gout
         retval = []
 
@@ -1977,7 +1979,7 @@ class Sub(BinaryScalarOp):
         (z,) = outputs
         return f"{z} = {x} - {y};"
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x, y) = inputs
         (gz,) = gout
         if gz.type in complex_types:
@@ -2027,7 +2029,7 @@ class TrueDiv(BinaryScalarOp):
             return f"{z} = ((double){x}) / {y};"
         return f"{z} = {x} / {y};"
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x, y) = inputs
         (gz,) = gout
         if x.type in complex_types:
@@ -2148,7 +2150,7 @@ class IntDiv(BinaryScalarOp):
     def c_code_cache_version(self):
         return (6,)
 
-    def grad(self, inputs, g_output):
+    def pullback(self, inputs, outputs, g_output):
         return [inp.zeros_like(dtype=config.floatX) for inp in inputs]
 
 
@@ -2264,7 +2266,7 @@ class Mod(BinaryScalarOp):
             """
         )
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x, y) = inputs
         (gz,) = gout
         if outputs[0].type in discrete_types:
@@ -2292,7 +2294,7 @@ class Pow(BinaryScalarOp):
             raise NotImplementedError("type not supported", type)
         return f"{z} = pow({x}, {y});"
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x, y) = inputs
         (gz,) = gout
         if gz.type in complex_types:
@@ -2382,7 +2384,7 @@ class Clip(ScalarOp):
         (z,) = outputs
         return f"{z} = {x} < {min} ? {min} : {x} > {max} ? {max} : {x};"
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x, mn, mx) = inputs
         (gz,) = gout
         assert gz.type not in complex_types
@@ -2422,7 +2424,7 @@ class Second(BinaryScalarOp):
 
         return [[False], [True]]
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (_x, y) = inputs
         (gz,) = gout
         if y.type in continuous_types:
@@ -2448,7 +2450,7 @@ class Identity(UnaryScalarOp):
         (z,) = outputs
         return f"{z} = {x};"
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if x.type in continuous_types:
@@ -2487,7 +2489,7 @@ class Cast(UnaryScalarOp):
             return f"{z} = ({x}) ? 1 : 0;"
         return f"{z} = ({node.outputs[0].type.dtype_specs()[1]}){x};"
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if self.o_type in continuous_types:
@@ -2571,7 +2573,7 @@ class Abs(UnaryScalarOp):
     def impl(self, x):
         return np.abs(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if outputs[0].type in discrete_types:
@@ -2618,7 +2620,7 @@ class Sign(UnaryScalarOp):
         # casting to output type is handled by filter
         return np.sign(x)
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (_gz,) = gout
         rval = x.zeros_like()
@@ -2659,7 +2661,7 @@ class Ceil(UnaryScalarOp):
     def impl(self, x):
         return np.ceil(x)
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (_gz,) = gout
         rval = x.zeros_like()
@@ -2685,7 +2687,7 @@ class Floor(UnaryScalarOp):
     def impl(self, x):
         return np.floor(x)
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (_gz,) = gout
         rval = x.zeros_like()
@@ -2711,7 +2713,7 @@ class Trunc(UnaryScalarOp):
     def impl(self, x):
         return np.trunc(x)
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (_gz,) = gout
         return [x.zeros_like(dtype=config.floatX)]
@@ -2739,7 +2741,7 @@ class RoundHalfToEven(UnaryScalarOp):
     def impl(self, x):
         return np.round(x)
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (_gz,) = gout
         rval = x.zeros_like()
@@ -2825,7 +2827,7 @@ class RoundHalfAwayFromZero(UnaryScalarOp):
     def impl(self, x):
         return round_half_away_from_zero_vec(x)
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (_gz,) = gout
         rval = x.zeros_like()
@@ -2856,7 +2858,7 @@ class Neg(UnaryScalarOp):
     def impl(self, x):
         return -x
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if outputs[0].type in discrete_types:
@@ -2893,7 +2895,7 @@ class Reciprocal(UnaryScalarOp):
     def impl(self, x):
         return np.float32(1.0) / x
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if x.type in complex_types:
@@ -2935,7 +2937,7 @@ class Log(UnaryScalarOp):
             return np.log(x, dtype=np.float32)
         return np.log(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if x.type in complex_types:
@@ -2981,7 +2983,7 @@ class Log2(UnaryScalarOp):
             return np.log2(x, dtype=np.float32)
         return np.log2(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if x.type in complex_types:
@@ -3024,7 +3026,7 @@ class Log10(UnaryScalarOp):
             return np.log10(x, dtype=np.float32)
         return np.log10(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if x.type in complex_types:
@@ -3065,7 +3067,7 @@ class Log1p(UnaryScalarOp):
             return np.log1p(x, dtype=np.float32)
         return np.log1p(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if gz.type in complex_types:
@@ -3103,7 +3105,7 @@ class Exp(UnaryScalarOp):
             return np.exp(x, dtype=np.float32)
         return np.exp(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if x.type in complex_types:
@@ -3139,7 +3141,7 @@ class Exp2(UnaryScalarOp):
             return np.exp2(x, dtype=np.float32)
         return np.exp2(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if x.type in complex_types:
@@ -3175,7 +3177,7 @@ class Expm1(UnaryScalarOp):
             return np.expm1(x, dtype=np.float32)
         return np.expm1(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if x.type in complex_types:
@@ -3209,7 +3211,7 @@ class Sqr(UnaryScalarOp):
     def impl(self, x):
         return x * x
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if gz.type in complex_types:
@@ -3242,7 +3244,7 @@ class Sqrt(UnaryScalarOp):
             return np.sqrt(x, dtype=np.float32)
         return np.sqrt(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if gz.type in complex_types:
@@ -3278,7 +3280,7 @@ class Deg2Rad(UnaryScalarOp):
             return np.deg2rad(x, dtype=np.float32)
         return np.deg2rad(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if gz.type in complex_types:
@@ -3313,7 +3315,7 @@ class Rad2Deg(UnaryScalarOp):
             return np.rad2deg(x, dtype=np.float32)
         return np.rad2deg(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if gz.type in complex_types:
@@ -3350,7 +3352,7 @@ class Cos(UnaryScalarOp):
             return np.cos(x, dtype=np.float32)
         return np.cos(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if gz.type in complex_types:
@@ -3386,7 +3388,7 @@ class ArcCos(UnaryScalarOp):
             return np.arccos(x, dtype=np.float32)
         return np.arccos(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if gz.type in complex_types:
@@ -3424,7 +3426,7 @@ class Sin(UnaryScalarOp):
             return np.sin(x, dtype=np.float32)
         return np.sin(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if x.type in complex_types:
@@ -3460,7 +3462,7 @@ class ArcSin(UnaryScalarOp):
             return np.arcsin(x, dtype=np.float32)
         return np.arcsin(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if gz.type in complex_types:
@@ -3496,7 +3498,7 @@ class Tan(UnaryScalarOp):
             return np.tan(x, dtype=np.float32)
         return np.tan(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if x.type in complex_types:
@@ -3532,7 +3534,7 @@ class ArcTan(UnaryScalarOp):
             return np.arctan(x, dtype=np.float32)
         return np.arctan(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if gz.type in complex_types:
@@ -3570,7 +3572,7 @@ class ArcTan2(BinaryScalarOp):
                 return np.arctan2(y, x, dtype=np.float32)
         return np.arctan2(y, x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (y, x) = inputs
         (gz,) = gout
         if gz.type in complex_types:
@@ -3619,7 +3621,7 @@ class Cosh(UnaryScalarOp):
             return np.cosh(x, dtype=np.float32)
         return np.cosh(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if x.type in complex_types:
@@ -3655,7 +3657,7 @@ class ArcCosh(UnaryScalarOp):
             return np.arccosh(x, dtype=np.float32)
         return np.arccosh(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if x.type in complex_types:
@@ -3696,7 +3698,7 @@ class Sinh(UnaryScalarOp):
             return np.sinh(x, dtype=np.float32)
         return np.sinh(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if x.type in complex_types:
@@ -3732,7 +3734,7 @@ class ArcSinh(UnaryScalarOp):
             return np.arcsinh(x, dtype=np.float32)
         return np.arcsinh(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if x.type in complex_types:
@@ -3774,7 +3776,7 @@ class Tanh(UnaryScalarOp):
             return np.tanh(x, dtype=np.float32)
         return np.tanh(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if x.type in complex_types:
@@ -3810,7 +3812,7 @@ class ArcTanh(UnaryScalarOp):
             return np.arctanh(x, dtype=np.float32)
         return np.arctanh(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if x.type in complex_types:
@@ -3847,7 +3849,7 @@ class Real(UnaryScalarOp):
     def impl(self, x):
         return np.real(x)
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (_x,) = inputs
         (gz,) = gout
         return [complex(gz, 0)]
@@ -3865,7 +3867,7 @@ class Imag(UnaryScalarOp):
     def impl(self, x):
         return np.imag(x)
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if x.type in complex_types:
@@ -3888,7 +3890,7 @@ class Angle(UnaryScalarOp):
     def impl(self, x):
         return np.angle(x)
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         # y = x.imag
         # r = sqrt(y**2 + x.real**2)
         # g = y/r
@@ -3939,7 +3941,7 @@ class Complex(BinaryScalarOp):
     def impl(self, x, y):
         return builtins.complex(x, y)
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x, y) = inputs
         (gz,) = gout
         return [cast(real(gz), x.type.dtype), cast(imag(gz), y.type.dtype)]
@@ -3984,7 +3986,7 @@ class ComplexFromPolar(BinaryScalarOp):
         else:
             return np.complex128(builtins.complex(x, y))
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (r, theta) = inputs
         (gz,) = gout
         gr = gz * complex_from_polar(1, theta)
@@ -4229,7 +4231,7 @@ class Composite(ScalarInnerGraphOp):
         for storage, out_val in zip(output_storage, outputs):
             storage[0] = out_val
 
-    def grad(self, inputs, output_grads):
+    def pullback(self, inputs, outputs, output_grads):
         raise NotImplementedError("grad is not implemented for Composite")
 
     @property

--- a/pytensor/scalar/math.py
+++ b/pytensor/scalar/math.py
@@ -54,7 +54,7 @@ class Erf(UnaryScalarOp):
     def impl(self, x):
         return special.erf(x)
 
-    def L_op(self, inputs, outputs, grads):
+    def pullback(self, inputs, outputs, grads):
         (x,) = inputs
         (gz,) = grads
         if x.type in complex_types:
@@ -88,7 +88,7 @@ class Erfc(UnaryScalarOp):
     def impl(self, x):
         return special.erfc(x)
 
-    def L_op(self, inputs, outputs, grads):
+    def pullback(self, inputs, outputs, grads):
         (x,) = inputs
         (gz,) = grads
         if x.type in complex_types:
@@ -137,7 +137,7 @@ class Erfcx(UnaryScalarOp):
     def impl(self, x):
         return special.erfcx(x)
 
-    def L_op(self, inputs, outputs, grads):
+    def pullback(self, inputs, outputs, grads):
         (x,) = inputs
         (gz,) = grads
         if x.type in complex_types:
@@ -193,7 +193,7 @@ class Erfinv(UnaryScalarOp):
     def impl(self, x):
         return special.erfinv(x)
 
-    def L_op(self, inputs, outputs, grads):
+    def pullback(self, inputs, outputs, grads):
         (x,) = inputs
         (gz,) = grads
         if x.type in complex_types:
@@ -228,7 +228,7 @@ class Erfcinv(UnaryScalarOp):
     def impl(self, x):
         return special.erfcinv(x)
 
-    def L_op(self, inputs, outputs, grads):
+    def pullback(self, inputs, outputs, grads):
         (x,) = inputs
         (gz,) = grads
         if x.type in complex_types:
@@ -263,7 +263,7 @@ class Owens_t(BinaryScalarOp):
     def impl(self, h, a):
         return special.owens_t(h, a)
 
-    def grad(self, inputs, grads):
+    def pullback(self, inputs, outputs, grads):
         (h, a) = inputs
         (gz,) = grads
         return [
@@ -288,7 +288,7 @@ class Gamma(UnaryScalarOp):
     def impl(self, x):
         return special.gamma(x)
 
-    def L_op(self, inputs, outputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if x.type in complex_types:
@@ -323,7 +323,7 @@ class GammaLn(UnaryScalarOp):
     def impl(self, x):
         return special.gammaln(x)
 
-    def L_op(self, inputs, outputs, grads):
+    def pullback(self, inputs, outputs, grads):
         (x,) = inputs
         (gz,) = grads
         if x.type in complex_types:
@@ -363,7 +363,7 @@ class Psi(UnaryScalarOp):
     def impl(self, x):
         return special.psi(x)
 
-    def L_op(self, inputs, outputs, grads):
+    def pullback(self, inputs, outputs, grads):
         (x,) = inputs
         (gz,) = grads
         if x.type in complex_types:
@@ -460,7 +460,7 @@ class TriGamma(UnaryScalarOp):
     def impl(self, x):
         return special.polygamma(1, x)
 
-    def L_op(self, inputs, outputs, outputs_gradients):
+    def pullback(self, inputs, outputs, outputs_gradients):
         (x,) = inputs
         (g_out,) = outputs_gradients
         if x in complex_types:
@@ -559,7 +559,7 @@ class PolyGamma(BinaryScalarOp):
     def impl(self, n, x):
         return special.polygamma(n, x)
 
-    def L_op(self, inputs, outputs, output_gradients):
+    def pullback(self, inputs, outputs, output_gradients):
         (n, x) = inputs
         (g_out,) = output_gradients
         if x in complex_types:
@@ -586,7 +586,7 @@ class GammaInc(BinaryScalarOp):
     def impl(self, k, x):
         return special.gammainc(k, x)
 
-    def grad(self, inputs, grads):
+    def pullback(self, inputs, outputs, grads):
         (k, x) = inputs
         (gz,) = grads
         return [
@@ -633,7 +633,7 @@ class GammaIncC(BinaryScalarOp):
     def impl(self, k, x):
         return special.gammaincc(k, x)
 
-    def grad(self, inputs, grads):
+    def pullback(self, inputs, outputs, grads):
         (k, x) = inputs
         (gz,) = grads
         return [
@@ -680,7 +680,7 @@ class GammaIncInv(BinaryScalarOp):
     def impl(self, k, x):
         return special.gammaincinv(k, x)
 
-    def grad(self, inputs, grads):
+    def pullback(self, inputs, outputs, grads):
         (k, x) = inputs
         (gz,) = grads
         return [
@@ -705,7 +705,7 @@ class GammaIncCInv(BinaryScalarOp):
     def impl(self, k, x):
         return special.gammainccinv(k, x)
 
-    def grad(self, inputs, grads):
+    def pullback(self, inputs, outputs, grads):
         (k, x) = inputs
         (gz,) = grads
         return [
@@ -1004,7 +1004,7 @@ class Jv(BinaryScalarOp):
     def impl(self, v, x):
         return special.jv(v, x)
 
-    def grad(self, inputs, grads):
+    def pullback(self, inputs, outputs, grads):
         v, x = inputs
         (gz,) = grads
         return [
@@ -1029,7 +1029,7 @@ class J1(UnaryScalarOp):
     def impl(self, x):
         return special.j1(x)
 
-    def grad(self, inputs, grads):
+    def pullback(self, inputs, outputs, grads):
         (x,) = inputs
         (gz,) = grads
         return [gz * (j0(x) - jv(2, x)) / 2.0]
@@ -1056,7 +1056,7 @@ class J0(UnaryScalarOp):
     def impl(self, x):
         return special.j0(x)
 
-    def grad(self, inp, grads):
+    def pullback(self, inp, outputs, grads):
         (x,) = inp
         (gz,) = grads
         return [gz * -1 * j1(x)]
@@ -1083,7 +1083,7 @@ class I1(UnaryScalarOp):
     def impl(self, x):
         return special.i1(x)
 
-    def grad(self, inputs, grads):
+    def pullback(self, inputs, outputs, grads):
         (x,) = inputs
         (gz,) = grads
         return [gz * (i0(x) + ive(2, x) * exp(abs(x))) / 2.0]
@@ -1105,7 +1105,7 @@ class I0(UnaryScalarOp):
     def impl(self, x):
         return special.i0(x)
 
-    def grad(self, inp, grads):
+    def pullback(self, inp, outputs, grads):
         (x,) = inp
         (gz,) = grads
         return [gz * i1(x)]
@@ -1127,7 +1127,7 @@ class Ive(BinaryScalarOp):
     def impl(self, v, x):
         return special.ive(v, x)
 
-    def grad(self, inputs, grads):
+    def pullback(self, inputs, outputs, grads):
         v, x = inputs
         (gz,) = grads
         return [
@@ -1152,7 +1152,7 @@ class Kve(BinaryScalarOp):
     def impl(self, v, x):
         return special.kve(v, x)
 
-    def L_op(self, inputs, outputs, output_grads):
+    def pullback(self, inputs, outputs, output_grads):
         v, x = inputs
         [kve_vx] = outputs
         [g_out] = output_grads
@@ -1182,7 +1182,7 @@ class Sigmoid(UnaryScalarOp):
     def impl(self, x):
         return special.expit(x)
 
-    def grad(self, inp, grads):
+    def pullback(self, inp, outputs, grads):
         (x,) = inp
         (gz,) = grads
         y = sigmoid(x)
@@ -1250,7 +1250,7 @@ class Softplus(UnaryScalarOp):
         else:
             return x
 
-    def grad(self, inp, grads):
+    def pullback(self, inp, outputs, grads):
         (x,) = inp
         (gz,) = grads
         return [gz * sigmoid(x)]
@@ -1318,7 +1318,7 @@ class Log1mexp(UnaryScalarOp):
         else:
             return np.log(-np.expm1(x))
 
-    def grad(self, inp, grads):
+    def pullback(self, inp, outputs, grads):
         (x,) = inp
         (gz,) = grads
         res = true_div(-1.0, expm1(-x))
@@ -1353,7 +1353,7 @@ class BetaInc(ScalarOp):
     def impl(self, a, b, x):
         return special.betainc(a, b, x)
 
-    def grad(self, inp, grads):
+    def pullback(self, inp, outputs, grads):
         a, b, x = inp
         (gz,) = grads
 
@@ -1611,7 +1611,7 @@ class BetaIncInv(ScalarOp):
     def impl(self, a, b, x):
         return special.betaincinv(a, b, x)
 
-    def grad(self, inputs, grads):
+    def pullback(self, inputs, outputs, grads):
         (a, b, x) = inputs
         (gz,) = grads
         return [
@@ -1650,7 +1650,7 @@ class Hyp2F1(ScalarOp):
     def impl(self, a, b, c, z):
         return special.hyp2f1(a, b, c, z)
 
-    def grad(self, inputs, grads):
+    def pullback(self, inputs, outputs, grads):
         a, b, c, z = inputs
         (gz,) = grads
         grad_a, grad_b, grad_c = hyp2f1_grad(a, b, c, z, wrt=[0, 1, 2])

--- a/pytensor/scan/op.py
+++ b/pytensor/scan/op.py
@@ -65,10 +65,10 @@ from pytensor.configdefaults import config
 from pytensor.gradient import (
     DisconnectedType,
     NullType,
-    Rop,
     disconnected_type,
     grad,
     grad_undefined,
+    pushforward,
 )
 from pytensor.graph.basic import (
     Apply,
@@ -2423,7 +2423,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         node.tag.connection_pattern = connection_pattern
         return connection_pattern
 
-    def L_op(self, inputs, outs, dC_douts):
+    def pullback(self, inputs, outs, dC_douts):
         # Computes the gradient of this Scan by constructing a new backward Scan
         # that runs in reverse. The method:
         # 1. Differentiates the inner function symbolically (compute_all_gradients)
@@ -3189,7 +3189,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
                 gradients[idx] = disconnected_type()
         return gradients
 
-    def R_op(self, inputs, eval_points):
+    def pushforward(self, inputs, outputs, eval_points):
         # Step 0. Prepare some shortcut variable
         info = self.info
         self_inputs = self.inner_inputs
@@ -3207,11 +3207,11 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
             rop_self_outputs = self_outputs
         if info.n_untraced_sit_sot > 0:
             rop_self_outputs = rop_self_outputs[: -info.n_untraced_sit_sot]
-        rop_outs = Rop(
+        rop_outs = pushforward(
             rop_self_outputs,
             rop_of_inputs,
-            inner_eval_points,
-            use_op_rop_implementation=True,
+            tangents=inner_eval_points,
+            use_op_pushforward=True,
         )
         if not isinstance(rop_outs, list | tuple):
             rop_outs = [rop_outs]
@@ -3237,7 +3237,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         ie = info.n_seqs
         clean_eval_points = []
         for inp, evp in zip(inputs[b:e], eval_points[b:e], strict=True):
-            if evp is not None:
+            if not isinstance(evp.type, DisconnectedType):
                 clean_eval_points.append(evp)
             else:
                 clean_eval_points.append(inp.zeros_like())
@@ -3252,7 +3252,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         ie = ie + int(sum(len(x) for x in info.mit_mot_in_slices))
         clean_eval_points = []
         for inp, evp in zip(inputs[b:e], eval_points[b:e], strict=True):
-            if evp is not None:
+            if not isinstance(evp.type, DisconnectedType):
                 clean_eval_points.append(evp)
             else:
                 clean_eval_points.append(inp.zeros_like())
@@ -3267,7 +3267,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         ie = ie + int(sum(len(x) for x in info.mit_sot_in_slices))
         clean_eval_points = []
         for inp, evp in zip(inputs[b:e], eval_points[b:e], strict=True):
-            if evp is not None:
+            if not isinstance(evp.type, DisconnectedType):
                 clean_eval_points.append(evp)
             else:
                 clean_eval_points.append(inp.zeros_like())
@@ -3282,7 +3282,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         ie = ie + info.n_sit_sot
         clean_eval_points = []
         for inp, evp in zip(inputs[b:e], eval_points[b:e], strict=True):
-            if evp is not None:
+            if not isinstance(evp.type, DisconnectedType):
                 clean_eval_points.append(evp)
             else:
                 clean_eval_points.append(inp.zeros_like())
@@ -3306,7 +3306,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         # All other arguments
         clean_eval_points = []
         for inp, evp in zip(inputs[e:], eval_points[e:], strict=True):
-            if evp is not None:
+            if not isinstance(evp.type, DisconnectedType):
                 clean_eval_points.append(evp)
             else:
                 clean_eval_points.append(inp.zeros_like())
@@ -3401,7 +3401,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         b = e + info.n_nit_sot
         e = e + info.n_nit_sot * 2
         final_outs += outputs[b:e]
-        final_outs += [None] * info.n_untraced_sit_sot
+        final_outs += [disconnected_type()] * info.n_untraced_sit_sot
 
         return final_outs
 

--- a/pytensor/scan/op.py
+++ b/pytensor/scan/op.py
@@ -425,6 +425,18 @@ class ScanMethodsMixin:
         offset = self.info.n_mit_sot + n_taps + self.info.n_sit_sot
         return list_outputs[offset : offset + self.info.n_nit_sot]
 
+    def nit_sot_core_shapes(self):
+        """Return static core shapes for nit_sot outputs, or None if any are unknown.
+
+        When all nit_sot inner outputs have fully known static shapes,
+        returns a tuple of shape tuples. Otherwise returns None,
+        meaning n_steps=0 cannot be handled without executing the inner function.
+        """
+        nit_sot_inner_outs = self.inner_nitsot_outs(self.inner_outputs)
+        if all(all(s is not None for s in v.type.shape) for v in nit_sot_inner_outs):
+            return tuple(v.type.shape for v in nit_sot_inner_outs)
+        return None
+
     def outer_nitsot_outs(self, list_outputs):
         offset = self.info.n_mit_mot + self.info.n_mit_sot + self.info.n_sit_sot
         return list_outputs[offset : offset + self.info.n_nit_sot]
@@ -1560,6 +1572,8 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
             isinstance(out, TensorVariable) for out in self.fn.maker.fgraph.outputs
         ]
 
+        _nit_sot_core_shapes = self.nit_sot_core_shapes()
+
         try:
             if impl == "py":
                 raise MissingGXX
@@ -1657,6 +1671,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
                         outputs,
                         outer_output_dtypes,
                         outer_output_ndims,
+                        _nit_sot_core_shapes,
                         self.fn.vm,
                     )
                 except InnerFunctionError as exc:
@@ -1792,13 +1807,21 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
                 output_storage[idx][0] = inputs[self.seqs_arg_offset + idx].copy()
 
         if n_steps == 0:
+            nit_sot_core_shapes = self.nit_sot_core_shapes()
+            if nit_sot_core_shapes is None and info.n_nit_sot > 0:
+                raise ValueError(
+                    "Scan has nit_sot outputs with unknown static shapes "
+                    "and n_steps=0. The output core shapes cannot be "
+                    "determined without executing the inner function."
+                )
             nit_sot_end = self.n_tap_outs + info.n_nit_sot
             for idx in range(self.n_tap_outs, nit_sot_end):
-                out_var = node.outputs[idx]
-                assert isinstance(out_var, TensorVariable)
-                # This is plainly wrong, should use static shape or raise if it can't be inferred
+                core_shape = nit_sot_core_shapes[idx - self.n_tap_outs]
+                nit_sot_var = self.inner_nitsot_outs(self.inner_outputs)[
+                    idx - self.n_tap_outs
+                ]
                 output_storage[idx][0] = np.empty(
-                    (0,) * out_var.type.ndim, dtype=out_var.type.dtype
+                    (0, *core_shape), dtype=nit_sot_var.type.numpy_dtype
                 )
 
             for j in range(info.n_untraced_sit_sot):

--- a/pytensor/scan/scan_perform.pyx
+++ b/pytensor/scan/scan_perform.pyx
@@ -62,7 +62,7 @@ numpy.import_array()
 
 
 def get_version():
-    return 0.327
+    return 0.328
 
 
 @cython.cdivision(True)
@@ -100,6 +100,7 @@ def perform(
     list outer_outputs not None,
     tuple outer_output_dtypes not None,
     const unsigned int[:] outer_output_ndims not None,
+    tuple nit_sot_core_shapes,
     fn,
 ) -> (time_t, int):
     """
@@ -273,9 +274,16 @@ def perform(
             outer_outputs_idx[0] = outer_inputs_offset_idx.copy()
 
     if n_steps == 0:
+        if nit_sot_core_shapes is None and n_nit_sot > 0:
+            raise ValueError(
+                "Scan has nit_sot outputs with unknown static shapes "
+                "and n_steps=0. The output core shapes cannot be "
+                "determined without executing the inner function."
+            )
         for idx in range(n_outs, n_outs + n_nit_sot):
             if outs_is_tensor[idx]:
-                outer_outputs[idx][0] = numpy.empty((0,) * outer_output_ndims[idx], dtype=outer_output_dtypes[idx])
+                core_shape = nit_sot_core_shapes[idx - n_outs]
+                outer_outputs[idx][0] = numpy.empty((0, *core_shape), dtype=outer_output_dtypes[idx])
             else:
                 outer_outputs[idx][0] = None
         for j in range(n_untraced_sit_sot):

--- a/pytensor/scan/scan_perform_ext.py
+++ b/pytensor/scan/scan_perform_ext.py
@@ -9,7 +9,7 @@ To update the `Scan` Cython code you must
 from pytensor.scan.scan_perform import get_version, perform  # noqa: F401
 
 
-version = 0.327  # must match constant returned in function get_version()
+version = 0.328  # must match constant returned in function get_version()
 assert version == get_version(), (
     "Invalid extension, check the installation process, "
     "could be problem with .pyx file or Cython ext build process."

--- a/pytensor/sparse/basic.py
+++ b/pytensor/sparse/basic.py
@@ -307,7 +307,7 @@ class CSMProperties(Op):
         out[2][0] = np.asarray(csm.indptr, dtype="int32")
         out[3][0] = np.asarray(csm.shape, dtype="int32")
 
-    def grad(self, inputs, g):
+    def pullback(self, inputs, outputs, g):
         # g[1:] is all integers, so their Jacobian in this op
         # is 0. We thus don't need to worry about what their values
         # are.
@@ -479,7 +479,7 @@ class CSM(Op):
     def connection_pattern(self, node):
         return [[True], [False], [False], [False]]
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x_data, x_indices, x_indptr, x_shape) = inputs
         (g_out,) = gout
         g_data, g_indices, g_indptr, g_shape = csm_properties(g_out)
@@ -610,7 +610,7 @@ class Cast(Op):
         assert _is_sparse(x)
         out[0] = x.astype(self.out_type)
 
-    def grad(self, inputs, outputs_gradients):
+    def pullback(self, inputs, outputs, outputs_gradients):
         gz = outputs_gradients[0]
 
         if gz.dtype in complex_dtypes:
@@ -722,7 +722,7 @@ class DenseFromSparse(Op):
             out[0] = x.toarray()
         assert _is_dense(out[0])
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if self.sparse_grad:
@@ -797,7 +797,7 @@ class SparseFromDense(Op):
         (out,) = outputs
         out[0] = SparseTensorType.format_cls[self.format](x)
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         gx = dense_from_sparse(gz)
@@ -850,7 +850,7 @@ class GetItemList(Op):
         assert _is_sparse(x)
         out[0] = x[indices]
 
-    def grad(self, inputs, g_outputs):
+    def pullback(self, inputs, outputs, g_outputs):
         x, indices = inputs
         (gout,) = g_outputs
         return [
@@ -942,7 +942,7 @@ class GetItem2Lists(Op):
         # which isn't what we want, so we convert it into an `ndarray`
         out[0] = np.asarray(x[ind1, ind2]).flatten()
 
-    def grad(self, inputs, g_outputs):
+    def pullback(self, inputs, outputs, g_outputs):
         x, ind1, ind2 = inputs
         (gout,) = g_outputs
         return [
@@ -1233,7 +1233,7 @@ class Transpose(Op):
         assert _is_sparse(x)
         out[0] = x.transpose()
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         assert _is_sparse_variable(x) and _is_sparse_variable(gz)
@@ -1281,7 +1281,7 @@ class ColScaleCSC(Op):
 
         z[0] = y
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         from pytensor.sparse.math import sp_sum
 
         (x, s) = inputs
@@ -1332,7 +1332,7 @@ class RowScaleCSC(Op):
 
         z[0] = scipy.sparse.csc_matrix((y_data, indices, indptr), (M, N))
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         from pytensor.sparse.math import sp_sum
 
         (x, s) = inputs
@@ -1433,7 +1433,7 @@ class Diag(Op):
             raise ValueError("Diag only apply on square matrix")
         z[0] = x.diagonal()
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (_x,) = inputs
         (gz,) = gout
         return [square_diagonal(gz)]
@@ -1495,7 +1495,7 @@ class EnsureSortedIndices(Op):
         else:
             z[0] = x.sorted_indices()
 
-    def grad(self, inputs, output_grad):
+    def pullback(self, inputs, outputs, output_grad):
         return [output_grad[0]]
 
     def infer_shape(self, fgraph, node, i0_shapes):
@@ -1591,7 +1591,7 @@ class HStack(Stack):
         if out[0].dtype != self.dtype:
             out[0] = out[0].astype(self.dtype)
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (gz,) = gout
         is_continuous = [
             (inputs[i].dtype in tensor_continuous_dtypes) for i in range(len(inputs))
@@ -1688,7 +1688,7 @@ class VStack(Stack):
         if out[0].dtype != self.dtype:
             out[0] = out[0].astype(self.dtype)
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (gz,) = gout
         is_continuous = [
             (inputs[i].dtype in tensor_continuous_dtypes) for i in range(len(inputs))
@@ -1795,7 +1795,7 @@ class Remove0(Op):
         c.eliminate_zeros()
         z[0] = c
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (_x,) = inputs
         (gz,) = gout
         return [gz]
@@ -1884,16 +1884,16 @@ class ConstructSparseFromList(Op):
         x = node.inputs[0]
         return [[x[0], x[1]]]
 
-    def R_op(self, inputs, eval_points):
-        if None in eval_points[:2]:
-            return [None]
+    def pushforward(self, inputs, outputs, eval_points):
+        if any(isinstance(t.type, DisconnectedType) for t in eval_points[:2]):
+            return [disconnected_type()]
         return self.make_node(eval_points[0], eval_points[1], *inputs[2:]).outputs
 
     def connection_pattern(self, node):
         rval = [[True], [True], [False]]
         return rval
 
-    def grad(self, inputs, grads):
+    def pullback(self, inputs, outputs, grads):
         (g_output,) = grads
         _x, _y = inputs[:2]
         idx_list = inputs[2:]

--- a/pytensor/sparse/math.py
+++ b/pytensor/sparse/math.py
@@ -293,7 +293,7 @@ class SpSum(Op):
         else:
             z[0] = np.asarray(x.sum(self.axis)).ravel()
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x,) = inputs
         (gz,) = gout
         if x.dtype not in psb.continuous_dtypes:
@@ -397,7 +397,7 @@ class AddSS(Op):
         assert x.shape == y.shape
         out[0] = x + y
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x, y) = inputs
         (gz,) = gout
         assert psb._is_sparse_variable(x) and psb._is_sparse_variable(y)
@@ -459,7 +459,7 @@ class AddSSData(Op):
         out[0] = x.copy()
         out[0].data += y.data
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (gz,) = gout
         is_continuous = [(i.dtype in psb.continuous_dtypes) for i in inputs]
         derivative = {True: gz, False: None}
@@ -500,7 +500,7 @@ class AddSD(Op):
         # numpy.matrixlib.defmatrix.matrix object and not an ndarray.
         out[0] = np.asarray(x + y, dtype=node.outputs[0].type.dtype)
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x, y) = inputs
         (gz,) = gout
         assert psb._is_sparse_variable(x) and psb._is_dense_variable(y)
@@ -560,7 +560,7 @@ class StructuredAddSV(Op):
         assert x.shape[1] == y.shape[0]
         out[0] = x.__class__(x + (x.toarray() != 0) * y)
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x, y) = inputs
         (gz,) = gout
         assert psb._is_sparse_variable(x) and not psb._is_sparse_variable(y)
@@ -692,7 +692,7 @@ class SparseSparseMultiply(Op):
         # x * y calls dot...
         out[0] = x.multiply(y)
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x, y) = inputs
         (gz,) = gout
         return y * gz, x * gz
@@ -779,7 +779,7 @@ class SparseDenseMultiply(Op):
                         j = indices[j_idx]
                         z_data[j_idx] *= y[i, j]
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x, y) = inputs
         (gz,) = gout
         assert psb._is_sparse_variable(x) and psb._is_dense_variable(y)
@@ -853,7 +853,7 @@ class SparseDenseVectorMultiply(Op):
         assert x.shape[1] == y.shape[0]
         out[0] = x.__class__(x.toarray() * y)
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x, y) = inputs
         (gz,) = gout
         assert psb._is_sparse_variable(x) and psb._is_dense_variable(y)
@@ -1270,7 +1270,7 @@ class TrueDot(Op):
                 )
         out[0] = rval
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x, y) = inputs
         (gz,) = gout
         assert psb._is_sparse_variable(gz)
@@ -1400,7 +1400,7 @@ class StructuredDot(Op):
         # _asarray function documentation.
         out[0] = np.asarray(variable, str(variable.dtype))
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         # NOTE: a is sparse; b and g_out are both dense or sparse.
         # Python and Numba backends support sparse b and g_out.
         # C backend only supports dense b and g_out.
@@ -1820,7 +1820,7 @@ class SamplingDot(Op):
 
         out[0] = p.__class__(p.multiply(np.dot(x, y.T)))
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x, y, p) = inputs
         (gz,) = gout
         rval = [dot(p * gz, y), dot((p * gz).T, x), grad_not_implemented(self, 2, p)]
@@ -1922,7 +1922,7 @@ class Dot(Op):
 
         out[0] = np.asarray(rval, dtype=node.outputs[0].dtype)
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x, y) = inputs
         (gz,) = gout
         assert psb._is_sparse_variable(x) or psb._is_sparse_variable(y)

--- a/pytensor/tensor/_linalg/solve/linear_control.py
+++ b/pytensor/tensor/_linalg/solve/linear_control.py
@@ -157,7 +157,7 @@ def solve_sylvester(A: TensorLike, B: TensorLike, Q: TensorLike) -> TensorVariab
     op = SolveSylvester(
         inputs=[A_matrix, B_matrix, Q_matrix],
         outputs=[X],
-        lop_overrides=_lop_solve_continuous_sylvester,
+        pullback=_lop_solve_continuous_sylvester,
     )
 
     return cast(TensorVariable, Blockwise(op)(A, B, Q))
@@ -443,7 +443,7 @@ def solve_discrete_are(
     core_op = SolveDiscreteARE(
         inputs=[A_core, B_core, Q_core, R_core],
         outputs=[result],
-        lop_overrides=_lop_solve_discrete_are,
+        pullback=_lop_solve_discrete_are,
     )
 
     return cast(TensorVariable, Blockwise(core_op)(A, B, Q, R))

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -631,7 +631,7 @@ class TensorFromScalar(COp):
     def infer_shape(self, fgraph, node, in_shapes):
         return [()]
 
-    def grad(self, inp, grads):
+    def pullback(self, inp, outputs, grads):
         (s,) = inp
         (dt,) = grads
         if s.type.dtype in float_dtypes:
@@ -692,14 +692,14 @@ class ScalarFromTensor(COp):
     def infer_shape(self, fgraph, node, in_shapes):
         return [()]
 
-    def grad(self, inp, grads):
+    def pullback(self, inp, outputs, grads):
         (_s,) = inp
         (dt,) = grads
         return [tensor_from_scalar(dt)]
 
-    def R_op(self, inputs, eval_points):
-        if None in eval_points:
-            return [None]
+    def pushforward(self, inputs, outputs, eval_points):
+        if any(isinstance(t.type, DisconnectedType) for t in eval_points):
+            return [disconnected_type()]
         return self.make_node(*eval_points).outputs
 
     def c_code(self, node, name, inputs, outputs, sub):
@@ -985,7 +985,7 @@ class Nonzero(Op):
         for i, res in enumerate(result_tuple):
             out_[i][0] = res.astype("int64")
 
-    def grad(self, inp, grads):
+    def pullback(self, inp, outputs, grads):
         return [grad_undefined(self, 0, inp[0])]
 
 
@@ -1374,7 +1374,7 @@ class Eye(Op):
         out_shape = [node.inputs[0], node.inputs[1]]
         return [out_shape]
 
-    def grad(self, inp, grads):
+    def pullback(self, inp, outputs, grads):
         return [grad_undefined(self, i, inp[i]) for i in range(3)]
 
     @staticmethod
@@ -1707,7 +1707,7 @@ class Alloc(COp):
 
         return rval
 
-    def grad(self, inputs, grads):
+    def pullback(self, inputs, outputs, grads):
         x = inputs[0]
         gz = grads[0]
         n_axes_to_sum = gz.ndim - x.ndim
@@ -1742,9 +1742,9 @@ class Alloc(COp):
         # change.
         return [gx, *(disconnected_type() for _ in range(len(inputs) - 1))]
 
-    def R_op(self, inputs, eval_points):
-        if eval_points[0] is None:
-            return [None]
+    def pushforward(self, inputs, outputs, eval_points):
+        if isinstance(eval_points[0].type, DisconnectedType):
+            return [disconnected_type()]
         return self(eval_points[0], *inputs[1:], return_list=True)
 
     def do_constant_folding(self, fgraph, node):
@@ -1960,7 +1960,7 @@ class MakeVector(COp):
     def infer_shape(self, fgraph, node, ishapes):
         return [(len(ishapes),)]
 
-    def grad(self, inputs, output_gradients):
+    def pullback(self, inputs, outputs, output_gradients):
         # If the output is of an integer dtype, no gradient shall pass
         if self.dtype in discrete_dtypes:
             return [ipt.zeros_like(dtype=config.floatX) for ipt in inputs]
@@ -1968,9 +1968,9 @@ class MakeVector(COp):
         grads = [output_gradients[0][i] for i in range(len(inputs))]
         return grads
 
-    def R_op(self, inputs, eval_points):
-        if None in eval_points:
-            return [None]
+    def pushforward(self, inputs, outputs, eval_points):
+        if any(isinstance(t.type, DisconnectedType) for t in eval_points):
+            return [disconnected_type()]
         return self.make_node(*eval_points).outputs
 
 
@@ -2265,7 +2265,7 @@ class Split(COp):
             [False] * n_out,
         ]
 
-    def L_op(self, inputs, outputs, g_outputs):
+    def pullback(self, inputs, outputs, g_outputs):
         """Join the gradients along the axis that was used to split x."""
         _x, axis, _n = inputs
 
@@ -2283,9 +2283,9 @@ class Split(COp):
             disconnected_type(),
         ]
 
-    def R_op(self, inputs, eval_points):
-        if eval_points[0] is None:
-            return [None for i in self.len_splits]
+    def pushforward(self, inputs, outputs, eval_points):
+        if isinstance(eval_points[0].type, DisconnectedType):
+            return [disconnected_type() for i in self.len_splits]
         return self.make_node(eval_points[0], *inputs[1:]).outputs
 
     def c_code_cache_version(self):
@@ -2660,12 +2660,12 @@ class Join(COp):
         """
         return code
 
-    def R_op(self, inputs, eval_points):
-        if None in eval_points[1:]:
-            return [None]
+    def pushforward(self, inputs, outputs, eval_points):
+        if any(isinstance(t.type, DisconnectedType) for t in eval_points[1:]):
+            return [disconnected_type()]
         return self.make_node(inputs[0], *eval_points[1:]).outputs
 
-    def L_op(self, inputs, outputs, grads):
+    def pullback(self, inputs, outputs, grads):
         """The gradient wrt a join op is a `Split`, used to partition
         the gradient along the `axis` which was used for joining.
         """
@@ -3329,7 +3329,7 @@ class ARange(COp):
     def connection_pattern(self, node):
         return [[True], [False], [True]]
 
-    def L_op(self, inputs, outputs, grads):
+    def pullback(self, inputs, outputs, grads):
         start, _stop, step = inputs
         (gz,) = grads
         # `start` and `step` affect the output values
@@ -3354,8 +3354,8 @@ class ARange(COp):
                 (gz * arange(num_steps_taken, dtype=self.dtype)).sum(),
             ]
 
-    def R_op(self, inputs, eval_points):
-        return [None]
+    def pushforward(self, inputs, outputs, eval_points):
+        return [disconnected_type()]
 
 
 _arange = {}
@@ -3641,7 +3641,7 @@ class PermuteRowElements(Op):
         out_shape = [maximum(sx, sy) for sx, sy in zip(shp_x, shp_y, strict=True)]
         return [out_shape]
 
-    def grad(self, inp, grads):
+    def pullback(self, inp, outputs, grads):
         from pytensor.tensor.math import Sum
 
         x, y = inp
@@ -3859,7 +3859,7 @@ class ExtractDiag(COp):
     def c_code_cache_version(self):
         return (0,)
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         # Avoid circular import
         from pytensor.tensor.subtensor import set_subtensor
 
@@ -4381,10 +4381,10 @@ class AllocEmpty(COp):
     def connection_pattern(self, node):
         return [[False] for i in node.inputs]
 
-    def grad(self, inputs, grads):
+    def pullback(self, inputs, outputs, grads):
         return [disconnected_type() for _ in range(len(inputs))]
 
-    def R_op(self, inputs, eval_points):
+    def pushforward(self, inputs, outputs, eval_points):
         return [zeros(inputs, self.dtype)]
 
 

--- a/pytensor/tensor/blas.py
+++ b/pytensor/tensor/blas.py
@@ -96,6 +96,7 @@ except ImportError:
 
 import pytensor.scalar
 from pytensor.configdefaults import config
+from pytensor.gradient import DisconnectedType, disconnected_type
 from pytensor.graph.basic import Apply
 from pytensor.graph.op import Op
 from pytensor.graph.utils import InconsistencyError, MethodNotDefined
@@ -1597,7 +1598,7 @@ class BatchedDot(COp):
 
         return (6, blas_header_version())
 
-    def grad(self, inp, grads):
+    def pullback(self, inp, outputs, grads):
         x, y = inp
         (gz,) = grads
 
@@ -1619,23 +1620,24 @@ class BatchedDot(COp):
 
         return xgrad, ygrad
 
-    def R_op(self, inputs, eval_points):
-        # R_op for batched_dot(a, b) evaluated at c for a and d for b is
-        # simply batched_dot(c, b) + batched_dot(a, d)
-
+    def pushforward(self, inputs, outputs, eval_points):
         assert len(inputs) == 2
         assert len(eval_points) == 2
-        if eval_points[0] is None and eval_points[1] is None:
-            return [None]
+        if isinstance(eval_points[0].type, DisconnectedType) and isinstance(
+            eval_points[1].type, DisconnectedType
+        ):
+            return [disconnected_type()]
 
-        if eval_points[0]:
+        if not isinstance(eval_points[0].type, DisconnectedType):
             t1 = self(eval_points[0], inputs[1])
-        if eval_points[1]:
+        if not isinstance(eval_points[1].type, DisconnectedType):
             t2 = self(inputs[0], eval_points[1])
 
-        if eval_points[0] and eval_points[1]:
+        if not isinstance(eval_points[0].type, DisconnectedType) and not isinstance(
+            eval_points[1].type, DisconnectedType
+        ):
             return [t1 + t2]
-        elif eval_points[0]:
+        elif not isinstance(eval_points[0].type, DisconnectedType):
             return [t1]
         else:
             return [t2]

--- a/pytensor/tensor/blockwise.py
+++ b/pytensor/tensor/blockwise.py
@@ -421,7 +421,7 @@ class Blockwise(COp):
 
         return [[True for _ in node.outputs] for _ in node.inputs]
 
-    def L_op(self, inputs, outputs, output_gradients):
+    def pullback(self, inputs, outputs, output_gradients):
         batch_ndim = self.batch_ndim(outputs[0].owner)
 
         # Obtain core_op gradients
@@ -444,7 +444,7 @@ class Blockwise(COp):
             )
         ]
 
-        core_input_gradients = self.core_op.L_op(
+        core_input_gradients = self.core_op.pullback(
             core_inputs, core_outputs, core_output_gradients
         )
 

--- a/pytensor/tensor/elemwise.py
+++ b/pytensor/tensor/elemwise.py
@@ -8,7 +8,7 @@ from numpy.lib.array_utils import normalize_axis_tuple
 
 import pytensor.tensor.basic
 from pytensor.configdefaults import config
-from pytensor.gradient import DisconnectedType
+from pytensor.gradient import DisconnectedType, disconnected_type
 from pytensor.graph.basic import Apply
 from pytensor.graph.null_type import NullType
 from pytensor.graph.replace import _vectorize_node, _vectorize_not_needed
@@ -267,12 +267,12 @@ class DimShuffle(ExternalCOp):
             rval.insert(augm, 1)
         return [rval]
 
-    def R_op(self, inputs, eval_points):
-        if None in eval_points:
-            return [None]
-        return self(*eval_points, return_list=True)
+    def pushforward(self, inputs, outputs, tangents):
+        if any(isinstance(t.type, DisconnectedType) for t in tangents):
+            return [disconnected_type()]
+        return self(*tangents, return_list=True)
 
-    def grad(self, inp, grads):
+    def pullback(self, inp, outputs, grads):
         (x,) = inp
         (gz,) = grads
         grad_order = ["x"] * x.type.ndim
@@ -481,9 +481,9 @@ class Elemwise(OpenMPOp):
             return self.name
         return str(self.scalar_op).capitalize()
 
-    def R_op(self, inputs, eval_points):
+    def pushforward(self, inputs, outputs, tangents):
         outs = self(*inputs, return_list=True)
-        rval = [None for x in outs]
+        rval = [disconnected_type() for x in outs]
         # For each output
         for idx, out in enumerate(outs):
             # make such that _bgrads computes only the gradients of the
@@ -494,9 +494,7 @@ class Elemwise(OpenMPOp):
             bgrads = self._bgrad(inputs, outs, ograds)
             rop_out = None
 
-            for jdx, (inp, eval_point) in enumerate(
-                zip(inputs, eval_points, strict=True)
-            ):
+            for jdx, (inp, eval_point) in enumerate(zip(inputs, tangents, strict=True)):
                 # if None, then we can just ignore this branch ..
                 # what we do is to assume that for any non-differentiable
                 # branch, the gradient is actually 0, which I think is not
@@ -507,13 +505,13 @@ class Elemwise(OpenMPOp):
                     bgrads[jdx].type, DisconnectedType
                 ):
                     pass
-                elif eval_point is not None:
+                elif not isinstance(eval_point.type, DisconnectedType):
                     if rop_out is None:
                         rop_out = bgrads[jdx] * eval_point
                     else:
                         rop_out = rop_out + bgrads[jdx] * eval_point
 
-            rval[idx] = rop_out
+            rval[idx] = disconnected_type() if rop_out is None else rop_out
 
         return rval
 
@@ -523,7 +521,7 @@ class Elemwise(OpenMPOp):
 
         return [[True for output in node.outputs] for ipt in node.inputs]
 
-    def L_op(self, inputs, outs, ograds):
+    def pullback(self, inputs, outs, ograds):
         from pytensor.tensor.math import sum as pt_sum
 
         # Compute grad with respect to broadcasted input
@@ -562,7 +560,7 @@ class Elemwise(OpenMPOp):
         scalar_outputs = self.scalar_op.make_node(
             *[get_scalar_type(dtype=i.type.dtype).make_variable() for i in inputs]
         ).outputs
-        scalar_igrads = self.scalar_op.L_op(
+        scalar_igrads = self.scalar_op.pullback(
             scalar_inputs, scalar_outputs, scalar_ograds
         )
         for igrad in scalar_igrads:

--- a/pytensor/tensor/extra_ops.py
+++ b/pytensor/tensor/extra_ops.py
@@ -75,7 +75,7 @@ class CpuContiguous(COp):
         assert x.flags["C_CONTIGUOUS"]
         y[0] = x
 
-    def grad(self, inputs, dout):
+    def pullback(self, inputs, outputs, dout):
         return [ptb.as_tensor_variable(dout[0])]
 
     def c_code(self, node, name, inames, onames, sub):
@@ -209,7 +209,7 @@ class SearchsortedOp(COp):
     def c_code_cache_version(self):
         return (2,)
 
-    def grad(self, inputs, output_gradients):
+    def pullback(self, inputs, outputs, output_gradients):
         num_ins = len(inputs)
         if num_ins == 3:
             x, v, _sorter = inputs
@@ -321,7 +321,7 @@ class CumOp(COp):
         else:
             z[0] = np.cumprod(x, axis=self.axis)
 
-    def L_op(self, inputs, outputs, output_gradients):
+    def pullback(self, inputs, outputs, output_gradients):
         (x,) = inputs
         (gi,) = output_gradients
 
@@ -700,7 +700,7 @@ class Repeat(Op):
     def connection_pattern(self, node):
         return [[True], [False]]
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         (x, repeats) = inputs
         (gz,) = gout
         axis = self.axis
@@ -854,7 +854,7 @@ class Bartlett(Op):
         M = ptb.switch(lt(temp, 0), ptb.cast(0, temp.dtype), temp)
         return [[M]]
 
-    def grad(self, inputs, output_grads):
+    def pullback(self, inputs, outputs, output_grads):
         return [None for i in inputs]
 
 
@@ -931,7 +931,7 @@ class FillDiagonal(Op):
 
         output_storage[0][0] = a
 
-    def grad(self, inp, cost_grad):
+    def pullback(self, inp, outputs, cost_grad):
         """
         Notes
         -----
@@ -1058,7 +1058,7 @@ class FillDiagonalOffset(Op):
 
         output_storage[0][0] = a
 
-    def grad(self, inp, cost_grad):
+    def pullback(self, inp, outputs, cost_grad):
         """
         Notes
         -----

--- a/pytensor/tensor/fft.py
+++ b/pytensor/tensor/fft.py
@@ -47,7 +47,7 @@ class RFFTOp(Op):
         out[..., 0], out[..., 1] = np.real(A), np.imag(A)
         output_storage[0][0] = out
 
-    def grad(self, inputs, output_grads):
+    def pullback(self, inputs, outputs, output_grads):
         (gout,) = output_grads
         s = inputs[1]
         # Divide the last dimension of the output gradients by 2, they are
@@ -108,7 +108,7 @@ class IRFFTOp(Op):
         # Cast to input type (numpy outputs float64 by default)
         output_storage[0][0] = (out * s.prod()).astype(a.dtype)
 
-    def grad(self, inputs, output_grads):
+    def pullback(self, inputs, outputs, output_grads):
         (gout,) = output_grads
         s = inputs[1]
         gf = rfft_op(gout, s)

--- a/pytensor/tensor/fourier.py
+++ b/pytensor/tensor/fourier.py
@@ -127,7 +127,7 @@ class Fourier(Op):
         axis = inputs[2]
         output_storage[0][0] = np.fft.fft(a, n=int(n), axis=axis.item())
 
-    def grad(self, inputs, cost_grad):
+    def pullback(self, inputs, outputs, cost_grad):
         """
         In defining the gradient, the Finite Fourier Transform is viewed as
         a complex-differentiable function of a complex variable

--- a/pytensor/tensor/math.py
+++ b/pytensor/tensor/math.py
@@ -9,6 +9,7 @@ from numpy.lib.array_utils import normalize_axis_tuple
 
 from pytensor import config, printing
 from pytensor import scalar as ps
+from pytensor.gradient import DisconnectedType, disconnected_type
 from pytensor.graph.basic import Apply, Variable
 from pytensor.graph.op import Op
 from pytensor.graph.replace import _vectorize_node
@@ -264,11 +265,11 @@ class Argmax(COp):
         )
         return [rval]
 
-    def R_op(self, inputs, eval_points):
+    def pushforward(self, inputs, outputs, eval_points):
         raise ValueError("Argmax is non-diifferentiable")
 
-    def grad(self, inp, grads):
-        (x,) = inp
+    def pullback(self, inputs, outputs, output_grads):
+        (x,) = inputs
 
         return [x.zeros_like()]
 
@@ -409,7 +410,7 @@ class Max(NonZeroDimsCAReduce):
         axis = kwargs.get("axis", self.axis)
         return type(self)(axis=axis)
 
-    def L_op(self, inputs, outputs, grads):
+    def pullback(self, inputs, outputs, output_grads):
         # The strict sense mathematical gradient of the maximum function is
         # not calculated here for it is not defined at every point where some
         # coordinates are identical. However, since the latter set has null
@@ -425,7 +426,7 @@ class Max(NonZeroDimsCAReduce):
         # does it automatically
         [x] = inputs
         [out] = outputs
-        [g_out] = grads
+        [g_out] = output_grads
 
         axis = tuple(range(x.ndim)) if self.axis is None else self.axis
         out_pad = expand_dims(out, axis)
@@ -435,10 +436,10 @@ class Max(NonZeroDimsCAReduce):
         g_x = eq(out_pad, x) * g_out_pad
         return (g_x,)
 
-    def R_op(self, inputs, eval_points):
+    def pushforward(self, inputs, outputs, eval_points):
         [x] = inputs
-        if eval_points[0] is None:
-            return [None]
+        if isinstance(eval_points[0].type, DisconnectedType):
+            return [disconnected_type()]
         axis = tuple(range(x.ndim) if self.axis is None else self.axis)
         if isinstance(axis, int):
             axis = [axis]
@@ -3057,9 +3058,9 @@ class Dot(Op):
     def perform(self, node, inputs, output_storage):
         output_storage[0][0] = np.matmul(*inputs)
 
-    def grad(self, inp, grads):
-        x, y = inp
-        (gz,) = grads
+    def pullback(self, inputs, outputs, output_grads):
+        x, y = inputs
+        (gz,) = output_grads
 
         xgrad = self(gz, y.T)
         ygrad = self(x.T, gz)
@@ -3080,23 +3081,27 @@ class Dot(Op):
 
         return xgrad, ygrad
 
-    def R_op(self, inputs, eval_points):
+    def pushforward(self, inputs, outputs, eval_points):
         # R_op for a \dot b evaluated at c for a and d for b is
         # simply c \dot b + a \dot d
 
         assert len(inputs) == 2
         assert len(eval_points) == 2
-        if eval_points[0] is None and eval_points[1] is None:
-            return [None]
+        if isinstance(eval_points[0].type, DisconnectedType) and isinstance(
+            eval_points[1].type, DisconnectedType
+        ):
+            return [disconnected_type()]
 
-        if eval_points[0] is not None:
+        if not isinstance(eval_points[0].type, DisconnectedType):
             t1 = self(eval_points[0], inputs[1])
-        if eval_points[1] is not None:
+        if not isinstance(eval_points[1].type, DisconnectedType):
             t2 = self(inputs[0], eval_points[1])
 
-        if eval_points[0] is not None and eval_points[1] is not None:
+        if not isinstance(eval_points[0].type, DisconnectedType) and not isinstance(
+            eval_points[1].type, DisconnectedType
+        ):
             return [t1 + t2]
-        elif eval_points[0] is not None:
+        elif not isinstance(eval_points[0].type, DisconnectedType):
             return [t1]
         else:
             return [t2]
@@ -3426,8 +3431,8 @@ class All(FixedOpCAReduce):
         ret = super().make_node(input)
         return ret
 
-    def grad(self, inp, grads):
-        (x,) = inp
+    def pullback(self, inputs, outputs, output_grads):
+        (x,) = inputs
         return [x.zeros_like(config.floatX)]
 
     def clone(self, **kwargs):
@@ -3456,8 +3461,8 @@ class Any(FixedOpCAReduce):
         ret = super().make_node(input)
         return ret
 
-    def grad(self, inp, grads):
-        (x,) = inp
+    def pullback(self, inputs, outputs, output_grads):
+        (x,) = inputs
         return [x.zeros_like(config.floatX)]
 
     def clone(self, **kwargs):
@@ -3486,13 +3491,13 @@ class Sum(FixedOpCAReduce):
             upcast_discrete_output=True,
         )
 
-    def L_op(self, inp, out, grads):
-        (x,) = inp
+    def pullback(self, inputs, outputs, output_grads):
+        (x,) = inputs
 
-        if out[0].dtype not in continuous_dtypes:
+        if outputs[0].dtype not in continuous_dtypes:
             return [x.zeros_like(dtype=config.floatX)]
 
-        (gz,) = grads
+        (gz,) = output_grads
         gz = as_tensor_variable(gz)
         axis = self.axis
         if axis is None:
@@ -3510,11 +3515,11 @@ class Sum(FixedOpCAReduce):
         gx = Elemwise(ps.second)(x, gz.dimshuffle(new_dims))
         return [gx]
 
-    def R_op(self, inputs, eval_points):
+    def pushforward(self, inputs, outputs, eval_points):
         # There is just one element in inputs and eval_points, the axis are
         # part of self
-        if None in eval_points:
-            return [None]
+        if isinstance(eval_points[0].type, DisconnectedType):
+            return [disconnected_type()]
         return self(*eval_points, return_list=True)
 
     def clone(self, **kwargs):
@@ -3577,7 +3582,7 @@ class Prod(FixedOpCAReduce):
         )
         self.no_zeros_in_input = no_zeros_in_input
 
-    def L_op(self, inp, out, grads):
+    def pullback(self, inp, out, grads):
         """
         The grad of this Op could be very easy, if it is was not for the case
         where zeros are present in a given "group" (ie. elements reduced
@@ -3793,7 +3798,7 @@ class ProdWithoutZeros(FixedOpCAReduce):
             upcast_discrete_output=True,
         )
 
-    def grad(self, inp, grads):
+    def pullback(self, inp, outputs, grads):
         from pytensor.gradient import grad_not_implemented
 
         (a,) = inp

--- a/pytensor/tensor/nlinalg.py
+++ b/pytensor/tensor/nlinalg.py
@@ -53,7 +53,7 @@ class MatrixPinv(Op):
         (z,) = outputs
         z[0] = np.linalg.pinv(x, hermitian=self.hermitian)
 
-    def L_op(self, inputs, outputs, g_outputs):
+    def pullback(self, inputs, outputs, g_outputs):
         r"""The gradient function should return
 
             .. math:: V\frac{\partial X^+}{\partial X},
@@ -137,7 +137,7 @@ class MatrixInverse(Op):
         (z,) = outputs
         z[0] = np.linalg.inv(x)
 
-    def grad(self, inputs, g_outputs):
+    def pullback(self, inputs, outputs, g_outputs):
         r"""The gradient function should return
 
             .. math:: V\frac{\partial X^{-1}}{\partial X},
@@ -156,7 +156,7 @@ class MatrixInverse(Op):
         # ptm.dot(gz.T,xi)
         return [-matrix_dot(xi, gz.T, xi).T]
 
-    def R_op(self, inputs, eval_points):
+    def pushforward(self, inputs, outputs, eval_points):
         r"""The gradient function should return
 
             .. math:: \frac{\partial X^{-1}}{\partial X}V,
@@ -172,8 +172,8 @@ class MatrixInverse(Op):
         (x,) = inputs
         xi = self(x)
         (ev,) = eval_points
-        if ev is None:
-            return [None]
+        if isinstance(ev.type, DisconnectedType):
+            return [disconnected_type()]
         return [-matrix_dot(xi, ev, xi)]
 
     def infer_shape(self, fgraph, node, shapes):
@@ -244,7 +244,7 @@ class Det(Op):
         except Exception as e:
             raise ValueError("Failed to compute determinant", x) from e
 
-    def grad(self, inputs, g_outputs):
+    def pullback(self, inputs, outputs, g_outputs):
         (gz,) = g_outputs
         (x,) = inputs
         return [gz * self(x) * matrix_inverse(x).T]
@@ -368,7 +368,7 @@ class Eig(Op):
 
         return [(n,), (n, n)]
 
-    def L_op(self, inputs, outputs, output_grads):
+    def pullback(self, inputs, outputs, output_grads):
         raise NotImplementedError(
             "Gradients for Eig is not implemented because it always returns complex values, "
             "for which autodiff is not yet supported in PyTensor (PRs welcome :) ).\n"
@@ -425,7 +425,7 @@ class Eigh(Eig):
         (w, v) = outputs
         w[0], v[0] = np.linalg.eigh(x, self.UPLO)
 
-    def L_op(self, inputs, outputs, output_grads):
+    def pullback(self, inputs, outputs, output_grads):
         r"""The gradient function should return
 
            .. math:: \sum_n\left(W_n\frac{\partial\,w_n}
@@ -607,7 +607,7 @@ class SVD(Op):
         else:
             return [s_shape]
 
-    def L_op(
+    def pullback(
         self,
         inputs: Sequence[Variable],
         outputs: Sequence[Variable],

--- a/pytensor/tensor/optimize.py
+++ b/pytensor/tensor/optimize.py
@@ -543,7 +543,7 @@ class MinimizeScalarOp(ScipyScalarWrapperOp):
         outputs[0][0] = np.array(res.x, dtype=x0.dtype)
         outputs[1][0] = np.bool_(res.success)
 
-    def L_op(self, inputs, outputs, output_grads):
+    def pullback(self, inputs, outputs, output_grads):
         # TODO: Handle disconnected inputs
         x, *args = inputs
         x_star, _ = outputs
@@ -686,7 +686,7 @@ class MinimizeOp(ScipyVectorWrapperOp):
         outputs[0][0] = res.x.reshape(x0.shape).astype(x0.dtype)
         outputs[1][0] = np.bool_(res.success)
 
-    def L_op(self, inputs, outputs, output_grads):
+    def pullback(self, inputs, outputs, output_grads):
         x, *args = inputs
         x_star, _success = outputs
         output_grad, _ = output_grads
@@ -879,7 +879,7 @@ class RootScalarOp(ScipyScalarWrapperOp):
         outputs[0][0] = np.array(res.root)
         outputs[1][0] = np.bool_(res.converged)
 
-    def L_op(self, inputs, outputs, output_grads):
+    def pullback(self, inputs, outputs, output_grads):
         x, *args = inputs
         x_star, _ = outputs
         output_grad, _ = output_grads
@@ -1052,7 +1052,7 @@ class RootOp(ScipyVectorWrapperOp):
         outputs[0][0] = res.x.reshape(variables.shape).astype(variables.dtype)
         outputs[1][0] = np.bool_(res.success)
 
-    def L_op(self, inputs, outputs, output_grads):
+    def pullback(self, inputs, outputs, output_grads):
         x, *args = inputs
         x_star, _ = outputs
         output_grad, _ = output_grads

--- a/pytensor/tensor/random/op.py
+++ b/pytensor/tensor/random/op.py
@@ -467,7 +467,7 @@ class RandomVariable(RNGConsumerOp):
             dtype=self.dtype,
         )
 
-    def grad(self, inputs, outputs):
+    def pullback(self, inputs, outputs, output_grads):
         return [
             pytensor.gradient.grad_undefined(
                 self, k, inp, "No gradient defined for random variables"
@@ -475,8 +475,10 @@ class RandomVariable(RNGConsumerOp):
             for k, inp in enumerate(inputs)
         ]
 
-    def R_op(self, inputs, eval_points):
-        return [None for i in eval_points]
+    def pushforward(self, inputs, outputs, eval_points):
+        from pytensor.gradient import disconnected_type
+
+        return [disconnected_type() for i in eval_points]
 
 
 class AbstractRNGConstructor(Op):

--- a/pytensor/tensor/reshape.py
+++ b/pytensor/tensor/reshape.py
@@ -84,7 +84,7 @@ class JoinDims(Op):
 
         out[0] = x.reshape(output_shape)
 
-    def L_op(self, inputs, outputs, output_grads):
+    def pullback(self, inputs, outputs, output_grads):
         (x,) = inputs
         (g_out,) = output_grads
 
@@ -208,7 +208,7 @@ class SplitDims(Op):
     def connection_pattern(self, node):
         return [[True], [False]]
 
-    def L_op(self, inputs, outputs, output_grads):
+    def pullback(self, inputs, outputs, output_grads):
         (x, _) = inputs
         (g_out,) = output_grads
         n_axes = g_out.ndim - x.ndim + 1

--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -257,7 +257,6 @@ def local_lift_transpose_through_dot(fgraph, node):
     # Output is dot product of transposed inputs in reverse order
     ret = node.op(y.mT, x.mT)
 
-    client.out.dprint(depth=2, print_shape=True)
     # Copy over stack trace to output from result of dot-product
     copy_stack_trace(node.out, ret)
 

--- a/pytensor/tensor/shape.py
+++ b/pytensor/tensor/shape.py
@@ -10,7 +10,7 @@ import numpy as np
 from numpy.lib.array_utils import normalize_axis_tuple
 
 import pytensor
-from pytensor.gradient import disconnected_type
+from pytensor.gradient import DisconnectedType, disconnected_type
 from pytensor.graph import Op
 from pytensor.graph.basic import Apply, Variable
 from pytensor.graph.replace import _vectorize_node
@@ -92,7 +92,7 @@ class Shape(COp):
         # part of the graph
         return [[False]]
 
-    def grad(self, inp, grads):
+    def pullback(self, inputs, outputs, output_grads):
         # the grad returns the gradient with respect to the
         # elements of a tensor variable
         # the elements of the tensor variable do not participate
@@ -100,8 +100,8 @@ class Shape(COp):
         # part of the graph
         return [disconnected_type()]
 
-    def R_op(self, inputs, eval_points):
-        return [None]
+    def pushforward(self, inputs, outputs, eval_points):
+        return [disconnected_type()]
 
     def c_code(self, node, name, inames, onames, sub):
         (iname,) = inames
@@ -308,12 +308,12 @@ class Shape_i(COp):
         # part of the graph
         return [[False]]
 
-    def grad(self, inp, grads):
+    def pullback(self, inputs, outputs, output_grads):
         return [
             pytensor.gradient.grad_not_implemented(
                 op=self,
                 x_pos=0,
-                x=inp[0],
+                x=inputs[0],
                 comment="No gradient for the shape of a matrix is implemented.",
             )
         ]
@@ -466,18 +466,17 @@ class SpecifyShape(COp):
     def connection_pattern(self, node):
         return [[True], *[[False]] * len(node.inputs[1:])]
 
-    def grad(self, inp, grads):
-        _x, *shape = inp
-        (gz,) = grads
+    def pullback(self, inputs, outputs, output_grads):
+        _x, *shape = inputs
+        (gz,) = output_grads
         return [
             specify_shape(gz, shape),
             *(disconnected_type() for _ in range(len(shape))),
         ]
 
-    def R_op(self, inputs, eval_points):
-        if eval_points[0] is None:
-            # It means that this op sits on top of a non-differentiable path
-            return [None]
+    def pushforward(self, inputs, outputs, eval_points):
+        if isinstance(eval_points[0].type, DisconnectedType):
+            return [disconnected_type()]
         return self.make_node(eval_points[0], *inputs[1:]).outputs
 
     def c_code(self, node, name, i_names, o_names, sub):
@@ -718,14 +717,14 @@ class Reshape(COp):
     def connection_pattern(self, node):
         return [[True], [False]]
 
-    def grad(self, inp, grads):
-        x, _shp = inp
-        (g_out,) = grads
+    def pullback(self, inputs, outputs, output_grads):
+        x, _shp = inputs
+        (g_out,) = output_grads
         return [reshape(g_out, shape(x), ndim=x.ndim), disconnected_type()]
 
-    def R_op(self, inputs, eval_points):
-        if eval_points[0] is None:
-            return [None]
+    def pushforward(self, inputs, outputs, eval_points):
+        if isinstance(eval_points[0].type, DisconnectedType):
+            return [disconnected_type()]
         return self(eval_points[0], *inputs[1:], return_list=True)
 
     def infer_shape(self, fgraph, node, ishapes):

--- a/pytensor/tensor/signal/conv.py
+++ b/pytensor/tensor/signal/conv.py
@@ -91,7 +91,7 @@ class AbstractConvolveNd:
     def connection_pattern(self, node):
         return [[True], [True], [False]]
 
-    def L_op(self, inputs, outputs, output_grads):
+    def pullback(self, inputs, outputs, output_grads):
         in1, in2, full_mode = inputs
         [grad] = output_grads
 

--- a/pytensor/tensor/slinalg.py
+++ b/pytensor/tensor/slinalg.py
@@ -97,7 +97,7 @@ class Cholesky(Op):
             # Transpose result if input was transposed
             out[0] = c.T if c_contiguous_input else c
 
-    def L_op(self, inputs, outputs, gradients):
+    def pullback(self, inputs, outputs, gradients):
         """
         Cholesky decomposition reverse-mode gradient update.
 
@@ -283,7 +283,7 @@ class SolveBase(Op):
             cols = Bshape[1]
             return [(rows, cols)]
 
-    def L_op(self, inputs, outputs, output_gradients):
+    def pullback(self, inputs, outputs, output_gradients):
         r"""Reverse-mode gradient updates for matrix solve operation :math:`c = A^{-1} b`.
 
         Symbolic expression for updates taken from [#]_.
@@ -375,7 +375,7 @@ class CholeskySolve(SolveBase):
 
         output_storage[0][0] = x
 
-    def L_op(self, *args, **kwargs):
+    def pullback(self, *args, **kwargs):
         # TODO: Base impl should work, let's try it
         raise NotImplementedError()
 
@@ -503,7 +503,7 @@ class LU(Op):
         else:
             return self
 
-    def L_op(
+    def pullback(
         self,
         inputs: Sequence[ptb.Variable],
         outputs: Sequence[ptb.Variable],
@@ -688,7 +688,7 @@ class LUFactor(Op):
         outputs[0][0] = LU
         outputs[1][0] = p
 
-    def L_op(self, inputs, outputs, output_gradients):
+    def pullback(self, inputs, outputs, output_gradients):
         [A] = inputs
         LU_bar, _ = output_gradients
         LU, p_indices = outputs
@@ -883,8 +883,8 @@ class SolveTriangular(SolveBase):
 
         outputs[0][0] = x
 
-    def L_op(self, inputs, outputs, output_gradients):
-        res = super().L_op(inputs, outputs, output_gradients)
+    def pullback(self, inputs, outputs, output_gradients):
+        res = super().pullback(inputs, outputs, output_gradients)
 
         if self.lower:
             res[0] = ptb.tril(res[0])
@@ -1165,7 +1165,7 @@ class Eigvalsh(Op):
         else:
             w[0] = scipy_linalg.eigvalsh(a=inputs[0], b=None, lower=self.lower)
 
-    def grad(self, inputs, g_outputs):
+    def pullback(self, inputs, outputs, g_outputs):
         a, b = inputs
         (gw,) = g_outputs
         return EigvalshGrad(self.lower)(a, b, gw)
@@ -1256,7 +1256,7 @@ class Expm(Op):
         (expm,) = outputs
         expm[0] = scipy_linalg.expm(A)
 
-    def L_op(self, inputs, outputs, output_grads):
+    def pullback(self, inputs, outputs, output_grads):
         # Kalbfleisch and Lawless, J. Am. Stat. Assoc. 80 (1985) Equation 3.4
         # Kind of... You need to do some algebra from there to arrive at
         # this expression.
@@ -1309,7 +1309,7 @@ class BaseBlockDiagonal(Op):
             raise ValueError("n_inputs must be greater than 1")
         self.n_inputs = n_inputs
 
-    def grad(self, inputs, gout):
+    def pullback(self, inputs, outputs, gout):
         shapes = pt.stack([i.shape for i in inputs])
         index_end = shapes.cumsum(0)
         index_begin = index_end - shapes
@@ -1616,7 +1616,7 @@ class QR(Op):
         if self.pivoting:
             outputs[2][0] = jpvt
 
-    def L_op(self, inputs, outputs, output_grads):
+    def pullback(self, inputs, outputs, output_grads):
         """
         Reverse-mode gradient of the QR function.
 

--- a/pytensor/tensor/sort.py
+++ b/pytensor/tensor/sort.py
@@ -59,7 +59,7 @@ class SortOp(Op):
         assert inputs_shapes[1] == ()
         return [inputs_shapes[0]]
 
-    def grad(self, inputs, output_grads):
+    def pullback(self, inputs, outputs, output_grads):
         a, axis = inputs
         indices = self.__get_argsort_indices(a, axis)
         inp_grad = output_grads[0][tuple(indices)]
@@ -109,14 +109,14 @@ class SortOp(Op):
         return indices
 
     """
-    def R_op(self, inputs, eval_points):
-        # R_op can receive None as eval_points.
+    def pushforward(self, inputs, outputs, eval_points):
+        # pushforward can receive DisconnectedType as eval_points.
         # That mean there is no diferientiable path through that input
         # If this imply that you cannot compute some outputs,
-        # return None for those.
-        if eval_points[0] is None:
-            return eval_points
-        return self.grad(inputs, eval_points)
+        # return disconnected_type() for those.
+        if isinstance(eval_points[0].type, DisconnectedType):
+            return list(eval_points)
+        return self.pullback(inputs, outputs, eval_points)
     """
 
 
@@ -190,7 +190,7 @@ class ArgSortOp(Op):
         assert inputs_shapes[1] == ()
         return [inputs_shapes[0]]
 
-    def grad(self, inputs, output_grads):
+    def pullback(self, inputs, outputs, output_grads):
         # No grad defined for integers.
         inp, axis = inputs
         inp_grad = inp.zeros_like()
@@ -204,14 +204,14 @@ class ArgSortOp(Op):
         return [inp_grad, axis_grad]
 
     """
-    def R_op(self, inputs, eval_points):
-        # R_op can receive None as eval_points.
+    def pushforward(self, inputs, outputs, eval_points):
+        # pushforward can receive DisconnectedType as eval_points.
         # That mean there is no diferientiable path through that input
         # If this imply that you cannot compute some outputs,
-        # return None for those.
-        if eval_points[0] is None:
-            return eval_points
-        return self.grad(inputs, eval_points)
+        # return disconnected_type() for those.
+        if isinstance(eval_points[0].type, DisconnectedType):
+            return list(eval_points)
+        return self.pullback(inputs, outputs, eval_points)
     """
 
 

--- a/pytensor/tensor/special.py
+++ b/pytensor/tensor/special.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 import numpy as np
 import scipy
 
+from pytensor.gradient import DisconnectedType, disconnected_type
 from pytensor.graph.basic import Apply
 from pytensor.graph.replace import _vectorize_node
 from pytensor.link.c.op import COp
@@ -44,7 +45,7 @@ class SoftmaxGrad(COp):
         dx = dy_times_sm - np.sum(dy_times_sm, axis=self.axis, keepdims=True) * sm
         output_storage[0][0] = dx
 
-    def grad(self, inp, grads):
+    def pullback(self, inp, outputs, grads):
         dy, sm = inp
         (g,) = grads
 
@@ -273,17 +274,15 @@ class Softmax(COp):
         (z,) = output_storage
         z[0] = scipy.special.softmax(x, axis=self.axis)
 
-    def L_op(self, inp, outputs, grads):
+    def pullback(self, inp, outputs, grads):
         (_x,) = inp
         (g_sm,) = grads
         return [SoftmaxGrad(axis=self.axis)(g_sm, outputs[0])]
 
-    def R_op(self, inputs, eval_points):
-        # I think the Jacobian is symmetric so the R_op
-        # is the same as the grad
-        if None in eval_points:
-            return [None]
-        return self.L_op(inputs, [self(*inputs)], eval_points)
+    def pushforward(self, inputs, outputs, eval_points):
+        if any(isinstance(t.type, DisconnectedType) for t in eval_points):
+            return [disconnected_type()]
+        return self.pullback(inputs, outputs, eval_points)
 
     def infer_shape(self, fgraph, node, shape):
         return shape
@@ -528,17 +527,15 @@ class LogSoftmax(COp):
         (z,) = output_storage
         z[0] = scipy.special.log_softmax(x, axis=self.axis)
 
-    def grad(self, inp, grads):
+    def pullback(self, inp, outputs, grads):
         (x,) = inp
         sm = Softmax(axis=self.axis)(x)
         return [grads[0] - sum(grads[0], axis=self.axis, keepdims=True) * sm]
 
-    def R_op(self, inputs, eval_points):
-        # I think the Jacobian is symmetric so the R_op
-        # is the same as the grad
-        if None in eval_points:
-            return [None]
-        return self.grad(inputs, eval_points)
+    def pushforward(self, inputs, outputs, eval_points):
+        if any(isinstance(t.type, DisconnectedType) for t in eval_points):
+            return [disconnected_type()]
+        return self.pullback(inputs, outputs, eval_points)
 
     def infer_shape(self, fgraph, node, shape):
         return shape

--- a/pytensor/tensor/subtensor.py
+++ b/pytensor/tensor/subtensor.py
@@ -11,7 +11,7 @@ from numpy.lib.array_utils import normalize_axis_tuple
 import pytensor
 from pytensor import scalar as ps
 from pytensor.configdefaults import config
-from pytensor.gradient import disconnected_type
+from pytensor.gradient import DisconnectedType, disconnected_type
 from pytensor.graph.basic import Apply, Constant, Variable
 from pytensor.graph.op import Op
 from pytensor.graph.replace import _vectorize_node
@@ -887,8 +887,8 @@ class Subtensor(BaseSubtensor, COp):
         assert len(outshp) == node.outputs[0].ndim
         return [outshp]
 
-    def grad(self, inputs, grads):
-        (gz,) = grads
+    def pullback(self, inputs, outputs, output_grads):
+        (gz,) = output_grads
         x, *index_variables = inputs
         if x.dtype in discrete_dtypes:
             first = x.zeros_like(dtype=config.floatX)
@@ -1259,12 +1259,12 @@ class Subtensor(BaseSubtensor, COp):
             return ()
         return (4, hv)
 
-    def R_op(self, inputs, eval_points):
+    def pushforward(self, inputs, outputs, eval_points):
         # Subtensor is not differentiable wrt to its indices, therefore we
         # do not even need to consider the eval_points provided for those
         # (they should be defaulted to zeros_like by the global R_op)
-        if eval_points[0] is None:
-            return [None]
+        if isinstance(eval_points[0].type, DisconnectedType):
+            return [disconnected_type()]
         _x, *index_variables = inputs
         return self(eval_points[0], *index_variables, return_list=True)
 
@@ -1692,9 +1692,11 @@ class IncSubtensor(BaseSubtensor, COp):
     def infer_shape(self, fgraph, node, shapes):
         return [shapes[0]]
 
-    def R_op(self, inputs, eval_points):
-        if eval_points[0] is None or eval_points[1] is None:
-            return [None]
+    def pushforward(self, inputs, outputs, eval_points):
+        if isinstance(eval_points[0].type, DisconnectedType) or isinstance(
+            eval_points[1].type, DisconnectedType
+        ):
+            return [disconnected_type()]
         # Again we ignore eval points for indices because incsubtensor is
         # not differentiable wrt to those
         _x, _y, *index_variables = inputs
@@ -1706,8 +1708,8 @@ class IncSubtensor(BaseSubtensor, COp):
 
         return rval
 
-    def grad(self, inputs, grads):
-        (g_output,) = grads
+    def pullback(self, inputs, outputs, output_grads):
+        (g_output,) = output_grads
         x, y, *index_variables = inputs
 
         if x.dtype in discrete_dtypes:
@@ -1836,9 +1838,9 @@ class AdvancedSubtensor1(COp):
 
         return rval
 
-    def grad(self, inputs, grads):
+    def pullback(self, inputs, outputs, output_grads):
         x, ilist = inputs
-        (gz,) = grads
+        (gz,) = output_grads
         assert len(inputs) == 2
         if self.sparse_grad:
             if x.type.ndim != 2:
@@ -1859,9 +1861,9 @@ class AdvancedSubtensor1(COp):
             rval1 = advanced_inc_subtensor1(gx, gz, ilist)
         return [rval1, *(disconnected_type() for _ in range(len(inputs) - 1))]
 
-    def R_op(self, inputs, eval_points):
-        if eval_points[0] is None:
-            return [None]
+    def pushforward(self, inputs, outputs, eval_points):
+        if isinstance(eval_points[0].type, DisconnectedType):
+            return [disconnected_type()]
         _x, *index_variables = inputs
         return self.make_node(eval_points[0], *index_variables).outputs
 
@@ -2219,9 +2221,9 @@ class AdvancedIncSubtensor1(BaseSubtensor, COp):
         x, _y, _ilist = ishapes
         return [x]
 
-    def R_op(self, inputs, eval_points):
-        if None in eval_points[:2]:
-            return [None]
+    def pushforward(self, inputs, outputs, eval_points):
+        if any(isinstance(t.type, DisconnectedType) for t in eval_points[:2]):
+            return [disconnected_type()]
         _x, _y, *index_variables = inputs
         return self.make_node(eval_points[0], eval_points[1], *index_variables).outputs
 
@@ -2229,8 +2231,8 @@ class AdvancedIncSubtensor1(BaseSubtensor, COp):
         rval = [[True], [True], [False]]
         return rval
 
-    def grad(self, inputs, grads):
-        (g_output,) = grads
+    def pullback(self, inputs, outputs, output_grads):
+        (g_output,) = output_grads
         x, y, idx_list = inputs
         if x.dtype in discrete_dtypes:
             # The output dtype is the same as x
@@ -2384,9 +2386,9 @@ class AdvancedSubtensor(BaseSubtensor, COp):
             [tensor(dtype=x.type.dtype, shape=tuple(indexed_shape))],
         )
 
-    def R_op(self, inputs, eval_points):
-        if eval_points[0] is None:
-            return [None]
+    def pushforward(self, inputs, outputs, eval_points):
+        if isinstance(eval_points[0].type, DisconnectedType):
+            return [disconnected_type()]
         _x, *index_variables = inputs
         return self.make_node(eval_points[0], *index_variables).outputs
 
@@ -2463,8 +2465,8 @@ class AdvancedSubtensor(BaseSubtensor, COp):
 
         return rval
 
-    def grad(self, inputs, grads):
-        (gz,) = grads
+    def pullback(self, inputs, outputs, output_grads):
+        (gz,) = output_grads
         x, *index_variables = inputs
         if x.dtype in discrete_dtypes:
             # The output dtype is the same as x
@@ -2626,15 +2628,15 @@ class AdvancedIncSubtensor(BaseSubtensor, Op):
 
         return rval
 
-    def R_op(self, inputs, eval_points):
-        if None in eval_points[:2]:
-            return [None]
+    def pushforward(self, inputs, outputs, eval_points):
+        if any(isinstance(t.type, DisconnectedType) for t in eval_points[:2]):
+            return [disconnected_type()]
         _x, _y, *index_variables = inputs
         return self.make_node(eval_points[0], eval_points[1], *index_variables).outputs
 
-    def grad(self, inpt, output_gradients):
-        x, y, *index_variables = inpt
-        (outgrad,) = output_gradients
+    def pullback(self, inputs, outputs, output_grads):
+        x, y, *index_variables = inputs
+        (outgrad,) = output_grads
         if x.dtype in discrete_dtypes:
             # The output dtype is the same as x
             gx = x.zeros_like(dtype=config.floatX)

--- a/pytensor/tensor/type_other.py
+++ b/pytensor/tensor/type_other.py
@@ -43,7 +43,7 @@ class MakeSlice(Op):
         (out,) = out_
         out[0] = slice(*inp)
 
-    def grad(self, inputs, grads):
+    def pullback(self, inputs, outputs, grads):
         return [disconnected_type() for _ in range(len(inputs))]
 
 

--- a/pytensor/tensor/xlogx.py
+++ b/pytensor/tensor/xlogx.py
@@ -15,7 +15,7 @@ class XlogX(ps.UnaryScalarOp):
             return 0.0
         return x * np.log(x)
 
-    def grad(self, inputs, grads):
+    def pullback(self, inputs, outputs, grads):
         (x,) = inputs
         (gz,) = grads
         return [gz * (1 + ps.log(x))]
@@ -46,7 +46,7 @@ class XlogY0(ps.BinaryScalarOp):
             return 0.0
         return x * np.log(y)
 
-    def grad(self, inputs, grads):
+    def pullback(self, inputs, outputs, grads):
         x, y = inputs
         (gz,) = grads
         return [gz * ps.log(y), gz * x / y]

--- a/pytensor/xtensor/basic.py
+++ b/pytensor/xtensor/basic.py
@@ -48,7 +48,7 @@ class TensorFromXTensor(XTypeCastOp):
         output = TensorType(x.type.dtype, shape=x.type.shape)()
         return Apply(self, [x], [output])
 
-    def L_op(self, inputs, outs, g_outs):
+    def pullback(self, inputs, outs, g_outs):
         [x] = inputs
         [g_out] = g_outs
         return [xtensor_from_tensor(g_out, dims=x.type.dims)]
@@ -81,7 +81,7 @@ class XTensorFromTensor(XTypeCastOp):
         output = xtensor(dtype=x.type.dtype, dims=self.dims, shape=x.type.shape)
         return Apply(self, [x], [output])
 
-    def L_op(self, inputs, outs, g_outs):
+    def pullback(self, inputs, outs, g_outs):
         [g_out] = g_outs
         return [tensor_from_xtensor(g_out)]
 
@@ -114,7 +114,7 @@ class Rename(XTypeCastOp):
         output = x.type.clone(dims=self.new_dims)()
         return Apply(self, [x], [output])
 
-    def L_op(self, inputs, outs, g_outs):
+    def pullback(self, inputs, outs, g_outs):
         [x] = inputs
         [g_out] = g_outs
         return [rename(g_out, dims=x.type.dims)]

--- a/tests/compile/test_builders.py
+++ b/tests/compile/test_builders.py
@@ -192,11 +192,11 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         "cls_ofg", [OpFromGraph, partial(OpFromGraph, inline=True)]
     )
     @pytest.mark.parametrize("use_deprecated_name", [False, True])
-    def test_lop_override(self, cls_ofg, use_deprecated_name):
+    def test_pullback_override(self, cls_ofg, use_deprecated_name):
         x = vector()
         y = 1.0 / (1.0 + exp(-x))
 
-        def lop_ov(inps, outs, grads):
+        def pullback_ov(inps, outs, grads):
             (y_,) = outs
             (dedy_,) = grads
             return [2.0 * y_ * (1.0 - y_) * dedy_]
@@ -208,7 +208,7 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         yy1 = pt_sum(sigmoid(xx))
         gyy1 = 2.0 * grad(yy1, xx)
 
-        for ov in [lop_ov, op_lop_ov]:
+        for ov in [pullback_ov, op_lop_ov]:
             if use_deprecated_name:
                 with pytest.warns(FutureWarning, match="lop_overrides is deprecated"):
                     op = cls_ofg([x], [y], lop_overrides=ov)
@@ -226,7 +226,7 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         "cls_ofg", [OpFromGraph, partial(OpFromGraph, inline=True)]
     )
     @pytest.mark.parametrize("use_op_pushforward", [True, False])
-    def test_rop(self, cls_ofg, use_op_pushforward):
+    def test_pushforward(self, cls_ofg, use_op_pushforward):
         a = vector()
         M = matrix()
         b = dot(a, M)
@@ -245,7 +245,7 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         np.testing.assert_array_almost_equal(dvval2, dvval, 4)
 
     @pytest.mark.parametrize("use_op_pushforward", [True, False])
-    def test_rop_multiple_outputs(self, use_op_pushforward):
+    def test_pushforward_multiple_outputs(self, use_op_pushforward):
         a = vector()
         M = matrix()
         b = dot(a, M)
@@ -293,7 +293,9 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         ],
     )
     @pytest.mark.parametrize("use_deprecated_name", [False, True])
-    def test_rop_override(self, cls_ofg, use_op_pushforward, use_deprecated_name):
+    def test_pushforward_override(
+        self, cls_ofg, use_op_pushforward, use_deprecated_name
+    ):
         x, y = vectors("xy")
 
         def ro(inps, epts):
@@ -581,7 +583,7 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         out = test_ofg(y, y)
         assert out.eval() == 4
 
-    def test_L_op_disconnected_output_grad(self):
+    def test_pullback_disconnected_output_grad(self):
         x, y = dscalars("x", "y")
         rng = np.random.default_rng(594)
         point = list(rng.normal(size=(2,)))

--- a/tests/compile/test_builders.py
+++ b/tests/compile/test_builders.py
@@ -18,7 +18,6 @@ from pytensor.gradient import (
 )
 from pytensor.graph.basic import equal_computations
 from pytensor.graph.fg import FunctionGraph
-from pytensor.graph.null_type import NullType, null_type
 from pytensor.graph.rewriting.basic import MergeOptimizer
 from pytensor.graph.rewriting.utils import rewrite_graph
 from pytensor.graph.utils import MissingInputError
@@ -31,7 +30,6 @@ from pytensor.tensor.random.utils import RandomStream
 from pytensor.tensor.rewriting.shape import ShapeOptimizer
 from pytensor.tensor.shape import specify_shape
 from pytensor.tensor.type import (
-    TensorType,
     dscalars,
     matrices,
     matrix,
@@ -112,16 +110,9 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
     def test_overrides_deprecated_api(self):
         inp = scalar("x")
         out = inp + 1
-        for kwarg in ("lop_overrides", "grad_overrides", "rop_overrides"):
-            with pytest.raises(
-                ValueError, match="'default' is no longer a valid value for overrides"
-            ):
-                OpFromGraph([inp], [out], **{kwarg: "default"})
-
-            with pytest.raises(
-                TypeError, match="Variables are no longer valid types for overrides"
-            ):
-                OpFromGraph([inp], [out], **{kwarg: null_type()})
+        for kwarg in ("lop_overrides", "rop_overrides"):
+            with pytest.warns(FutureWarning):
+                OpFromGraph([inp], [out], **{kwarg: lambda *args: [inp + 1]})
 
     @pytest.mark.parametrize(
         "cls_ofg", [OpFromGraph, partial(OpFromGraph, inline=True)]
@@ -196,85 +187,6 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         f = f - grad(pt_sum(f), s)
         fn = function([x, y, z], f)
         np.testing.assert_array_almost_equal(15.0 + s.get_value(), fn(xv, yv, zv), 4)
-
-    @pytest.mark.parametrize(
-        "cls_ofg", [OpFromGraph, partial(OpFromGraph, inline=True)]
-    )
-    def test_grad_override(self, cls_ofg):
-        x, y = vectors("xy")
-
-        def go(inps, gs):
-            x, y = inps
-            (g,) = gs
-            return [g * y * 2, g * x * 1.5]
-
-        dedz = vector("dedz")
-        op_mul_grad = cls_ofg([x, y, dedz], go([x, y], [dedz]))
-
-        with pytest.warns(FutureWarning, match="grad_overrides is deprecated"):
-            op_mul = cls_ofg([x, y], [x * y], grad_overrides=go)
-            op_mul2 = cls_ofg([x, y], [x * y], grad_overrides=op_mul_grad)
-
-        # single override case (function or OfG instance)
-        xx, yy = vector("xx"), vector("yy")
-        for op in [op_mul, op_mul2]:
-            zz = pt_sum(op(xx, yy))
-            dx, dy = grad(zz, [xx, yy])
-            fn = function([xx, yy], [dx, dy])
-            xv = np.random.random((16,)).astype(config.floatX)
-            yv = np.random.random((16,)).astype(config.floatX)
-            dxv, dyv = fn(xv, yv)
-            np.testing.assert_array_almost_equal(yv * 2, dxv, 4)
-            np.testing.assert_array_almost_equal(xv * 1.5, dyv, 4)
-
-        # list override case
-        def go1(inps, gs):
-            _x, w, _b = inps
-            g = gs[0]
-            return g * w * 2
-
-        def go2(inps, gs):
-            x, _w, _b = inps
-            g = gs[0]
-            return g * x * 1.5
-
-        w, b = vectors("wb")
-        # we make the 3rd gradient default (no override)
-        with pytest.warns(FutureWarning, match="grad_overrides is deprecated"):
-            op_linear = cls_ofg([x, w, b], [x * w + b], grad_overrides=[go1, go2, None])
-        xx, ww, bb = vector("xx"), vector("yy"), vector("bb")
-        zz = pt_sum(op_linear(xx, ww, bb))
-        dx, dw, db = grad(zz, [xx, ww, bb])
-        fn = function([xx, ww, bb], [dx, dw, db])
-        xv = np.random.random((16,)).astype(config.floatX)
-        wv = np.random.random((16,)).astype(config.floatX)
-        bv = np.random.random((16,)).astype(config.floatX)
-        dxv, dwv, dbv = fn(xv, wv, bv)
-        np.testing.assert_array_almost_equal(wv * 2, dxv, 4)
-        np.testing.assert_array_almost_equal(xv * 1.5, dwv, 4)
-        np.testing.assert_array_almost_equal(np.ones(16, dtype=config.floatX), dbv, 4)
-
-        # NullType and DisconnectedType
-        with pytest.warns(FutureWarning, match="grad_overrides is deprecated"):
-            op_linear2 = cls_ofg(
-                [x, w, b],
-                [x * w + b],
-                grad_overrides=[go1, NullType()(), DisconnectedType()()],
-                # This is a fake override, so a fake connection_pattern must be provided as well
-                connection_pattern=[[True], [True], [False]],
-            )
-        zz2 = pt_sum(op_linear2(xx, ww, bb))
-        dx2, dw2, db2 = grad(
-            zz2,
-            [xx, ww, bb],
-            return_disconnected="Disconnected",
-            disconnected_inputs="ignore",
-            null_gradients="return",
-        )
-        assert isinstance(dx2.type, TensorType)
-        assert dx2.ndim == 1
-        assert isinstance(dw2.type, NullType)
-        assert isinstance(db2.type, DisconnectedType)
 
     @pytest.mark.parametrize(
         "cls_ofg", [OpFromGraph, partial(OpFromGraph, inline=True)]
@@ -420,17 +332,16 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
             # and we don't care about the gradient wrt y.
             return y + pt_round(y)
 
-        def f1_back(inputs, output_gradients):
+        def f1_back(inputs, outputs, output_gradients):
             return [output_gradients[0], disconnected_type()]
 
-        with pytest.warns(FutureWarning, match="grad_overrides is deprecated"):
-            op = cls_ofg(
-                inputs=[x, y],
-                outputs=[f1(x, y)],
-                grad_overrides=f1_back,
-                connection_pattern=[[True], [False]],
-                on_unused_input="ignore",
-            )
+        op = cls_ofg(
+            inputs=[x, y],
+            outputs=[f1(x, y)],
+            lop_overrides=f1_back,
+            connection_pattern=[[True], [False]],
+            on_unused_input="ignore",
+        )
 
         c = op(x, y)
 

--- a/tests/compile/test_builders.py
+++ b/tests/compile/test_builders.py
@@ -11,9 +11,9 @@ from pytensor.compile.maker import function
 from pytensor.configdefaults import config
 from pytensor.gradient import (
     DisconnectedType,
-    Rop,
     disconnected_type,
     grad,
+    pushforward,
     verify_grad,
 )
 from pytensor.graph.basic import equal_computations
@@ -191,7 +191,8 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
     @pytest.mark.parametrize(
         "cls_ofg", [OpFromGraph, partial(OpFromGraph, inline=True)]
     )
-    def test_lop_override(self, cls_ofg):
+    @pytest.mark.parametrize("use_deprecated_name", [False, True])
+    def test_lop_override(self, cls_ofg, use_deprecated_name):
         x = vector()
         y = 1.0 / (1.0 + exp(-x))
 
@@ -208,7 +209,11 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         gyy1 = 2.0 * grad(yy1, xx)
 
         for ov in [lop_ov, op_lop_ov]:
-            op = cls_ofg([x], [y], lop_overrides=ov)
+            if use_deprecated_name:
+                with pytest.warns(FutureWarning, match="lop_overrides is deprecated"):
+                    op = cls_ofg([x], [y], lop_overrides=ov)
+            else:
+                op = cls_ofg([x], [y], pullback=ov)
             yy2 = pt_sum(op(xx))
             gyy2 = grad(yy2, xx)
             fn = function([xx], [gyy1, gyy2])
@@ -220,8 +225,8 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
     @pytest.mark.parametrize(
         "cls_ofg", [OpFromGraph, partial(OpFromGraph, inline=True)]
     )
-    @pytest.mark.parametrize("use_op_rop_implementation", [True, False])
-    def test_rop(self, cls_ofg, use_op_rop_implementation):
+    @pytest.mark.parametrize("use_op_pushforward", [True, False])
+    def test_rop(self, cls_ofg, use_op_pushforward):
         a = vector()
         M = matrix()
         b = dot(a, M)
@@ -230,7 +235,7 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         W = matrix()
         y = op_matmul(x, W)
         du = vector()
-        dv = Rop(y, x, du, use_op_rop_implementation=use_op_rop_implementation)
+        dv = pushforward(y, x, du, use_op_pushforward=use_op_pushforward)
         fn = function([x, W, du], dv)
         xval = np.random.random((16,)).astype(config.floatX)
         Wval = np.random.random((16, 16)).astype(config.floatX)
@@ -239,8 +244,8 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         dvval2 = fn(xval, Wval, duval)
         np.testing.assert_array_almost_equal(dvval2, dvval, 4)
 
-    @pytest.mark.parametrize("use_op_rop_implementation", [True, False])
-    def test_rop_multiple_outputs(self, use_op_rop_implementation):
+    @pytest.mark.parametrize("use_op_pushforward", [True, False])
+    def test_rop_multiple_outputs(self, use_op_pushforward):
         a = vector()
         M = matrix()
         b = dot(a, M)
@@ -255,21 +260,21 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         duval = np.random.random((16,)).astype(config.floatX)
 
         y = op_matmul(x, W)[0]
-        dv = Rop(y, x, du, use_op_rop_implementation=use_op_rop_implementation)
+        dv = pushforward(y, x, du, use_op_pushforward=use_op_pushforward)
         fn = function([x, W, du], dv)
         result_dvval = fn(xval, Wval, duval)
         expected_dvval = np.dot(duval, Wval)
         np.testing.assert_array_almost_equal(result_dvval, expected_dvval, 4)
 
         y = op_matmul(x, W)[1]
-        dv = Rop(y, x, du, use_op_rop_implementation=use_op_rop_implementation)
+        dv = pushforward(y, x, du, use_op_pushforward=use_op_pushforward)
         fn = function([x, W, du], dv)
         result_dvval = fn(xval, Wval, duval)
         expected_dvval = -np.dot(duval, Wval)
         np.testing.assert_array_almost_equal(result_dvval, expected_dvval, 4)
 
         y = pt.add(*op_matmul(x, W))
-        dv = Rop(y, x, du, use_op_rop_implementation=use_op_rop_implementation)
+        dv = pushforward(y, x, du, use_op_pushforward=use_op_pushforward)
         fn = function([x, W, du], dv)
         result_dvval = fn(xval, Wval, duval)
         expected_dvval = np.zeros_like(np.dot(duval, Wval))
@@ -279,7 +284,7 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         "cls_ofg", [OpFromGraph, partial(OpFromGraph, inline=True)]
     )
     @pytest.mark.parametrize(
-        "use_op_rop_implementation",
+        "use_op_pushforward",
         [
             True,
             pytest.param(
@@ -287,7 +292,8 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
             ),
         ],
     )
-    def test_rop_override(self, cls_ofg, use_op_rop_implementation):
+    @pytest.mark.parametrize("use_deprecated_name", [False, True])
+    def test_rop_override(self, cls_ofg, use_op_pushforward, use_deprecated_name):
         x, y = vectors("xy")
 
         def ro(inps, epts):
@@ -297,19 +303,24 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
 
         u, v = vectors("uv")
         op_mul_rop = cls_ofg([x, y, u, v], ro([x, y], [u, v]))
-        op_mul = cls_ofg([x, y], [x * y], rop_overrides=ro)
-        op_mul2 = cls_ofg([x, y], [x * y], rop_overrides=op_mul_rop)
+        if use_deprecated_name:
+            with pytest.warns(FutureWarning, match="rop_overrides is deprecated"):
+                op_mul = cls_ofg([x, y], [x * y], rop_overrides=ro)
+                op_mul2 = cls_ofg([x, y], [x * y], rop_overrides=op_mul_rop)
+        else:
+            op_mul = cls_ofg([x, y], [x * y], pushforward=ro)
+            op_mul2 = cls_ofg([x, y], [x * y], pushforward=op_mul_rop)
 
         # single override case
         xx, yy = vector("xx"), vector("yy")
         du, dv = vector("du"), vector("dv")
         for op in [op_mul, op_mul2]:
             zz = op_mul(xx, yy)
-            dw = Rop(
+            dw = pushforward(
                 zz,
                 [xx, yy],
                 [du, dv],
-                use_op_rop_implementation=use_op_rop_implementation,
+                use_op_pushforward=use_op_pushforward,
             )
             fn = function([xx, yy, du, dv], dw)
             vals = np.random.random((4, 32)).astype(config.floatX)
@@ -338,7 +349,7 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         op = cls_ofg(
             inputs=[x, y],
             outputs=[f1(x, y)],
-            lop_overrides=f1_back,
+            pullback=f1_back,
             connection_pattern=[[True], [False]],
             on_unused_input="ignore",
         )
@@ -675,7 +686,7 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         op_with_lop = OpFromGraph(
             [x, y],
             [e],
-            lop_overrides=lambda inps, outs, grads: [grads[0], grads[0]],
+            pullback=lambda inps, outs, grads: [grads[0], grads[0]],
         )
         assert op_plain != op_with_lop
 
@@ -683,7 +694,7 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         op_with_lop2 = OpFromGraph(
             [x, y],
             [e],
-            lop_overrides=lambda inps, outs, grads: [grads[0], grads[0]],
+            pullback=lambda inps, outs, grads: [grads[0], grads[0]],
         )
         assert op_with_lop == op_with_lop2
 
@@ -691,7 +702,7 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         op_with_lop3 = OpFromGraph(
             [x, y],
             [e],
-            lop_overrides=lambda inps, outs, grads: [grads[0] * 2, grads[0]],
+            pullback=lambda inps, outs, grads: [grads[0] * 2, grads[0]],
         )
         assert op_with_lop != op_with_lop3
 
@@ -699,12 +710,12 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         op_disc_y = OpFromGraph(
             [x, y],
             [e],
-            lop_overrides=lambda inps, outs, grads: [grads[0], disconnected_type()],
+            pullback=lambda inps, outs, grads: [grads[0], disconnected_type()],
         )
         op_disc_x = OpFromGraph(
             [x, y],
             [e],
-            lop_overrides=lambda inps, outs, grads: [disconnected_type(), grads[0]],
+            pullback=lambda inps, outs, grads: [disconnected_type(), grads[0]],
         )
         assert op_disc_y != op_disc_x
 
@@ -712,7 +723,7 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         op_disc_y2 = OpFromGraph(
             [x, y],
             [e],
-            lop_overrides=lambda inps, outs, grads: [grads[0], disconnected_type()],
+            pullback=lambda inps, outs, grads: [grads[0], disconnected_type()],
         )
         assert op_disc_y == op_disc_y2
 
@@ -720,7 +731,7 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         op_all_disc = OpFromGraph(
             [x, y],
             [e],
-            lop_overrides=lambda inps, outs, grads: [
+            pullback=lambda inps, outs, grads: [
                 disconnected_type(),
                 disconnected_type(),
             ],
@@ -732,12 +743,12 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         op_with_rop = OpFromGraph(
             [x, y],
             [e],
-            rop_overrides=lambda inps, epts: [epts[0] + epts[1]],
+            pushforward=lambda inps, epts: [epts[0] + epts[1]],
         )
         op_with_rop2 = OpFromGraph(
             [x, y],
             [e],
-            rop_overrides=lambda inps, epts: [epts[0] + epts[1]],
+            pushforward=lambda inps, epts: [epts[0] + epts[1]],
         )
         assert op_with_rop == op_with_rop2
         assert op_with_rop != op_plain
@@ -749,18 +760,18 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         def scale_grad(inps, outs, grads):
             return grads[0] * 2
 
-        op1 = OpFromGraph([x, y], [e], lop_overrides=[scale_grad, None])
-        op2 = OpFromGraph([x, y], [e], lop_overrides=[scale_grad, None])
+        op1 = OpFromGraph([x, y], [e], pullback=[scale_grad, None])
+        op2 = OpFromGraph([x, y], [e], pullback=[scale_grad, None])
         assert op1 == op2
 
         def scale_grad_3x(inps, outs, grads):
             return grads[0] * 3
 
-        op3 = OpFromGraph([x, y], [e], lop_overrides=[scale_grad_3x, None])
+        op3 = OpFromGraph([x, y], [e], pullback=[scale_grad_3x, None])
         assert op1 != op3
 
         # Position of None vs callable matters
-        op4 = OpFromGraph([x, y], [e], lop_overrides=[None, scale_grad])
+        op4 = OpFromGraph([x, y], [e], pullback=[None, scale_grad])
         assert op1 != op4
 
     def test_merge_identical_ofgs(self):

--- a/tests/scan/test_basic.py
+++ b/tests/scan/test_basic.py
@@ -26,7 +26,7 @@ from pytensor.compile.mode import Mode, get_default_mode, get_mode
 from pytensor.compile.rebuild import rebuild_collect_shared
 from pytensor.compile.sharedvalue import shared
 from pytensor.configdefaults import config
-from pytensor.gradient import NullTypeGradError, Rop, disconnected_grad, grad
+from pytensor.gradient import NullTypeGradError, disconnected_grad, grad, pushforward
 from pytensor.graph.basic import Apply, Variable, equal_computations
 from pytensor.graph.fg import FunctionGraph
 from pytensor.graph.op import Op
@@ -2001,8 +2001,8 @@ class TestScan:
         fgrad = function([], g_sh)
         assert fgrad() == 1
 
-    @pytest.mark.parametrize("use_op_rop_implementation", [True, False])
-    def test_R_op(self, use_op_rop_implementation):
+    @pytest.mark.parametrize("use_op_pushforward", [True, False])
+    def test_R_op(self, use_op_pushforward):
         seed = utt.fetch_seed()
         rng = np.random.default_rng(seed)
         floatX = config.floatX
@@ -2042,9 +2042,9 @@ class TestScan:
         eh0 = vector("eh0")
         eW = matrix("eW")
 
-        nwo_u = Rop(o, _u, eu, use_op_rop_implementation=use_op_rop_implementation)
-        nwo_h0 = Rop(o, _h0, eh0, use_op_rop_implementation=use_op_rop_implementation)
-        nwo_W = Rop(o, _W, eW, use_op_rop_implementation=use_op_rop_implementation)
+        nwo_u = pushforward(o, _u, eu, use_op_pushforward=use_op_pushforward)
+        nwo_h0 = pushforward(o, _h0, eh0, use_op_pushforward=use_op_pushforward)
+        nwo_W = pushforward(o, _W, eW, use_op_pushforward=use_op_pushforward)
         fn_rop = function(
             [u, h0, W, eu, eh0, eW], [nwo_u, nwo_h0, nwo_W], on_unused_input="ignore"
         )
@@ -2085,8 +2085,8 @@ class TestScan:
         np.testing.assert_allclose(vnW, tnW, atol=1e-6)
 
     @pytest.mark.slow
-    @pytest.mark.parametrize("use_op_rop_implementation", [True, False])
-    def test_R_op_2(self, use_op_rop_implementation):
+    @pytest.mark.parametrize("use_op_pushforward", [True, False])
+    def test_R_op_2(self, use_op_pushforward):
         seed = utt.fetch_seed()
         rng = np.random.default_rng(seed)
         floatX = config.floatX
@@ -2129,9 +2129,9 @@ class TestScan:
         eh0 = vector("eh0")
         eW = matrix("eW")
 
-        nwo_u = Rop(o, _u, eu, use_op_rop_implementation=use_op_rop_implementation)
-        nwo_h0 = Rop(o, _h0, eh0, use_op_rop_implementation=use_op_rop_implementation)
-        nwo_W = Rop(o, _W, eW, use_op_rop_implementation=use_op_rop_implementation)
+        nwo_u = pushforward(o, _u, eu, use_op_pushforward=use_op_pushforward)
+        nwo_h0 = pushforward(o, _h0, eh0, use_op_pushforward=use_op_pushforward)
+        nwo_W = pushforward(o, _W, eW, use_op_pushforward=use_op_pushforward)
         fn_rop = function(
             [u, h0, W, eu, eh0, eW], [nwo_u, nwo_h0, nwo_W, o], on_unused_input="ignore"
         )
@@ -2167,8 +2167,8 @@ class TestScan:
         np.testing.assert_allclose(vnh0, tnh0, atol=1e-6)
         np.testing.assert_allclose(vnW, tnW, atol=2e-6)
 
-    @pytest.mark.parametrize("use_op_rop_implementation", [True, False])
-    def test_R_op_mitmot(self, use_op_rop_implementation):
+    @pytest.mark.parametrize("use_op_pushforward", [True, False])
+    def test_R_op_mitmot(self, use_op_pushforward):
         # this test is a copy paste from the script given by Justin Bayer to
         # reproduce this bug
         # We have 2 parameter groups with the following shapes.
@@ -2216,12 +2216,12 @@ class TestScan:
         d_cost_wrt_pars = grad(cost, pars)
 
         p = dvector()
-        # TODO: We should test something about the Rop!
-        Rop(
+        # TODO: We should test something about the pushforward!
+        pushforward(
             d_cost_wrt_pars,
             pars,
             p,
-            use_op_rop_implementation=use_op_rop_implementation,
+            use_op_pushforward=use_op_pushforward,
         )
 
     def test_second_derivative_disconnected_cost_with_mit_mot(self):

--- a/tests/scan/test_basic.py
+++ b/tests/scan/test_basic.py
@@ -12,6 +12,7 @@ Questions and notes about scan that should be answered :
 import os
 import pickle
 import shutil
+from contextlib import nullcontext
 from pathlib import Path
 from tempfile import mkdtemp
 
@@ -4203,3 +4204,38 @@ def test_zero_steps_untraced_sit_sot(mode):
     assert res1 != res2
 
     assert f(n_steps=0) == np.pi
+
+
+@pytest.mark.parametrize("linker", ["py", "cvm", "numba"])
+@pytest.mark.parametrize(
+    "known_core_shape, expectation",
+    [
+        (True, nullcontext()),
+        (False, pytest.raises(ValueError, match="unknown static shapes")),
+    ],
+)
+def test_zero_steps_nit_sot_core_shape(linker, known_core_shape, expectation):
+    """Regression test: n_steps=0 nit_sot outputs must have correct core shape."""
+    mode = Mode(linker=linker, optimizer=None)
+    x = pt.tensor("x", shape=(None, None))
+    n_steps = pt.iscalar("n_steps")
+
+    if known_core_shape:
+
+        def inner_fn(x_i):
+            return specify_shape(x_i, (5,))
+    else:
+
+        def inner_fn(x_i):
+            return x_i * 2
+
+    result = scan(inner_fn, sequences=x, n_steps=n_steps, return_updates=False)
+    f = function([x, n_steps], result, mode=mode)
+
+    with expectation:
+        out = f(np.empty((0, 5), dtype="float64"), 0)
+        assert out.shape == (0, 5)
+
+    # Non-zero steps should always work regardless of known_core_shape
+    out = f(np.ones((3, 5), dtype="float64"), 3)
+    assert out.shape == (3, 5)

--- a/tests/scan/test_basic.py
+++ b/tests/scan/test_basic.py
@@ -1333,7 +1333,7 @@ class TestScan:
     def test_high_order_grad_sitsot(self):
         """Test higher-order derivatives through a sit-sot scan.
 
-        The L_op of a sit-sot scan creates a mit-mot backward scan where
+        The pullback of a sit-sot scan creates a mit-mot backward scan where
         one buffer position is both read and written.
         This is analogous to set_subtensor(x, y, i): the gradient w.r.t. x
         must zero out position i, routing gradient only through y.
@@ -2002,7 +2002,7 @@ class TestScan:
         assert fgrad() == 1
 
     @pytest.mark.parametrize("use_op_pushforward", [True, False])
-    def test_R_op(self, use_op_pushforward):
+    def test_pushforward(self, use_op_pushforward):
         seed = utt.fetch_seed()
         rng = np.random.default_rng(seed)
         floatX = config.floatX
@@ -2045,7 +2045,7 @@ class TestScan:
         nwo_u = pushforward(o, _u, eu, use_op_pushforward=use_op_pushforward)
         nwo_h0 = pushforward(o, _h0, eh0, use_op_pushforward=use_op_pushforward)
         nwo_W = pushforward(o, _W, eW, use_op_pushforward=use_op_pushforward)
-        fn_rop = function(
+        fn_pushforward = function(
             [u, h0, W, eu, eh0, eW], [nwo_u, nwo_h0, nwo_W], on_unused_input="ignore"
         )
 
@@ -2077,7 +2077,7 @@ class TestScan:
             [u, h0, W, eu, eh0, eW], [n2o_u, n2o_h0, n2o_W], on_unused_input="ignore"
         )
 
-        vnu, vnh0, vnW = fn_rop(v_u, v_h0, v_W, v_eu, v_eh0, v_eW)
+        vnu, vnh0, vnW = fn_pushforward(v_u, v_h0, v_W, v_eu, v_eh0, v_eW)
         tnu, tnh0, tnW = fn_test(v_u, v_h0, v_W, v_eu, v_eh0, v_eW)
 
         np.testing.assert_allclose(vnu, tnu, atol=1e-6)
@@ -2086,7 +2086,7 @@ class TestScan:
 
     @pytest.mark.slow
     @pytest.mark.parametrize("use_op_pushforward", [True, False])
-    def test_R_op_2(self, use_op_pushforward):
+    def test_pushforward_2(self, use_op_pushforward):
         seed = utt.fetch_seed()
         rng = np.random.default_rng(seed)
         floatX = config.floatX
@@ -2132,10 +2132,10 @@ class TestScan:
         nwo_u = pushforward(o, _u, eu, use_op_pushforward=use_op_pushforward)
         nwo_h0 = pushforward(o, _h0, eh0, use_op_pushforward=use_op_pushforward)
         nwo_W = pushforward(o, _W, eW, use_op_pushforward=use_op_pushforward)
-        fn_rop = function(
+        fn_pushforward = function(
             [u, h0, W, eu, eh0, eW], [nwo_u, nwo_h0, nwo_W, o], on_unused_input="ignore"
         )
-        vnu, vnh0, vnW, _vno = fn_rop(v_u, v_h0, v_W, v_eu, v_eh0, v_eW)
+        vnu, vnh0, vnW, _vno = fn_pushforward(v_u, v_h0, v_W, v_eu, v_eh0, v_eW)
 
         n2o_u, _ = scan(
             lambda i, o, u, h0, W, eu: (grad(o[i], u) * eu).sum(),
@@ -2168,7 +2168,7 @@ class TestScan:
         np.testing.assert_allclose(vnW, tnW, atol=2e-6)
 
     @pytest.mark.parametrize("use_op_pushforward", [True, False])
-    def test_R_op_mitmot(self, use_op_pushforward):
+    def test_pushforward_mitmot(self, use_op_pushforward):
         # this test is a copy paste from the script given by Justin Bayer to
         # reproduce this bug
         # We have 2 parameter groups with the following shapes.

--- a/tests/tensor/random/rewriting/test_basic.py
+++ b/tests/tensor/random/rewriting/test_basic.py
@@ -10,7 +10,11 @@ from pytensor.compile.mode import Mode, get_default_mode
 from pytensor.graph.basic import Constant, Variable
 from pytensor.graph.basic import equal_computations as assert_equal_computations
 from pytensor.graph.fg import FunctionGraph
-from pytensor.graph.rewriting.basic import EquilibriumGraphRewriter, check_stack_trace
+from pytensor.graph.rewriting.basic import (
+    EquilibriumGraphRewriter,
+    check_stack_trace,
+    dfs_rewriter,
+)
 from pytensor.graph.rewriting.db import RewriteDatabaseQuery
 from pytensor.graph.traversal import ancestors
 from pytensor.tensor import constant
@@ -25,12 +29,13 @@ from pytensor.tensor.random.basic import (
     poisson,
     uniform,
 )
-from pytensor.tensor.random.op import RandomVariable
+from pytensor.tensor.random.op import RandomVariable, RandomVariableWithCoreShape
 from pytensor.tensor.random.rewriting import (
     local_dimshuffle_rv_lift,
     local_rv_size_lift,
     local_subtensor_rv_lift,
 )
+from pytensor.tensor.random.rewriting.numba import introduce_explicit_core_shape_rv
 from pytensor.tensor.random.type import random_generator_type
 from pytensor.tensor.rewriting.shape import ShapeFeature, ShapeOptimizer
 from pytensor.tensor.subtensor import AdvancedSubtensor, AdvancedSubtensor1, Subtensor
@@ -998,6 +1003,10 @@ def test_unused_rng():
     assert (
         sum(
             isinstance(node.op, NormalRV)
+            or (
+                isinstance(node.op, RandomVariableWithCoreShape)
+                and isinstance(node.op.core_op, NormalRV)
+            )
             for node in fn_excluding.maker.fgraph.apply_nodes
         )
         == 3
@@ -1010,7 +1019,18 @@ def test_unused_rng():
         next_rng, _y = next_rng.normal([1.0, 1.0, 1.0], [1])
         final_rng, z = next_rng.normal(1, 2)
 
+        expected = [final_rng, z]
+
+        # In NUMBA mode, RandomVariable nodes are wrapped in RandomVariableWithCoreShape
+        if any(
+            isinstance(node.op, RandomVariableWithCoreShape)
+            for node in fn_excluding.maker.fgraph.apply_nodes
+        ):
+            expected_fg = FunctionGraph(outputs=expected, clone=False)
+            dfs_rewriter(introduce_explicit_core_shape_rv).rewrite(expected_fg)
+            expected = expected_fg.outputs
+
         assert assert_equal_computations(
             fn_excluding.maker.fgraph.outputs,
-            [final_rng, z],
+            expected,
         )

--- a/tests/tensor/rewriting/test_linalg.py
+++ b/tests/tensor/rewriting/test_linalg.py
@@ -117,10 +117,10 @@ def test_matrix_inverse_rop_lop():
     v = vector("v")
     y = MatrixInverse()(mx).sum(axis=0)
 
-    yv = pytensor.gradient.Rop(y, mx, mv, use_op_rop_implementation=True)
+    yv = pytensor.gradient.pushforward(y, mx, mv, use_op_pushforward=True)
     rop_f = function([mx, mv], yv)
 
-    yv_via_lop = pytensor.gradient.Rop(y, mx, mv, use_op_rop_implementation=False)
+    yv_via_lop = pytensor.gradient.pushforward(y, mx, mv, use_op_pushforward=False)
     rop_via_lop_f = function([mx, mv], yv_via_lop)
 
     sy, _ = pytensor.scan(
@@ -139,15 +139,15 @@ def test_matrix_inverse_rop_lop():
     np.testing.assert_allclose(rop_via_lop_f(vx, vv), v_ref, rtol=rtol)
 
     with pytest.raises(ValueError):
-        pytensor.gradient.Rop(
+        pytensor.gradient.pushforward(
             clone_replace(y, replace={mx: break_op(mx)}),
             mx,
             mv,
-            use_op_rop_implementation=True,
+            use_op_pushforward=True,
         )
 
     vv = np.asarray(rng.uniform(size=(4,)), pytensor.config.floatX)
-    yv = pytensor.gradient.Lop(y, mx, v)
+    yv = pytensor.gradient.pullback(y, mx, v)
     lop_f = function([mx, v], yv)
 
     sy = pytensor.gradient.grad((v * y).sum(), mx)

--- a/tests/tensor/rewriting/test_linalg.py
+++ b/tests/tensor/rewriting/test_linalg.py
@@ -110,7 +110,7 @@ def test_deeply_nested_blockdiag_fusion():
     )
 
 
-def test_matrix_inverse_rop_lop():
+def test_matrix_inverse_pushforward_pullback():
     rtol = 1e-7 if config.floatX == "float64" else 1e-5
     mx = matrix("mx")
     mv = matrix("mv")
@@ -118,10 +118,10 @@ def test_matrix_inverse_rop_lop():
     y = MatrixInverse()(mx).sum(axis=0)
 
     yv = pytensor.gradient.pushforward(y, mx, mv, use_op_pushforward=True)
-    rop_f = function([mx, mv], yv)
+    pushforward_f = function([mx, mv], yv)
 
     yv_via_lop = pytensor.gradient.pushforward(y, mx, mv, use_op_pushforward=False)
-    rop_via_lop_f = function([mx, mv], yv_via_lop)
+    pushforward_via_pullback_f = function([mx, mv], yv_via_lop)
 
     sy, _ = pytensor.scan(
         lambda i, y, x, v: (pytensor.gradient.grad(y[i], x) * v).sum(),
@@ -135,8 +135,8 @@ def test_matrix_inverse_rop_lop():
     vv = np.asarray(rng.standard_normal((4, 4)), pytensor.config.floatX)
 
     v_ref = scan_f(vx, vv)
-    np.testing.assert_allclose(rop_f(vx, vv), v_ref, rtol=rtol)
-    np.testing.assert_allclose(rop_via_lop_f(vx, vv), v_ref, rtol=rtol)
+    np.testing.assert_allclose(pushforward_f(vx, vv), v_ref, rtol=rtol)
+    np.testing.assert_allclose(pushforward_via_pullback_f(vx, vv), v_ref, rtol=rtol)
 
     with pytest.raises(ValueError):
         pytensor.gradient.pushforward(
@@ -148,13 +148,13 @@ def test_matrix_inverse_rop_lop():
 
     vv = np.asarray(rng.uniform(size=(4,)), pytensor.config.floatX)
     yv = pytensor.gradient.pullback(y, mx, v)
-    lop_f = function([mx, v], yv)
+    pullback_f = function([mx, v], yv)
 
     sy = pytensor.gradient.grad((v * y).sum(), mx)
     scan_f = function([mx, v], sy)
 
     v_ref = scan_f(vx, vv)
-    v = lop_f(vx, vv)
+    v = pullback_f(vx, vv)
     np.testing.assert_allclose(v, v_ref, rtol=rtol)
 
 

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -2165,7 +2165,7 @@ def test_ScalarFromTensor(cast_policy):
 
         pts = lscalar()
         ss = scalar_from_tensor(pts)
-        ss.owner.op.grad([pts], [ss])
+        ss.owner.op.pullback([pts], [ss], [ss])
         fff = function([pts], ss)
         v = fff(np.asarray(5))
         assert v == 5

--- a/tests/tensor/test_nlinalg.py
+++ b/tests/tensor/test_nlinalg.py
@@ -118,7 +118,7 @@ class TestMatrixInverse(utt.InferShapeTester):
 
         self._compile_and_check([x], [xi], [r], self.op_class, warn=False)
 
-    def test_rop_lop(self):
+    def test_pushforward_pullback(self):
         rtol = 1e-7 if config.floatX == "float64" else 1e-5
         mx = matrix("mx")
         mv = matrix("mv")
@@ -126,10 +126,10 @@ class TestMatrixInverse(utt.InferShapeTester):
         y = MatrixInverse()(mx).sum(axis=0)
 
         yv = pytensor.gradient.pushforward(y, mx, mv, use_op_pushforward=True)
-        rop_f = function([mx, mv], yv)
+        pushforward_f = function([mx, mv], yv)
 
         yv_via_lop = pytensor.gradient.pushforward(y, mx, mv, use_op_pushforward=False)
-        rop_via_lop_f = function([mx, mv], yv_via_lop)
+        pushforward_via_pullback_f = function([mx, mv], yv_via_lop)
 
         sy, _ = pytensor.scan(
             lambda i, y, x, v: (pytensor.gradient.grad(y[i], x) * v).sum(),
@@ -143,8 +143,8 @@ class TestMatrixInverse(utt.InferShapeTester):
         vv = np.asarray(rng.standard_normal((4, 4)), pytensor.config.floatX)
 
         v_ref = scan_f(vx, vv)
-        np.testing.assert_allclose(rop_f(vx, vv), v_ref, rtol=rtol)
-        np.testing.assert_allclose(rop_via_lop_f(vx, vv), v_ref, rtol=rtol)
+        np.testing.assert_allclose(pushforward_f(vx, vv), v_ref, rtol=rtol)
+        np.testing.assert_allclose(pushforward_via_pullback_f(vx, vv), v_ref, rtol=rtol)
 
         with pytest.raises(ValueError):
             pytensor.gradient.pushforward(
@@ -156,13 +156,13 @@ class TestMatrixInverse(utt.InferShapeTester):
 
         vv = np.asarray(rng.uniform(size=(4,)), pytensor.config.floatX)
         yv = pytensor.gradient.pullback(y, mx, v)
-        lop_f = function([mx, v], yv)
+        pullback_f = function([mx, v], yv)
 
         sy = pytensor.gradient.grad((v * y).sum(), mx)
         scan_f = function([mx, v], sy)
 
         v_ref = scan_f(vx, vv)
-        v = lop_f(vx, vv)
+        v = pullback_f(vx, vv)
         np.testing.assert_allclose(v, v_ref, rtol=rtol)
 
 

--- a/tests/tensor/test_nlinalg.py
+++ b/tests/tensor/test_nlinalg.py
@@ -125,10 +125,10 @@ class TestMatrixInverse(utt.InferShapeTester):
         v = vector("v")
         y = MatrixInverse()(mx).sum(axis=0)
 
-        yv = pytensor.gradient.Rop(y, mx, mv, use_op_rop_implementation=True)
+        yv = pytensor.gradient.pushforward(y, mx, mv, use_op_pushforward=True)
         rop_f = function([mx, mv], yv)
 
-        yv_via_lop = pytensor.gradient.Rop(y, mx, mv, use_op_rop_implementation=False)
+        yv_via_lop = pytensor.gradient.pushforward(y, mx, mv, use_op_pushforward=False)
         rop_via_lop_f = function([mx, mv], yv_via_lop)
 
         sy, _ = pytensor.scan(
@@ -147,15 +147,15 @@ class TestMatrixInverse(utt.InferShapeTester):
         np.testing.assert_allclose(rop_via_lop_f(vx, vv), v_ref, rtol=rtol)
 
         with pytest.raises(ValueError):
-            pytensor.gradient.Rop(
+            pytensor.gradient.pushforward(
                 clone_replace(y, replace={mx: break_op(mx)}),
                 mx,
                 mv,
-                use_op_rop_implementation=True,
+                use_op_pushforward=True,
             )
 
         vv = np.asarray(rng.uniform(size=(4,)), pytensor.config.floatX)
-        yv = pytensor.gradient.Lop(y, mx, v)
+        yv = pytensor.gradient.pullback(y, mx, v)
         lop_f = function([mx, v], yv)
 
         sy = pytensor.gradient.grad((v * y).sum(), mx)

--- a/tests/tensor/test_shape.py
+++ b/tests/tensor/test_shape.py
@@ -46,7 +46,7 @@ from pytensor.typed_list import make_list
 from tests import unittest_tools as utt
 from tests.graph.utils import MyType2
 from tests.tensor.utils import eval_outputs, random
-from tests.test_rop import RopLopChecker
+from tests.test_rop import PushforwardPullbackChecker
 
 
 def test_shape_basic():
@@ -638,19 +638,21 @@ class TestSpecifyBroadcastable:
             specify_broadcastable(x, axis)
 
 
-class TestRopLop(RopLopChecker):
+class TestPushforwardPullback(PushforwardPullbackChecker):
     def test_shape(self):
-        self.check_nondiff_rop(self.x.shape[0], self.x, self.v)
+        self.check_nondiff_pushforward(self.x.shape[0], self.x, self.v)
 
     def test_specifyshape(self):
-        self.check_rop_lop(specify_shape(self.x, self.in_shape), self.in_shape)
+        self.check_pushforward_pullback(
+            specify_shape(self.x, self.in_shape), self.in_shape
+        )
 
     def test_reshape(self):
         new_shape = constant(
             np.asarray([self.mat_in_shape[0] * self.mat_in_shape[1]], dtype="int64")
         )
 
-        self.check_mat_rop_lop(
+        self.check_mat_pushforward_pullback(
             self.mx.reshape(new_shape), (self.mat_in_shape[0] * self.mat_in_shape[1],)
         )
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -25,6 +25,8 @@ def test_root_module_not_polluted():
         "grad",
         "ifelse",
         "map",
+        "pullback",
+        "pushforward",
         "scan",
         "shared",
         "wrap_jax",

--- a/tests/test_gradient.py
+++ b/tests/test_gradient.py
@@ -810,7 +810,7 @@ class TestZeroGrad:
 
             assert np.allclose(f(a), f2(a))
 
-    def test_rop(self):
+    def test_pushforward(self):
         x = vector()
         v = vector()
         y = zero_grad(x)
@@ -1183,7 +1183,7 @@ class TestHessianVectorProduct:
         np.testing.assert_allclose(hessp_y_eval, [-6, -4, -2])
 
 
-def test_scalar_Lop():
+def test_scalar_pullback():
     xtm1 = float64("xtm1")
     xt = xtm1**2
 

--- a/tests/test_gradient.py
+++ b/tests/test_gradient.py
@@ -11,9 +11,7 @@ from pytensor.gradient import (
     DisconnectedType,
     GradClip,
     GradScale,
-    Lop,
     NullTypeGradError,
-    Rop,
     UndefinedGrad,
     disconnected_grad,
     disconnected_grad_,
@@ -25,6 +23,8 @@ from pytensor.gradient import (
     hessian,
     hessian_vector_product,
     jacobian,
+    pullback,
+    pushforward,
     subgraph_grad,
     zero_grad,
     zero_grad_,
@@ -815,7 +815,7 @@ class TestZeroGrad:
         v = vector()
         y = zero_grad(x)
 
-        rop = Rop(y, x, v)
+        rop = pushforward(y, x, v)
         f = pytensor.function([x, v], rop, on_unused_input="ignore")
 
         a = np.asarray(self.rng.standard_normal(5), dtype=config.floatX)
@@ -1188,6 +1188,6 @@ def test_scalar_Lop():
     xt = xtm1**2
 
     dout_dxt = float64("dout_dxt")
-    dout_dxtm1 = Lop(xt, wrt=xtm1, eval_points=dout_dxt)
+    dout_dxtm1 = pullback(xt, wrt=xtm1, cotangents=dout_dxt)
     assert dout_dxtm1.type == dout_dxt.type
     assert dout_dxtm1.eval({xtm1: 3.0, dout_dxt: 1.5}) == 2 * 3.0 * 1.5

--- a/tests/test_rop.py
+++ b/tests/test_rop.py
@@ -1,14 +1,12 @@
 """
-WRITE ME
+Tests for pushforward / pullback (forward / reverse mode autodiff).
 
-Tests for the R operator / L operator
-
-For the list of op with r op defined, with or without missing test
+For the list of ops with pushforward defined, with or without missing test
 see this file: doc/library/tensor/basic.txt
 
-For function to automatically test your pushforward implementation, look at
-the docstring of the functions: check_mat_rop_lop, check_rop_lop,
-check_nondiff_rop,
+For functions to automatically test your pushforward implementation, look at
+the docstring of the functions: check_mat_pushforward_pullback,
+check_pushforward_pullback, check_nondiff_pushforward,
 """
 
 import numpy as np
@@ -33,7 +31,7 @@ from pytensor.tensor.type import matrix, vector
 from tests import unittest_tools as utt
 
 
-class BreakRop(Op):
+class BreakPushforward(Op):
     """
     Special Op created to test what happens when you have one op that is not
     differentiable in the computational graph
@@ -58,10 +56,10 @@ class BreakRop(Op):
         return [None]
 
 
-break_op = BreakRop()
+break_op = BreakPushforward()
 
 
-class RopLopChecker:
+class PushforwardPullbackChecker:
     """
     Don't perform any test, but provide the function to test the
     pushforward to class that inherit from it.
@@ -82,7 +80,7 @@ class RopLopChecker:
         self.mv = matrix("mv")
         self.mat_in_shape = (5 + self.rng.integers(3), 5 + self.rng.integers(3))
 
-    def check_nondiff_rop(self, y, x, v):
+    def check_nondiff_pushforward(self, y, x, v):
         """
         If your op is not differentiable(so you can't define pushforward)
         test that an error is raised.
@@ -90,7 +88,7 @@ class RopLopChecker:
         with pytest.raises(ValueError):
             pushforward(y, x, v, use_op_pushforward=True)
 
-    def check_mat_rop_lop(self, y, out_shape):
+    def check_mat_pushforward_pullback(self, y, out_shape):
         """
         Test the pushforward/pullback when input is a matrix and the output is a vector
 
@@ -103,7 +101,7 @@ class RopLopChecker:
         If the Op has more than 1 input, one of them must be mx, while
         others must be shared variables / constants. We will test only
         against the input self.mx, so you must call
-        check_mat_rop_lop/check_rop_lop for the other inputs.
+        check_mat_pushforward_pullback/check_pushforward_pullback for the other inputs.
 
         We expect all inputs/outputs have dtype floatX.
 
@@ -117,10 +115,10 @@ class RopLopChecker:
             self.rng.uniform(size=self.mat_in_shape), pytensor.config.floatX
         )
         yv = pushforward(y, self.mx, self.mv, use_op_pushforward=True)
-        rop_f = function([self.mx, self.mv], yv, on_unused_input="ignore")
+        pushforward_f = function([self.mx, self.mv], yv, on_unused_input="ignore")
 
         yv_through_lop = pushforward(y, self.mx, self.mv, use_op_pushforward=False)
-        rop_through_lop_f = function(
+        pushforward_via_pullback_f = function(
             [self.mx, self.mv], yv_through_lop, on_unused_input="ignore"
         )
 
@@ -132,10 +130,10 @@ class RopLopChecker:
         scan_f = function([self.mx, self.mv], sy, on_unused_input="ignore")
 
         v_ref = scan_f(vx, vv)
-        np.testing.assert_allclose(rop_f(vx, vv), v_ref)
-        np.testing.assert_allclose(rop_through_lop_f(vx, vv), v_ref)
+        np.testing.assert_allclose(pushforward_f(vx, vv), v_ref)
+        np.testing.assert_allclose(pushforward_via_pullback_f(vx, vv), v_ref)
 
-        self.check_nondiff_rop(
+        self.check_nondiff_pushforward(
             clone_replace(y, replace={self.mx: break_op(self.mx)}),
             self.mx,
             self.mv,
@@ -143,31 +141,33 @@ class RopLopChecker:
 
         vv = np.asarray(self.rng.uniform(size=out_shape), pytensor.config.floatX)
         yv = pullback(y, self.mx, self.v)
-        lop_f = function([self.mx, self.v], yv)
+        pullback_f = function([self.mx, self.v], yv)
 
         sy = grad((self.v * y).sum(), self.mx)
         scan_f = function([self.mx, self.v], sy)
 
-        v = lop_f(vx, vv)
+        v = pullback_f(vx, vv)
         v_ref = scan_f(vx, vv)
         np.testing.assert_allclose(v, v_ref)
 
-    def check_rop_lop(self, y, out_shape, check_nondiff_rop: bool = True):
+    def check_pushforward_pullback(
+        self, y, out_shape, check_nondiff_pushforward: bool = True
+    ):
         """
-        As check_mat_rop_lop, except the input is self.x which is a
+        As check_mat_pushforward_pullback, except the input is self.x which is a
         vector. The output is still a vector.
         """
         rtol = self.rtol()
 
-        # TEST ROP
+        # TEST PUSHFORWARD
         vx = np.asarray(self.rng.uniform(size=self.in_shape), pytensor.config.floatX)
         vv = np.asarray(self.rng.uniform(size=self.in_shape), pytensor.config.floatX)
 
         yv = pushforward(y, self.x, self.v, use_op_pushforward=True)
-        rop_f = function([self.x, self.v], yv, on_unused_input="ignore")
+        pushforward_f = function([self.x, self.v], yv, on_unused_input="ignore")
 
         yv_through_lop = pushforward(y, self.x, self.v, use_op_pushforward=False)
-        rop_through_lop_f = function(
+        pushforward_via_pullback_f = function(
             [self.x, self.v], yv_through_lop, on_unused_input="ignore"
         )
 
@@ -180,11 +180,11 @@ class RopLopChecker:
         scan_f = function([self.x, self.v], sy, on_unused_input="ignore")
 
         v_ref = scan_f(vx, vv)
-        np.testing.assert_allclose(rop_f(vx, vv), v_ref, rtol=rtol)
-        np.testing.assert_allclose(rop_through_lop_f(vx, vv), v_ref, rtol=rtol)
+        np.testing.assert_allclose(pushforward_f(vx, vv), v_ref, rtol=rtol)
+        np.testing.assert_allclose(pushforward_via_pullback_f(vx, vv), v_ref, rtol=rtol)
 
-        if check_nondiff_rop:
-            self.check_nondiff_rop(
+        if check_nondiff_pushforward:
+            self.check_nondiff_pushforward(
                 clone_replace(y, replace={self.x: break_op(self.x)}),
                 self.x,
                 self.v,
@@ -194,7 +194,7 @@ class RopLopChecker:
         vv = np.asarray(self.rng.uniform(size=out_shape), pytensor.config.floatX)
 
         yv = pullback(y, self.x, self.v)
-        lop_f = function([self.x, self.v], yv, on_unused_input="ignore")
+        pullback_f = function([self.x, self.v], yv, on_unused_input="ignore")
         J, _ = pytensor.scan(
             lambda i, y, x: grad(y[i], x),
             sequences=pt.arange(y.shape[0]),
@@ -203,100 +203,112 @@ class RopLopChecker:
         sy = dot(self.v, J)
         scan_f = function([self.x, self.v], sy)
 
-        v = lop_f(vx, vv)
+        v = pullback_f(vx, vv)
         v_ref = scan_f(vx, vv)
         np.testing.assert_allclose(v, v_ref, rtol=rtol)
 
 
-class TestRopLop(RopLopChecker):
+class TestPushforwardPullback(PushforwardPullbackChecker):
     def test_max(self):
-        self.check_mat_rop_lop(pt_max(self.mx, axis=0), (self.mat_in_shape[1],))
-        self.check_mat_rop_lop(pt_max(self.mx, axis=1), (self.mat_in_shape[0],))
+        self.check_mat_pushforward_pullback(
+            pt_max(self.mx, axis=0), (self.mat_in_shape[1],)
+        )
+        self.check_mat_pushforward_pullback(
+            pt_max(self.mx, axis=1), (self.mat_in_shape[0],)
+        )
 
     def test_argmax(self):
-        self.check_nondiff_rop(argmax(self.mx, axis=1), self.mx, self.mv)
+        self.check_nondiff_pushforward(argmax(self.mx, axis=1), self.mx, self.mv)
 
     def test_subtensor(self):
-        self.check_rop_lop(self.x[:4], (4,))
+        self.check_pushforward_pullback(self.x[:4], (4,))
 
     def test_incsubtensor1(self):
         tv = np.asarray(self.rng.uniform(size=(3,)), pytensor.config.floatX)
         t = pytensor.shared(tv)
         out = pytensor.tensor.subtensor.inc_subtensor(self.x[:3], t)
-        self.check_rop_lop(out, self.in_shape)
+        self.check_pushforward_pullback(out, self.in_shape)
 
     def test_incsubtensor2(self):
         tv = np.asarray(self.rng.uniform(size=(10,)), pytensor.config.floatX)
         t = pytensor.shared(tv)
         out = pytensor.tensor.subtensor.inc_subtensor(t[:4], self.x[:4])
-        self.check_rop_lop(out, (10,))
+        self.check_pushforward_pullback(out, (10,))
 
     def test_setsubtensor1(self):
         tv = np.asarray(self.rng.uniform(size=(3,)), pytensor.config.floatX)
         t = pytensor.shared(tv)
         out = pytensor.tensor.subtensor.set_subtensor(self.x[:3], t)
-        self.check_rop_lop(out, self.in_shape)
+        self.check_pushforward_pullback(out, self.in_shape)
 
     def test_print(self):
         out = pytensor.printing.Print("x", attrs=("shape",))(self.x)
-        self.check_rop_lop(out, self.in_shape)
+        self.check_pushforward_pullback(out, self.in_shape)
 
     def test_setsubtensor2(self):
         tv = np.asarray(self.rng.uniform(size=(10,)), pytensor.config.floatX)
         t = pytensor.shared(tv)
         out = pytensor.tensor.subtensor.set_subtensor(t[:4], self.x[:4])
-        self.check_rop_lop(out, (10,))
+        self.check_pushforward_pullback(out, (10,))
 
     def test_dimshuffle(self):
         # I need the sum, because the setup expects the output to be a
         # vector
-        self.check_rop_lop(self.x[:4].dimshuffle("x", 0).sum(axis=0), (4,))
+        self.check_pushforward_pullback(self.x[:4].dimshuffle("x", 0).sum(axis=0), (4,))
 
     def test_join(self):
         tv = np.asarray(self.rng.uniform(size=(10,)), pytensor.config.floatX)
         t = pytensor.shared(tv)
         out = pt.join(0, self.x, t)
-        self.check_rop_lop(out, (self.in_shape[0] + 10,))
+        self.check_pushforward_pullback(out, (self.in_shape[0] + 10,))
 
     def test_dot(self):
         insh = self.in_shape[0]
         vW = np.asarray(self.rng.uniform(size=(insh, insh)), pytensor.config.floatX)
         W = pytensor.shared(vW)
-        # check_nondiff_rop reveals an error in how legacy pushforward handles non-differentiable paths
-        # See: test_Rop_partially_differentiable_paths
-        self.check_rop_lop(dot(self.x, W), self.in_shape, check_nondiff_rop=False)
+        # check_nondiff_pushforward reveals an error in how legacy pushforward handles non-differentiable paths
+        # See: test_pushforward_partially_differentiable_paths
+        self.check_pushforward_pullback(
+            dot(self.x, W), self.in_shape, check_nondiff_pushforward=False
+        )
 
     def test_elemwise0(self):
-        # check_nondiff_rop reveals an error in how legacy pushforward handles non-differentiable paths
-        # See: test_Rop_partially_differentiable_paths
-        self.check_rop_lop((self.x + 1) ** 2, self.in_shape, check_nondiff_rop=False)
+        # check_nondiff_pushforward reveals an error in how legacy pushforward handles non-differentiable paths
+        # See: test_pushforward_partially_differentiable_paths
+        self.check_pushforward_pullback(
+            (self.x + 1) ** 2, self.in_shape, check_nondiff_pushforward=False
+        )
 
     def test_elemwise1(self):
-        self.check_rop_lop(self.x + pt.cast(self.x, "int32"), self.in_shape)
+        self.check_pushforward_pullback(
+            self.x + pt.cast(self.x, "int32"), self.in_shape
+        )
 
     def test_flatten(self):
-        self.check_mat_rop_lop(
+        self.check_mat_pushforward_pullback(
             self.mx.flatten(), (self.mat_in_shape[0] * self.mat_in_shape[1],)
         )
 
     def test_sum(self):
-        self.check_mat_rop_lop(self.mx.sum(axis=1), (self.mat_in_shape[0],))
+        self.check_mat_pushforward_pullback(
+            self.mx.sum(axis=1), (self.mat_in_shape[0],)
+        )
 
     def test_softmax(self):
-        self.check_rop_lop(
+        self.check_pushforward_pullback(
             pytensor.tensor.special.softmax(self.x, axis=-1), self.in_shape
         )
 
     def test_alloc(self):
         # Alloc of the sum of x into a vector
         out1d = pt.alloc(self.x.sum(), self.in_shape[0])
-        self.check_rop_lop(out1d, self.in_shape[0])
+        self.check_pushforward_pullback(out1d, self.in_shape[0])
 
         # Alloc of x into a 3-D tensor, flattened
         out3d = pt.alloc(
             self.x, self.mat_in_shape[0], self.mat_in_shape[1], self.in_shape[0]
         )
-        self.check_rop_lop(
+        self.check_pushforward_pullback(
             out3d.flatten(),
             self.mat_in_shape[0] * self.mat_in_shape[1] * self.in_shape[0],
         )
@@ -350,7 +362,7 @@ class TestRopLop(RopLopChecker):
         "use_op_pushforward",
         [pytest.param(True, marks=pytest.mark.xfail()), False],
     )
-    def test_Rop_partially_differentiable_paths(self, use_op_pushforward):
+    def test_pushforward_partially_differentiable_paths(self, use_op_pushforward):
         # This test refers to a bug reported by Jeremiah Lowin on 18th Oct
         # 2013. The bug consists when through a dot operation there is only
         # one differentiable path (i.e. there is no gradient wrt to one of

--- a/tests/test_rop.py
+++ b/tests/test_rop.py
@@ -6,7 +6,7 @@ Tests for the R operator / L operator
 For the list of op with r op defined, with or without missing test
 see this file: doc/library/tensor/basic.txt
 
-For function to automatically test your Rop implementation, look at
+For function to automatically test your pushforward implementation, look at
 the docstring of the functions: check_mat_rop_lop, check_rop_lop,
 check_nondiff_rop,
 """
@@ -18,11 +18,11 @@ import pytensor
 import pytensor.tensor as pt
 from pytensor import config, function
 from pytensor.gradient import (
-    Lop,
     NullTypeGradError,
-    Rop,
     grad,
     grad_undefined,
+    pullback,
+    pushforward,
 )
 from pytensor.graph.basic import Apply
 from pytensor.graph.op import Op
@@ -64,7 +64,7 @@ break_op = BreakRop()
 class RopLopChecker:
     """
     Don't perform any test, but provide the function to test the
-    Rop to class that inherit from it.
+    pushforward to class that inherit from it.
     """
 
     @staticmethod
@@ -84,19 +84,19 @@ class RopLopChecker:
 
     def check_nondiff_rop(self, y, x, v):
         """
-        If your op is not differentiable(so you can't define Rop)
+        If your op is not differentiable(so you can't define pushforward)
         test that an error is raised.
         """
         with pytest.raises(ValueError):
-            Rop(y, x, v, use_op_rop_implementation=True)
+            pushforward(y, x, v, use_op_pushforward=True)
 
     def check_mat_rop_lop(self, y, out_shape):
         """
-        Test the Rop/Lop when input is a matrix and the output is a vector
+        Test the pushforward/pullback when input is a matrix and the output is a vector
 
         :param y: the output variable of the op applied to self.mx
         :param out_shape: Used to generate a random tensor
-                          corresponding to the evaluation point of the Rop
+                          corresponding to the evaluation point of the pushforward
                           (i.e. the tensor with which you multiply the
                           Jacobian). It should be a tuple of ints.
 
@@ -116,10 +116,10 @@ class RopLopChecker:
         vv = np.asarray(
             self.rng.uniform(size=self.mat_in_shape), pytensor.config.floatX
         )
-        yv = Rop(y, self.mx, self.mv, use_op_rop_implementation=True)
+        yv = pushforward(y, self.mx, self.mv, use_op_pushforward=True)
         rop_f = function([self.mx, self.mv], yv, on_unused_input="ignore")
 
-        yv_through_lop = Rop(y, self.mx, self.mv, use_op_rop_implementation=False)
+        yv_through_lop = pushforward(y, self.mx, self.mv, use_op_pushforward=False)
         rop_through_lop_f = function(
             [self.mx, self.mv], yv_through_lop, on_unused_input="ignore"
         )
@@ -142,7 +142,7 @@ class RopLopChecker:
         )
 
         vv = np.asarray(self.rng.uniform(size=out_shape), pytensor.config.floatX)
-        yv = Lop(y, self.mx, self.v)
+        yv = pullback(y, self.mx, self.v)
         lop_f = function([self.mx, self.v], yv)
 
         sy = grad((self.v * y).sum(), self.mx)
@@ -163,10 +163,10 @@ class RopLopChecker:
         vx = np.asarray(self.rng.uniform(size=self.in_shape), pytensor.config.floatX)
         vv = np.asarray(self.rng.uniform(size=self.in_shape), pytensor.config.floatX)
 
-        yv = Rop(y, self.x, self.v, use_op_rop_implementation=True)
+        yv = pushforward(y, self.x, self.v, use_op_pushforward=True)
         rop_f = function([self.x, self.v], yv, on_unused_input="ignore")
 
-        yv_through_lop = Rop(y, self.x, self.v, use_op_rop_implementation=False)
+        yv_through_lop = pushforward(y, self.x, self.v, use_op_pushforward=False)
         rop_through_lop_f = function(
             [self.x, self.v], yv_through_lop, on_unused_input="ignore"
         )
@@ -193,7 +193,7 @@ class RopLopChecker:
         vx = np.asarray(self.rng.uniform(size=self.in_shape), pytensor.config.floatX)
         vv = np.asarray(self.rng.uniform(size=out_shape), pytensor.config.floatX)
 
-        yv = Lop(y, self.x, self.v)
+        yv = pullback(y, self.x, self.v)
         lop_f = function([self.x, self.v], yv, on_unused_input="ignore")
         J, _ = pytensor.scan(
             lambda i, y, x: grad(y[i], x),
@@ -262,12 +262,12 @@ class TestRopLop(RopLopChecker):
         insh = self.in_shape[0]
         vW = np.asarray(self.rng.uniform(size=(insh, insh)), pytensor.config.floatX)
         W = pytensor.shared(vW)
-        # check_nondiff_rop reveals an error in how legacy Rop handles non-differentiable paths
+        # check_nondiff_rop reveals an error in how legacy pushforward handles non-differentiable paths
         # See: test_Rop_partially_differentiable_paths
         self.check_rop_lop(dot(self.x, W), self.in_shape, check_nondiff_rop=False)
 
     def test_elemwise0(self):
-        # check_nondiff_rop reveals an error in how legacy Rop handles non-differentiable paths
+        # check_nondiff_rop reveals an error in how legacy pushforward handles non-differentiable paths
         # See: test_Rop_partially_differentiable_paths
         self.check_rop_lop((self.x + 1) ** 2, self.in_shape, check_nondiff_rop=False)
 
@@ -301,18 +301,18 @@ class TestRopLop(RopLopChecker):
             self.mat_in_shape[0] * self.mat_in_shape[1] * self.in_shape[0],
         )
 
-    @pytest.mark.parametrize("use_op_rop_implementation", [True, False])
-    def test_invalid_input(self, use_op_rop_implementation):
+    @pytest.mark.parametrize("use_op_pushforward", [True, False])
+    def test_invalid_input(self, use_op_pushforward):
         with pytest.raises(ValueError):
-            Rop(
+            pushforward(
                 0.0,
                 [matrix()],
                 [vector()],
-                use_op_rop_implementation=use_op_rop_implementation,
+                use_op_pushforward=use_op_pushforward,
             )
 
-    @pytest.mark.parametrize("use_op_rop_implementation", [True, False])
-    def test_multiple_outputs(self, use_op_rop_implementation):
+    @pytest.mark.parametrize("use_op_pushforward", [True, False])
+    def test_multiple_outputs(self, use_op_pushforward):
         m = matrix("m")
         v = vector("v")
         m_ = matrix("m_")
@@ -323,19 +323,19 @@ class TestRopLop(RopLopChecker):
         m_val = self.rng.uniform(size=(3, 7)).astype(pytensor.config.floatX)
         v_val = self.rng.uniform(size=(7,)).astype(pytensor.config.floatX)
 
-        rop_out1 = Rop(
+        rop_out1 = pushforward(
             [m, v, m + v],
             [m, v],
             [m_, v_],
-            use_op_rop_implementation=use_op_rop_implementation,
+            use_op_pushforward=use_op_pushforward,
         )
         assert isinstance(rop_out1, list)
         assert len(rop_out1) == 3
-        rop_out2 = Rop(
+        rop_out2 = pushforward(
             (m, v, m + v),
             [m, v],
             [m_, v_],
-            use_op_rop_implementation=use_op_rop_implementation,
+            use_op_pushforward=use_op_pushforward,
         )
         assert isinstance(rop_out2, tuple)
         assert len(rop_out2) == 3
@@ -347,10 +347,10 @@ class TestRopLop(RopLopChecker):
         f(mval, vval, m_val, v_val)
 
     @pytest.mark.parametrize(
-        "use_op_rop_implementation",
+        "use_op_pushforward",
         [pytest.param(True, marks=pytest.mark.xfail()), False],
     )
-    def test_Rop_partially_differentiable_paths(self, use_op_rop_implementation):
+    def test_Rop_partially_differentiable_paths(self, use_op_pushforward):
         # This test refers to a bug reported by Jeremiah Lowin on 18th Oct
         # 2013. The bug consists when through a dot operation there is only
         # one differentiable path (i.e. there is no gradient wrt to one of
@@ -359,16 +359,16 @@ class TestRopLop(RopLopChecker):
         v = pytensor.shared(np.ones([20]), name="v")
         d = dot(x, v).sum()
 
-        Rop(
+        pushforward(
             grad(d, v),
             v,
             v,
-            use_op_rop_implementation=use_op_rop_implementation,
+            use_op_pushforward=use_op_pushforward,
             # 2025: This is a tricky case, the gradient of the gradient does not depend on v
             # although v still exists in the graph inside a `Second` operator.
-            # The original test was checking that Rop wouldn't raise an error, but Lop does.
+            # The original test was checking that pushforward wouldn't raise an error, but pullback does.
             # Since the correct behavior is ambiguous, I let both implementations off the hook.
-            disconnected_outputs="raise" if use_op_rop_implementation else "ignore",
+            disconnected_outputs="raise" if use_op_pushforward else "ignore",
         )
 
         # 2025: Here is an unambiguous test for the original commented issue:
@@ -376,35 +376,35 @@ class TestRopLop(RopLopChecker):
         y = pt.matrix("y")
         out = dot(x, break_op(y)).sum()
         # Should not raise an error
-        Rop(
+        pushforward(
             out,
             [x],
             [x.type()],
-            use_op_rop_implementation=use_op_rop_implementation,
+            use_op_pushforward=use_op_pushforward,
             disconnected_outputs="raise",
         )
 
-        # More extensive testing shows that the legacy Rop implementation FAILS to raise when
+        # More extensive testing shows that the legacy pushforward implementation FAILS to raise when
         # the cost is linked through strictly non-differentiable paths.
         # This is not Dot specific, we would observe the same with any operation where the gradient
         # with respect to one of the inputs does not depend on the original input (such as `mul`, `add`, ...)
         out = dot(break_op(x), y).sum()
         with pytest.raises((ValueError, NullTypeGradError)):
-            Rop(
+            pushforward(
                 out,
                 [x],
                 [x.type()],
-                use_op_rop_implementation=use_op_rop_implementation,
+                use_op_pushforward=use_op_pushforward,
                 disconnected_outputs="raise",
             )
 
         # Only when both paths are non-differentiable is an error correctly raised again.
         out = dot(break_op(x), break_op(y)).sum()
         with pytest.raises((ValueError, NullTypeGradError)):
-            Rop(
+            pushforward(
                 out,
                 [x],
                 [x.type()],
-                use_op_rop_implementation=use_op_rop_implementation,
+                use_op_pushforward=use_op_pushforward,
                 disconnected_outputs="raise",
             )


### PR DESCRIPTION
When n_steps=0, Scan's perform method was creating nit_sot output arrays with shape (0,)*ndim instead of (0, *core_shape). This caused silent shape mismatches in downstream operations like concatenation or broadcasting.

Add Scan.nit_sot_core_shapes() method that returns static core shapes when all are known, or None otherwise. All three backends (Python, Cython, Numba) now use correct shapes when known, and raise a clear
ValueError when shapes are unknown and n_steps=0.

We could consider making the shapes a symbolic input (PyTensor can often lift it out of the computation), a bit like numba BlockwiseWithCoreShape and RandomVariableWithCoreShape, but that's an improvement, not a must.

Now we don't silently return garbage.

Closes #1287 
