### PR TITLE
Rewrite sigmoid gradient into numerically stable form

### DIFF
--- a/pytensor/scalar/math.py
+++ b/pytensor/scalar/math.py
@@ -1178,8 +1178,13 @@ class Sigmoid(UnaryScalarOp):
     def pullback(self, inp, outputs, grads):
         (x,) = inp
         (gz,) = grads
-        y = sigmoid(x)
-        rval = gz * y * (1.0 - y)
+        # sigmoid'(x) == sigmoid(x) * (1 - sigmoid(x)) needs a single sigmoid, but 1 - sigmoid(x)
+        # cancels to exactly zero for x >~ 37. A backward-only graph could stay at one sigmoid with
+        # y = sigmoid(switch(x >= 0, -x, x)); y * (1 - y), bounded by 0.5 so it never cancels.
+        # We pay for a second sigmoid to reuse the forward one, usually needed too and, being the
+        # same node, cancellable in ratios: grad(log(sigmoid(x))) is
+        # sigmoid(x) * sigmoid(-x) / sigmoid(x) -> sigmoid(-x).
+        rval = gz * sigmoid(x) * sigmoid(-x)
 
         assert rval.type.dtype.find("float") != -1
 

--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -3799,15 +3799,19 @@ def local_reciprocal_1_plus_exp(fgraph, node):
 
 
 # 1 - sigmoid(x) -> sigmoid(-x)
-local_1msigmoid = PatternNodeRewriter(
-    (sub, dict(pattern="y", constraint=_is_1), (sigmoid, "x")),
-    (sigmoid, (neg, "x")),
-    tracks=[sigmoid],
-    get_nodes=get_clients_at_depth1,
-    name="local_1msigmoid",
-)
-register_stabilize(local_1msigmoid)
-register_specialize(local_1msigmoid)
+# Stabilize version allows multiple clients to handle e.g. sigmoid(x) * (1 - sigmoid(x))
+# TODO: Maybe this is overkill and multiple clients is always fine?
+for _register in (register_stabilize, register_specialize):
+    _register(
+        PatternNodeRewriter(
+            (sub, dict(pattern="y", constraint=_is_1), (sigmoid, "x")),
+            (sigmoid, (neg, "x")),
+            allow_multiple_clients=_register is register_stabilize,
+            tracks=[sigmoid],
+            get_nodes=get_clients_at_depth1,
+            name="local_1msigmoid",
+        )
+    )
 
 
 @register_stabilize

--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -3899,16 +3899,46 @@ def local_reciprocal_1_plus_exp(fgraph, node):
                     return [new_out]
 
 
-# 1 - sigmoid(x) -> sigmoid(-x)
-local_1msigmoid = PatternNodeRewriter(
-    (sub, dict(pattern="y", constraint=_is_1), (sigmoid, "x")),
-    (sigmoid, (neg, "x")),
-    tracks=[sigmoid],
-    get_nodes=get_clients_at_depth1,
-    name="local_1msigmoid",
-)
-register_stabilize(local_1msigmoid)
-register_specialize(local_1msigmoid)
+@register_canonicalize
+@register_stabilize
+@register_specialize
+@node_rewriter([sigmoid])
+def local_1msigmoid(fgraph, node):
+    """``1 - sigmoid(x) -> sigmoid(-x)``
+
+    Only applied when it doesn't leave an extra sigmoid behind: either ``sigmoid(x)`` has
+    no other client, or ``sigmoid(-x)`` is already in the graph and can be reused. The
+    latter is what lets the two spellings cancel, as in ``grad(log(1 - sigmoid(x)))``,
+    whose numerator holds the ``sigmoid(x) * sigmoid(-x)`` emitted by the sigmoid pullback.
+    """
+    sigm_x = node.outputs[0]
+    one_minus_sigm_x = [
+        client.outputs[0]
+        for client, i in fgraph.clients[sigm_x]
+        if client.op == sub and i == 1 and _is_1(client.inputs[0])
+    ]
+    if not one_minus_sigm_x:
+        return None
+
+    (x,) = node.inputs
+    sigm_minus_x = next(
+        (
+            neg_client.outputs[0]
+            for neg_node, _ in fgraph.clients[x]
+            if neg_node.op == neg
+            for neg_client, _ in fgraph.clients[neg_node.outputs[0]]
+            if neg_client.op == sigmoid
+        ),
+        None,
+    )
+    if sigm_minus_x is None:
+        if len(fgraph.clients[sigm_x]) > len(one_minus_sigm_x):
+            return None
+        sigm_minus_x = sigmoid(neg(x))
+        copy_stack_trace(one_minus_sigm_x[0], sigm_minus_x)
+
+    # The subtracted constant can upcast the output beyond the dtype of sigmoid(x)
+    return {out: cast(sigm_minus_x, out.dtype) for out in one_minus_sigm_x}
 
 
 @register_stabilize

