### PR TITLE
Implement `rich` debugprint format via `file="rich"`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,9 +163,9 @@ jobs:
         run: |
 
           if [[ $OS == "macos-15" ]]; then
-            micromamba install --yes -q "python~=${PYTHON_VERSION}" numpy "scipy<1.17.0" "numba>=0.63" pip graphviz cython pytest coverage pytest-cov pytest-benchmark pytest-mock pytest-sphinx libblas=*=*accelerate;
+            micromamba install --yes -q "python~=${PYTHON_VERSION}" numpy "scipy<1.17.0" "numba>=0.63" pip graphviz cython pytest coverage pytest-cov pytest-benchmark pytest-mock pytest-sphinx libblas=*=*accelerate rich;
           else
-            micromamba install --yes -q "python~=${PYTHON_VERSION}" numpy "scipy<1.17.0" "numba>=0.63" pip graphviz cython pytest coverage pytest-cov pytest-benchmark pytest-mock pytest-sphinx mkl mkl-service;
+            micromamba install --yes -q "python~=${PYTHON_VERSION}" numpy "scipy<1.17.0" "numba>=0.63" pip graphviz cython pytest coverage pytest-cov pytest-benchmark pytest-mock pytest-sphinx mkl mkl-service rich;
           fi
           if [[ $INSTALL_JAX == "1" ]]; then micromamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}" && pip install "jax>=0.8,<0.9.1" jaxlib numpyro equinox tfp-nightly; fi
           if [[ $INSTALL_TORCH == "1" ]]; then micromamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}" pytorch pytorch-cuda=12.1 "mkl<=2024.0" -c pytorch -c nvidia; fi

--- a/environment-osx-arm64.yml
+++ b/environment-osx-arm64.yml
@@ -49,3 +49,4 @@ dependencies:
   - cython
   - graphviz
   - pydot
+  - rich

--- a/environment.yml
+++ b/environment.yml
@@ -55,3 +55,4 @@ dependencies:
   - cython
   - graphviz
   - pydot
+  - rich

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
     "logical-unification",
     "miniKanren",
     "cons",
+    "rich",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ dependencies = [
     "logical-unification",
     "miniKanren",
     "cons",
-    "rich",
 ]
 
 [project.urls]

--- a/pytensor/printing.py
+++ b/pytensor/printing.py
@@ -1153,8 +1153,8 @@ def _build_rich_tree(
     def _color_label(label: str, color: str) -> str:
         return f"[{color}]{label}[/{color}]"
 
-    def _sentinel_label() -> str:
-        return "···"
+    def _sentinel_label(color: str) -> str:
+        return f"[{color}]···[/{color}]"
 
     def _assign_color(node_key) -> str:
         """Return the color for node_key, assigning one if needed and
@@ -1167,10 +1167,6 @@ def _build_rich_tree(
         return node_colors[node_key]
 
     root = rich.tree.Tree("", hide_root=True)
-
-    # Track parent tree nodes that have already received a ··· sentinel child
-    # so each parent shows at most one ··· regardless of how many repeated inputs it has.
-    sentinel_emitted: set = set()  # set of id(parent_tree)
 
     for var, topo_order, profile, storage_map in zip(
         outputs, topo_orders, profiles, storage_maps, strict=True
@@ -1195,13 +1191,26 @@ def _build_rich_tree(
             node_key = gnode.var.owner if gnode.var.owner is not None else gnode.var
 
             if gnode.is_already_done:
-                # Repeated node: color the canonical occurrence and emit one ···
-                # per parent — at most one sentinel child per parent tree node.
-                _assign_color(node_key)
+                # Repeated node: show its colored label, then ··· as a child
+                # to indicate its subtree is omitted.
+                color = _assign_color(node_key)
+                label = rich.markup.escape(
+                    _build_label(
+                        gnode,
+                        done=done,
+                        used_ids=used_ids,
+                        id_type=id_type,
+                        print_type=print_type,
+                        print_shape=print_shape,
+                        print_destroy_map=print_destroy_map,
+                        print_view_map=print_view_map,
+                        print_op_info=print_op_info,
+                        op_information=op_information,
+                    )
+                )
                 parent_tree = depth_stack[current_depth]
-                if id(parent_tree) not in sentinel_emitted:
-                    sentinel_emitted.add(id(parent_tree))
-                    parent_tree.add(_sentinel_label())
+                repeat_tree = parent_tree.add(_color_label(label, color))
+                repeat_tree.add(_sentinel_label(color))
                 continue
 
             if gnode.is_repeat and not gnode.is_inner_graph_header:
@@ -1291,11 +1300,24 @@ def _build_rich_tree(
                     node_key = (
                         gnode.var.owner if gnode.var.owner is not None else gnode.var
                     )
-                    _assign_color(node_key)
+                    color = _assign_color(node_key)
+                    label = rich.markup.escape(
+                        _build_label(
+                            gnode,
+                            done=done,
+                            used_ids=used_ids,
+                            id_type=id_type,
+                            print_type=print_type,
+                            print_shape=print_shape,
+                            print_destroy_map=print_destroy_map,
+                            print_view_map=print_view_map,
+                            print_op_info=print_op_info,
+                            op_information=op_information,
+                        )
+                    )
                     parent_tree = ig_depth_stack[current_depth]
-                    if id(parent_tree) not in sentinel_emitted:
-                        sentinel_emitted.add(id(parent_tree))
-                        parent_tree.add(_sentinel_label())
+                    repeat_tree = parent_tree.add(_color_label(label, color))
+                    repeat_tree.add(_sentinel_label(color))
                     continue
                 if gnode.is_repeat and not gnode.is_inner_graph_header:
                     continue
@@ -1354,11 +1376,24 @@ def _build_rich_tree(
                             if gnode.var.owner is not None
                             else gnode.var
                         )
-                        _assign_color(node_key)
+                        color = _assign_color(node_key)
+                        label = rich.markup.escape(
+                            _build_label(
+                                gnode,
+                                done=done,
+                                used_ids=used_ids,
+                                id_type=id_type,
+                                print_type=print_type,
+                                print_shape=print_shape,
+                                print_destroy_map=print_destroy_map,
+                                print_view_map=print_view_map,
+                                print_op_info=print_op_info,
+                                op_information=op_information,
+                            )
+                        )
                         parent_tree = out_stack[current_depth]
-                        if id(parent_tree) not in sentinel_emitted:
-                            sentinel_emitted.add(id(parent_tree))
-                            parent_tree.add(_sentinel_label())
+                        repeat_tree = parent_tree.add(_color_label(label, color))
+                        repeat_tree.add(_sentinel_label(color))
                         continue
                     if gnode.is_repeat and not gnode.is_inner_graph_header:
                         continue

--- a/pytensor/printing.py
+++ b/pytensor/printing.py
@@ -1253,12 +1253,11 @@ def _build_rich_tree(
                     op_information=op_information,
                 )
                 label = rich.markup.escape(label)
-                if gnode.is_repeat and not gnode.is_inner_graph_header:
-                    label = f"[dim]{label} ···[/dim]"
-                else:
-                    label = f"[dim]{label}[/dim]"
+                label = f"[dim]{label}[/dim]"
                 parent_tree = ig_depth_stack[current_depth]
                 child_tree = parent_tree.add(label)
+                if gnode.is_repeat and not gnode.is_inner_graph_header:
+                    child_tree.add("[italic dim]···[/italic dim]")
                 ig_depth_stack = [*ig_depth_stack[: current_depth + 1], child_tree]
 
             # The header tree node is the first child of inner_root
@@ -1304,12 +1303,11 @@ def _build_rich_tree(
                         op_information=op_information,
                     )
                     label = rich.markup.escape(label)
-                    if gnode.is_repeat and not gnode.is_inner_graph_header:
-                        label = f"[dim]{label} ···[/dim]"
-                    else:
-                        label = f"[dim]{label}[/dim]"
+                    label = f"[dim]{label}[/dim]"
                     parent_tree = out_stack[current_depth]
                     child_tree = parent_tree.add(label)
+                    if gnode.is_repeat and not gnode.is_inner_graph_header:
+                        child_tree.add("[italic dim]···[/italic dim]")
                     out_stack = [*out_stack[: current_depth + 1], child_tree]
 
     return root

--- a/pytensor/printing.py
+++ b/pytensor/printing.py
@@ -79,9 +79,13 @@ class GraphNode:
         The `Variable` this record represents.  The single source of truth —
         all graph structure is accessed through it via ``var.owner`` etc.
     is_repeat
-        ``True`` if this node's owner `Apply` was already expanded earlier in
-        the traversal.  Renderers should show a placeholder (e.g. ``"···"``)
-        rather than re-expanding children.
+        ``True`` when this record is a synthetic sentinel used to render a
+        ``"···"`` placeholder.  Such sentinels are yielded as the sole child
+        of a node whose children are not expanded — either because the `Apply`
+        owner was already visited earlier in the traversal, or because
+        ``stop_on_name`` stopped recursion.  The text renderer prints
+        ``"···"`` at this position; the rich renderer shows the label dimmed
+        with a ``"···"`` suffix.
     is_last_child
         ``True`` if this node is the last input among its siblings.  Used by
         the text renderer to choose ``"└─"`` vs ``"├─"``.
@@ -380,19 +384,30 @@ def _iter_graph_nodes(
     node = var.owner
     already_done = node in done
 
-    if already_done:
-        gnode.is_repeat = True
-        yield gnode
-        return
+    # Mark as visited before yielding to handle DAG diamonds; the `already_done`
+    # flag is captured above and used below to decide whether to recurse.
+    done[node] = ""
 
     yield gnode
 
-    if stop_on_name and var.name is not None:
-        # Yield the node itself but don't recurse — text renderer adds "···"
+    if already_done or (stop_on_name and var.name is not None):
+        if not is_inner_graph_header:
+            # Yield the node label, then a sentinel that renders as "···"
+            child_ancestor = [*ancestor_is_last, is_last_child]
+            yield GraphNode(
+                var=var,
+                is_repeat=True,
+                is_last_child=True,
+                ancestor_is_last=child_ancestor,
+                parent_node=node,
+                inner_to_outer=inner_to_outer,
+                inner_graph_node=inner_graph_node,
+                is_inner_graph_header=False,
+                topo_order=topo_order,
+                profile=profile,
+                storage_map=storage_map,
+            )
         return
-
-    # Mark as visited before recursing to handle DAG diamonds
-    done[node] = ""
 
     child_ancestor = [*ancestor_is_last, is_last_child]
 

--- a/pytensor/printing.py
+++ b/pytensor/printing.py
@@ -1210,7 +1210,8 @@ def _build_rich_tree(
                 )
                 parent_tree = depth_stack[current_depth]
                 repeat_tree = parent_tree.add(_color_label(label, color))
-                repeat_tree.add(_sentinel_label(color))
+                if gnode.var.owner is not None:
+                    repeat_tree.add(_sentinel_label(color))
                 continue
 
             if gnode.is_repeat and not gnode.is_inner_graph_header:
@@ -1317,7 +1318,8 @@ def _build_rich_tree(
                     )
                     parent_tree = ig_depth_stack[current_depth]
                     repeat_tree = parent_tree.add(_color_label(label, color))
-                    repeat_tree.add(_sentinel_label(color))
+                    if gnode.var.owner is not None:
+                        repeat_tree.add(_sentinel_label(color))
                     continue
                 if gnode.is_repeat and not gnode.is_inner_graph_header:
                     continue
@@ -1393,7 +1395,8 @@ def _build_rich_tree(
                         )
                         parent_tree = out_stack[current_depth]
                         repeat_tree = parent_tree.add(_color_label(label, color))
-                        repeat_tree.add(_sentinel_label(color))
+                        if gnode.var.owner is not None:
+                            repeat_tree.add(_sentinel_label(color))
                         continue
                     if gnode.is_repeat and not gnode.is_inner_graph_header:
                         continue

--- a/pytensor/printing.py
+++ b/pytensor/printing.py
@@ -1188,7 +1188,7 @@ def _build_rich_tree(
             depth_stack = [*depth_stack[: current_depth + 1], child_tree]
 
     if inner_graph_vars:
-        inner_root = root.add("[bold]Inner graphs:[/bold]")
+        inner_root = root.add("[dim bold]Inner graphs:[/dim bold]")
         printed = set()
         for ig_var in inner_graph_vars:
             if ig_var.owner in printed:
@@ -1255,6 +1255,8 @@ def _build_rich_tree(
                 label = rich.markup.escape(label)
                 if gnode.is_repeat and not gnode.is_inner_graph_header:
                     label = f"[dim]{label} ···[/dim]"
+                else:
+                    label = f"[dim]{label}[/dim]"
                 parent_tree = ig_depth_stack[current_depth]
                 child_tree = parent_tree.add(label)
                 ig_depth_stack = [*ig_depth_stack[: current_depth + 1], child_tree]
@@ -1304,6 +1306,8 @@ def _build_rich_tree(
                     label = rich.markup.escape(label)
                     if gnode.is_repeat and not gnode.is_inner_graph_header:
                         label = f"[dim]{label} ···[/dim]"
+                    else:
+                        label = f"[dim]{label}[/dim]"
                     parent_tree = out_stack[current_depth]
                     child_tree = parent_tree.add(label)
                     out_stack = [*out_stack[: current_depth + 1], child_tree]

--- a/pytensor/printing.py
+++ b/pytensor/printing.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import Any, Literal, TextIO
 
 import numpy as np
-import rich.tree
 
 from pytensor.compile import SharedVariable
 from pytensor.compile.debug.profiling import ProfileStats
@@ -484,7 +483,7 @@ def debugprint(
     print_view_map: bool = False,
     print_memory_map: bool = False,
     print_fgraph_inputs: bool = False,
-) -> "str | TextIO | rich.tree.Tree":
+) -> "str | TextIO | Any":  # rich.tree.Tree when file="rich"
     r"""Print a graph as text.
 
     Each line printed represents a `Variable` in a graph.
@@ -1049,7 +1048,7 @@ def _build_rich_tree(
     topo_orders: list[Sequence[Apply] | None] | None = None,
     profiles: list | None = None,
     storage_maps: list | None = None,
-) -> rich.tree.Tree:
+) -> Any:  # rich.tree.Tree when rich is installed
     """Build a ``rich.Tree`` for one or more output `Variable`s.
 
     Returns a single ``rich.Tree`` with ``hide_root=True`` when there are
@@ -1066,7 +1065,13 @@ def _build_rich_tree(
     topo_orders, profiles, storage_maps
         Per-output metadata lists; ``None`` entries mean "not available".
     """