--- a/tests/scalar/test_math.py
+++ b/tests/scalar/test_math.py
@@ -8,6 +8,7 @@ import scipy.special as sp
 import pytensor.tensor as pt
 from pytensor import function
 from pytensor.compile.mode import Mode
+from pytensor.gradient import grad
 from pytensor.graph import ancestors
 from pytensor.graph.fg import FunctionGraph
 from pytensor.link.c.basic import CLinker
@@ -19,6 +20,7 @@ from pytensor.scalar.math import (
     gammaincc,
     hyp2f1,
     psi,
+    sigmoid,
 )
 from tests.link.test_link import make_function
 
@@ -186,3 +188,27 @@ def test_psi(linker):
 
     np.testing.assert_allclose(fn(x_test), scipy.special.psi(x_test))
     np.testing.assert_allclose(fn(-x_test), scipy.special.psi(-x_test))
+
+
+def test_sigmoid_grad_precision():
+    x = float64("x")
+    grad_fn = function([x], grad(sigmoid(x), x))
+
+    # sigmoid'(z) == sigmoid'(-z) for all z (symmetric around 0).
+    # The naive form expit(z) * (1 - expit(z)) breaks this: at z=50,
+    # (1 - expit(50)) rounds to 0, giving sigmoid'(50) = 0 != sigmoid'(-50).
+    for z in [50.0, 100.0, 500.0]:
+        result = grad_fn(z)
+        assert result > 0.0
+        np.testing.assert_allclose(result, grad_fn(-z))
+
+
+def test_sigmoid_grad_at_zero():
+    x = float64("x")
+    # sigmoid^(n)(0) is (2 ** (n + 1) - 1) * bernoulli(n + 1) / (n + 1) for odd n, zero otherwise
+    expected_orders = [1 / 4, 0, -1 / 8, 0, 1 / 4]
+
+    grad_x = sigmoid(x)
+    for expected in expected_orders:
+        grad_x = grad(grad_x, wrt=x)
+        np.testing.assert_allclose(grad_x.eval({x: 0}), expected)

--- a/tests/tensor/test_math.py
+++ b/tests/tensor/test_math.py
@@ -3652,6 +3652,23 @@ def test_grad_useless_sum():
     )
 
 
+@pytest.mark.skipif(
+    config.mode == "FAST_COMPILE",
+    reason="Requires stabilize rewrites not present in FAST_COMPILE",
+)
+def test_sigmoid_grad_precision():
+    x = dscalar("x")
+    grad_fn = function([x], grad(sigmoid(x), x))
+
+    # sigmoid'(z) == sigmoid'(-z) for all z (symmetric around 0).
+    # The naive form expit(z) * (1 - expit(z)) breaks this: at z=50,
+    # (1 - expit(50)) rounds to 0, giving sigmoid'(50) = 0 != sigmoid'(-50).
+    for z in [50.0, 100.0, 500.0]:
+        result = grad_fn(z)
+        assert result > 0.0
+        np.testing.assert_allclose(result, grad_fn(-z))
+
+
 def test_tanh_grad_broadcast():
     # FIXME: This is not a real test.
     # This crashed in the past.


### PR DESCRIPTION
~~Replace sigmoid(x) * (1 - sigmoid(x)) with sigmoid(x) * sigmoid(-x) in the Sigmoid pullback. The naive form suffers catastrophic cancellation for large |x| because (1 - expit(x)) rounds to zero.~~

Instead of doing that (which we may want to). I left as is but let the stabilize rewrite be more aggressive and rewrite 1-sigmoid(x) -> sigmoid(-x), even if sigmoid(x) is used elsewhere. (Users who don't care about this can exclude "stabilize" then)

This may be too much tip-toeing. Maybe we want the rewrite to always be eager (and in this case implement the pullback already in this format). There was one test that checked whether the grad of a naive `log(1 - sigmoid(x))` simplified (to not have a sum), and that one ended up cancelling a sigmoid(x) / sigmoid(x), that an eager stable pullback didn't produce. (rewrite ordering is fun).

I don't know if sigmoids are expensive enough to worry about duplicating use in the first place.