-    import rich.markup
+    try:
+        import rich.markup
+        import rich.tree
+    except ImportError as e:
+        raise ImportError(
+            "rich is required for file='rich'. Install it with: pip install rich"
+        ) from e
 
     if topo_orders is None:
         topo_orders = [None] * len(outputs)

--- a/pytensor/printing.py
+++ b/pytensor/printing.py
@@ -83,8 +83,13 @@ class GraphNode:
         of a node whose children are not expanded — either because the `Apply`
         owner was already visited earlier in the traversal, or because
         ``stop_on_name`` stopped recursion.  The text renderer prints
-        ``"···"`` at this position; the rich renderer shows the label dimmed
-        with a ``"···"`` suffix.
+        ``"···"`` at this position; the rich renderer shows a colored ``"···"``
+        at the slot without repeating the node label.
+    is_already_done
+        ``True`` for the node-label record that immediately precedes its
+        ``is_repeat`` sentinel — i.e. the second occurrence of an already-visited
+        node.  The text renderer renders the label normally; the rich renderer
+        suppresses this record and emits a colored ``"···"`` directly instead.
     is_last_child
         ``True`` if this node is the last input among its siblings.  Used by
         the text renderer to choose ``"└─"`` vs ``"├─"``.
@@ -115,6 +120,7 @@ class GraphNode:
 
     var: Variable
     is_repeat: bool
+    is_already_done: bool
     is_last_child: bool
     ancestor_is_last: list[bool]
     parent_node: Apply | None
@@ -364,6 +370,7 @@ def _iter_graph_nodes(
     gnode = GraphNode(
         var=var,
         is_repeat=False,
+        is_already_done=False,
         is_last_child=is_last_child,
         ancestor_is_last=ancestor_is_last,
         parent_node=parent_node,
@@ -376,7 +383,26 @@ def _iter_graph_nodes(
     )
 
     if var.owner is None:
-        # Leaf node — input variable or constant
+        # Leaf node — input variable or constant.
+        # Track repeated leaves (e.g. shared inner-graph inputs like i0) so
+        # they can be colored and replaced by a sentinel on second occurrence.
+        already_done_leaf = var in done
+        done[var] = ""
+        if already_done_leaf:
+            gnode = GraphNode(
+                var=var,
+                is_repeat=False,
+                is_already_done=True,
+                is_last_child=is_last_child,
+                ancestor_is_last=ancestor_is_last,
+                parent_node=parent_node,
+                inner_to_outer=inner_to_outer,
+                inner_graph_node=inner_graph_node,
+                is_inner_graph_header=is_inner_graph_header,
+                topo_order=topo_order,
+                profile=profile,
+                storage_map=storage_map,
+            )
         yield gnode
         return
 
@@ -402,15 +428,32 @@ def _iter_graph_nodes(
     ):
         inner_graph_ops.append(var)
 
+    if already_done and not is_inner_graph_header:
+        gnode = GraphNode(
+            var=var,
+            is_repeat=False,
+            is_already_done=True,
+            is_last_child=is_last_child,
+            ancestor_is_last=ancestor_is_last,
+            parent_node=parent_node,
+            inner_to_outer=inner_to_outer,
+            inner_graph_node=inner_graph_node,
+            is_inner_graph_header=is_inner_graph_header,
+            topo_order=topo_order,
+            profile=profile,
+            storage_map=storage_map,
+        )
+
     yield gnode
 
     if already_done or (stop_on_name and var.name is not None):
         if not is_inner_graph_header:
-            # Yield the node label, then a sentinel that renders as "···"
+            # Yield sentinel that renders as "···"
             child_ancestor = [*ancestor_is_last, is_last_child]
             yield GraphNode(
                 var=var,
                 is_repeat=True,
+                is_already_done=False,
                 is_last_child=True,
                 ancestor_is_last=child_ancestor,
                 parent_node=node,
@@ -1110,13 +1153,13 @@ def _build_rich_tree(
     def _color_label(label: str, color: str) -> str:
         return f"[{color}]{label}[/{color}]"
 
-    def _sentinel_label(color: str) -> str:
-        """Style the ··· sentinel child.  Uses a bright_ variant of the parent's
-        color so the sentinel is visually linked but distinct.  Falls back to
-        italic dim alone if the color is already a bright_ variant."""
+    def _sentinel_label(color: str, dim: bool = False) -> str:
+        """Sentinel for repeated nodes.  Bold+bright color links back to the
+        canonical occurrence.  Pass dim=True for inner graph context."""
+        extra = " dim" if dim else ""
         if color.startswith("bright_"):
-            return "[italic dim]···[/italic dim]"
-        return f"[bright_{color} italic dim]···[/bright_{color} italic dim]"
+            return f"[bold{extra}]···[/bold{extra}]"
+        return f"[bright_{color} bold{extra}]···[/bright_{color} bold{extra}]"
 
     def _assign_color(node_key) -> str:
         """Return the color for node_key, assigning one if needed and
@@ -1152,14 +1195,17 @@ def _build_rich_tree(
             current_depth = len(gnode.ancestor_is_last)
             node_key = gnode.var.owner if gnode.var.owner is not None else gnode.var
 
-            if gnode.is_repeat and not gnode.is_inner_graph_header:
-                # Assign/retrieve color for this shared node, retroactively
-                # coloring all canonical occurrences emitted so far.
+            if gnode.is_already_done:
+                # Second occurrence of an already-visited node: emit a colored
+                # ··· directly at this slot and skip the following sentinel.
                 color = _assign_color(node_key)
-                # Sentinel child: just ··· styled as bright_<color> italic dim.
                 parent_tree = depth_stack[current_depth]
                 parent_tree.add(_sentinel_label(color))
-                # Sentinel is a leaf; no depth_stack push needed.
+                continue
+
+            if gnode.is_repeat and not gnode.is_inner_graph_header:
+                # Sentinel emitted by _iter_graph_nodes after is_already_done node;
+                # already handled above — skip.
                 continue
 
             label = _build_label(
@@ -1240,6 +1286,16 @@ def _build_rich_tree(
                 is_last_child=True,
             ):
                 current_depth = len(gnode.ancestor_is_last)
+                if gnode.is_already_done:
+                    node_key = (
+                        gnode.var.owner if gnode.var.owner is not None else gnode.var
+                    )
+                    color = _assign_color(node_key)
+                    parent_tree = ig_depth_stack[current_depth]
+                    parent_tree.add(_sentinel_label(color, dim=True))
+                    continue
+                if gnode.is_repeat and not gnode.is_inner_graph_header:
+                    continue
                 label = _build_label(
                     gnode,
                     done=done,
@@ -1253,11 +1309,10 @@ def _build_rich_tree(
                     op_information=op_information,
                 )
                 label = rich.markup.escape(label)
-                label = f"[dim]{label}[/dim]"
+                node_key = gnode.var.owner if gnode.var.owner is not None else gnode.var
                 parent_tree = ig_depth_stack[current_depth]
-                child_tree = parent_tree.add(label)
-                if gnode.is_repeat and not gnode.is_inner_graph_header:
-                    child_tree.add("[italic dim]···[/italic dim]")
+                child_tree = parent_tree.add(f"[dim]{label}[/dim]")
+                node_tree_map.setdefault(node_key, []).append(child_tree)
                 ig_depth_stack = [*ig_depth_stack[: current_depth + 1], child_tree]
 
             # The header tree node is the first child of inner_root
@@ -1290,6 +1345,18 @@ def _build_rich_tree(
                     is_last_child=True,
                 ):
                     current_depth = len(gnode.ancestor_is_last)
+                    if gnode.is_already_done:
+                        node_key = (
+                            gnode.var.owner
+                            if gnode.var.owner is not None
+                            else gnode.var
+                        )
+                        color = _assign_color(node_key)
+                        parent_tree = out_stack[current_depth]
+                        parent_tree.add(_sentinel_label(color, dim=True))
+                        continue
+                    if gnode.is_repeat and not gnode.is_inner_graph_header:
+                        continue
                     label = _build_label(
                         gnode,
                         done=done,
@@ -1303,11 +1370,12 @@ def _build_rich_tree(
                         op_information=op_information,
                     )
                     label = rich.markup.escape(label)
-                    label = f"[dim]{label}[/dim]"
+                    node_key = (
+                        gnode.var.owner if gnode.var.owner is not None else gnode.var
+                    )
                     parent_tree = out_stack[current_depth]
-                    child_tree = parent_tree.add(label)
-                    if gnode.is_repeat and not gnode.is_inner_graph_header:
-                        child_tree.add("[italic dim]···[/italic dim]")
+                    child_tree = parent_tree.add(f"[dim]{label}[/dim]")
+                    node_tree_map.setdefault(node_key, []).append(child_tree)
                     out_stack = [*out_stack[: current_depth + 1], child_tree]
 
     return root

--- a/pytensor/printing.py
+++ b/pytensor/printing.py
@@ -387,6 +387,21 @@ def _iter_graph_nodes(
     # flag is captured above and used below to decide whether to recurse.
     done[node] = ""
 
+    # Collect this node itself if it owns an inner graph — needed when the
+    # HasInnerGraph op is a top-level output and never appears as an input.
+    if (
+        not is_inner_graph_header
+        and (
+            isinstance(node.op, HasInnerGraph)
+            or (
+                hasattr(node.op, "scalar_op")
+                and isinstance(node.op.scalar_op, HasInnerGraph)
+            )
+        )
+        and var not in inner_graph_ops
+    ):
+        inner_graph_ops.append(var)
+
     yield gnode
 
     if already_done or (stop_on_name and var.name is not None):
@@ -1085,6 +1100,29 @@ def _build_rich_tree(
     op_information: dict[Apply, dict[Variable, str]] = {}
     inner_graph_vars: list[Variable] = []
 
+    # Colors assigned to shared (repeated) nodes so canonical and repeat
+    # occurrences are visually linked.  Populated lazily when a repeat is seen.
+    _REPEAT_COLORS = ["red", "green", "yellow", "blue", "magenta", "cyan"]
+    node_colors: dict = {}  # Apply/Variable key → color string
+    # All rich.Tree nodes emitted for a given key (for retroactive coloring).
+    node_tree_map: dict = {}  # Apply/Variable key → list[rich.tree.Tree]
+
+    def _color_label(label: str, color: str) -> str:
+        return f"[{color}]{label}[/{color}]"
+
+    def _repeat_label(label: str) -> str:
+        return f"{label} ···"
+
+    def _assign_color(node_key) -> str:
+        """Return the color for node_key, assigning one if needed and
+        retroactively updating all previously-emitted rich.Tree nodes."""
+        if node_key not in node_colors:
+            color = _REPEAT_COLORS[len(node_colors) % len(_REPEAT_COLORS)]
+            node_colors[node_key] = color
+            for prior_tree_node in node_tree_map.get(node_key, []):
+                prior_tree_node.label = _color_label(str(prior_tree_node.label), color)
+        return node_colors[node_key]
+
     root = rich.tree.Tree("", hide_root=True)
 
     for var, topo_order, profile, storage_map in zip(
@@ -1093,6 +1131,13 @@ def _build_rich_tree(
         # Stack maps traversal depth → rich.Tree node at that depth.
         # Depth 0 is the output variable itself (child of root).
         depth_stack: list[rich.tree.Tree] = [root]
+
+        # When a node has already been visited, _iter_graph_nodes yields the
+        # node itself (is_repeat=False) followed immediately by a sentinel
+        # (is_repeat=True) as a synthetic child one level deeper.  We collapse
+        # this pair into a single line by buffering the non-repeat half and
+        # rendering the sentinel at the buffered depth (without a child indent).
+        pending_repeat_parent: GraphNode | None = None
 
         for gnode in _iter_graph_nodes(
             var,
@@ -1107,6 +1152,88 @@ def _build_rich_tree(
             is_last_child=True,
         ):
             current_depth = len(gnode.ancestor_is_last)
+            node_key = gnode.var.owner if gnode.var.owner is not None else gnode.var
+
+            if gnode.is_repeat and not gnode.is_inner_graph_header:
+                if pending_repeat_parent is not None:
+                    # Collapse the buffered parent + this sentinel into one line.
+                    # Use the parent's gnode for the label and depth, but append
+                    # ··· to indicate this is a back-reference.
+                    label = _build_label(
+                        pending_repeat_parent,
+                        done=done,
+                        used_ids=used_ids,
+                        id_type=id_type,
+                        print_type=print_type,
+                        print_shape=print_shape,
+                        print_destroy_map=print_destroy_map,
+                        print_view_map=print_view_map,
+                        print_op_info=print_op_info,
+                        op_information=op_information,
+                    )
+                    label = rich.markup.escape(label)
+                    parent_depth = len(pending_repeat_parent.ancestor_is_last)
+                    pending_repeat_parent = None
+
+                    color = _assign_color(node_key)
+                    label = _color_label(_repeat_label(label), color)
+
+                    parent_tree = depth_stack[parent_depth]
+                    child_tree = parent_tree.add(label)
+                    # Sentinel is a leaf; no need to push onto depth_stack.
+                    continue
+
+                # Fallback: no pending parent (shouldn't occur in normal graphs).
+                label = _build_label(
+                    gnode,
+                    done=done,
+                    used_ids=used_ids,
+                    id_type=id_type,
+                    print_type=print_type,
+                    print_shape=print_shape,
+                    print_destroy_map=print_destroy_map,
+                    print_view_map=print_view_map,
+                    print_op_info=print_op_info,
+                    op_information=op_information,
+                )
+                label = rich.markup.escape(label)
+                color = _assign_color(node_key)
+                label = _color_label(_repeat_label(label), color)
+                parent_tree = depth_stack[current_depth]
+                child_tree = parent_tree.add(label)
+                depth_stack = [*depth_stack[: current_depth + 1], child_tree]
+                continue
+
+            # Flush any pending repeat parent that was NOT followed by a sentinel
+            # (defensive; should not happen with current _iter_graph_nodes).
+            if pending_repeat_parent is not None:
+                flush_gnode = pending_repeat_parent
+                pending_repeat_parent = None
+                flush_depth = len(flush_gnode.ancestor_is_last)
+                flush_label = _build_label(
+                    flush_gnode,
+                    done=done,
+                    used_ids=used_ids,
+                    id_type=id_type,
+                    print_type=print_type,
+                    print_shape=print_shape,
+                    print_destroy_map=print_destroy_map,
+                    print_view_map=print_view_map,
+                    print_op_info=print_op_info,
+                    op_information=op_information,
+                )
+                flush_label = rich.markup.escape(flush_label)
+                flush_key = (
+                    flush_gnode.var.owner
+                    if flush_gnode.var.owner is not None
+                    else flush_gnode.var
+                )
+                if flush_key in node_colors:
+                    flush_label = _color_label(flush_label, node_colors[flush_key])
+                flush_parent = depth_stack[flush_depth]
+                flush_child = flush_parent.add(flush_label)
+                node_tree_map.setdefault(flush_key, []).append(flush_child)
+                depth_stack = [*depth_stack[: flush_depth + 1], flush_child]
 
             label = _build_label(
                 gnode,
@@ -1122,11 +1249,23 @@ def _build_rich_tree(
             )
 
             label = rich.markup.escape(label)
-            if gnode.is_repeat and not gnode.is_inner_graph_header:
-                label = f"[dim]{label} ···[/dim]"
+
+            if node_key in node_colors:
+                # Already known to be shared; color immediately.
+                label = _color_label(label, node_colors[node_key])
+
+            # Check if this non-repeat node is already in node_tree_map, which
+            # means it has been emitted before and will be followed by a sentinel.
+            # Buffer it instead of adding to the tree immediately.
+            # Only Apply nodes (var.owner is not None) get sentinels; leaf
+            # variables are always rendered directly.
+            if node_key in node_tree_map and gnode.var.owner is not None:
+                pending_repeat_parent = gnode
+                continue
 
             parent_tree = depth_stack[current_depth]
             child_tree = parent_tree.add(label)
+            node_tree_map.setdefault(node_key, []).append(child_tree)
             # Trim the stack to this depth and push the new node.
             depth_stack = [*depth_stack[: current_depth + 1], child_tree]
 

--- a/pytensor/printing.py
+++ b/pytensor/printing.py
@@ -1153,13 +1153,8 @@ def _build_rich_tree(
     def _color_label(label: str, color: str) -> str:
         return f"[{color}]{label}[/{color}]"
 
-    def _sentinel_label(color: str, dim: bool = False) -> str:
-        """Sentinel for repeated nodes.  Bold+bright color links back to the
-        canonical occurrence.  Pass dim=True for inner graph context."""
-        extra = " dim" if dim else ""
-        if color.startswith("bright_"):
-            return f"[bold{extra}]···[/bold{extra}]"
-        return f"[bright_{color} bold{extra}]···[/bright_{color} bold{extra}]"
+    def _sentinel_label() -> str:
+        return "···"
 
     def _assign_color(node_key) -> str:
         """Return the color for node_key, assigning one if needed and
@@ -1172,6 +1167,10 @@ def _build_rich_tree(
         return node_colors[node_key]
 
     root = rich.tree.Tree("", hide_root=True)
+
+    # Track parent tree nodes that have already received a ··· sentinel child
+    # so each parent shows at most one ··· regardless of how many repeated inputs it has.
+    sentinel_emitted: set = set()  # set of id(parent_tree)
 
     for var, topo_order, profile, storage_map in zip(
         outputs, topo_orders, profiles, storage_maps, strict=True
@@ -1196,11 +1195,13 @@ def _build_rich_tree(
             node_key = gnode.var.owner if gnode.var.owner is not None else gnode.var
 
             if gnode.is_already_done:
-                # Second occurrence of an already-visited node: emit a colored
-                # ··· directly at this slot and skip the following sentinel.
-                color = _assign_color(node_key)
+                # Repeated node: color the canonical occurrence and emit one ···
+                # per parent — at most one sentinel child per parent tree node.
+                _assign_color(node_key)
                 parent_tree = depth_stack[current_depth]
-                parent_tree.add(_sentinel_label(color))
+                if id(parent_tree) not in sentinel_emitted:
+                    sentinel_emitted.add(id(parent_tree))
+                    parent_tree.add(_sentinel_label())
                 continue
 
             if gnode.is_repeat and not gnode.is_inner_graph_header:
@@ -1234,7 +1235,7 @@ def _build_rich_tree(
             depth_stack = [*depth_stack[: current_depth + 1], child_tree]
 
     if inner_graph_vars:
-        inner_root = root.add("[dim bold]Inner graphs:[/dim bold]")
+        inner_root = root.add("[bold]Inner graphs:[/bold]")
         printed = set()
         for ig_var in inner_graph_vars:
             if ig_var.owner in printed:
@@ -1290,9 +1291,11 @@ def _build_rich_tree(
                     node_key = (
                         gnode.var.owner if gnode.var.owner is not None else gnode.var
                     )
-                    color = _assign_color(node_key)
+                    _assign_color(node_key)
                     parent_tree = ig_depth_stack[current_depth]
-                    parent_tree.add(_sentinel_label(color, dim=True))
+                    if id(parent_tree) not in sentinel_emitted:
+                        sentinel_emitted.add(id(parent_tree))
+                        parent_tree.add(_sentinel_label())
                     continue
                 if gnode.is_repeat and not gnode.is_inner_graph_header:
                     continue
@@ -1311,7 +1314,7 @@ def _build_rich_tree(
                 label = rich.markup.escape(label)
                 node_key = gnode.var.owner if gnode.var.owner is not None else gnode.var
                 parent_tree = ig_depth_stack[current_depth]
-                child_tree = parent_tree.add(f"[dim]{label}[/dim]")
+                child_tree = parent_tree.add(label)
                 node_tree_map.setdefault(node_key, []).append(child_tree)
                 ig_depth_stack = [*ig_depth_stack[: current_depth + 1], child_tree]
 
@@ -1351,9 +1354,11 @@ def _build_rich_tree(
                             if gnode.var.owner is not None
                             else gnode.var
                         )
-                        color = _assign_color(node_key)
+                        _assign_color(node_key)
                         parent_tree = out_stack[current_depth]
-                        parent_tree.add(_sentinel_label(color, dim=True))
+                        if id(parent_tree) not in sentinel_emitted:
+                            sentinel_emitted.add(id(parent_tree))
+                            parent_tree.add(_sentinel_label())
                         continue
                     if gnode.is_repeat and not gnode.is_inner_graph_header:
                         continue
@@ -1374,7 +1379,7 @@ def _build_rich_tree(
                         gnode.var.owner if gnode.var.owner is not None else gnode.var
                     )
                     parent_tree = out_stack[current_depth]
-                    child_tree = parent_tree.add(f"[dim]{label}[/dim]")
+                    child_tree = parent_tree.add(label)
                     node_tree_map.setdefault(node_key, []).append(child_tree)
                     out_stack = [*out_stack[: current_depth + 1], child_tree]
 

--- a/pytensor/printing.py
+++ b/pytensor/printing.py
@@ -4,9 +4,10 @@ import hashlib
 import logging
 import sys
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Generator, Sequence
 from contextlib import contextmanager
 from copy import copy
+from dataclasses import dataclass
 from functools import reduce, singledispatch
 from io import StringIO
 from pathlib import Path
@@ -61,6 +62,370 @@ def char_from_number(number: int) -> str:
         remainders = [0]
 
     return "".join(chr(ord("A") + r) for r in remainders[::-1])
+
+
+@dataclass
+class GraphNode:
+    """A record of a single node in a `debugprint` / `print_graph` traversal.
+
+    Carries the graph variable, its structural position in the traversal, and
+    any render-time context needed to build a label.  Renderers consume a
+    stream of these objects produced by `_iter_graph_nodes`.
+
+    Parameters
+    ----------
+    var
+        The `Variable` this record represents.  The single source of truth —
+        all graph structure is accessed through it via ``var.owner`` etc.
+    is_repeat
+        ``True`` if this node's owner `Apply` was already expanded earlier in
+        the traversal.  Renderers should show a placeholder (e.g. ``"···"``)
+        rather than re-expanding children.
+    is_last_child
+        ``True`` if this node is the last input among its siblings.  Used by
+        the text renderer to choose ``"└─"`` vs ``"├─"``.
+    ancestor_is_last
+        One ``bool`` per ancestor level (outermost first), recording whether
+        that ancestor was itself a last child.  ``False`` → draw a ``" │ "``
+        continuation column; ``True`` → draw ``"   "`` (no bar).  Used
+        exclusively by the text renderer — the rich renderer ignores it.
+    parent_node
+        The `Apply` node whose input list contains ``var``.  Needed for
+        ``op_information`` annotation lookup.
+    inner_to_outer
+        Mapping from inner-graph `Variable` s to their corresponding
+        outer-graph counterparts, used to print ``"-> [id X]"`` suffixes.
+    inner_graph_node
+        The `Apply` node that owns the inner graph in which ``var`` lives.
+    is_inner_graph_header
+        ``True`` for the single header line of an inner-graph op (prints
+        only ``op + id``, without type/name/annotation details).
+    topo_order
+        Toposort of the enclosing `FunctionGraph`, used to print topo index.
+    profile
+        Profiling stats for the enclosing compiled function.
+    storage_map
+        VM storage map (only available after a function has been executed
+        with ``allow_gc=False``).
+    """
+
+    var: Variable
+    is_repeat: bool
+    is_last_child: bool
+    ancestor_is_last: list[bool]
+    parent_node: Apply | None
+    inner_to_outer: dict[Variable, Variable] | None
+    inner_graph_node: Apply | None
+    is_inner_graph_header: bool
+    topo_order: Sequence[Apply] | None
+    profile: "ProfileStats | None"
+    storage_map: "StorageMapType | None"
+
+    @property
+    def node(self) -> Apply | None:
+        """The `Apply` node that produced ``var``, or ``None`` for leaves."""
+        return self.var.owner
+
+    @property
+    def is_leaf(self) -> bool:
+        """``True`` if ``var`` has no owner (graph input or constant)."""
+        return self.var.owner is None
+
+    @property
+    def output_idx(self) -> str:
+        """``".N"`` suffix for multi-output ops, empty string otherwise."""
+        node = self.var.owner
+        if node is None or len(node.outputs) == 1:
+            return ""
+        return f".{node.outputs.index(self.var)}"
+
+
+def _assign_id(
+    obj: "Literal['output'] | Apply | Variable",
+    used_ids: dict,
+    done: dict,
+    id_type: IDTypesType,
+    var: "Variable",
+) -> str:
+    """Return (and register) the ``[id X]`` string for *obj*.
+
+    The ``var`` argument is the `Variable` currently being printed; it is
+    used for ``id_type="id"`` and ``id_type="auto"``.
+    """
+    if obj in used_ids:
+        return used_ids[obj]
+    if obj == "output":
+        id_str = "output"
+    elif id_type == "id":
+        id_str = f"[id {id(var)}]"
+    elif id_type == "int":
+        id_str = f"[id {len(used_ids)}]"
+    elif id_type == "CHAR":
+        id_str = f"[id {char_from_number(len(used_ids))}]"
+    elif id_type == "auto":
+        id_str = f"[id {var.auto_name}]"
+    else:
+        id_str = ""
+    done[obj] = id_str
+    used_ids[obj] = id_str
+    return id_str
+
+
+def _build_label(
+    gnode: GraphNode,
+    done: dict,
+    used_ids: dict,
+    id_type: IDTypesType,
+    print_type: bool,
+    print_shape: bool,
+    print_destroy_map: bool,
+    print_view_map: bool,
+    print_op_info: bool,
+    op_information: dict,
+) -> str:
+    """Return the formatted label string for a single `GraphNode`.
+
+    This is a pure function with respect to the graph; its only side-effects
+    are updating the shared ``done`` and ``used_ids`` registries.
+
+    Parameters
+    ----------
+    gnode
+        The node to label.
+    done
+        Shared registry mapping `Apply`/`Variable` objects to their id
+        strings, used for repeat-detection.
+    used_ids
+        Shared registry mapping objects to their ``[id X]`` strings, ensuring
+        stable IDs across an entire print call.
+    id_type, print_type, print_shape, print_destroy_map, print_view_map,
+    print_op_info, op_information
+        Same semantics as the identically-named parameters of `debugprint`.
+
+    Returns
+    -------
+    str
+        The formatted label, ready to be written or passed to ``rich.Tree``.
+    """
+    var = gnode.var
+
+    if print_type:
+        type_str = f" <{var.type}>"
+    else:
+        type_str = ""
+
+    if print_shape and hasattr(var.type, "shape"):
+        shape_str = f" shape={str(var.type.shape).replace('None', '?')}"
+    else:
+        shape_str = ""
+
+    if gnode.is_leaf:
+        id_str = _assign_id(var, used_ids, done, id_type, var)
+        if id_str:
+            id_str = f" {id_str}"
+
+        if gnode.storage_map and var in gnode.storage_map:
+            data = f" {gnode.storage_map[var]}"
+        else:
+            data = ""
+
+        label = f"{var}{id_str}{type_str}{shape_str}{data}"
+
+        if print_op_info and var.owner and var.owner not in op_information:
+            op_information.update(op_debug_information(var.owner.op, var.owner))
+
+        if gnode.inner_to_outer is not None and var in gnode.inner_to_outer:
+            outer_var = gnode.inner_to_outer[var]
+            outer_id_str = _assign_id(
+                outer_var.owner if outer_var.owner else outer_var,
+                used_ids,
+                done,
+                id_type,
+                outer_var,
+            )
+            label = f"{label} -> {outer_id_str}"
+
+        # TODO: This entire approach will only print `Op` info for two levels
+        # of nesting.
+        for node in dict.fromkeys(
+            [gnode.inner_graph_node, gnode.parent_node, var.owner]
+        ):
+            node_info = op_information.get(node)
+            if node_info and var in node_info:
+                label = f"{label} ({node_info[var]})"
+
+        return label
+
+    # Owned variable — label is built from the Apply node
+    node = gnode.node
+    assert node is not None
+
+    id_str = _assign_id(node, used_ids, done, id_type, var)
+    if id_str:
+        id_str = f" {id_str}"
+
+    var_name = getattr(var, "name", "") or ""
+    if var_name:
+        var_name = f" '{var_name}'"
+
+    destroy_map_str = (
+        f" d={node.op.destroy_map}" if print_destroy_map and node.op.destroy_map else ""
+    )
+    view_map_str = (
+        f" v={node.op.view_map}" if print_view_map and node.op.view_map else ""
+    )
+
+    topo_str = f" {gnode.topo_order.index(node)}" if gnode.topo_order else ""
+
+    if gnode.storage_map and node.outputs[0] in gnode.storage_map:
+        data = f" {gnode.storage_map[node.outputs[0]]}"
+    else:
+        data = ""
+
+    if gnode.is_inner_graph_header:
+        return f"{node.op}{id_str}{destroy_map_str}{view_map_str}{topo_str}"
+
+    label = f"{node.op}{gnode.output_idx}{id_str}{type_str}{shape_str}{var_name}{destroy_map_str}{view_map_str}{topo_str}{data}"
+
+    if print_op_info and node not in op_information:
+        op_information.update(op_debug_information(node.op, node))
+
+    node_info = (
+        gnode.parent_node and op_information.get(gnode.parent_node)
+    ) or op_information.get(node)
+    if node_info and var in node_info:
+        label = f"{label} ({node_info[var]})"
+
+    return label
+
+
+def _iter_graph_nodes(
+    var: Variable,
+    depth: int = -1,
+    done: dict | None = None,
+    stop_on_name: bool = False,
+    inner_graph_ops: list | None = None,
+    inner_to_outer: dict | None = None,
+    topo_order: Sequence | None = None,
+    profile: "ProfileStats | None" = None,
+    storage_map: "StorageMapType | None" = None,
+    parent_node: Apply | None = None,
+    inner_graph_node: Apply | None = None,
+    is_inner_graph_header: bool = False,
+    ancestor_is_last: list[bool] | None = None,
+    is_last_child: bool = True,
+    _current_depth: int = 0,
+) -> Generator[GraphNode, None, None]:
+    """Yield `GraphNode` records for a depth-first pre-order traversal of *var*.
+
+    This generator encapsulates all graph-traversal logic that was previously
+    embedded in the recursive `_debugprint` function.  Renderers consume the
+    yielded records without needing to understand graph structure.
+
+    Parameters
+    ----------
+    var
+        The root `Variable` to start traversal from.
+    depth
+        Maximum traversal depth (``-1`` for unlimited).
+    done
+        Shared dict mapping `Apply` nodes to their id strings.  Nodes already
+        present are not re-expanded — a repeat `GraphNode` is yielded instead.
+    stop_on_name
+        When ``True``, stop recursing into a node's inputs if that node's
+        output variable has a non-``None`` name.
+    inner_graph_ops
+        Accumulator list — inner-graph op variables are appended here as they
+        are discovered, for the caller's second-pass inner-graph printing.
+    inner_to_outer, topo_order, profile, storage_map, parent_node,
+    inner_graph_node, is_inner_graph_header
+        Passed through to each yielded `GraphNode` unchanged.
+    ancestor_is_last
+        Tracks whether each ancestor level was itself a last child.
+    is_last_child
+        Whether this call is for the last input among its siblings.
+    _current_depth
+        Internal recursion counter.
+    """
+    if done is None:
+        done = {}
+    if inner_graph_ops is None:
+        inner_graph_ops = []
+    if ancestor_is_last is None:
+        ancestor_is_last = []
+
+    if depth != -1 and _current_depth >= depth:
+        return
+
+    gnode = GraphNode(
+        var=var,
+        is_repeat=False,
+        is_last_child=is_last_child,
+        ancestor_is_last=ancestor_is_last,
+        parent_node=parent_node,
+        inner_to_outer=inner_to_outer,
+        inner_graph_node=inner_graph_node,
+        is_inner_graph_header=is_inner_graph_header,
+        topo_order=topo_order,
+        profile=profile,
+        storage_map=storage_map,
+    )
+
+    if var.owner is None:
+        # Leaf node — input variable or constant
+        yield gnode
+        return
+
+    node = var.owner
+    already_done = node in done
+
+    if already_done:
+        gnode.is_repeat = True
+        yield gnode
+        return
+
+    yield gnode
+
+    if stop_on_name and var.name is not None:
+        # Yield the node itself but don't recurse — text renderer adds "···"
+        return
+
+    # Mark as visited before recursing to handle DAG diamonds
+    done[node] = ""
+
+    child_ancestor = [*ancestor_is_last, is_last_child]
+
+    for in_idx, in_var in enumerate(node.inputs):
+        child_is_last = in_idx == len(node.inputs) - 1
+
+        # Collect inner-graph ops for the second pass
+        if hasattr(in_var, "owner") and hasattr(in_var.owner, "op"):
+            if (
+                isinstance(in_var.owner.op, HasInnerGraph)
+                or (
+                    hasattr(in_var.owner.op, "scalar_op")
+                    and isinstance(in_var.owner.op.scalar_op, HasInnerGraph)
+                )
+            ) and in_var not in inner_graph_ops:
+                inner_graph_ops.append(in_var)
+
+        yield from _iter_graph_nodes(
+            in_var,
+            depth=depth,
+            done=done,
+            stop_on_name=stop_on_name,
+            inner_graph_ops=inner_graph_ops,
+            inner_to_outer=inner_to_outer,
+            topo_order=topo_order,
+            profile=profile,
+            storage_map=storage_map,
+            parent_node=node,
+            inner_graph_node=inner_graph_node,
+            is_inner_graph_header=False,
+            ancestor_is_last=child_ancestor,
+            is_last_child=child_is_last,
+            _current_depth=_current_depth + 1,
+        )
 
 
 @singledispatch
@@ -538,213 +903,98 @@ def _debugprint(
     if depth == 0:
         return file
 
-    if topo_order is None:
-        topo_order = []
-
     if done is None:
-        _done = dict()
-    else:
-        _done = done
-
+        done = {}
+    if used_ids is None:
+        used_ids = {}
     if inner_graph_ops is None:
         inner_graph_ops = []
-
-    if print_type:
-        type_str = f" <{var.type}>"
-    else:
-        type_str = ""
-
-    if print_shape and hasattr(var.type, "shape"):
-        shape_str = f" shape={str(var.type.shape).replace('None', '?')}"
-    else:
-        shape_str = ""
-
-    if prefix_child is None:
-        prefix_child = prefix
-
-    if used_ids is None:
-        _used_ids = dict()
-    else:
-        _used_ids = used_ids
-
     if op_information is None:
         op_information = {}
 
-    def get_id_str(
-        obj: Literal["output"] | Apply | Variable, get_printed: bool = True
-    ) -> str:
-        id_str: str = ""
-        if obj in _used_ids:
-            id_str = _used_ids[obj]
-        elif obj == "output":
-            id_str = "output"
-        elif id_type == "id":
-            id_str = f"[id {id(var)}]"
-        elif id_type == "int":
-            id_str = f"[id {len(_used_ids)}]"
-        elif id_type == "CHAR":
-            id_str = f"[id {char_from_number(len(_used_ids))}]"
-        elif id_type == "auto":
-            id_str = f"[id {var.auto_name}]"
-        elif id_type == "":
-            id_str = ""
-        if get_printed:
-            _done[obj] = id_str
-        _used_ids[obj] = id_str
-        return id_str
+    # In the original recursive _debugprint, `prefix` is the string written
+    # before the current node, and `prefix_child` is the base for children.
+    # Normally prefix_child == prefix; the only exception is inner-graph outputs
+    # which are called with prefix=" ← " and prefix_child="   ".
+    # We replicate this by tracking an effective "child base" string and using
+    # it for all nodes that are not the root of this _debugprint call.
+    if prefix_child is None:
+        prefix_child = prefix
+    has_child_offset = prefix_child != prefix  # True only for inner-graph outputs
 
-    if var.owner:
-        # This variable is the output of a computation, so just print out the
-        # `Apply` node
-        node = var.owner
-
-        var_name = getattr(var, "name", "")
-
-        if var_name is None:
-            var_name = ""
-        if var_name:
-            var_name = f" '{var_name}'"
-
-        if print_destroy_map and node.op.destroy_map:
-            destroy_map_str = f" d={node.op.destroy_map}"
+    for gnode in _iter_graph_nodes(
+        var,
+        depth=depth,
+        done=done,
+        stop_on_name=stop_on_name,
+        inner_graph_ops=inner_graph_ops,
+        inner_to_outer=inner_to_outer_inputs,
+        topo_order=topo_order,
+        profile=profile,
+        storage_map=storage_map,
+        parent_node=parent_node,
+        inner_graph_node=inner_graph_node,
+        is_inner_graph_header=is_inner_graph_header,
+        ancestor_is_last=[],
+        is_last_child=True,
+    ):
+        # Reconstruct the indentation prefix from ancestor_is_last.
+        # The root node (depth 0) has ancestor_is_last=[] and no connector.
+        # Deeper nodes build column bars from all but the last entry, then
+        # append the connector selected by is_last_child.
+        #
+        # When prefix_child != prefix (inner-graph output case), the root uses
+        # `prefix` and all children use `prefix_child` as their base.
+        is_root = not gnode.ancestor_is_last
+        if is_root:
+            col_bars = ""
+            connector = ""
+            base = prefix
         else:
-            destroy_map_str = ""
+            col_bars = "".join(
+                "   " if last else " │ " for last in gnode.ancestor_is_last
+            )
+            connector = " └─ " if gnode.is_last_child else " ├─ "
+            base = prefix_child if has_child_offset else prefix
 
-        if print_view_map and node.op.view_map:
-            view_map_str = f" v={node.op.view_map}"
-        else:
-            view_map_str = ""
+        full_prefix = base + col_bars + connector
 
-        if topo_order:
-            o = f" {topo_order.index(node)}"
-        else:
-            o = ""
+        label = _build_label(
+            gnode,
+            done=done,
+            used_ids=used_ids,
+            id_type=id_type,
+            print_type=print_type,
+            print_shape=print_shape,
+            print_destroy_map=print_destroy_map,
+            print_view_map=print_view_map,
+            print_op_info=print_op_info,
+            op_information=op_information,
+        )
 
-        already_done = node in _done
-        id_str = get_id_str(node)
+        if gnode.is_repeat and not gnode.is_inner_graph_header:
+            print(f"{full_prefix}···", file=file)
+            continue
 
-        if len(node.outputs) == 1:
-            output_idx = ""
-        else:
-            output_idx = f".{node.outputs.index(var)}"
-
-        if id_str:
-            id_str = f" {id_str}"
-
-        if storage_map and node.outputs[0] in storage_map:
-            data = f" {storage_map[node.outputs[0]]}"
-        else:
-            data = ""
-
-        if is_inner_graph_header:
-            var_output = f"{prefix}{node.op}{id_str}{destroy_map_str}{view_map_str}{o}"
-        else:
-            var_output = f"{prefix}{node.op}{output_idx}{id_str}{type_str}{shape_str}{var_name}{destroy_map_str}{view_map_str}{o}{data}"
-
-        if print_op_info and node not in op_information:
-            op_information.update(op_debug_information(node.op, node))
-
-        node_info = (
-            parent_node and op_information.get(parent_node)
-        ) or op_information.get(node)
-        if node_info and var in node_info and not is_inner_graph_header:
-            var_output = f"{var_output} ({node_info[var]})"
-
-        if profile and profile.apply_time and node in profile.apply_time:
-            op_time = profile.apply_time[node]
-            op_time_percent = (op_time / profile.fct_call_time) * 100
-            tot_time_dict = profile.compute_total_times()
+        if (
+            gnode.profile
+            and gnode.profile.apply_time
+            and gnode.node in gnode.profile.apply_time
+        ):
+            node = gnode.node
+            assert node is not None
+            op_time = gnode.profile.apply_time[node]
+            op_time_percent = (op_time / gnode.profile.fct_call_time) * 100
+            tot_time_dict = gnode.profile.compute_total_times()
             tot_time = tot_time_dict[node]
-            tot_time_percent = (tot_time_dict[node] / profile.fct_call_time) * 100
-
+            tot_time_percent = tot_time_dict[node] / gnode.profile.fct_call_time * 100
             print(
-                f"{var_output} --> {op_time:8.2e}s {op_time_percent:4.1f}% {tot_time:8.2e}s {tot_time_percent:4.1f}%",
+                f"{full_prefix}{label} --> {op_time:8.2e}s {op_time_percent:4.1f}%"
+                f" {tot_time:8.2e}s {tot_time_percent:4.1f}%",
                 file=file,
             )
         else:
-            print(var_output, file=file)
-
-        if not already_done and not (
-            stop_on_name and hasattr(var, "name") and var.name is not None
-        ):
-            new_prefix = prefix_child + " ├─ "
-            new_prefix_child = prefix_child + " │ "
-
-            for in_idx, in_var in enumerate(node.inputs):
-                if in_idx == len(node.inputs) - 1:
-                    new_prefix = prefix_child + " └─ "
-                    new_prefix_child = prefix_child + "   "
-
-                if hasattr(in_var, "owner") and hasattr(in_var.owner, "op"):
-                    if (
-                        isinstance(in_var.owner.op, HasInnerGraph)
-                        or (
-                            hasattr(in_var.owner.op, "scalar_op")
-                            and isinstance(in_var.owner.op.scalar_op, HasInnerGraph)
-                        )
-                    ) and in_var not in inner_graph_ops:
-                        inner_graph_ops.append(in_var)
-
-                _debugprint(
-                    in_var,
-                    new_prefix,
-                    depth=depth - 1,
-                    done=_done,
-                    print_type=print_type,
-                    print_shape=print_shape,
-                    file=file,
-                    topo_order=topo_order,
-                    id_type=id_type,
-                    stop_on_name=stop_on_name,
-                    prefix_child=new_prefix_child,
-                    inner_graph_ops=inner_graph_ops,
-                    profile=profile,
-                    inner_to_outer_inputs=inner_to_outer_inputs,
-                    storage_map=storage_map,
-                    used_ids=_used_ids,
-                    op_information=op_information,
-                    parent_node=node,
-                    print_op_info=print_op_info,
-                    print_destroy_map=print_destroy_map,
-                    print_view_map=print_view_map,
-                    inner_graph_node=inner_graph_node,
-                )
-        elif not is_inner_graph_header:
-            print(prefix_child + " └─ ···", file=file)
-    else:
-        id_str = get_id_str(var)
-
-        if id_str:
-            id_str = f" {id_str}"
-
-        if storage_map and var in storage_map:
-            data = f" {storage_map[var]}"
-        else:
-            data = ""
-
-        var_output = f"{prefix}{var}{id_str}{type_str}{shape_str}{data}"
-
-        if print_op_info and var.owner and var.owner not in op_information:
-            op_information.update(op_debug_information(var.owner.op, var.owner))
-
-        if inner_to_outer_inputs is not None and var in inner_to_outer_inputs:
-            outer_var = inner_to_outer_inputs[var]
-
-            if outer_var.owner:
-                outer_id_str = get_id_str(outer_var.owner)
-            else:
-                outer_id_str = get_id_str(outer_var)
-
-            var_output = f"{var_output} -> {outer_id_str}"
-
-        # TODO: This entire approach will only print `Op` info for two levels
-        # of nesting.
-        for node in dict.fromkeys([inner_graph_node, parent_node, var.owner]):
-            node_info = op_information.get(node)
-            if node_info and var in node_info:
-                var_output = f"{var_output} ({node_info[var]})"
-
-        print(var_output, file=file)
+            print(f"{full_prefix}{label}", file=file)
 
     return file
 

--- a/pytensor/printing.py
+++ b/pytensor/printing.py
@@ -1100,9 +1100,9 @@ def _build_rich_tree(
     op_information: dict[Apply, dict[Variable, str]] = {}
     inner_graph_vars: list[Variable] = []
 
-    # Colors assigned to shared (repeated) nodes so canonical and repeat
+    # Colors assigned to shared (repeated) nodes so canonical and sentinel
     # occurrences are visually linked.  Populated lazily when a repeat is seen.
-    _REPEAT_COLORS = ["red", "green", "yellow", "blue", "magenta", "cyan"]
+    _REPEAT_COLORS = ["blue", "cyan", "green", "yellow", "magenta"]
     node_colors: dict = {}  # Apply/Variable key → color string
     # All rich.Tree nodes emitted for a given key (for retroactive coloring).
     node_tree_map: dict = {}  # Apply/Variable key → list[rich.tree.Tree]
@@ -1110,8 +1110,13 @@ def _build_rich_tree(
     def _color_label(label: str, color: str) -> str:
         return f"[{color}]{label}[/{color}]"
 
-    def _repeat_label(label: str) -> str:
-        return f"{label} ···"
+    def _sentinel_label(color: str) -> str:
+        """Style the ··· sentinel child.  Uses a bright_ variant of the parent's
+        color so the sentinel is visually linked but distinct.  Falls back to
+        italic dim alone if the color is already a bright_ variant."""
+        if color.startswith("bright_"):
+            return "[italic dim]···[/italic dim]"
+        return f"[bright_{color} italic dim]···[/bright_{color} italic dim]"
 
     def _assign_color(node_key) -> str:
         """Return the color for node_key, assigning one if needed and
@@ -1132,13 +1137,6 @@ def _build_rich_tree(
         # Depth 0 is the output variable itself (child of root).
         depth_stack: list[rich.tree.Tree] = [root]
 
-        # When a node has already been visited, _iter_graph_nodes yields the
-        # node itself (is_repeat=False) followed immediately by a sentinel
-        # (is_repeat=True) as a synthetic child one level deeper.  We collapse
-        # this pair into a single line by buffering the non-repeat half and
-        # rendering the sentinel at the buffered depth (without a child indent).
-        pending_repeat_parent: GraphNode | None = None
-
         for gnode in _iter_graph_nodes(
             var,
             depth=depth,
@@ -1155,85 +1153,14 @@ def _build_rich_tree(
             node_key = gnode.var.owner if gnode.var.owner is not None else gnode.var
 
             if gnode.is_repeat and not gnode.is_inner_graph_header:
-                if pending_repeat_parent is not None:
-                    # Collapse the buffered parent + this sentinel into one line.
-                    # Use the parent's gnode for the label and depth, but append
-                    # ··· to indicate this is a back-reference.
-                    label = _build_label(
-                        pending_repeat_parent,
-                        done=done,
-                        used_ids=used_ids,
-                        id_type=id_type,
-                        print_type=print_type,
-                        print_shape=print_shape,
-                        print_destroy_map=print_destroy_map,
-                        print_view_map=print_view_map,
-                        print_op_info=print_op_info,
-                        op_information=op_information,
-                    )
-                    label = rich.markup.escape(label)
-                    parent_depth = len(pending_repeat_parent.ancestor_is_last)
-                    pending_repeat_parent = None
-
-                    color = _assign_color(node_key)
-                    label = _color_label(_repeat_label(label), color)
-
-                    parent_tree = depth_stack[parent_depth]
-                    child_tree = parent_tree.add(label)
-                    # Sentinel is a leaf; no need to push onto depth_stack.
-                    continue
-
-                # Fallback: no pending parent (shouldn't occur in normal graphs).
-                label = _build_label(
-                    gnode,
-                    done=done,
-                    used_ids=used_ids,
-                    id_type=id_type,
-                    print_type=print_type,
-                    print_shape=print_shape,
-                    print_destroy_map=print_destroy_map,
-                    print_view_map=print_view_map,
-                    print_op_info=print_op_info,
-                    op_information=op_information,
-                )
-                label = rich.markup.escape(label)
+                # Assign/retrieve color for this shared node, retroactively
+                # coloring all canonical occurrences emitted so far.
                 color = _assign_color(node_key)
-                label = _color_label(_repeat_label(label), color)
+                # Sentinel child: just ··· styled as bright_<color> italic dim.
                 parent_tree = depth_stack[current_depth]
-                child_tree = parent_tree.add(label)
-                depth_stack = [*depth_stack[: current_depth + 1], child_tree]
+                parent_tree.add(_sentinel_label(color))
+                # Sentinel is a leaf; no depth_stack push needed.
                 continue
-
-            # Flush any pending repeat parent that was NOT followed by a sentinel
-            # (defensive; should not happen with current _iter_graph_nodes).
-            if pending_repeat_parent is not None:
-                flush_gnode = pending_repeat_parent
-                pending_repeat_parent = None
-                flush_depth = len(flush_gnode.ancestor_is_last)
-                flush_label = _build_label(
-                    flush_gnode,
-                    done=done,
-                    used_ids=used_ids,
-                    id_type=id_type,
-                    print_type=print_type,
-                    print_shape=print_shape,
-                    print_destroy_map=print_destroy_map,
-                    print_view_map=print_view_map,
-                    print_op_info=print_op_info,
-                    op_information=op_information,
-                )
-                flush_label = rich.markup.escape(flush_label)
-                flush_key = (
-                    flush_gnode.var.owner
-                    if flush_gnode.var.owner is not None
-                    else flush_gnode.var
-                )
-                if flush_key in node_colors:
-                    flush_label = _color_label(flush_label, node_colors[flush_key])
-                flush_parent = depth_stack[flush_depth]
-                flush_child = flush_parent.add(flush_label)
-                node_tree_map.setdefault(flush_key, []).append(flush_child)
-                depth_stack = [*depth_stack[: flush_depth + 1], flush_child]
 
             label = _build_label(
                 gnode,
@@ -1253,15 +1180,6 @@ def _build_rich_tree(
             if node_key in node_colors:
                 # Already known to be shared; color immediately.
                 label = _color_label(label, node_colors[node_key])
-
-            # Check if this non-repeat node is already in node_tree_map, which
-            # means it has been emitted before and will be followed by a sentinel.
-            # Buffer it instead of adding to the tree immediately.
-            # Only Apply nodes (var.owner is not None) get sentinels; leaf
-            # variables are always rendered directly.
-            if node_key in node_tree_map and gnode.var.owner is not None:
-                pending_repeat_parent = gnode
-                continue
 
             parent_tree = depth_stack[current_depth]
             child_tree = parent_tree.add(label)

--- a/pytensor/printing.py
+++ b/pytensor/printing.py
@@ -974,7 +974,7 @@ def _debugprint(
             base = prefix
         else:
             col_bars = "".join(
-                "   " if last else " │ " for last in gnode.ancestor_is_last
+                "   " if last else " │ " for last in gnode.ancestor_is_last[1:]
             )
             connector = " └─ " if gnode.is_last_child else " ├─ "
             base = prefix_child if has_child_offset else prefix

--- a/pytensor/printing.py
+++ b/pytensor/printing.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Literal, TextIO
 
 import numpy as np
+import rich.tree
 
 from pytensor.compile import SharedVariable
 from pytensor.compile.debug.profiling import ProfileStats
@@ -457,7 +458,7 @@ def debugprint(
     depth: int = -1,
     print_type: bool = False,
     print_shape: bool = False,
-    file: Literal["str"] | TextIO | None = None,
+    file: Literal["str", "rich"] | TextIO | None = None,
     id_type: IDTypesType = "CHAR",
     stop_on_name: bool = False,
     done: dict[Literal["output"] | Variable | Apply, str] | None = None,
@@ -468,7 +469,7 @@ def debugprint(
     print_view_map: bool = False,
     print_memory_map: bool = False,
     print_fgraph_inputs: bool = False,
-) -> str | TextIO:
+) -> "str | TextIO | rich.tree.Tree":
     r"""Print a graph as text.
 
     Each line printed represents a `Variable` in a graph.
@@ -497,7 +498,8 @@ def debugprint(
     file
         When `file` extends `TextIO`, print to it; when `file` is
         equal to ``"str"``, return a string; when `file` is ``None``, print to
-        `sys.stdout`.
+        `sys.stdout`; when `file` is ``"rich"``, return a ``rich.tree.Tree``
+        that can be rendered with ``rich.print()``.
     id_type
         Determines the type of identifier used for `Variable`\s:
           - ``"id"``: print the python id value,
@@ -531,7 +533,9 @@ def debugprint(
 
     Returns
     -------
-    A string representing the printed graph, if `file` is a string, else `file`.
+    A string representing the printed graph if ``file="str"``, a
+    ``rich.tree.Tree`` if ``file="rich"``, otherwise `file` (or ``None``
+    when printing to stdout).
 
     """
     if not isinstance(depth, int):
@@ -539,6 +543,8 @@ def debugprint(
 
     if file == "str":
         _file: TextIO | StringIO = StringIO()
+    elif file == "rich":
+        _file = sys.stdout  # placeholder; early return below will bypass text path
     elif file is None:
         _file = sys.stdout
     else:
@@ -608,6 +614,22 @@ def debugprint(
             topo_orders.append(None)
         else:
             raise TypeError(f"debugprint cannot print an object type {type(obj)}")
+
+    if file == "rich":
+        return _build_rich_tree(
+            outputs_to_print,
+            depth=depth,
+            id_type=id_type,
+            print_type=print_type,
+            print_shape=print_shape,
+            print_destroy_map=print_destroy_map,
+            print_view_map=print_view_map,
+            print_op_info=print_op_info,
+            stop_on_name=stop_on_name,
+            topo_orders=topo_orders,
+            profiles=profile_list,
+            storage_maps=storage_maps,
+        )
 
     inner_graph_vars: list[Variable] = []
 
@@ -997,6 +1019,219 @@ def _debugprint(
             print(f"{full_prefix}{label}", file=file)
 
     return file
+
+
+def _build_rich_tree(
+    outputs: list[Variable],
+    depth: int = -1,
+    id_type: IDTypesType = "CHAR",
+    print_type: bool = False,
+    print_shape: bool = False,
+    print_destroy_map: bool = False,
+    print_view_map: bool = False,
+    print_op_info: bool = False,
+    stop_on_name: bool = False,
+    topo_orders: list[Sequence[Apply] | None] | None = None,
+    profiles: list | None = None,
+    storage_maps: list | None = None,
+) -> rich.tree.Tree:
+    """Build a ``rich.Tree`` for one or more output `Variable`s.
+
+    Returns a single ``rich.Tree`` with ``hide_root=True`` when there are
+    multiple outputs (so the invisible root holds sibling output trees), or
+    a plain tree when there is exactly one output.
+
+    Parameters
+    ----------
+    outputs
+        List of root `Variable`s to render.
+    depth, id_type, print_type, print_shape, print_destroy_map,
+    print_view_map, print_op_info, stop_on_name
+        Same semantics as the identically-named parameters of `debugprint`.
+    topo_orders, profiles, storage_maps
+        Per-output metadata lists; ``None`` entries mean "not available".
+    """
+    import rich.markup
+
+    if topo_orders is None:
+        topo_orders = [None] * len(outputs)
+    if profiles is None:
+        profiles = [None] * len(outputs)
+    if storage_maps is None:
+        storage_maps = [None] * len(outputs)
+
+    done: dict = {}
+    used_ids: dict = {}
+    op_information: dict[Apply, dict[Variable, str]] = {}
+    inner_graph_vars: list[Variable] = []
+
+    root = rich.tree.Tree("", hide_root=True)
+
+    for var, topo_order, profile, storage_map in zip(
+        outputs, topo_orders, profiles, storage_maps, strict=True
+    ):
+        # Stack maps traversal depth → rich.Tree node at that depth.
+        # Depth 0 is the output variable itself (child of root).
+        depth_stack: list[rich.tree.Tree] = [root]
+
+        for gnode in _iter_graph_nodes(
+            var,
+            depth=depth,
+            done=done,
+            stop_on_name=stop_on_name,
+            inner_graph_ops=inner_graph_vars,
+            topo_order=topo_order,
+            profile=profile,
+            storage_map=storage_map,
+            ancestor_is_last=[],
+            is_last_child=True,
+        ):
+            current_depth = len(gnode.ancestor_is_last)
+
+            label = _build_label(
+                gnode,
+                done=done,
+                used_ids=used_ids,
+                id_type=id_type,
+                print_type=print_type,
+                print_shape=print_shape,
+                print_destroy_map=print_destroy_map,
+                print_view_map=print_view_map,
+                print_op_info=print_op_info,
+                op_information=op_information,
+            )
+
+            label = rich.markup.escape(label)
+            if gnode.is_repeat and not gnode.is_inner_graph_header:
+                label = f"[dim]{label} ···[/dim]"
+
+            parent_tree = depth_stack[current_depth]
+            child_tree = parent_tree.add(label)
+            # Trim the stack to this depth and push the new node.
+            depth_stack = [*depth_stack[: current_depth + 1], child_tree]
+
+    if inner_graph_vars:
+        inner_root = root.add("[bold]Inner graphs:[/bold]")
+        printed = set()
+        for ig_var in inner_graph_vars:
+            if ig_var.owner in printed:
+                continue
+            printed.add(ig_var.owner)
+
+            inner_fn = getattr(ig_var.owner.op, "_fn", None)
+            if inner_fn:
+                inner_inputs = inner_fn.maker.fgraph.inputs
+                inner_outputs = inner_fn.maker.fgraph.outputs
+            else:
+                if hasattr(ig_var.owner.op, "scalar_op"):
+                    inner_inputs = ig_var.owner.op.scalar_op.inner_inputs
+                    inner_outputs = ig_var.owner.op.scalar_op.inner_outputs
+                else:
+                    inner_inputs = ig_var.owner.op.inner_inputs
+                    inner_outputs = ig_var.owner.op.inner_outputs
+
+            outer_inputs = ig_var.owner.inputs
+            inner_to_outer: dict[Variable, Variable] | None
+            if hasattr(ig_var.owner.op, "get_oinp_iinp_iout_oout_mappings"):
+                inner_to_outer = {
+                    inner_inputs[i]: outer_inputs[o]
+                    for i, o in ig_var.owner.op.get_oinp_iinp_iout_oout_mappings()[
+                        "outer_inp_from_inner_inp"
+                    ].items()
+                }
+            else:
+                inner_to_outer = None
+
+            if print_op_info:
+                op_information.update(
+                    op_debug_information(ig_var.owner.op, ig_var.owner)
+                )
+
+            # Header node for the inner graph op
+            ig_depth_stack: list[rich.tree.Tree] = [inner_root]
+            for gnode in _iter_graph_nodes(
+                ig_var,
+                depth=depth,
+                done=done,
+                stop_on_name=stop_on_name,
+                inner_graph_ops=inner_graph_vars,
+                inner_to_outer=inner_to_outer,
+                parent_node=ig_var.owner,
+                inner_graph_node=ig_var.owner,
+                is_inner_graph_header=True,
+                ancestor_is_last=[],
+                is_last_child=True,
+            ):
+                current_depth = len(gnode.ancestor_is_last)
+                label = _build_label(
+                    gnode,
+                    done=done,
+                    used_ids=used_ids,
+                    id_type=id_type,
+                    print_type=print_type,
+                    print_shape=print_shape,
+                    print_destroy_map=print_destroy_map,
+                    print_view_map=print_view_map,
+                    print_op_info=print_op_info,
+                    op_information=op_information,
+                )
+                label = rich.markup.escape(label)
+                if gnode.is_repeat and not gnode.is_inner_graph_header:
+                    label = f"[dim]{label} ···[/dim]"
+                parent_tree = ig_depth_stack[current_depth]
+                child_tree = parent_tree.add(label)
+                ig_depth_stack = [*ig_depth_stack[: current_depth + 1], child_tree]
+
+            # The header tree node is the first child of inner_root
+            header_tree = inner_root.children[-1]
+
+            for out in inner_outputs:
+                if (
+                    out.owner is not None
+                    and (
+                        isinstance(out.owner.op, HasInnerGraph)
+                        or isinstance(
+                            getattr(out.owner.op, "scalar_op", None), HasInnerGraph
+                        )
+                    )
+                    and out not in inner_graph_vars
+                ):
+                    inner_graph_vars.append(out)
+
+                out_stack: list[rich.tree.Tree] = [header_tree]
+                for gnode in _iter_graph_nodes(
+                    out,
+                    depth=depth,
+                    done=done,
+                    stop_on_name=stop_on_name,
+                    inner_graph_ops=inner_graph_vars,
+                    inner_to_outer=inner_to_outer,
+                    parent_node=ig_var.owner,
+                    inner_graph_node=ig_var.owner,
+                    ancestor_is_last=[],
+                    is_last_child=True,
+                ):
+                    current_depth = len(gnode.ancestor_is_last)
+                    label = _build_label(
+                        gnode,
+                        done=done,
+                        used_ids=used_ids,
+                        id_type=id_type,
+                        print_type=print_type,
+                        print_shape=print_shape,
+                        print_destroy_map=print_destroy_map,
+                        print_view_map=print_view_map,
+                        print_op_info=print_op_info,
+                        op_information=op_information,
+                    )
+                    label = rich.markup.escape(label)
+                    if gnode.is_repeat and not gnode.is_inner_graph_header:
+                        label = f"[dim]{label} ···[/dim]"
+                    parent_tree = out_stack[current_depth]
+                    child_tree = parent_tree.add(label)
+                    out_stack = [*out_stack[: current_depth + 1], child_tree]
+
+    return root
 
 
 def _print_fn(op, xin):

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -497,3 +497,120 @@ def test_summary_with_profile_optimizer():
     s = StringIO()
     f.profile.summary(file=s)
     assert "Rewriter Profile" in s.getvalue()
+
+
+class TestDebugprintRich:
+    """Tests for debugprint(..., file="rich").
+
+    We test PyTensor's tree-building contract only — not Rich's rendering.
+    Rich's own test suite covers rendering; our job is to verify that we
+    construct the right tree structure and don't crash on various graph shapes.
+    """
+
+    def test_return_type(self):
+        import rich.tree
+
+        x = dvector("x")
+        tree = debugprint(x.sum(), file="rich")
+        assert isinstance(tree, rich.tree.Tree)
+
+    def test_single_output_has_one_child(self):
+        # One output variable → the hidden root should have exactly one child.
+        x = dvector("x")
+        tree = debugprint(x.sum(), file="rich")
+        assert len(tree.children) == 1
+
+    def test_multiple_outputs_have_multiple_children(self):
+        # Two output variables → the hidden root has two children.
+        x = dvector("x")
+        mean = x.mean()
+        std = x.std()
+        tree = debugprint([mean, std], file="rich")
+        assert len(tree.children) == 2
+
+    def test_linear_graph(self):
+        # sum(x * 2): root → sum_node → mul_node → [x_leaf, 2_leaf]
+        x = dvector("x")
+        y = (x * 2).sum()
+        tree = debugprint(y, file="rich")
+        sum_node = tree.children[0]
+        mul_node = sum_node.children[0]
+        assert len(mul_node.children) == 2
+
+    def test_named_var(self):
+        # Named intermediate: the label of the mul node contains its name.
+        x = dvector("x")
+        y = x * 2
+        y.name = "doubled"
+        tree = debugprint(y.sum(), file="rich")
+        mul_node = tree.children[0].children[0]
+        assert "doubled" in str(mul_node.label)
+
+    def test_dag_shared_leaf(self):
+        # x + x: the add node has two children, both representing x.
+        x = dvector("x")
+        tree = debugprint(x + x, file="rich")
+        add_node = tree.children[0]
+        assert len(add_node.children) == 2
+
+    def test_diamond_dag(self):
+        # (x*2) + (x+1): add has two children; each has x as a child,
+        # but the second occurrence of x is a repeat (still a child node).
+        x = dvector("x")
+        a = x * 2
+        b = x + 1
+        tree = debugprint(a + b, file="rich")
+        add_node = tree.children[0]
+        assert len(add_node.children) == 2
+        # Each branch (mul, add) has x as a child.
+        assert len(add_node.children[0].children) >= 1
+        assert len(add_node.children[1].children) >= 1
+
+    def test_depth_limit(self):
+        # depth=1: the root op node is present but its inputs are not expanded.
+        x = dvector("x")
+        y = (x * 2).sum()
+        tree = debugprint(y, depth=1, file="rich")
+        sum_node = tree.children[0]
+        assert len(sum_node.children) == 0
+
+    def test_stop_on_name(self):
+        # stop_on_name=True: traversal stops when it hits the named leaf x,
+        # so the mul node's child (x) has no further children.
+        x = dvector("x")
+        x.name = "x"
+        tree = debugprint((x * 2).sum(), stop_on_name=True, file="rich")
+        sum_node = tree.children[0]
+        mul_node = sum_node.children[0]
+        x_node = mul_node.children[0]
+        assert len(x_node.children) == 0
+
+    def test_print_type(self):
+        # print_type=True: the type annotation appears in the root op's label.
+        x = dvector("x")
+        tree = debugprint(x.sum(), print_type=True, file="rich")
+        sum_node = tree.children[0]
+        assert "<" in str(sum_node.label)
+
+    def test_function_graph(self):
+        # FunctionGraph: one output → one child under the hidden root.
+        from pytensor.graph.fg import FunctionGraph
+
+        x = dvector("x")
+        y = x.sum()
+        fg = FunctionGraph([x], [y])
+        tree = debugprint(fg, file="rich")
+        assert len(tree.children) == 1
+
+    def test_inner_graph_op(self):
+        # HasInnerGraph op: the output node is the single root child, with its
+        # two inputs as children.
+        igo_in_1, igo_in_2 = MyVariable("x"), MyVariable("y")
+        igo_out = MyOp("op")(igo_in_1, igo_in_2)
+        op = MyInnerGraphOp([igo_in_1, igo_in_2], [igo_out])
+        a, b = MyVariable("a"), MyVariable("b")
+        out = op(a, b)
+        tree = debugprint(out, file="rich")
+        assert len(tree.children) == 1
+        op_node = tree.children[0]
+        assert len(op_node.children) == 2

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -605,14 +605,66 @@ class TestDebugprintRich:
         assert len(tree.children) == 1
 
     def test_inner_graph_op(self):
-        # HasInnerGraph op: the output node is the single root child, with its
-        # two inputs as children.
+        # HasInnerGraph op: root has two children — the op node and the
+        # "Inner graphs:" section. The op node has the two outer inputs as children.
         igo_in_1, igo_in_2 = MyVariable("x"), MyVariable("y")
         igo_out = MyOp("op")(igo_in_1, igo_in_2)
         op = MyInnerGraphOp([igo_in_1, igo_in_2], [igo_out])
         a, b = MyVariable("a"), MyVariable("b")
         out = op(a, b)
         tree = debugprint(out, file="rich")
-        assert len(tree.children) == 1
+        assert len(tree.children) == 2  # op node + "Inner graphs:" section
         op_node = tree.children[0]
         assert len(op_node.children) == 2
+
+    def test_opfromgraph_expands_inner_graph(self):
+        # OpFromGraph should produce an "Inner graphs:" section as a second
+        # top-level child of the hidden root, matching the text renderer.
+        from pytensor.compile.builders import OpFromGraph
+
+        x = dvector("x")
+        out = OpFromGraph([x], [x.std()])(x)
+        tree = debugprint(out, file="rich")
+        # root child 0: the op node; root child 1: "Inner graphs:" section
+        assert len(tree.children) == 2
+        inner_section = tree.children[1]
+        assert len(inner_section.children) >= 1
+
+    def test_repeated_node_no_duplication(self):
+        # When a node is repeated, it should appear as a single labeled line
+        # with ··· appended (not as a parent line with a ··· child beneath it).
+        x = dvector("x")
+        shared = x * 2
+        tree = debugprint(shared + shared, file="rich")
+        add_node = tree.children[0]
+        # The add has two children: canonical Mul and sentinel Mul ···
+        assert len(add_node.children) == 2
+        sentinel = add_node.children[1]
+        # The sentinel should have ··· in its label and NO children of its own
+        assert "···" in str(sentinel.label), (
+            f"Expected '···' in sentinel label, got: {sentinel.label!r}"
+        )
+        assert len(sentinel.children) == 0, (
+            f"Sentinel should be a leaf, but has children: {sentinel.children}"
+        )
+
+    def test_repeated_nodes_same_color(self):
+        # A shared Apply node appears once canonically and once as a ··· sentinel
+        # on the same level.  Both should carry the same Rich color markup so the
+        # user can visually trace where the shared subgraph comes from.
+        import re
+
+        x = dvector("x")
+        shared = x * 2
+        tree = debugprint(shared + shared, file="rich")
+        add_node = tree.children[0]
+        canonical_mul = add_node.children[0]  # Mul [id B]  (colored)
+        repeat_mul = add_node.children[1]  # Mul [id B] ···  (colored, no children)
+        color_re = re.compile(r"\[(\w+)\]")
+        canonical_colors = color_re.findall(str(canonical_mul.label))
+        repeat_colors = color_re.findall(str(repeat_mul.label))
+        assert canonical_colors, "canonical shared node should have a color tag"
+        assert repeat_colors, "repeat shared node should have a color tag"
+        assert canonical_colors[0] == repeat_colors[0], (
+            "canonical and repeat occurrences of the same node should share a color"
+        )

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -629,73 +629,45 @@ class TestDebugprintRich:
         inner_section = tree.children[1]
         assert len(inner_section.children) >= 1
 
-    def test_inner_graph_nodes_are_dimmed(self):
-        # The "Inner graphs:" header and all nodes within it should carry [dim]
-        # markup so the inner-graph section has lower visual contrast than the
-        # outer graph, making it easier to focus on the main computation.
+    def test_inner_graph_header_is_bold(self):
+        # The "Inner graphs:" header should be bold.
         x = dvector("x")
         out = OpFromGraph([x], [x.std()])(x)
         tree = debugprint(out, file="rich")
         inner_section = tree.children[1]
-        # Header label should be dim
-        assert "dim" in str(inner_section.label), (
-            f"'Inner graphs:' header should have dim markup, got: {inner_section.label!r}"
-        )
-
-        # All nodes beneath the header should also be dim
-        def collect_labels(node):
-            return [str(node.label)] + [
-                lbl for child in node.children for lbl in collect_labels(child)
-            ]
-
-        inner_labels = collect_labels(inner_section)
-        non_dim = [lbl for lbl in inner_labels[1:] if "dim" not in lbl]
-        assert not non_dim, (
-            f"All inner-graph node labels should have dim markup, but these do not: {non_dim}"
+        assert "bold" in str(inner_section.label), (
+            f"'Inner graphs:' header should have bold markup, got: {inner_section.label!r}"
         )
 
     def test_repeated_node_no_duplication(self):
-        # A repeated node renders canonically the first time (with full children)
-        # and as a colored stub the second time, with ··· as its only child.
+        # The second occurrence of a shared node is replaced by a colored ···
+        # sentinel directly — no repeated label, no nesting.
         x = dvector("x")
         shared = x * 2
         tree = debugprint(shared + shared, file="rich")
         add_node = tree.children[0]
-        # The add has two children: canonical Mul and second Mul occurrence
+        # The add has two children: canonical Mul and the ··· sentinel
         assert len(add_node.children) == 2
-        second_mul = add_node.children[1]
-        # The second occurrence has exactly one child: the ··· sentinel
-        assert len(second_mul.children) == 1, (
-            f"Second occurrence should have exactly one (sentinel) child, got: {second_mul.children}"
-        )
-        sentinel = second_mul.children[0]
+        sentinel = add_node.children[1]
         assert "···" in str(sentinel.label), (
-            f"Expected '···' in sentinel label, got: {sentinel.label!r}"
+            f"Expected '···' sentinel as second child of add, got: {sentinel.label!r}"
         )
         assert len(sentinel.children) == 0, (
             f"Sentinel should be a leaf, but has children: {sentinel.children}"
         )
 
     def test_repeated_nodes_same_color(self):
-        # Both the canonical occurrence and the second (stub) occurrence of a
-        # shared node should carry the same Rich color markup so the user can
-        # visually trace where the shared subgraph comes from.
+        # The canonical occurrence should be colored, and the ··· sentinel that
+        # replaces the second occurrence should share the same color family.
         x = dvector("x")
         shared = x * 2
         tree = debugprint(shared + shared, file="rich")
         add_node = tree.children[0]
         canonical_mul = add_node.children[0]  # Mul [id B]  (colored, full children)
-        second_mul = add_node.children[1]  # Mul [id B]  (colored, ··· child only)
+        sentinel = add_node.children[1]  # ··· colored sentinel
         color_re = re.compile(r"\[(\w+)\]")
         canonical_colors = color_re.findall(str(canonical_mul.label))
-        second_colors = color_re.findall(str(second_mul.label))
         assert canonical_colors, "canonical shared node should have a color tag"
-        assert second_colors, "second occurrence of shared node should have a color tag"
-        assert canonical_colors[0] == second_colors[0], (
-            "canonical and second occurrences of the same node should share a color"
-        )
-        # The sentinel child beneath the second occurrence uses a bright_ variant.
-        sentinel = second_mul.children[0]
         assert "bright_" in str(sentinel.label), (
             f"Sentinel should use a bright_ color, got: {sentinel.label!r}"
         )
@@ -741,43 +713,42 @@ class TestDebugprintRich:
         console.print(tree)  # raises MarkupError if escaping is broken
 
     def test_deep_shared_node_sentinel_depth(self):
-        # A shared node at depth > 1 should have its ··· sentinel as a child of
-        # its own stub entry, not misplaced at the wrong level in the tree.
+        # A shared node at depth > 1 should place its ··· sentinel directly at
+        # the node's slot in the tree, not at the wrong level.
         x = dvector("x")
         shared = x * 2  # will appear at depth 2 (grandchild of add)
         out = shared.sum() + shared.mean()
         tree = debugprint(out, file="rich")
         add_node = tree.children[0]
-        # Second branch is mean (True_div); its Sum child wraps the shared Mul stub.
+        # Second branch is mean (True_div); its Sum child has the ··· sentinel.
         mean_node = add_node.children[1]  # True_div 'mean'
-        sum_under_mean = mean_node.children[0]  # Sum wrapping the shared Mul
-        shared_stub = sum_under_mean.children[0]  # colored Mul stub
-        assert "···" not in str(shared_stub.label), (
-            "The stub label itself should not contain ···; sentinel must be a child"
+        sum_under_mean = mean_node.children[0]  # Sum
+        sentinel = sum_under_mean.children[0]  # ··· sentinel directly
+        assert "···" in str(sentinel.label), (
+            f"Expected ··· sentinel as child of Sum, got: {sentinel.label!r}"
         )
-        assert len(shared_stub.children) == 1, (
-            f"Stub should have exactly one child (sentinel), got: {shared_stub.children}"
-        )
-        assert "···" in str(shared_stub.children[0].label)
+        assert len(sentinel.children) == 0, "Sentinel should be a leaf"
 
     def test_shared_node_colored_across_outputs(self):
-        # A node shared between two separate outputs should be colored in both
-        # output subtrees, since node_colors and node_tree_map span all outputs.
+        # A node shared between two separate outputs should produce a colored
+        # canonical label in the first subtree and a colored ··· sentinel in the
+        # second, since node_colors spans all outputs.
         x = dvector("x")
         shared = x * 2
         tree = debugprint([shared.sum(), shared.mean()], file="rich")
-        color_re = re.compile(r"\[(\w+)\]")
 
-        def find_colored_labels(node):
-            labels = []
-            if color_re.search(str(node.label)):
-                labels.append(str(node.label))
+        def find_sentinel_and_colored(node):
+            results = []
+            label = str(node.label)
+            if re.search(r"\[(\w+)\]", label) or "···" in label:
+                results.append(label)
             for child in node.children:
-                labels.extend(find_colored_labels(child))
-            return labels
+                results.extend(find_sentinel_and_colored(child))
+            return results
 
-        colored = find_colored_labels(tree)
-        # The shared Mul node appears at least twice with a color tag.
-        assert len(colored) >= 2, (
-            f"Expected shared node colored in both output subtrees, got: {colored}"
-        )
+        found = find_sentinel_and_colored(tree)
+        # At minimum: one colored canonical Mul and one ··· sentinel
+        colored = [l for l in found if re.search(r"\[(\w+)\]", l) and "···" not in l]
+        sentinels = [l for l in found if "···" in l]
+        assert colored, "canonical shared node should be colored"
+        assert sentinels, "second occurrence should produce a ··· sentinel"

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -13,6 +13,7 @@ import pytest
 
 import pytensor
 from pytensor import config
+from pytensor.compile.builders import OpFromGraph
 from pytensor.compile.debug.profiling import ProfileStats
 from pytensor.compile.mode import get_mode
 from pytensor.compile.ops import deep_copy_op
@@ -620,8 +621,6 @@ class TestDebugprintRich:
     def test_opfromgraph_expands_inner_graph(self):
         # OpFromGraph should produce an "Inner graphs:" section as a second
         # top-level child of the hidden root, matching the text renderer.
-        from pytensor.compile.builders import OpFromGraph
-
         x = dvector("x")
         out = OpFromGraph([x], [x.std()])(x)
         tree = debugprint(out, file="rich")
@@ -629,6 +628,31 @@ class TestDebugprintRich:
         assert len(tree.children) == 2
         inner_section = tree.children[1]
         assert len(inner_section.children) >= 1
+
+    def test_inner_graph_nodes_are_dimmed(self):
+        # The "Inner graphs:" header and all nodes within it should carry [dim]
+        # markup so the inner-graph section has lower visual contrast than the
+        # outer graph, making it easier to focus on the main computation.
+        x = dvector("x")
+        out = OpFromGraph([x], [x.std()])(x)
+        tree = debugprint(out, file="rich")
+        inner_section = tree.children[1]
+        # Header label should be dim
+        assert "dim" in str(inner_section.label), (
+            f"'Inner graphs:' header should have dim markup, got: {inner_section.label!r}"
+        )
+
+        # All nodes beneath the header should also be dim
+        def collect_labels(node):
+            return [str(node.label)] + [
+                lbl for child in node.children for lbl in collect_labels(child)
+            ]
+
+        inner_labels = collect_labels(inner_section)
+        non_dim = [lbl for lbl in inner_labels[1:] if "dim" not in lbl]
+        assert not non_dim, (
+            f"All inner-graph node labels should have dim markup, but these do not: {non_dim}"
+        )
 
     def test_repeated_node_no_duplication(self):
         # A repeated node renders canonically the first time (with full children)

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -631,16 +631,20 @@ class TestDebugprintRich:
         assert len(inner_section.children) >= 1
 
     def test_repeated_node_no_duplication(self):
-        # When a node is repeated, it should appear as a single labeled line
-        # with ··· appended (not as a parent line with a ··· child beneath it).
+        # A repeated node renders canonically the first time (with full children)
+        # and as a colored stub the second time, with ··· as its only child.
         x = dvector("x")
         shared = x * 2
         tree = debugprint(shared + shared, file="rich")
         add_node = tree.children[0]
-        # The add has two children: canonical Mul and sentinel Mul ···
+        # The add has two children: canonical Mul and second Mul occurrence
         assert len(add_node.children) == 2
-        sentinel = add_node.children[1]
-        # The sentinel should have ··· in its label and NO children of its own
+        second_mul = add_node.children[1]
+        # The second occurrence has exactly one child: the ··· sentinel
+        assert len(second_mul.children) == 1, (
+            f"Second occurrence should have exactly one (sentinel) child, got: {second_mul.children}"
+        )
+        sentinel = second_mul.children[0]
         assert "···" in str(sentinel.label), (
             f"Expected '···' in sentinel label, got: {sentinel.label!r}"
         )
@@ -649,22 +653,27 @@ class TestDebugprintRich:
         )
 
     def test_repeated_nodes_same_color(self):
-        # A shared Apply node appears once canonically and once as a ··· sentinel
-        # on the same level.  Both should carry the same Rich color markup so the
-        # user can visually trace where the shared subgraph comes from.
+        # Both the canonical occurrence and the second (stub) occurrence of a
+        # shared node should carry the same Rich color markup so the user can
+        # visually trace where the shared subgraph comes from.
         import re
 
         x = dvector("x")
         shared = x * 2
         tree = debugprint(shared + shared, file="rich")
         add_node = tree.children[0]
-        canonical_mul = add_node.children[0]  # Mul [id B]  (colored)
-        repeat_mul = add_node.children[1]  # Mul [id B] ···  (colored, no children)
+        canonical_mul = add_node.children[0]  # Mul [id B]  (colored, full children)
+        second_mul = add_node.children[1]  # Mul [id B]  (colored, ··· child only)
         color_re = re.compile(r"\[(\w+)\]")
         canonical_colors = color_re.findall(str(canonical_mul.label))
-        repeat_colors = color_re.findall(str(repeat_mul.label))
+        second_colors = color_re.findall(str(second_mul.label))
         assert canonical_colors, "canonical shared node should have a color tag"
-        assert repeat_colors, "repeat shared node should have a color tag"
-        assert canonical_colors[0] == repeat_colors[0], (
-            "canonical and repeat occurrences of the same node should share a color"
+        assert second_colors, "second occurrence of shared node should have a color tag"
+        assert canonical_colors[0] == second_colors[0], (
+            "canonical and second occurrences of the same node should share a color"
+        )
+        # The sentinel child beneath the second occurrence uses a bright_ variant.
+        sentinel = second_mul.children[0]
+        assert "bright_" in str(sentinel.label), (
+            f"Sentinel should use a bright_ color, got: {sentinel.label!r}"
         )

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -657,19 +657,18 @@ class TestDebugprintRich:
         )
 
     def test_repeated_nodes_same_color(self):
-        # The canonical occurrence should be colored, and the ··· sentinel that
-        # replaces the second occurrence should share the same color family.
+        # The canonical occurrence should be colored; the ··· sentinel is plain text.
         x = dvector("x")
         shared = x * 2
         tree = debugprint(shared + shared, file="rich")
         add_node = tree.children[0]
         canonical_mul = add_node.children[0]  # Mul [id B]  (colored, full children)
-        sentinel = add_node.children[1]  # ··· colored sentinel
+        sentinel = add_node.children[1]  # ··· plain sentinel
         color_re = re.compile(r"\[(\w+)\]")
         canonical_colors = color_re.findall(str(canonical_mul.label))
         assert canonical_colors, "canonical shared node should have a color tag"
-        assert "bright_" in str(sentinel.label), (
-            f"Sentinel should use a bright_ color, got: {sentinel.label!r}"
+        assert str(sentinel.label) == "···", (
+            f"Sentinel should be plain '···', got: {sentinel.label!r}"
         )
 
     def test_two_distinct_shared_nodes_get_different_colors(self):

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -507,6 +507,8 @@ class TestDebugprintRich:
     construct the right tree structure and don't crash on various graph shapes.
     """
 
+    rich = pytest.importorskip("rich")
+
     def test_return_type(self):
         import rich.tree
 

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -640,35 +640,51 @@ class TestDebugprintRich:
         )
 
     def test_repeated_node_no_duplication(self):
-        # The second occurrence of a shared node is replaced by a colored ···
-        # sentinel directly — no repeated label, no nesting.
+        # The second occurrence of a shared node shows its colored label with
+        # ··· as a child — no full subtree expansion.
         x = dvector("x")
         shared = x * 2
         tree = debugprint(shared + shared, file="rich")
         add_node = tree.children[0]
-        # The add has two children: canonical Mul and the ··· sentinel
+        # The add has two children: canonical Mul (full subtree) and repeat Mul (··· child)
         assert len(add_node.children) == 2
-        sentinel = add_node.children[1]
+        repeat_entry = add_node.children[1]
+        assert "···" not in str(repeat_entry.label), (
+            f"Repeat entry label should be the node label, not ···: {repeat_entry.label!r}"
+        )
+        assert len(repeat_entry.children) == 1, (
+            f"Repeat entry should have exactly one child (···), got: {repeat_entry.children}"
+        )
+        sentinel = repeat_entry.children[0]
         assert "···" in str(sentinel.label), (
-            f"Expected '···' sentinel as second child of add, got: {sentinel.label!r}"
+            f"Expected '···' as child of repeat entry, got: {sentinel.label!r}"
         )
-        assert len(sentinel.children) == 0, (
-            f"Sentinel should be a leaf, but has children: {sentinel.children}"
-        )
+        assert len(sentinel.children) == 0, "··· should be a leaf"
 
     def test_repeated_nodes_same_color(self):
-        # The canonical occurrence should be colored; the ··· sentinel is plain text.
+        # The canonical label, the repeat entry label, and the ··· sentinel
+        # should all share the same color.
         x = dvector("x")
         shared = x * 2
         tree = debugprint(shared + shared, file="rich")
         add_node = tree.children[0]
-        canonical_mul = add_node.children[0]  # Mul [id B]  (colored, full children)
-        sentinel = add_node.children[1]  # ··· plain sentinel
+        canonical_mul = add_node.children[0]
+        repeat_entry = add_node.children[1]
+        sentinel = repeat_entry.children[0]
         color_re = re.compile(r"\[(\w+)\]")
         canonical_colors = color_re.findall(str(canonical_mul.label))
+        repeat_colors = color_re.findall(str(repeat_entry.label))
+        sentinel_colors = color_re.findall(str(sentinel.label))
         assert canonical_colors, "canonical shared node should have a color tag"
-        assert str(sentinel.label) == "···", (
-            f"Sentinel should be plain '···', got: {sentinel.label!r}"
+        assert repeat_colors, (
+            f"repeat entry should have a color tag, got: {repeat_entry.label!r}"
+        )
+        assert sentinel_colors, (
+            f"sentinel should have a color tag, got: {sentinel.label!r}"
+        )
+        assert canonical_colors[0] == repeat_colors[0] == sentinel_colors[0], (
+            f"canonical, repeat entry, and sentinel should share the same color: "
+            f"{canonical_colors[0]!r}, {repeat_colors[0]!r}, {sentinel_colors[0]!r}"
         )
 
     def test_two_distinct_shared_nodes_get_different_colors(self):
@@ -712,21 +728,25 @@ class TestDebugprintRich:
         console.print(tree)  # raises MarkupError if escaping is broken
 
     def test_deep_shared_node_sentinel_depth(self):
-        # A shared node at depth > 1 should place its ··· sentinel directly at
-        # the node's slot in the tree, not at the wrong level.
+        # A shared node at depth > 1 should show its colored label with ···
+        # as a child at the correct depth in the tree.
         x = dvector("x")
         shared = x * 2  # will appear at depth 2 (grandchild of add)
         out = shared.sum() + shared.mean()
         tree = debugprint(out, file="rich")
         add_node = tree.children[0]
-        # Second branch is mean (True_div); its Sum child has the ··· sentinel.
+        # Second branch is mean (True_div); its Sum child has the repeat entry.
         mean_node = add_node.children[1]  # True_div 'mean'
         sum_under_mean = mean_node.children[0]  # Sum
-        sentinel = sum_under_mean.children[0]  # ··· sentinel directly
-        assert "···" in str(sentinel.label), (
-            f"Expected ··· sentinel as child of Sum, got: {sentinel.label!r}"
+        repeat_entry = sum_under_mean.children[0]  # colored repeat entry
+        assert len(repeat_entry.children) == 1, (
+            f"Repeat entry should have exactly one child (···), got: {repeat_entry.children}"
         )
-        assert len(sentinel.children) == 0, "Sentinel should be a leaf"
+        sentinel = repeat_entry.children[0]
+        assert "···" in str(sentinel.label), (
+            f"Expected ··· as child of repeat entry, got: {sentinel.label!r}"
+        )
+        assert len(sentinel.children) == 0, "··· should be a leaf"
 
     def test_shared_node_colored_across_outputs(self):
         # A node shared between two separate outputs should produce a colored

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -2,7 +2,9 @@
 Tests of printing functionality
 """
 
+import io
 import logging
+import re
 from io import StringIO
 from textwrap import dedent
 
@@ -510,11 +512,9 @@ class TestDebugprintRich:
     rich = pytest.importorskip("rich")
 
     def test_return_type(self):
-        import rich.tree
-
         x = dvector("x")
         tree = debugprint(x.sum(), file="rich")
-        assert isinstance(tree, rich.tree.Tree)
+        assert isinstance(tree, self.rich.tree.Tree)
 
     def test_single_output_has_one_child(self):
         # One output variable → the hidden root should have exactly one child.
@@ -656,8 +656,6 @@ class TestDebugprintRich:
         # Both the canonical occurrence and the second (stub) occurrence of a
         # shared node should carry the same Rich color markup so the user can
         # visually trace where the shared subgraph comes from.
-        import re
-
         x = dvector("x")
         shared = x * 2
         tree = debugprint(shared + shared, file="rich")
@@ -676,4 +674,86 @@ class TestDebugprintRich:
         sentinel = second_mul.children[0]
         assert "bright_" in str(sentinel.label), (
             f"Sentinel should use a bright_ color, got: {sentinel.label!r}"
+        )
+
+    def test_two_distinct_shared_nodes_get_different_colors(self):
+        # Two independently shared nodes should each get a distinct color so
+        # they can be visually distinguished from one another.
+        x = dvector("x")
+        a = x * 2
+        b = x + 1
+        tree = debugprint((a + b) + (a - b), file="rich")
+        # Walk the tree and collect all color tags used on colored nodes.
+        color_re = re.compile(r"\[(\w+)\]")
+
+        def collect_colors(node):
+            colors = set()
+            m = color_re.findall(str(node.label))
+            if m:
+                colors.add(m[0])
+            for child in node.children:
+                colors |= collect_colors(child)
+            return colors
+
+        colors = collect_colors(tree)
+        # Both shared nodes must have been assigned a color, and they must differ.
+        assert len(colors) >= 2, (
+            f"Expected at least 2 distinct colors for 2 shared nodes, got: {colors}"
+        )
+
+    def test_markup_escaping(self):
+        # If a variable name or op contains Rich markup delimiters like [ or ],
+        # the label must be escaped so rendering does not raise.
+        x = dvector("x")
+        y = x * 2
+        y.name = "result[0]"  # square brackets would break Rich markup if unescaped
+        tree = debugprint(y.sum(), file="rich")
+        # Verify the name is present in the label (escaped form is still readable).
+        mul_node = tree.children[0].children[0]
+        assert "result" in str(mul_node.label)
+        # Verify Rich can render the tree without raising a markup error.
+        buf = io.StringIO()
+        console = self.rich.console.Console(file=buf, highlight=False)
+        console.print(tree)  # raises MarkupError if escaping is broken
+
+    def test_deep_shared_node_sentinel_depth(self):
+        # A shared node at depth > 1 should have its ··· sentinel as a child of
+        # its own stub entry, not misplaced at the wrong level in the tree.
+        x = dvector("x")
+        shared = x * 2  # will appear at depth 2 (grandchild of add)
+        out = shared.sum() + shared.mean()
+        tree = debugprint(out, file="rich")
+        add_node = tree.children[0]
+        # Second branch is mean (True_div); its Sum child wraps the shared Mul stub.
+        mean_node = add_node.children[1]  # True_div 'mean'
+        sum_under_mean = mean_node.children[0]  # Sum wrapping the shared Mul
+        shared_stub = sum_under_mean.children[0]  # colored Mul stub
+        assert "···" not in str(shared_stub.label), (
+            "The stub label itself should not contain ···; sentinel must be a child"
+        )
+        assert len(shared_stub.children) == 1, (
+            f"Stub should have exactly one child (sentinel), got: {shared_stub.children}"
+        )
+        assert "···" in str(shared_stub.children[0].label)
+
+    def test_shared_node_colored_across_outputs(self):
+        # A node shared between two separate outputs should be colored in both
+        # output subtrees, since node_colors and node_tree_map span all outputs.
+        x = dvector("x")
+        shared = x * 2
+        tree = debugprint([shared.sum(), shared.mean()], file="rich")
+        color_re = re.compile(r"\[(\w+)\]")
+
+        def find_colored_labels(node):
+            labels = []
+            if color_re.search(str(node.label)):
+                labels.append(str(node.label))
+            for child in node.children:
+                labels.extend(find_colored_labels(child))
+            return labels
+
+        colored = find_colored_labels(tree)
+        # The shared Mul node appears at least twice with a color tag.
+        assert len(colored) >= 2, (
+            f"Expected shared node colored in both output subtrees, got: {colored}"
         )


### PR DESCRIPTION
Closes #1034

Adds `file="rich"` as a new sentinel to `debugprint`, returning a
`rich.tree.Tree` instead of printing text.

```python
import pytensor.tensor as pt
from pytensor.printing import debugprint
from rich.console import Console

x = pt.vector("x")
tree = debugprint([x.mean(), x.std()], file="rich")

console = Console()
console.print(tree)
```

```
True_div [id A] 'mean'
├── Sum{axes=None} [id B]
│   └── x [id C]
└── Subtensor{i} [id D]
    ├── Cast{float64} [id E]
    │   └── Shape [id F]
    │       └── x [id C]
    └── 0 [id G]
Sqrt [id H] 'std'
└── True_div [id I] 'var'
    ├── Sum{axis=0} [id J]
    │   └── Pow [id K]
    │       ├── Sub [id L]
    │       │   ├── x [id C]
    │       │   └── True_div [id M] 'mean'
    │       │       ├── ExpandDims{axis=0} [id N]
    │       │       │   └── Sum{axis=0} [id O]
    │       │       │       └── x [id C]
    │       │       └── ExpandDims{axis=0} [id P]
    │       │           └── Subtensor{i} [id Q]
    │       │               ├── Cast{float64} [id R]
    │       │               │   └── Shape [id S]
    │       │               │       └── x [id C]
    │       │               └── 0 [id T]
    │       └── ExpandDims{axis=0} [id U]
    │           └── 2.0 [id V]
    └── Subtensor{i} [id W]
        ├── Cast{float64} [id X]
        │   └── Shape [id Y]
        │       └── Pow [id K] ···
        └── 0 [id Z]
```

`rich` is added as a hard dependency. The refactor also extracts
`GraphNode`, `_assign_id`, `_build_label`, and `_iter_graph_nodes` from
the monolithic `_debugprint` function, which both the text and rich
renderers now consume.

The `"rich"` sentinel slots in alongside `"str"` and `None` — the text
output path is unchanged.