### PR TITLE
More rewrites for ExtractDiag

### DIFF
--- a/pytensor/graph/rewriting/utils.py
+++ b/pytensor/graph/rewriting/utils.py
@@ -47,7 +47,7 @@ def rewrite_graph(
         fgraph = graph
     else:
         outputs = [graph] if isinstance(graph, Variable) else graph
-        fgraph = FunctionGraph(outputs=outputs, clone=clone)
+        fgraph = FunctionGraph(outputs=outputs, clone=clone, copy_inputs=False)
 
     query_rewrites = optdb.query(RewriteDatabaseQuery(include=include, **kwargs))
     query_rewrites.rewrite(fgraph)

--- a/pytensor/tensor/extra_ops.py
+++ b/pytensor/tensor/extra_ops.py
@@ -1534,14 +1534,17 @@ def broadcast_shape_iter(
             # Only one shape might not be broadcastable in this dimension
             result_dims.extend(non_bcast_shapes)
         else:
-            # More than one shape might not be broadcastable in this dimension
-            nonconst_nb_shapes: set[int] = set()
-            const_nb_shapes: set[Variable] = set()
+            # More than one shape might not be broadcastable in this dimension.
+            # ``nonconst_nb_shapes`` is a dict (used as ordered set) so iteration
+            # order is deterministic across processes — set iteration is
+            # hash-randomized and would yield non-deterministic graphs.
+            const_nb_shapes: set[int] = set()
+            nonconst_nb_shapes: dict[Variable, None] = {}
             for shape in non_bcast_shapes:
                 if isinstance(shape, Constant):
                     const_nb_shapes.add(shape.value.item())
                 else:
-                    nonconst_nb_shapes.add(shape)
+                    nonconst_nb_shapes[shape] = None
 
             if len(const_nb_shapes) > 1:
                 raise ValueError(
@@ -1550,7 +1553,7 @@ def broadcast_shape_iter(
 
             if len(const_nb_shapes) == 1:
                 (first_length,) = const_nb_shapes
-                other_lengths = nonconst_nb_shapes
+                other_lengths = list(nonconst_nb_shapes)
                 first_length = ps.as_scalar(first_length)
             else:
                 first_length, *other_lengths = nonconst_nb_shapes

--- a/pytensor/tensor/rewriting/basic.py
+++ b/pytensor/tensor/rewriting/basic.py
@@ -63,6 +63,7 @@ from pytensor.tensor import TensorLike
 from pytensor.tensor.basic import (
     Alloc,
     AllocEmpty,
+    ExtractDiag,
     Join,
     MakeVector,
     ScalarFromTensor,
@@ -72,6 +73,7 @@ from pytensor.tensor.basic import (
     as_tensor_variable,
     atleast_Nd,
     cast,
+    diagonal,
     get_scalar_constant_value,
     join,
     register_infer_shape,
@@ -1444,3 +1446,25 @@ def local_join_of_alloc(fgraph, node):
     new_out = alloc(new_join, *post_join_shape)
     copy_stack_trace(node.outputs[0], new_out)
     return [new_out]
+
+
+@register_canonicalize
+@register_stabilize
+@register_specialize
+@node_rewriter([ExtractDiag])
+def extract_diag_of_transpose(fgraph, node):
+    """ExtractDiag(X.T, offset=k) -> ExtractDiag(X, offset=-k)
+
+    Strip a matrix transpose so it cannot block other ExtractDiag rewrites.
+    """
+    op = node.op
+    [inp] = node.inputs
+    ndim = inp.type.ndim
+    if op.axis1 != ndim - 2 or op.axis2 != ndim - 1:
+        return None
+
+    match inp.owner_op_and_inputs:
+        case (DimShuffle(is_matrix_transpose=True), inner):
+            return [diagonal(inner, offset=-op.offset, axis1=op.axis1, axis2=op.axis2)]
+        case _:
+            return None

--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -16,7 +16,7 @@ from pytensor.graph.rewriting.basic import (
     node_rewriter,
 )
 from pytensor.raise_op import Assert
-from pytensor.scalar import Add, ScalarConstant
+from pytensor.scalar import Add, ScalarConstant, ScalarMinimum
 from pytensor.scalar import constant as scalar_constant
 from pytensor.tensor.basic import (
     Alloc,
@@ -37,7 +37,7 @@ from pytensor.tensor.basic import (
 )
 from pytensor.tensor.basic import constant as tensor_constant
 from pytensor.tensor.blockwise import _squeeze_left
-from pytensor.tensor.elemwise import Elemwise
+from pytensor.tensor.elemwise import DimShuffle, Elemwise
 from pytensor.tensor.exceptions import NotScalarConstantError
 from pytensor.tensor.extra_ops import broadcast_to
 from pytensor.tensor.math import (
@@ -60,6 +60,8 @@ from pytensor.tensor.rewriting.basic import (
 )
 from pytensor.tensor.rewriting.blockwise import blockwise_of
 from pytensor.tensor.shape import (
+    Shape,
+    Shape_i,
     shape_padleft,
     shape_padright,
     shape_tuple,
@@ -265,6 +267,37 @@ def local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1(fgraph, node):
     return [new_res]
 
 
+def _is_shape_of_x_at(var, x, axis):
+    """``True`` when ``var`` is statically equivalent to ``x.shape[axis]``."""
+    if isinstance(var, TensorConstant):
+        s = x.type.shape[axis]
+        return s is not None and int(var.data) == s
+    op = var.owner_op
+    if isinstance(op, Shape_i):
+        return op.i == axis and var.owner.inputs[0] is x
+    if isinstance(op, Subtensor):
+        shape_node = var.owner.inputs[0]
+        if not isinstance(shape_node.owner_op, Shape):
+            return False
+        if shape_node.owner.inputs[0] is not x:
+            return False
+        try:
+            idx_val = get_constant_idx(
+                var.owner.op.idx_list, var.owner.inputs, allow_partial=False
+            )
+        except NotScalarConstantError:
+            return False
+        return len(idx_val) == 1 and idx_val[0] == axis
+    if isinstance(op, DimShuffle) and op.new_order == ():
+        # ``Squeeze(Shape(x))`` collapses Shape(x) (length-1 vector) to scalar:
+        # only valid when ``x`` is 1-D, in which case it's ``x.shape[0]``.
+        shape_node = var.owner.inputs[0]
+        if not isinstance(shape_node.owner_op, Shape):
+            return False
+        return axis == 0 and shape_node.owner.inputs[0] is x
+    return False
+
+
 @register_infer_shape
 @register_useless
 @register_canonicalize
@@ -356,6 +389,33 @@ def local_useless_slice(fgraph, node):
                 if -stop_val > dim_length:
                     change_flag = True
                     stop = None
+
+        # Drop a redundant stop that equals ``x.shape[dim]`` or is wrapped in
+        # ``min(..., x.shape[dim])``: ``Subtensor`` already clips at runtime,
+        # so such stops are just noise. Peek through ``ScalarFromTensor``.
+        if positive_step and stop is not None:
+            tensor_stop = (
+                stop.owner.inputs[0]
+                if isinstance(stop.owner_op, ScalarFromTensor)
+                else stop
+            )
+            if _is_shape_of_x_at(tensor_stop, x, dim):
+                change_flag = True
+                stop = None
+            elif isinstance(tensor_stop.owner_op, Elemwise) and isinstance(
+                tensor_stop.owner.op.scalar_op, ScalarMinimum
+            ):
+                a, b = tensor_stop.owner.inputs
+                kept = (
+                    a
+                    if _is_shape_of_x_at(b, x, dim)
+                    else b
+                    if _is_shape_of_x_at(a, x, dim)
+                    else None
+                )
+                if kept is not None:
+                    change_flag = True
+                    stop = kept
 
         if start is not None or stop is not None or step is not None:
             last_useful_idx = dim

--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -1,6 +1,6 @@
-import itertools
 import sys
 import warnings
+from itertools import pairwise, zip_longest
 
 import numpy as np
 
@@ -79,6 +79,7 @@ from pytensor.tensor.subtensor import (
     advanced_inc_subtensor1,
     advanced_subtensor1,
     as_index_constant,
+    as_index_literal,
     basic_subtensor,
     flatten_index_variables,
     get_canonical_form_slice,
@@ -87,6 +88,7 @@ from pytensor.tensor.subtensor import (
     get_slice_elements,
     inc_subtensor,
     indices_from_subtensor,
+    unflatten_index_variables,
 )
 from pytensor.tensor.type import TensorType
 from pytensor.tensor.variable import TensorConstant, TensorVariable
@@ -1696,6 +1698,90 @@ def local_read_of_write_same_indices(fgraph, node):
         return [r]
 
 
+def _slice_to_arange(sl, dim_length):
+    """Convert ``sl`` to the equivalent ``arange``-shaped index, or ``None``.
+
+    - constant ``slice(start, stop, step)`` with all ``>= 0`` and ``step > 0``
+      → ``tensor_constant(np.arange(start, stop, step))``.
+    - symbolic ``slice(0|None, stop, 1|None)`` with provably non-negative
+      ``stop`` → ``arange(minimum(stop, dim_length))``.
+    - ``slice(None, None, None)`` → ``arange(dim_length)``.
+    """
+    try:
+        start = 0 if sl.start is None else int(as_index_literal(sl.start))
+        stop = int(as_index_literal(sl.stop))
+        step = 1 if sl.step is None else int(as_index_literal(sl.step))
+        if start >= 0 and stop >= 0 and step > 0:
+            return tensor_constant(np.arange(start, stop, step))
+        return None
+    except (TypeError, NotScalarConstantError):
+        pass
+    if sl.start is not None:
+        try:
+            if int(as_index_literal(sl.start)) != 0:
+                return None
+        except (TypeError, NotScalarConstantError):
+            return None
+    if sl.step is not None:
+        try:
+            if int(as_index_literal(sl.step)) != 1:
+                return None
+        except (TypeError, NotScalarConstantError):
+            return None
+    if sl.stop is None:
+        return arange(dim_length)
+    if not _is_provably_non_negative(sl.stop):
+        return None
+    return arange(minimum(sl.stop, dim_length))
+
+
+@register_canonicalize("shape_unsafe")
+@register_specialize("shape_unsafe")
+@node_rewriter([Subtensor])
+def local_slice_read_of_write(fgraph, node):
+    """Simplify ``x[write_idx].set/inc(v)[slices]`` when we slice the written axes.
+
+    Converts slice indices to ``arange`` on axes where the write uses advanced
+    indexing, then delegates to ``local_advanced_read_of_write_constant_indices``.
+    """
+    read_node = node
+
+    write_node = node.inputs[0].owner
+    if not (write_node is not None and isinstance(write_node.op, AdvancedIncSubtensor)):
+        return None
+
+    read_idx_list = read_node.op.idx_list
+    write_idx_list = write_node.op.idx_list
+
+    if len(read_idx_list) > len(write_idx_list) or read_idx_list == write_idx_list:
+        return None
+
+    read_indices = unflatten_index_variables(read_node.inputs[1:], read_idx_list)
+    write_indices = unflatten_index_variables(write_node.inputs[2:], write_idx_list)
+
+    buffer_shape = tuple(write_node.inputs[0].shape)
+    new_indices: list = []
+    for axis, (read_idx, write_idx) in enumerate(
+        zip_longest(read_indices, write_indices, fillvalue=slice(None))
+    ):
+        read_is_slice = isinstance(read_idx, slice)
+        write_is_slice = isinstance(write_idx, slice)
+        if read_is_slice and not write_is_slice:
+            arange_index = _slice_to_arange(read_idx, buffer_shape[axis])
+            if arange_index is None:
+                return None
+            else:
+                new_indices.append(arange_index)
+                continue
+        elif read_is_slice != write_is_slice:
+            return None
+        else:
+            new_indices.append(read_idx)
+
+    new_read = write_node.out[tuple(new_indices)].owner
+    return local_advanced_read_of_write_constant_indices.fn(fgraph, new_read)
+
+
 @register_canonicalize("shape_unsafe")
 @register_specialize("shape_unsafe")
 @node_rewriter([AdvancedSubtensor])
@@ -1728,7 +1814,10 @@ def local_advanced_read_of_write_constant_indices(fgraph, node):
     - ``local_write_of_write_same_indices`` collapses nested write chains.
     """
     inner = node.inputs[0]
-    if not (inner.owner and isinstance(inner.owner.op, AdvancedIncSubtensor)):
+    if not (
+        inner.owner
+        and isinstance(inner.owner.op, AdvancedIncSubtensor | AdvancedIncSubtensor1)
+    ):
         return None
 
     inner_op = inner.owner.op
@@ -2111,9 +2200,7 @@ def local_join_subtensors(fgraph, node):
     except NotScalarConstantError:
         return
 
-    for subtensor1_idx, (subtensor1, subtensor2) in enumerate(
-        itertools.pairwise(tensors)
-    ):
+    for subtensor1_idx, (subtensor1, subtensor2) in enumerate(pairwise(tensors)):
         # Check that two consecutive Subtensors are operating on the same base tensor
         if not (
             (

--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -16,10 +16,11 @@ from pytensor.graph.rewriting.basic import (
     node_rewriter,
 )
 from pytensor.raise_op import Assert
-from pytensor.scalar import Add, ScalarConstant, ScalarMinimum
+from pytensor.scalar import Add, ScalarConstant, ScalarMinimum, Sub
 from pytensor.scalar import constant as scalar_constant
 from pytensor.tensor.basic import (
     Alloc,
+    ARange,
     ExtractDiag,
     Join,
     ScalarFromTensor,
@@ -39,7 +40,7 @@ from pytensor.tensor.basic import constant as tensor_constant
 from pytensor.tensor.blockwise import _squeeze_left
 from pytensor.tensor.elemwise import DimShuffle, Elemwise
 from pytensor.tensor.exceptions import NotScalarConstantError
-from pytensor.tensor.extra_ops import broadcast_to
+from pytensor.tensor.extra_ops import broadcast_to, squeeze
 from pytensor.tensor.math import (
     add,
     and_,
@@ -74,6 +75,7 @@ from pytensor.tensor.subtensor import (
     AdvancedSubtensor1,
     IncSubtensor,
     Subtensor,
+    _is_provably_non_negative,
     _non_consecutive_adv_indexing,
     advanced_inc_subtensor1,
     advanced_subtensor1,
@@ -203,6 +205,126 @@ def get_advsubtensor_axis(indices):
         indices[axis], TensorConstant | TensorVariable | TensorSharedVariable
     ):
         return axis
+
+
+def _constant_has_unique_indices(idx) -> bool:
+    """Check whether a constant index has no duplicate entries.
+
+    Boolean indices, scalars, and single-element arrays are trivially unique.
+    For larger integer arrays, indices that mix positive and negative values
+    may alias, so those are treated as potentially duplicated.  The result
+    is cached on ``idx.tag``.
+    """
+    if not isinstance(idx, Constant):
+        return False
+    cached = getattr(idx.tag, "unique_indices", None)
+    if cached is not None:
+        return bool(cached)
+    idx_val = np.asarray(idx.data)
+    if idx_val.dtype == bool:
+        result = True
+    elif idx_val.size <= 1:
+        result = True
+    else:
+        has_pos = (idx_val >= 0).any()
+        has_neg = (idx_val < 0).any()
+        result = not (has_pos and has_neg) and np.unique(idx_val).size == idx_val.size
+    idx.tag.unique_indices = result
+    return result
+
+
+def _constant_is_arange(idx) -> tuple[int, int, int] | None:
+    """Match ``idx`` to ``np.arange(offset, offset + d * step, step)``
+    and return ``(d, offset, step)``, else ``None``.
+
+    Single-element constants return ``(1, value, 1)``.  The result is cached
+    on ``idx.tag.is_arange`` (``False`` sentinels a no-match).
+    """
+    if not isinstance(idx, Constant):
+        return None
+    cached = getattr(idx.tag, "is_arange", None)
+    if cached is not None:
+        return cached if cached is not False else None
+    idx_val = np.asarray(idx.data)
+    if idx_val.ndim != 1 or idx_val.size == 0 or idx_val.dtype.kind not in "iu":
+        result: tuple[int, int, int] | None = None
+    elif idx_val.size == 1:
+        result = (1, int(idx_val[0]), 1)
+    else:
+        diffs = np.diff(idx_val)
+        step = int(diffs[0])
+        if step != 0 and np.all(diffs == step):
+            result = (int(idx_val.size), int(idx_val[0]), step)
+        else:
+            result = None
+    idx.tag.is_arange = result if result is not None else False
+    return result
+
+
+def _match_arange_0_to_d_plus_offset(idx):
+    """Match ``arange(0, d, 1) + offset`` and return ``(arange_node, offset)``
+    where ``arange_node`` is the ``arange(0, d, 1)`` output and ``offset`` is
+    a scalar ``TensorVariable`` (``constant(0)`` for bare aranges), else
+    ``None``.
+    """
+    if not isinstance(idx, TensorVariable):
+        return None
+    if isinstance(idx.owner_op, ARange):
+        start, _stop, step = idx.owner.inputs
+        if not (isinstance(start, TensorConstant) and int(start.data) == 0):
+            return None
+        if not (isinstance(step, TensorConstant) and int(step.data) == 1):
+            return None
+        return idx, tensor_constant(np.zeros((), dtype=idx.type.dtype))
+    if not (
+        isinstance(idx.owner_op, Elemwise) and isinstance(idx.owner.op.scalar_op, Add)
+    ):
+        return None
+    arange_node = None
+    offset_terms = []
+    for inp in idx.owner.inputs:
+        if (
+            arange_node is None
+            and isinstance(inp.owner_op, ARange)
+            and isinstance(inp.owner.inputs[0], TensorConstant)
+            and int(inp.owner.inputs[0].data) == 0
+            and isinstance(inp.owner.inputs[2], TensorConstant)
+            and int(inp.owner.inputs[2].data) == 1
+        ):
+            arange_node = inp
+        elif inp.type.shape == (1,):
+            offset_terms.append(inp)
+        else:
+            return None
+    if arange_node is None:
+        return None
+    return arange_node, variadic_add(*offset_terms)
+
+
+def eager_add_zero(x, y):
+    """``x + y``, but return ``x`` when ``y`` is provably zero."""
+    if isinstance(y, int | np.integer):
+        return x if y == 0 else x + y
+    try:
+        if int(get_underlying_scalar_constant_value(y)) == 0:
+            return x
+    except NotScalarConstantError:
+        pass
+    return x + y
+
+
+def _eager_scalar(x):
+    """Reduce a 0d or ``(1,)``-shaped tensor to the simplest scalar form."""
+    if isinstance(x, TensorConstant):
+        return int(x.data)
+    if isinstance(x.owner_op, DimShuffle) and x.owner.op.input_ndim == 0:
+        inner = x.owner.inputs[0]
+        return int(inner.data) if isinstance(inner, TensorConstant) else inner
+    if isinstance(x.owner_op, TensorFromScalar):
+        return x.owner.inputs[0]
+    if x.type.ndim > 0:
+        return squeeze(x)
+    return x
 
 
 @register_specialize
@@ -896,6 +1018,200 @@ def local_useless_AdvancedSubtensor1(fgraph, node):
     return [node.inputs[0]]
 
 
+def _arange_index_to_slice(idx):
+    """Return the Python ``slice`` equivalent to ``idx`` if it is a constant or
+    symbolic arange with non-negative offset, else ``None``.
+
+    Negative offsets are not currently supported — some could be mapped to
+    negative-start slices, but mixed-sign indices (where some wrap and some
+    don't) cannot.  Symbolic matching covers
+    step=1 only and additionally requires the arange ``stop`` to be provably
+    non-negative — for negative ``stop``, ``arange`` returns empty whereas
+    the slice ``[0:stop]`` wraps, and the two cannot be safely interchanged.
+    """
+    if not isinstance(idx, TensorVariable) or idx.type.ndim != 1:
+        return None
+
+    const_match = _constant_is_arange(idx)
+    if const_match is not None:
+        d, offset, step = const_match
+        if offset < 0 or offset + (d - 1) * step < 0:
+            return None
+        stop_int = offset + d * step
+        if step > 0:
+            return (
+                slice(offset, stop_int, step) if step != 1 else slice(offset, stop_int)
+            )
+        # Negative step: a negative ``stop`` would wrap, so walk through 0 with None.
+        stop = stop_int if stop_int >= 0 else None
+        return slice(offset, stop, step)
+
+    sym_match = _match_arange_0_to_d_plus_offset(idx)
+    if sym_match is None:
+        return None
+    arange_node, offset = sym_match
+    _, arange_stop, _ = arange_node.owner.inputs
+    arange_stop = _eager_scalar(arange_stop)
+    if isinstance(arange_stop, TensorVariable) and arange_stop.type.dtype != "int64":
+        arange_stop = arange_stop.astype("int64")
+    offset = _eager_scalar(offset)
+    if not _is_provably_non_negative(offset):
+        return None
+    if not _is_provably_non_negative(arange_stop):
+        return None
+    stop = eager_add_zero(arange_stop, offset)
+    return slice(offset, stop)
+
+
+@register_canonicalize
+@register_specialize
+@node_rewriter([AdvancedSubtensor, AdvancedSubtensor1])
+def local_adv_idx_to_diagonal(fgraph, node):
+    """Rewrite paired-arange advanced indices to ``base.diagonal(...)``.
+
+    Recognizes ``base[arange(d)+r, arange(d)+c]`` on consecutive axes
+    ``(a1, a2)`` and rewrites it to ``base.diagonal(offset=c-r, axis1=a1,
+    axis2=a2)``. The const arm requires ``d == min(dim_a - r, dim_b - c)``
+    (full diagonal coverage at this offset), making the rewrite shape-safe.
+    """
+    var, *idx_inputs = node.inputs
+    indices = list(indices_from_subtensor(idx_inputs, node.op.idx_list))
+    indices += [slice(None)] * (var.type.ndim - len(indices))
+
+    adv_axes = [axis for axis, idx in enumerate(indices) if not isinstance(idx, slice)]
+    if len(adv_axes) != 2 or adv_axes[1] != adv_axes[0] + 1:
+        return None
+    if any(isinstance(idx, slice) and idx != slice(None) for idx in indices):
+        return None
+
+    a1, a2 = adv_axes
+    idx1, idx2 = indices[a1], indices[a2]
+
+    # Match both indices as arange(d) + offset (const or symbolic).
+    # Both must be the same kind (both const or both symbolic).
+    def _match_arange(idx):
+        const = _constant_is_arange(idx)
+        if const is not None and const[2] == 1:
+            return "const", const[0], const[1]
+        sym = _match_arange_0_to_d_plus_offset(idx)
+        if sym is not None:
+            arange_node, offset = sym
+            try:
+                off_val = int(get_underlying_scalar_constant_value(offset))
+            except NotScalarConstantError:
+                return None
+            return "sym", arange_node, off_val
+        return None
+
+    m1 = _match_arange(idx1)
+    m2 = _match_arange(idx2)
+    if m1 is None or m2 is None or m1[0] != m2[0]:
+        return None
+    kind, const_d_or_arange_to_d, row_off = m1
+    _, const_d_or_arange_to_d2, col_off = m2
+
+    # diagonal(offset=k) maps to [arange(d), arange(d)+k] (k>=0) or
+    # [arange(d)+|k|, arange(d)] (k<0). Both offsets nonzero means this
+    # is a sub-range gather that diagonal() can't express.
+    if row_off != 0 and col_off != 0:
+        return None
+
+    # Both indices must cover the same number of elements.
+    if const_d_or_arange_to_d != const_d_or_arange_to_d2:
+        return None
+    if kind == "const":
+        stop = tensor_constant(np.int64(const_d_or_arange_to_d))
+    else:
+        stop = const_d_or_arange_to_d.owner.inputs[1]
+
+    # Verify that the arange spans the full diagonal at this offset:
+    # d == min(shape[a1] - row_off, shape[a2] - col_off).
+    def _is_diag_length_term(term, axis, offset):
+        if offset == 0:
+            return _is_shape_of_x_at(term, var, axis)
+        if not isinstance(term.owner_op, Elemwise):
+            return False
+        if not isinstance(term.owner.op.scalar_op, Sub):
+            return False
+        sub_a, sub_b = term.owner.inputs
+        if not _is_shape_of_x_at(sub_a, var, axis):
+            return False
+        try:
+            return int(get_underlying_scalar_constant_value(sub_b)) == offset
+        except NotScalarConstantError:
+            return False
+
+    try:
+        stop_val = int(get_underlying_scalar_constant_value(stop))
+    except NotScalarConstantError:
+        stop_val = None
+    if stop_val is not None:
+        dim_a, dim_b = var.type.shape[a1], var.type.shape[a2]
+        if dim_a is None or dim_b is None:
+            return None
+        if stop_val != min(dim_a - row_off, dim_b - col_off):
+            return None
+    else:
+        if not isinstance(stop.owner_op, Elemwise):
+            return None
+        if not isinstance(stop.owner.op.scalar_op, ScalarMinimum):
+            return None
+        term_a, term_b = stop.owner.inputs
+        if not (
+            (
+                _is_diag_length_term(term_a, a1, row_off)
+                and _is_diag_length_term(term_b, a2, col_off)
+            )
+            or (
+                _is_diag_length_term(term_a, a2, col_off)
+                and _is_diag_length_term(term_b, a1, row_off)
+            )
+        ):
+            return None
+
+    offset = col_off - row_off
+    out = var.diagonal(offset=offset, axis1=a1, axis2=a2)
+    # ``diagonal`` appends the diagonal as the last axis, but the original
+    # ``base[..., arange, arange, ...]`` keeps the broadcast group at ``a1``
+    # (consecutive advanced axes preserve their position in numpy).
+    if a1 != out.type.ndim - 1:
+        out = moveaxis(out, -1, a1)
+    copy_stack_trace(node.outputs[0], out)
+    return [out]
+
+
+@register_canonicalize("shape_unsafe")
+@register_specialize("shape_unsafe")
+@node_rewriter([AdvancedSubtensor, AdvancedSubtensor1])
+def local_adv_idx_to_slice(fgraph, node):
+    """Rewrite a single arange-shaped advanced index to a basic slice.
+
+    ``base[..., arange(d)+offset, ...]`` (all other axes full slices) becomes
+    ``base[..., offset:offset+d, ...]``. Tagged ``shape_unsafe``: the slice
+    silently truncates when the gather would be out-of-bounds, masking the
+    ``IndexError`` the original ``AdvancedSubtensor`` would raise.
+    """
+    var, *idx_inputs = node.inputs
+    indices = list(indices_from_subtensor(idx_inputs, node.op.idx_list))
+    indices += [slice(None)] * (var.type.ndim - len(indices))
+
+    adv_axes = [axis for axis, idx in enumerate(indices) if not isinstance(idx, slice)]
+    if len(adv_axes) != 1:
+        return None
+    if any(isinstance(idx, slice) and idx != slice(None) for idx in indices):
+        return None
+
+    [axis] = adv_axes
+    sl = _arange_index_to_slice(indices[axis])
+    if sl is None:
+        return None
+    new_indices = list(indices)
+    new_indices[axis] = sl
+    out = var[tuple(new_indices)]
+    copy_stack_trace(node.outputs[0], out)
+    return [out]
+
+
 def merge_two_slices(fgraph, slice1, len1, slice2, len2):
     """
      This function merges two slices into a single slice. The code works on
@@ -1283,32 +1599,6 @@ def local_setsubtensor_of_constants(fgraph, node):
             return False
 
 
-def _constant_has_unique_indices(idx) -> bool:
-    """Check whether a constant index has no duplicate entries.
-
-    Boolean indices, scalars, and single-element arrays are trivially unique.
-    For larger integer arrays, indices that mix positive and negative values
-    may alias, so those are treated as potentially duplicated.  The result
-    is cached on ``idx.tag``.
-    """
-    if not isinstance(idx, Constant):
-        return False
-    cached = getattr(idx.tag, "unique_indices", None)
-    if cached is not None:
-        return bool(cached)
-    idx_val = np.asarray(idx.data)
-    if idx_val.dtype == bool:
-        result = True
-    elif idx_val.size <= 1:
-        result = True
-    else:
-        has_pos = (idx_val >= 0).any()
-        has_neg = (idx_val < 0).any()
-        result = not (has_pos and has_neg) and np.unique(idx_val).size == idx_val.size
-    idx.tag.unique_indices = result
-    return result
-
-
 @register_canonicalize("shape_unsafe")
 @register_specialize("shape_unsafe")
 @node_rewriter([Subtensor, AdvancedSubtensor1, AdvancedSubtensor])
@@ -1331,7 +1621,7 @@ def local_read_of_write_same_indices(fgraph, node):
 
     - ``local_advanced_read_of_write_constant_indices`` handles the multi-axis
       case when read and write indices differ but are both constant.
-    - ``local_write_of_write_same_indices`` folds nested write chains.
+    - ``local_write_of_write_same_indices`` collapses nested write chains.
     """
     if isinstance(node.op, Subtensor):
         write_type = IncSubtensor
@@ -1403,7 +1693,7 @@ def local_advanced_read_of_write_constant_indices(fgraph, node):
 
     - ``local_read_of_write_same_indices`` handles the identity-check case
       (symbolic indices allowed) for basic and advanced subtensors.
-    - ``local_write_of_write_same_indices`` folds nested write chains.
+    - ``local_write_of_write_same_indices`` collapses nested write chains.
     """
     inner = node.inputs[0]
     if not (inner.owner and isinstance(inner.owner.op, AdvancedIncSubtensor)):
@@ -1588,7 +1878,7 @@ def local_advanced_read_of_write_constant_indices(fgraph, node):
 @register_specialize
 @node_rewriter([IncSubtensor, AdvancedIncSubtensor1, AdvancedIncSubtensor])
 def local_write_of_write_same_indices(fgraph, node):
-    """Fold nested write ops that share the same indices.
+    """Collapse nested write ops that share the same indices.
 
     .. code::
 

--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -21,7 +21,6 @@ from pytensor.scalar import constant as scalar_constant
 from pytensor.tensor.basic import (
     Alloc,
     ARange,
-    ExtractDiag,
     Join,
     ScalarFromTensor,
     TensorFromScalar,
@@ -2522,75 +2521,3 @@ optdb["specialize"].register(
     "shape_unsafe",  # It can mask invalid mask sizes
     use_db_name_as_tag=False,  # Not included if only "specialize" is requested
 )
-
-
-@register_stabilize("shape_unsafe")
-@register_specialize("shape_unsafe")
-@node_rewriter([ExtractDiag])
-def local_extract_diag_of_write(fgraph, node):
-    """Delegate ``extract_diag(advanced_inc_subtensor(...))`` to the constant-indices rewrite.
-
-    Rewrites ``extract_diag(x, offset=k)`` as the equivalent
-    ``x[..., arange(d) + max(0, -k), arange(d) + max(0, k), ...]`` and
-    calls ``local_advanced_read_of_write_constant_indices`` to do the
-    work.  Since ``extract_diag`` is a zero-copy view, we only commit the
-    replacement when the downstream rewrite eliminates the gather.
-
-    Requires statically-known sizes on the two diagonal axes.
-    """
-    op = node.op
-
-    inner = node.inputs[0]
-    # AdvancedIncSubtensor1 is intentionally not accepted: it writes whole
-    # rows/slices on a single axis, not specific (i, j) positions, so it
-    # can't express "write the diagonal" the way two paired index arrays can.
-    if not (inner.owner and isinstance(inner.owner.op, AdvancedIncSubtensor)):
-        return None
-
-    # Need static sizes on the two diagonal axes to build constant indices.
-    dim_a = inner.type.shape[op.axis1]
-    dim_b = inner.type.shape[op.axis2]
-    if dim_a is None or dim_b is None:
-        return None
-
-    k = op.offset
-    row_offset = max(0, -k)
-    col_offset = max(0, k)
-    d = min(dim_a - row_offset, dim_b - col_offset)
-    if d <= 0:
-        return None
-
-    # Build equivalent AdvancedSubtensor: inner[..., arange(d) + row_offset, ..., arange(d) + col_offset, ...]
-    base_arange = np.arange(d, dtype=np.int64)
-    rows = pytensor.tensor.as_tensor_variable(base_arange + row_offset)
-    cols = pytensor.tensor.as_tensor_variable(base_arange + col_offset)
-    idxs = [slice(None)] * inner.type.ndim
-    idxs[op.axis1] = rows
-    idxs[op.axis2] = cols
-    equiv = inner[tuple(idxs)]
-
-    if not (equiv.owner and isinstance(equiv.owner.op, AdvancedSubtensor)):
-        return None
-
-    # Delegate to the general read-after-write rewrite.
-    result = local_advanced_read_of_write_constant_indices.fn(fgraph, equiv.owner)
-    if not result:
-        return None
-
-    # Stay zero-copy where possible: when the simplification reduced to a
-    # gather of the inner write's base at our diagonal-arange pattern (i.e.
-    # the no-coverage case where the write is irrelevant for this read),
-    # re-emit as ExtractDiag so we keep the view semantics of the original.
-    base = inner.owner.inputs[0]
-    [result_var] = result
-    if (
-        result_var.owner
-        and isinstance(result_var.owner.op, AdvancedSubtensor)
-        and result_var.owner.inputs[0] is base
-    ):
-        out = base.diagonal(offset=k, axis1=op.axis1, axis2=op.axis2)
-        copy_stack_trace(node.outputs[0], out)
-        return [out]
-
-    copy_stack_trace(node.outputs[0], result)
-    return result

--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -327,6 +327,36 @@ def _eager_scalar(x):
     return x
 
 
+def _idx_to_int_array(idx):
+    """Materialize a 1-D integer index as a numpy array.
+
+    Handles ``TensorConstant`` (read ``.data``) and symbolic
+    ``arange(n) + offset`` with constant ``n`` and ``offset``
+    (eager constant-fold). Boolean masks are converted to integer positions.
+    Return ``None`` when the index can't be materialized at rewrite time.
+    """
+    if isinstance(idx, TensorConstant):
+        arr = np.asarray(idx.data)
+        if arr.dtype == bool:
+            return np.flatnonzero(arr)
+        return arr
+    sym = _match_arange_0_to_d_plus_offset(idx)
+    if sym is None:
+        return None
+    arange_node, offset = sym
+    _, stop, _ = arange_node.owner.inputs
+    if not isinstance(stop, TensorConstant):
+        return None
+    n = int(stop.data)
+    if n < 0:
+        return None
+    try:
+        off_val = int(get_underlying_scalar_constant_value(offset))
+    except NotScalarConstantError:
+        return None
+    return np.arange(n, dtype=np.int64) + off_val
+
+
 @register_specialize
 @node_rewriter([AdvancedSubtensor])
 def local_replace_AdvancedSubtensor(fgraph, node):
@@ -1685,9 +1715,12 @@ def local_advanced_read_of_write_constant_indices(fgraph, node):
             x[r_idx]                      (no coverage)
             x[r_idx].inc(v[k])[...]       (partial, unique writes)
 
-    Fires only when all advanced indices on both sides are 1-D integer
-    constants with matching ``idx_list``.  The inc case additionally requires
-    unique joint write coords so each read coord matches at most one write.
+    Fires when each advanced index is materializable: a 1-D integer
+    ``TensorConstant`` (boolean masks accepted) or a symbolic
+    ``arange(n_const) + offset`` whose stop is a ``TensorConstant``.  The
+    ``idx_list`` must match between read and write.  The inc case
+    additionally requires unique joint write coords so each read coord
+    matches at most one write.
 
     Companion rewrites:
 
@@ -1719,19 +1752,12 @@ def local_advanced_read_of_write_constant_indices(fgraph, node):
     read_arrs = []
     for w, r in zip(write_indices, read_indices, strict=True):
         if isinstance(w, TensorVariable) and isinstance(r, TensorVariable):
-            if not (isinstance(w, TensorConstant) and isinstance(r, TensorConstant)):
-                return None
-            # Require proper 1-D array indices, not broadcastable length-1.
             if w.type.broadcastable != (False,) or r.type.broadcastable != (False,):
                 return None
-            w_arr = np.asarray(w.data)
-            r_arr = np.asarray(r.data)
-            # Convert boolean masks to integer positions so coord-matching below
-            # works uniformly; `a[mask]` and `a[flatnonzero(mask)]` are equivalent.
-            if w_arr.dtype == bool:
-                w_arr = np.flatnonzero(w_arr)
-            if r_arr.dtype == bool:
-                r_arr = np.flatnonzero(r_arr)
+            w_arr = _idx_to_int_array(w)
+            r_arr = _idx_to_int_array(r)
+            if w_arr is None or r_arr is None:
+                return None
             # Reject only cross-sign within an axis — negatives can alias
             # positives on the same axis, but uniformly negative (or
             # uniformly non-negative) indices compare correctly as raw values.

--- a/pytensor/tensor/rewriting/subtensor_lift.py
+++ b/pytensor/tensor/rewriting/subtensor_lift.py
@@ -12,13 +12,20 @@ from pytensor.graph import (
     node_rewriter,
     vectorize_graph,
 )
-from pytensor.graph.rewriting.basic import NodeRewriter, copy_stack_trace
+from pytensor.graph.rewriting.basic import (
+    NodeRewriter,
+    SequentialGraphRewriter,
+    copy_stack_trace,
+    out2in,
+)
 from pytensor.tensor.basic import (
     Alloc,
     ARange,
+    ExtractDiag,
     Join,
     MakeVector,
     alloc,
+    arange,
     as_tensor,
     expand_dims,
     get_underlying_scalar_constant_value,
@@ -29,7 +36,7 @@ from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
 from pytensor.tensor.exceptions import NotScalarConstantError
 from pytensor.tensor.extra_ops import squeeze
-from pytensor.tensor.math import Dot, dot
+from pytensor.tensor.math import Dot, dot, minimum
 from pytensor.tensor.rewriting.basic import (
     register_canonicalize,
     register_specialize,
@@ -38,6 +45,10 @@ from pytensor.tensor.rewriting.basic import (
 from pytensor.tensor.rewriting.elemwise import local_dimshuffle_lift
 from pytensor.tensor.rewriting.subtensor import (
     _constant_has_unique_indices,
+    local_adv_idx_to_diagonal,
+    local_adv_idx_to_slice,
+    local_advanced_read_of_write_constant_indices,
+    local_useless_slice,
     register_useless,
 )
 from pytensor.tensor.shape import (
@@ -48,6 +59,7 @@ from pytensor.tensor.shape import (
 )
 from pytensor.tensor.special import Softmax, softmax
 from pytensor.tensor.subtensor import (
+    AdvancedIncSubtensor,
     AdvancedSubtensor,
     AdvancedSubtensor1,
     Subtensor,
@@ -771,6 +783,100 @@ def local_basic_subtensor_of_alloc(fgraph, node):
 @node_rewriter([Subtensor, AdvancedSubtensor, AdvancedSubtensor1])
 def local_subtensor_of_alloc(fgraph, node):
     return lift_subtensor_through_alloc(fgraph, node)
+
+
+def _diag_indices(ndim, a1, a2, d, row_off, col_off):
+    """``[slice(None)] * ndim`` with axes ``(a1, a2)`` set to paired aranges
+    sharing one ``arange(d)`` node so ``indexed_result_shape``'s same-node
+    fast path skips ``broadcast_shape``.
+    """
+    ar = arange(d, dtype="int64")
+    rows = ar + row_off if row_off else ar
+    cols = ar + col_off if col_off else ar
+    idxs: list = [slice(None)] * ndim
+    idxs[a1] = rows
+    idxs[a2] = cols
+    return idxs
+
+
+@node_rewriter([ExtractDiag])
+def local_extract_diag_lift(fgraph, node):
+    """Lower ``ExtractDiag(X)`` to ``X[..., arange(d)+r, arange(d)+c, ...]``
+    and commit only when the immediate next-step lift would consume it.
+
+    Each branch builds the hypothetical ``AdvancedSubtensor`` off-fgraph and
+    tests via the gating rewriter's ``.fn`` — no commit if the gate misses,
+    so we never leave an unhelpful paired-arange gather behind.
+
+    - ``Alloc`` parent — gated on ``local_subtensor_of_alloc``; rebuilds the
+      outer Alloc shape with the diag length ``d`` so ``Shape(arange(d))[0]``
+      doesn't survive.
+    - ``Elemwise`` / ``Blockwise`` parent — gated on
+      ``local_subtensor_of_batch_dims``. Blockwise core dims bail (the lift
+      can't push past core ndim).
+    - ``AdvancedIncSubtensor`` write-chain parent — gated on
+      ``local_advanced_read_of_write_constant_indices``.
+    """
+    inner = node.inputs[0]
+    op = node.op
+    a1, a2 = op.axis1, op.axis2
+    parent_op = inner.owner_op
+
+    if isinstance(parent_op, Alloc):
+        shape_inputs = inner.owner.inputs[1:]
+    elif isinstance(parent_op, Elemwise | Blockwise):
+        if isinstance(parent_op, Blockwise):
+            batch_ndim = inner.owner.op.batch_ndim(inner.owner)
+            if a1 >= batch_ndim or a2 >= batch_ndim:
+                return None
+        shape_inputs = inner.shape
+    elif isinstance(parent_op, AdvancedIncSubtensor):
+        shape_inputs = inner.shape
+    else:
+        return None
+
+    row_off, col_off = max(0, -op.offset), max(0, op.offset)
+
+    def _diag_dim(ax, off):
+        s = inner.type.shape[ax]
+        if s is not None:
+            return s - off
+        return shape_inputs[ax] - off if off else shape_inputs[ax]
+
+    a_term, b_term = _diag_dim(a1, row_off), _diag_dim(a2, col_off)
+    if isinstance(a_term, int) and isinstance(b_term, int):
+        diag_len = min(a_term, b_term)
+    else:
+        diag_len = a_term if a_term is b_term else minimum(a_term, b_term)
+    idxs = _diag_indices(inner.type.ndim, a1, a2, diag_len, row_off, col_off)
+    hypothetical = inner[tuple(idxs)].owner
+
+    if isinstance(parent_op, Alloc):
+        return local_subtensor_of_alloc.fn(fgraph, hypothetical)
+    elif isinstance(parent_op, Elemwise | Blockwise):
+        return local_subtensor_of_batch_dims.fn(fgraph, hypothetical)
+    else:
+        # AdvancedIncSubtensor write chain
+        return local_advanced_read_of_write_constant_indices.fn(fgraph, hypothetical)
+
+
+extract_diag_lift_pass = SequentialGraphRewriter(
+    out2in(
+        local_extract_diag_lift,
+        local_subtensor_of_alloc,
+        local_subtensor_of_batch_dims,
+        local_advanced_read_of_write_constant_indices,
+        name="extract_diag_lift_walker",
+    ),
+    out2in(
+        local_adv_idx_to_diagonal,
+        local_adv_idx_to_slice,
+        local_useless_slice,
+        name="extract_diag_cleanup",
+    ),
+)
+extract_diag_lift_pass.__name__ = "extract_diag_lift_pass"  # type: ignore[attr-defined]
+register_specialize(extract_diag_lift_pass, "shape_unsafe")  # type: ignore[arg-type]
 
 
 @register_canonicalize

--- a/pytensor/tensor/rewriting/subtensor_lift.py
+++ b/pytensor/tensor/rewriting/subtensor_lift.py
@@ -29,7 +29,7 @@ from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
 from pytensor.tensor.exceptions import NotScalarConstantError
 from pytensor.tensor.extra_ops import squeeze
-from pytensor.tensor.math import Dot, ceil_intdiv, dot
+from pytensor.tensor.math import Dot, dot
 from pytensor.tensor.rewriting.basic import (
     register_canonicalize,
     register_specialize,
@@ -53,9 +53,9 @@ from pytensor.tensor.subtensor import (
     Subtensor,
     _non_consecutive_adv_indexing,
     as_index_literal,
-    get_canonical_form_slice,
     get_constant_idx,
     get_idx_list,
+    indexed_result_shape,
     indices_from_subtensor,
 )
 from pytensor.tensor.type import TensorType
@@ -690,74 +690,87 @@ def local_subtensor_of_transpose(fgraph, node):
     return [new_out]
 
 
+def lift_subtensor_through_alloc(fgraph, node):
+    """``alloc(val, *shape)[idx]`` -> ``alloc(val[idx_on_kept_dims], *out_shape)``.
+
+    Push the read past Alloc so the broadcast happens at most once and
+    indexing operates on ``val`` (smaller) where possible. Covers basic
+    ``Subtensor``, ``AdvancedSubtensor``, and ``AdvancedSubtensor1`` reads.
+
+    On non-broadcast ``val`` dims an advanced index could expand ``val[idx]``
+    past ``val.size``; only fire when the index is provably smaller or when
+    the resulting Alloc is dropped.
+
+    Bail on boolean masks and non-consecutive advanced indexing.
+    """
+    src = node.inputs[0]
+    match src.owner_op_and_inputs:
+        case (Alloc(), val, *alloc_dims):
+            pass
+        case _:
+            return None
+    n_added_dims = src.type.ndim - val.type.ndim
+
+    indices = list(get_idx_list(node.inputs, node.op.idx_list))
+    indices += [slice(None)] * (src.type.ndim - len(indices))
+
+    if any(
+        isinstance(idx, TensorVariable) and idx.type.dtype == "bool" for idx in indices
+    ):
+        return None
+    # Non-consecutive advanced indices get hoisted to position 0 in the result
+    # but stay in place inside ``val[val_indexer]``, misaligning the Alloc shape.
+    if _non_consecutive_adv_indexing(indices):
+        return None
+
+    val_indexer: list = []
+    dangerous_index_reaches_val = False
+    for axis, idx in enumerate(indices):
+        if axis < n_added_dims:
+            # Axis was added by Alloc; index doesn't reach val.
+            continue
+        val_static_dim = val.type.shape[axis - n_added_dims]
+        if val_static_dim == 1:
+            # Broadcast val dim: slices stay (Alloc broadcasts on top);
+            # advanced indices become length-1 zeros for squeeze.
+            if isinstance(idx, slice):
+                val_indexer.append(slice(None))
+            else:
+                val_indexer.append(np.zeros((1,) * idx.type.ndim, dtype=np.int64))
+            continue
+        val_indexer.append(idx)
+        if not _index_provably_smaller(idx, val_static_dim):
+            # Per-axis check; doesn't account for net effect across all axes.
+            dangerous_index_reaches_val = True
+
+    nw_val = _canonical_indexing(val, val_indexer)
+    new_shape = indexed_result_shape(alloc_dims, indices)
+    drops_alloc = nw_val.type.broadcastable == node.outputs[0].type.broadcastable
+
+    if dangerous_index_reaches_val and not drops_alloc:
+        return None
+
+    if drops_alloc:
+        result = nw_val
+    else:
+        result = alloc(nw_val, *new_shape)
+
+    copy_stack_trace(node.outputs[0], result)
+    return [result]
+
+
 @register_infer_shape
+@node_rewriter([Subtensor])
+def local_basic_subtensor_of_alloc(fgraph, node):
+    return lift_subtensor_through_alloc(fgraph, node)
+
+
 @register_useless
 @register_canonicalize
 @register_specialize
-@node_rewriter([Subtensor])
+@node_rewriter([Subtensor, AdvancedSubtensor, AdvancedSubtensor1])
 def local_subtensor_of_alloc(fgraph, node):
-    """
-
-    alloc(val)[x:y] -> alloc(val[...])
-    alloc(val)[x:y] -> alloc(val)
-    This can be seen as a lift, but it also reduce the number of computation/memory.
-
-    """
-    if not isinstance(node.op, Subtensor):
-        return False
-    u = node.inputs[0]
-    if u.owner is None:
-        return False
-    if not isinstance(u.owner.op, Alloc):
-        return False
-    slices = get_idx_list(node.inputs, node.op.idx_list)
-    val = u.owner.inputs[0]
-    dims = u.owner.inputs[1:]
-    assert len(slices) <= len(dims)
-
-    # Number of dimensions added to val
-    n_added_dims = u.ndim - val.ndim
-    # Dimensions of the returned alloc
-    nw_dims = []
-    # Slices to take from val
-    val_slices = []
-
-    for i, (sl, dim) in enumerate(zip(slices, dims, strict=False)):
-        # If val was not copied over that dim,
-        # we need to take the appropriate subtensor on it.
-        if i >= n_added_dims:
-            # We check that the corresponding val dimensions was
-            # not a broadcasted dimensions.
-            if (
-                val.type.ndim > (i - n_added_dims)
-                and val.type.broadcastable[i - n_added_dims]
-            ):
-                val_slices.append(slice(None))
-            else:
-                val_slices.append(sl)
-
-        csl, _ = get_canonical_form_slice(sl, dim)
-        if type(csl) is not slice:
-            # That dimension is removed.
-            pass
-        else:
-            nw_dim = csl.stop - csl.start
-
-            if csl.step != 1:
-                # Do not add the ceil_intdiv() graphs in the graphs
-                # when this is not needed as it prevent detecting the
-                # correct broadcast pattern.
-                nw_dim = ceil_intdiv(nw_dim, csl.step)
-            nw_dims += [nw_dim]
-
-    nw_val = val[tuple(val_slices)]
-    nw_dims += dims[len(slices) :]
-    if nw_val.ndim > len(nw_dims):
-        return False
-    rval = alloc(nw_val, *nw_dims)
-    if not isinstance(rval, list | tuple):
-        rval = [rval]
-    return rval
+    return lift_subtensor_through_alloc(fgraph, node)
 
 
 @register_canonicalize

--- a/pytensor/tensor/rewriting/subtensor_lift.py
+++ b/pytensor/tensor/rewriting/subtensor_lift.py
@@ -15,6 +15,7 @@ from pytensor.graph import (
 from pytensor.graph.rewriting.basic import NodeRewriter, copy_stack_trace
 from pytensor.tensor.basic import (
     Alloc,
+    ARange,
     Join,
     MakeVector,
     alloc,
@@ -35,8 +36,12 @@ from pytensor.tensor.rewriting.basic import (
     register_stabilize,
 )
 from pytensor.tensor.rewriting.elemwise import local_dimshuffle_lift
-from pytensor.tensor.rewriting.subtensor import register_useless
+from pytensor.tensor.rewriting.subtensor import (
+    _constant_has_unique_indices,
+    register_useless,
+)
 from pytensor.tensor.shape import (
+    Reshape,
     Shape,
     SpecifyShape,
     specify_shape,
@@ -55,6 +60,72 @@ from pytensor.tensor.subtensor import (
 )
 from pytensor.tensor.type import TensorType
 from pytensor.tensor.variable import TensorVariable
+
+
+def _canonical_indexing(var, indices):
+    """Index ``var``, squeezing indexed broadcast dims whose index has size 1.
+
+    On a length-1 dim only zero is a valid index, so the index is
+    redundant — squeezing is equivalent and simpler.  If squeezed
+    indices contributed unique output dimensions, those are reinserted
+    via ``expand_dims`` after indexing.
+    """
+    squeeze_axes = []
+    kept_indices = []
+    max_drop_ndim = 0
+    max_kept_ndim = 0
+    first_adv_axis = None
+    for axis, (bcast, idx) in enumerate(
+        zip(var.type.broadcastable, indices, strict=False)
+    ):
+        if isinstance(idx, slice):
+            kept_indices.append(idx)
+        else:
+            if first_adv_axis is None:
+                first_adv_axis = axis
+
+            # np.ndim works for all supported cases: int, numpy arrays, pytensor variables
+            idx_ndim = np.ndim(idx)
+            if bcast:
+                match idx:
+                    case Variable():
+                        idx_size1 = all(idx.type.broadcastable)
+                    case np.ndarray():
+                        idx_size1 = idx.size == 1
+                    case int() | np.integer():
+                        idx_size1 = True
+                    case _:
+                        raise AssertionError
+
+                # idx only contributes dummy dimensions (if any), not actual shape
+                # It doesn't really matter what the index was, only valid values are zeros.
+                if idx_size1:
+                    max_drop_ndim = max(max_drop_ndim, idx_ndim)
+                    squeeze_axes.append(axis)
+                    continue
+
+            max_kept_ndim = max(max_kept_ndim, idx_ndim)
+            kept_indices.append(idx)
+
+    # Remove useless trailing slice(None) indices
+    while kept_indices and kept_indices[-1] == slice(None):
+        kept_indices.pop()
+
+    result = var
+
+    if squeeze_axes:
+        result = result.squeeze(axis=tuple(squeeze_axes))
+
+    if kept_indices:
+        result = result[tuple(kept_indices)]
+
+    if (lost := max_drop_ndim - max_kept_ndim) > 0:
+        assert first_adv_axis is not None
+        result = expand_dims(
+            result, tuple(range(first_adv_axis, first_adv_axis + lost))
+        )
+
+    return result
 
 
 def _dims_dropped_by_basic_index(idxs: Sequence[slice | int]) -> tuple[int, ...]:
@@ -110,6 +181,33 @@ def _lift_subtensor_non_axis(
 
     else:
         return None
+
+
+def _index_provably_smaller(idx, val_static_dim) -> bool:
+    # Per-axis check: non-repeating indices can't expand a single axis.
+    # Does not account for cross-axis broadcast expansion from outer indexing.
+    if isinstance(idx, slice) or idx.ndim == 0:
+        return True
+    if all(idx.type.broadcastable):
+        return True
+    if idx.type.dtype == "bool":
+        return True
+    if _constant_has_unique_indices(idx):
+        return True
+    if isinstance(idx.owner_op, ARange):
+        return True
+    if isinstance(idx.owner_op, Reshape | DimShuffle):
+        # Views that don't add dimensions
+        if _index_provably_smaller(idx.owner.inputs[0], val_static_dim):
+            return True
+
+    # Fallback to static shape analysis
+    if val_static_dim is None:
+        return False
+    idx_static_shape = idx.type.shape
+    if any(d is None for d in idx_static_shape):
+        return False
+    return bool(np.prod(idx_static_shape) < val_static_dim)
 
 
 @register_canonicalize
@@ -180,13 +278,19 @@ def local_subtensor_of_dot(fgraph, node):
 
 @register_canonicalize("shape_unsafe")
 @register_specialize("shape_unsafe")
-@node_rewriter([Subtensor])
+@node_rewriter([Subtensor, AdvancedSubtensor, AdvancedSubtensor1])
 def local_subtensor_of_batch_dims(fgraph, node):
-    """Lift a Subtensor through the batch dims of an (Elemwise or Blockwise) operation and its implicit broadcasting behavior.
+    """Lift a (basic or advanced) Subtensor through the batch dims of an Elemwise or Blockwise.
 
     exp(x)[:, 0] -> exp(x[:, 0])
     add(x, y)[0] -> add(x[0], y[0])
     add(x[None], y)[2] -> add(x, y[2])
+    add(x, y)[arange(d), arange(d)] -> add(x[arange(d), arange(d)], y[arange(d), arange(d)])
+
+    Bail on boolean masks and non-consecutive advanced indexing — numpy hoists
+    those advanced groups to position 0, which would misalign the lifted
+    indices. On a broadcast (length-1) axis of an input, replace the advanced
+    index with length-1 zeros so the lifted input still broadcasts correctly.
     """
     elem, *idx = node.inputs
 
@@ -200,6 +304,24 @@ def local_subtensor_of_batch_dims(fgraph, node):
 
     idx_tuple = indices_from_subtensor(idx, node.op.idx_list)
 
+    if any(isinstance(i, TensorVariable) and i.type.dtype == "bool" for i in idx_tuple):
+        # Boolean masks have data-dependent shape.
+        return None
+    if _non_consecutive_adv_indexing(idx_tuple):
+        return None
+
+    # Skip when lifting would expand a gather past a non-broadcast input's size.
+    for inp in elem.owner.inputs:
+        for axis, idx in enumerate(idx_tuple):
+            if axis >= inp.type.ndim:
+                break
+            if not isinstance(idx, TensorVariable) or idx.type.ndim == 0:
+                continue
+            if inp.type.broadcastable[axis]:
+                continue
+            if not _index_provably_smaller(idx, inp.type.shape[axis]):
+                return None
+
     batch_ndim = (
         elem.owner.op.batch_ndim(elem.owner)
         if isinstance(elem.owner.op, Blockwise)
@@ -211,6 +333,12 @@ def local_subtensor_of_batch_dims(fgraph, node):
         batch_indices, core_indices = idx_tuple[:batch_ndim], idx_tuple[batch_ndim:]
         if all(idx == slice(None) for idx in batch_indices):
             # No batch indices, nothing to do
+            return None
+        if any(not isinstance(i, slice) for i in batch_indices) and any(
+            isinstance(i, TensorVariable) for i in core_indices
+        ):
+            # Splitting advanced batch from advanced core indices would hoist
+            # the lifted batch indices to position 0.
             return None
         elem_with_batch_indices = elem[batch_indices]
         [elem_with_batch_indices_lifted] = local_subtensor_of_batch_dims.transform(
@@ -243,7 +371,7 @@ def local_subtensor_of_batch_dims(fgraph, node):
                 strict=False,
             )
         ):
-            if dim_idx == slice(None):
+            if isinstance(dim_idx, slice) and dim_idx == slice(None):
                 # Full slice can be safely applied to all inputs
                 continue
 
@@ -251,16 +379,18 @@ def local_subtensor_of_batch_dims(fgraph, node):
                 # This dim is not broadcasted for any of the inputs, original index can be applied to all inputs
                 continue
 
-            # Some dims are broadcasted, so we need to adapt their indices
-            # Slice indexing keeps the dimension, so we use a full slice for broadcasted inputs
-            # Integer indexing drops the dimension, so we index by zero for the broadcsated inputs
-            safe_bcast_dim_idx = slice(None) if isinstance(dim_idx, slice) else 0
+            # Slices stay; advanced indices become length-1 zeros
+            # that _canonical_indexing will squeeze.
+            if isinstance(dim_idx, slice):
+                safe_bcast_dim_idx = slice(None)
+            else:
+                safe_bcast_dim_idx = np.zeros((1,) * dim_idx.type.ndim, dtype="int64")
             for inp_idx, dim_bcast_inp in zip(new_idxs, dim_bcast_inputs, strict=True):
                 if dim_bcast_inp:
                     inp_idx[dim] = safe_bcast_dim_idx
 
         indexed_inputs = [
-            inp[tuple(new_idx)]
+            _canonical_indexing(inp, tuple(new_idx))
             for inp, new_idx in zip(elem_inputs, new_idxs, strict=True)
         ]
 

--- a/pytensor/tensor/rewriting/subtensor_lift.py
+++ b/pytensor/tensor/rewriting/subtensor_lift.py
@@ -50,6 +50,7 @@ from pytensor.tensor.rewriting.subtensor import (
     local_adv_idx_to_diagonal,
     local_adv_idx_to_slice,
     local_advanced_read_of_write_constant_indices,
+    local_slice_read_of_write,
     local_useless_slice,
     register_useless,
 )
@@ -924,6 +925,7 @@ extract_diag_lift_pass = SequentialGraphRewriter(
         local_extract_diag_lift,
         local_subtensor_of_alloc,
         local_subtensor_of_batch_dims,
+        local_slice_read_of_write,
         local_advanced_read_of_write_constant_indices,
         name="extract_diag_lift_walker",
     ),

--- a/pytensor/tensor/rewriting/subtensor_lift.py
+++ b/pytensor/tensor/rewriting/subtensor_lift.py
@@ -733,6 +733,8 @@ def local_subtensor_make_vector(fgraph, node):
                 node.op.idx_list, node.inputs, allow_partial=False
             )[0]
             sliced_inputs = x.owner.inputs[const_slice]
+            if not sliced_inputs:
+                return False
             if len(sliced_inputs) == 1:
                 ret = expand_dims(sliced_inputs[0], axis=0)
             else:

--- a/pytensor/tensor/rewriting/subtensor_lift.py
+++ b/pytensor/tensor/rewriting/subtensor_lift.py
@@ -20,8 +20,10 @@ from pytensor.graph.rewriting.basic import (
 )
 from pytensor.tensor.basic import (
     Alloc,
+    AllocDiag,
     ARange,
     ExtractDiag,
+    Eye,
     Join,
     MakeVector,
     alloc,
@@ -71,7 +73,7 @@ from pytensor.tensor.subtensor import (
     indices_from_subtensor,
 )
 from pytensor.tensor.type import TensorType
-from pytensor.tensor.variable import TensorVariable
+from pytensor.tensor.variable import TensorConstant, TensorVariable
 
 
 def _canonical_indexing(var, indices):
@@ -800,6 +802,61 @@ def _diag_indices(ndim, a1, a2, d, row_off, col_off):
 
 
 @node_rewriter([ExtractDiag])
+def local_extract_diag_of_alloc_diag(fgraph, node):
+    """Short-circuit ``extract_diag(alloc_diag(v, ..., k_alloc), offset)``.
+
+    Diagonals at different offsets never cross:
+
+    - ``offset == k_alloc``: full match ``->`` ``v``
+    - ``offset != k_alloc``: no overlap ``->`` ``alloc(0, ..., d)`` along the
+      read diagonal of the synthesized ``(L+|k_alloc|, L+|k_alloc|)`` matrix
+      where ``d = L + |k_alloc| - |offset|``
+    """
+    inner = node.inputs[0]
+    if not isinstance(inner.owner_op, AllocDiag):
+        return None
+    op = node.op
+    diag_op = inner.owner.op
+    if (op.axis1, op.axis2) != (diag_op.axis1, diag_op.axis2):
+        return None  # cross-axis case is rare; bail
+    [v] = inner.owner.inputs
+    if op.offset == diag_op.offset:
+        copy_stack_trace(node.outputs[0], v)
+        return [v]
+    v_shape = tuple(
+        s if s is not None else v.shape[i] for i, s in enumerate(v.type.shape)
+    )
+    d = v_shape[-1] + abs(diag_op.offset) - abs(op.offset)
+    out = alloc(np.asarray(0, dtype=v.dtype), *v_shape[:-1], d)
+    copy_stack_trace(node.outputs[0], out)
+    return [out]
+
+
+@node_rewriter([ExtractDiag])
+def local_extract_diag_of_eye(fgraph, node):
+    """Short-circuit ``extract_diag(eye(n, m, k_eye), offset)``.
+
+    The result is an ``alloc`` of ``1`` (matching offset) or ``0`` (mismatched
+    offset) along the diagonal length ``min(n - row_off, m - col_off)``.
+    """
+    inner = node.inputs[0]
+    if not isinstance(inner.owner_op, Eye):
+        return None
+    op = node.op
+    n, m, k_inp = inner.owner.inputs
+    if not isinstance(k_inp, TensorConstant):
+        return None
+    val = np.asarray(1 if op.offset == int(k_inp.data) else 0, dtype=inner.dtype)
+    row_off, col_off = max(0, -op.offset), max(0, op.offset)
+    a = n if row_off == 0 else n - row_off
+    b = m if col_off == 0 else m - col_off
+    d = a if a is b else minimum(a, b)
+    out = alloc(val, d)
+    copy_stack_trace(node.outputs[0], out)
+    return [out]
+
+
+@node_rewriter([ExtractDiag])
 def local_extract_diag_lift(fgraph, node):
     """Lower ``ExtractDiag(X)`` to ``X[..., arange(d)+r, arange(d)+c, ...]``
     and commit only when the immediate next-step lift would consume it.
@@ -862,6 +919,8 @@ def local_extract_diag_lift(fgraph, node):
 
 extract_diag_lift_pass = SequentialGraphRewriter(
     out2in(
+        local_extract_diag_of_alloc_diag,
+        local_extract_diag_of_eye,
         local_extract_diag_lift,
         local_subtensor_of_alloc,
         local_subtensor_of_batch_dims,

--- a/pytensor/tensor/subtensor.py
+++ b/pytensor/tensor/subtensor.py
@@ -19,7 +19,13 @@ from pytensor.graph.utils import MethodNotDefined
 from pytensor.link.c.op import COp
 from pytensor.link.c.params_type import ParamsType
 from pytensor.printing import Printer, pprint, set_precedence
-from pytensor.scalar.basic import ScalarConstant, ScalarVariable
+from pytensor.scalar.basic import (
+    Cast,
+    ScalarConstant,
+    ScalarMaximum,
+    ScalarMinimum,
+    ScalarVariable,
+)
 from pytensor.tensor import (
     TensorLike,
     _get_vector_length,
@@ -27,7 +33,9 @@ from pytensor.tensor import (
     get_vector_length,
 )
 from pytensor.tensor.basic import (
+    MakeVector,
     ScalarFromTensor,
+    TensorFromScalar,
     alloc,
     get_scalar_constant_value,
     nonzero,
@@ -36,11 +44,12 @@ from pytensor.tensor.basic import (
     constant as tensor_constant,
 )
 from pytensor.tensor.blockwise import vectorize_node_fallback
-from pytensor.tensor.elemwise import DimShuffle
+from pytensor.tensor.elemwise import DimShuffle, Elemwise
 from pytensor.tensor.exceptions import NotScalarConstantError
-from pytensor.tensor.math import add, clip
+from pytensor.tensor.math import add, clip, minimum
 from pytensor.tensor.shape import (
     Reshape,
+    Shape,
     Shape_i,
     specify_broadcastable,
 )
@@ -50,6 +59,7 @@ from pytensor.tensor.type import (
     discrete_dtypes,
     integer_dtypes,
     tensor,
+    uint_dtypes,
 )
 from pytensor.tensor.type_other import NoneTypeT
 from pytensor.tensor.variable import TensorConstant, TensorVariable
@@ -230,6 +240,54 @@ def as_index_literal(
     raise NotScalarConstantError()
 
 
+def _is_provably_non_negative(var) -> bool:
+    """``True`` when ``var`` can be statically shown to be non-negative.
+
+    Recognized cases:
+
+    - Python ``int`` / ``np.integer`` ``>= 0``.
+    - ``TensorConstant`` / ``ScalarConstant`` whose data is all ``>= 0``
+      (cached via ``tag.is_non_negative``).
+    - Unsigned-integer dtype.
+    - ``Shape`` / ``Shape_i`` outputs.
+    - ``MakeVector`` of provably non-negative inputs.
+    - View / shape-permutation ops — ``Subtensor``, ``ScalarFromTensor``,
+      ``TensorFromScalar``, ``DimShuffle`` — recurse to their input.
+    - ``Cast`` of a provably non-negative input.
+    - ``minimum(a, b)`` when both ``a`` and ``b`` are non-negative.
+    - ``maximum(a, b)`` when at least one of ``a``, ``b`` is non-negative.
+    """
+    if isinstance(var, int | np.integer):
+        return bool(var >= 0)
+    if isinstance(var, ScalarConstant | TensorConstant):
+        cached: bool | None = getattr(var.tag, "is_non_negative", None)
+        if cached is not None:
+            return cached
+        result = bool((np.asarray(var.data) >= 0).all())
+        var.tag.is_non_negative = result
+        return result
+    if not isinstance(var, Variable):
+        return False
+    if var.type.dtype in uint_dtypes:
+        return True
+    op = var.owner_op
+    if isinstance(op, Shape | Shape_i):
+        return True
+    if isinstance(op, MakeVector):
+        return all(_is_provably_non_negative(i) for i in var.owner.inputs)
+    if isinstance(op, Subtensor | ScalarFromTensor | TensorFromScalar | DimShuffle):
+        return _is_provably_non_negative(var.owner.inputs[0])
+    if isinstance(op, Elemwise):
+        scalar_op = op.scalar_op
+        if isinstance(scalar_op, Cast):
+            return _is_provably_non_negative(var.owner.inputs[0])
+        if isinstance(scalar_op, ScalarMinimum):
+            return all(_is_provably_non_negative(i) for i in var.owner.inputs)
+        if isinstance(scalar_op, ScalarMaximum):
+            return any(_is_provably_non_negative(i) for i in var.owner.inputs)
+    return False
+
+
 def get_idx_list(inputs, idx_list):
     return indices_from_subtensor(inputs[1:], idx_list)
 
@@ -367,8 +425,8 @@ def get_canonical_form_slice(
             if is_stop_length:
                 # Full slice.
                 return slice(0, length, 1), 1
-            if is_stop_constant and stop >= 0:
-                return (slice(0, switch(lt(stop, length), stop, length), 1), 1)
+            if _is_provably_non_negative(stop):
+                return (slice(0, minimum(stop, length), 1), 1)
             stop_plus_len = stop + length
             stop = switch(
                 lt(stop, 0),
@@ -484,6 +542,15 @@ def slice_len(slc, n):
     start, stop, step = tuple(
         as_index_constant(a) for a in [canon_slc.start, canon_slc.stop, canon_slc.step]
     )
+    # 0:stop:1 with non-negative stop: length is just ``stop``.
+    if (
+        isinstance(canon_slc.step, int)
+        and canon_slc.step == 1
+        and isinstance(canon_slc.start, int)
+        and canon_slc.start == 0
+        and _is_provably_non_negative(stop)
+    ):
+        return stop
     return switch(
         and_(gt(step, 0), lt(start, stop)),
         1 + (stop - 1 - start) // step,
@@ -594,6 +661,16 @@ def indexed_result_shape(array_shape, indices, indices_are_shapes=False):
         if basic:
             grp_shapes = tuple(array_shape[dim] for dim in dim_nums)
             res_shape += basic_shape(grp_shapes, grp_indices)
+        elif (
+            not indices_are_shapes
+            and len(grp_indices) > 1
+            and all(idx is grp_indices[0] for idx in grp_indices[1:])
+        ):
+            # All advanced indices in this group are the same Variable, so
+            # they share the same shape by construction — skip
+            # ``broadcast_shape``, which would emit a runtime broadcast
+            # assertion even though the shapes are already known to match.
+            res_shape += tuple(grp_indices[0].shape)
         else:
             from pytensor.tensor.extra_ops import broadcast_shape
 

--- a/pytensor/tensor/variable.py
+++ b/pytensor/tensor/variable.py
@@ -441,6 +441,10 @@ class _tensor_py_operators:
                 hasattr(args_el, "dtype") and args_el.dtype == "bool"
             ):
                 return True
+            # 0-d ndarrays satisfy ``isinstance(_, Iterable)`` but raise on
+            # iteration; the dtype branch above already handles them.
+            if isinstance(args_el, np.ndarray) and args_el.ndim == 0:
+                return False
             if not isinstance(args_el, Variable) and isinstance(args_el, Iterable):
                 for el in args_el:
                     if includes_bool(el):

--- a/tests/tensor/rewriting/test_basic.py
+++ b/tests/tensor/rewriting/test_basic.py
@@ -113,6 +113,7 @@ from pytensor.tensor.type import (
     vector,
 )
 from tests import unittest_tools as utt
+from tests.unittest_tools import assert_equal_computations
 
 
 rewrite_mode = config.mode
@@ -2073,3 +2074,30 @@ def test_topological_second_sink_broadcastable_change():
     topological_second_sink.rewrite(fg)
     [new_out] = fg.outputs
     assert equal_computations([new_out], [a + b])
+
+
+class TestExtractDiagOfTranspose:
+    """Coverage for ``extract_diag_of_transpose`` in ``rewriting/basic.py``."""
+
+    rewrite_kw = dict(include=("canonicalize", "stabilize", "specialize"))
+
+    def test_extract_diag_of_transpose(self):
+        x = pt.matrix("x", shape=(4, 6))
+        out = pt.diagonal(x.T)
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.diagonal(x)
+        assert_equal_computations([rewritten], [expected])
+
+    def test_extract_diag_of_transpose_offset(self):
+        x = pt.matrix("x", shape=(4, 6))
+        out = pt.diagonal(x.T, offset=2)
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.diagonal(x, offset=-2)
+        assert_equal_computations([rewritten], [expected])
+
+    def test_extract_diag_of_batched_transpose(self):
+        x = pt.tensor("x", shape=(3, 4, 5))
+        out = pt.diagonal(x.mT, axis1=-2, axis2=-1)
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.diagonal(x, axis1=-2, axis2=-1)
+        assert_equal_computations([rewritten], [expected])

--- a/tests/tensor/rewriting/test_subtensor.py
+++ b/tests/tensor/rewriting/test_subtensor.py
@@ -19,6 +19,7 @@ from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.math import Dot, dot, exp, sqr
 from pytensor.tensor.rewriting.subtensor import (
+    _slice_to_arange,
     local_add_of_sparse_write,
     local_adv_idx_to_slice,
     local_replace_AdvancedSubtensor,
@@ -1399,6 +1400,58 @@ class TestReadOfWriteSameIndices:
         out = inc_subtensor(x[:stop], v)[:stop]
         rewritten = rewrite_graph(out, include=("canonicalize", "specialize"))
         utt.assert_equal_computations([rewritten], [x[:stop] + v])
+
+
+@pytest.mark.parametrize("sl", [slice(None), slice(None, 5), slice(2, 8, 2)])
+def test_slice_to_arange_roundtrip(sl):
+    x = pt.vector("x", shape=(10,))
+
+    ar = _slice_to_arange(sl, x.shape[0])
+    assert ar is not None
+    arange_form = x[ar]
+    utt.assert_equal_computations([arange_form], [x[ar]])
+
+    useless_slice = out2in(local_adv_idx_to_slice, local_useless_slice)
+    folded = rewrite_graph(arange_form, include=(), custom_rewrite=useless_slice)
+    expected = x if sl == slice(None) else x[sl]
+    utt.assert_equal_computations([folded], [expected])
+
+
+def test_slice_read_of_write():
+    rw_kw = dict(
+        include=("canonicalize", "specialize"),
+        exclude=("local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1",),
+    )
+    buf = pt.vector("buf", shape=(5,))
+
+    # Full overlap: write [0,1,2], read [:3] -> val
+    val = pt.vector("val", shape=(3,), dtype=buf.dtype)
+    write_idx = pt.constant(np.array([0, 1, 2], dtype="int64"))
+    out = buf[write_idx].set(val)[:3]
+    rewritten = rewrite_graph(out, **rw_kw)
+    utt.assert_equal_computations([rewritten], [val])
+
+    # Partial overlap: write [0,2,4], read [:3] -> buf[:3][[0,2]].set(val[:2])
+    write_idx = pt.constant(np.array([0, 2, 4], dtype="int64"))
+    out = buf[write_idx].set(val)[:3]
+    rewritten = rewrite_graph(out, **rw_kw)
+    expected = buf[:3][np.array([0, 2])].set(val[:2])
+    utt.assert_equal_computations([rewritten], [expected])
+
+    # No overlap: write [3,4], read [:2] -> buf[:2]
+    val2 = pt.vector("val2", shape=(2,), dtype=buf.dtype)
+    write_idx = pt.constant(np.array([3, 4], dtype="int64"))
+    out = buf[write_idx].set(val2)[:2]
+    rewritten = rewrite_graph(out, **rw_kw)
+    utt.assert_equal_computations([rewritten], [buf[:2]])
+
+    # No match: slice on non-write axis
+    buf2 = pt.matrix("buf2", shape=(5, 5))
+    val3 = pt.vector("val3", shape=(5,), dtype=buf2.dtype)
+    write_idx = pt.constant(np.array([0, 2, 4], dtype="int64"))
+    out = buf2[write_idx].set(val3)[:, :3]
+    rewritten = rewrite_graph(out, **rw_kw)
+    utt.assert_equal_computations([rewritten], [out])
 
 
 class TestReadOfWriteConstantIndices:

--- a/tests/tensor/rewriting/test_subtensor.py
+++ b/tests/tensor/rewriting/test_subtensor.py
@@ -13,16 +13,18 @@ from pytensor.compile.ops import DeepCopyOp
 from pytensor.configdefaults import config
 from pytensor.graph import rewrite_graph, vectorize_graph
 from pytensor.graph.basic import Constant, Variable, equal_computations
-from pytensor.graph.rewriting.basic import check_stack_trace, in2out
+from pytensor.graph.rewriting.basic import check_stack_trace, in2out, out2in
 from pytensor.graph.traversal import ancestors
 from pytensor.tensor import as_tensor
-from pytensor.tensor.basic import Alloc, _convert_to_int8
+from pytensor.tensor.basic import Alloc, ExtractDiag, _convert_to_int8
 from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.math import Dot, dot, exp, sqr
 from pytensor.tensor.rewriting.subtensor import (
     local_add_of_sparse_write,
+    local_adv_idx_to_slice,
     local_replace_AdvancedSubtensor,
+    local_useless_slice,
 )
 from pytensor.tensor.shape import (
     SpecifyShape,
@@ -486,7 +488,11 @@ class TestLocalUselessSubtensor:
             assert prog[1].op == exp
             assert len(prog) == 2
         else:
-            assert any(isinstance(node.op, AdvancedSubtensor1) for node in prog)
+            # Arange-with-offset indices get rewritten to a Subtensor slice;
+            # other advanced indices stay as AdvancedSubtensor1.
+            assert any(
+                isinstance(node.op, AdvancedSubtensor1 | Subtensor) for node in prog
+            )
 
         x_val = np.array([[0, 1, 2], [3, 4, 5]], dtype=pytensor.config.floatX)
         idx_val = idx.eval() if isinstance(idx, Variable) else idx
@@ -1400,11 +1406,17 @@ class TestReadOfWriteSameIndices:
 class TestReadOfWriteConstantIndices:
     def setup_method(self):
         mode = get_default_mode()
+        # Exclude ``local_adv_idx_to_slice`` (the canonical arange→
+        # slice rewrite): otherwise it rewrites reads like ``[2, 4]`` into a basic
+        # ``Subtensor`` *before* the collapse rewrite gets a chance, hiding
+        # the AdvancedIncSubtensor parent the test is exercising. In
+        # FAST_RUN the diag_lift_pass's ``local_subtensor_of_write_to_advanced``
+        # gate would undo it in specialize, but FAST_COMPILE skips that.
         self.mode = mode.including(
             "local_replace_AdvancedSubtensor",
             "local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1",
             "local_advanced_read_of_write_constant_indices",
-        ).excluding("fusion")
+        ).excluding("fusion", "local_adv_idx_to_slice")
 
     def test_inc_multi_axis_unique_const(self):
         """Multi-axis ``x[idx_a, idx_b].inc(v)[idx_a, idx_b]`` with
@@ -1894,7 +1906,9 @@ def test_local_IncSubtensor_serialize():
 
 def test_local_set_to_inc_subtensor():
     v = fmatrix()
-    s = v[[2, 1]]
+    # Non-constant-step index keeps the AdvancedSubtensor1 in place for
+    # ``local_set_to_inc_subtensor`` to match against.
+    s = v[[2, 0, 1]]
     g = s + 3
     r = set_subtensor(s, g)
 
@@ -2453,6 +2467,111 @@ class TestUselessSlice:
         )
 
 
+class TestArangeRewrites:
+    """Coverage for the arange-recognition rewrites in ``rewriting/subtensor.py``:
+    ``local_adv_idx_to_slice`` and
+    ``local_adv_idx_to_diagonal``.
+    """
+
+    rewrite_kw = dict(
+        include=("canonicalize", "specialize"),
+        exclude=("local_replace_AdvancedSubtensor",),
+    )
+
+    @pytest.mark.parametrize("offset", [0, 2])
+    def test_constant_arange_step_one(self, offset):
+        """``x[arange(d) + r]`` with constant ``d``, ``r`` rewrites to ``x[r:r+d]``."""
+        x = pt.vector("x", shape=(10,))
+        out = x[pt.constant(np.arange(4, dtype=np.int64) + offset)]
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = x[offset : offset + 4] if offset else x[:4]
+        utt.assert_equal_computations([rewritten], [expected])
+
+    def test_constant_arange_positive_step(self):
+        """Stepped constant arange ``[2, 4, 6, 8]`` rewrites to ``x[2::2]``."""
+        x = pt.vector("x", shape=(10,))
+        idx = pt.constant(np.array([2, 4, 6, 8], dtype=np.int64))
+        rewritten = rewrite_graph(x[idx], **self.rewrite_kw)
+        expected = x[2::2]
+        utt.assert_equal_computations([rewritten], [expected])
+
+    def test_constant_arange_negative_step(self):
+        """Descending constant arange ``[5, 4, 3, 2, 1, 0]`` rewrites to ``x[5::-1]``.
+
+        Exercises the ``step < 0`` branch in ``_arange_index_to_slice`` that
+        rewrites a would-be-negative ``stop`` to ``None`` so the slice doesn't
+        wrap.
+        """
+        x = pt.vector("x", shape=(10,))
+        idx = pt.constant(np.array([5, 4, 3, 2, 1, 0], dtype=np.int64))
+        rewritten = rewrite_graph(x[idx], **self.rewrite_kw)
+        expected = x[5::-1]
+        utt.assert_equal_computations([rewritten], [expected])
+
+    def test_symbolic_arange_with_provably_non_negative_stop(self):
+        """``x[arange(n)]`` with provably non-negative symbolic ``n`` rewrites to a slice."""
+        x = pt.vector("x", shape=(10,))
+        n = pt.scalar("n", dtype="uint32")
+        out = x[pt.arange(n)]
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = x[: pt.cast(n, "int64")]
+        utt.assert_equal_computations([rewritten], [expected], strict_dtype=False)
+
+    def test_uniformly_negative_constant_does_not_rewrite(self):
+        """A constant arange whose first value is negative doesn't rewrite; numpy
+        wraps negative advanced indices to the tail, but a forward slice can't.
+        """
+        x = pt.vector("x", shape=(10,))
+        idx = pt.constant(np.array([-2, -1, 0], dtype=np.int64))
+        out = x[idx]
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        utt.assert_equal_computations([rewritten], [out])
+
+    @pytest.mark.parametrize("offset", [0, 2])
+    def test_arange_to_slice_roundtrip(self, offset):
+        """``x[k:]`` -> ``x[arange(n)+k]`` -> rewrite back -> ``x[k:]``."""
+        x = pt.vector("x", shape=(10,))
+        n = 10 - offset
+        slice_form = x[offset:] if offset else x
+
+        ar = pt.arange(n, dtype="int64")
+        arange_form = x[ar + offset] if offset else x[ar]
+        assert isinstance(arange_form.owner.op, AdvancedSubtensor | AdvancedSubtensor1)
+
+        folded = rewrite_graph(
+            arange_form,
+            include=(),
+            custom_rewrite=out2in(local_adv_idx_to_slice, local_useless_slice),
+        )
+        utt.assert_equal_computations([folded], [slice_form])
+
+    def test_paired_arange_both_nonzero_offsets_does_not_rewrite(self):
+        """``x[arange(d)+r, arange(d)+c]`` with both ``r`` and ``c`` non-zero
+        is a sub-diagonal gather that ``diagonal()`` can't express.
+        """
+        x = pt.matrix("x", shape=(5, 5))
+        d = pt.constant(np.int64(3))
+        out = x[pt.arange(d) + 1, pt.arange(d) + 2]
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        utt.assert_equal_computations([rewritten], [out])
+
+    def test_paired_arange_partial_coverage_does_not_rewrite(self):
+        """``x[arange(2), arange(2)]`` on a (5, 5) matrix is a sub-diagonal gather, not a diagonal."""
+        x = pt.matrix("x", shape=(5, 5))
+        d = pt.constant(np.int64(2))
+        out = x[pt.arange(d), pt.arange(d)]
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        utt.assert_equal_computations([rewritten], [out])
+
+    def test_paired_constant_arange_zero_offset(self):
+        """``x[[0,1,2], [0,1,2]]`` on (3, 3) rewrites to ``diagonal(x)``."""
+        x = pt.matrix("x", shape=(3, 3))
+        idx = pt.constant(np.arange(3, dtype=np.int64))
+        out = x[idx, idx]
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        utt.assert_equal_computations([rewritten], [pt.diagonal(x)])
+
+
 @pytest.mark.skipif(
     config.mode == "FAST_COMPILE", reason="Test requires specialization rewrites"
 )
@@ -2550,6 +2669,7 @@ def test_cholesky_unconstrain_grad(exp_before_materialize):
         IncSubtensor,
         AdvancedIncSubtensor1,
         AdvancedIncSubtensor,
+        ExtractDiag,
     )
     n_idx = sum(1 for n in f.maker.fgraph.toposort() if isinstance(n.op, idx_types))
     assert n_idx == 6

--- a/tests/tensor/rewriting/test_subtensor.py
+++ b/tests/tensor/rewriting/test_subtensor.py
@@ -1,5 +1,3 @@
-import random
-
 import numpy as np
 import pytest
 
@@ -1410,8 +1408,8 @@ class TestReadOfWriteConstantIndices:
         # slice rewrite): otherwise it rewrites reads like ``[2, 4]`` into a basic
         # ``Subtensor`` *before* the collapse rewrite gets a chance, hiding
         # the AdvancedIncSubtensor parent the test is exercising. In
-        # FAST_RUN the diag_lift_pass's ``local_subtensor_of_write_to_advanced``
-        # gate would undo it in specialize, but FAST_COMPILE skips that.
+        # FAST_RUN ``local_slice_read_of_write`` would convert the basic
+        # Subtensor back in specialize, but FAST_COMPILE skips that.
         self.mode = mode.including(
             "local_replace_AdvancedSubtensor",
             "local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1",
@@ -2570,53 +2568,6 @@ class TestArangeRewrites:
         out = x[idx, idx]
         rewritten = rewrite_graph(out, **self.rewrite_kw)
         utt.assert_equal_computations([rewritten], [pt.diagonal(x)])
-
-
-@pytest.mark.skipif(
-    config.mode == "FAST_COMPILE", reason="Test requires specialization rewrites"
-)
-def test_extract_diag_of_write():
-    """``extract_diag`` of a chain of diagonal writes should simplify away
-    the writes when the read overlaps a (fully or partially) written diagonal,
-    and otherwise reduce to ``extract_diag`` of the original base.
-    """
-    A = pt.full((2, 6, 6), np.nan)
-    rows = pt.arange(A.shape[-2])
-    cols = pt.arange(A.shape[-1])
-    write_offsets = [-2, -1, 0, 1, 2]
-    # Randomize write order to make sure the rewrite is not sensitive to it
-    random.shuffle(write_offsets)
-    for offset in write_offsets:
-        value = offset + 0.1 * offset
-        if offset == 0:
-            A = A[..., rows, cols].set(value)
-        elif offset > 0:
-            A = A[..., rows[:-offset], cols[offset:]].set(value)
-        else:
-            offset = -offset
-            A = A[..., rows[offset:], cols[:-offset]].set(value)
-    # Partial write along offset 3
-    A = A[..., rows[1:-3], cols[4:]].set(np.pi)
-
-    read_offsets = [-2, -1, 0, 1, 2, 3]
-    outs = [A.diagonal(offset=offset, axis1=-2, axis2=-1) for offset in read_offsets]
-
-    f_on = function([], outs)
-    f_off = function(
-        [],
-        outs,
-        mode=get_default_mode().excluding("local_extract_diag_of_write"),
-    )
-
-    # All AdvancedIncSubtensor writes should be eliminated by the rewrite.
-    on_topo = f_on.maker.fgraph.toposort()
-    assert not any(
-        isinstance(n.op, AdvancedIncSubtensor | AdvancedIncSubtensor1) for n in on_topo
-    )
-
-    # Numerical equivalence with the unrewritten reference.
-    for got, ref in zip(f_on(), f_off(), strict=True):
-        np.testing.assert_allclose(got, ref, equal_nan=True)
 
 
 @pytest.mark.skipif(

--- a/tests/tensor/rewriting/test_subtensor_lift.py
+++ b/tests/tensor/rewriting/test_subtensor_lift.py
@@ -593,7 +593,9 @@ class TestLocalSubtensorMakeVector:
 
         opt_fgraph = f.maker.fgraph
         assert opt_fgraph.outputs[0].dtype == "int32"
-        assert isinstance(opt_fgraph.outputs[0].owner.op, MakeVector)
+        assert_equal_computations(
+            [opt_fgraph.outputs[0].owner.inputs[0]], [expand_dims(x, 0)]
+        )
         assert f(0, 1, 2) == np.array([0], dtype=np.int32)
 
     def test_slice_idx_start(self):
@@ -771,10 +773,14 @@ def test_local_subtensor_shape_constant():
 @pytest.mark.parametrize(
     "original_fn, supported",
     [
-        (lambda x: x[:, [0, 1]][0], True),
-        (lambda x: x[:, [0, 1], [0, 0]][1:], True),
-        (lambda x: x[:, [[0, 1], [0, 0]]][1:], True),
-        (lambda x: x[:, None, [0, 1]][0], True),
+        # Use non-constant-step index permutations ([2, 0, 1] not [1, 0]) so
+        # ``local_adv_idx_to_slice`` doesn't rewrite the
+        # AdvancedSubtensor to a Subtensor before this rewrite gets a chance
+        # to fire.
+        (lambda x: x[:, [2, 0, 1]][0], True),
+        (lambda x: x[:, [2, 0, 1], [0, 0, 0]][1:], True),
+        (lambda x: x[:, [[2, 0], [0, 1]]][1:], True),
+        (lambda x: x[:, None, [2, 0, 1]][0], True),
         # Not supported, basic indexing on advanced indexing dim
         (lambda x: x[[0, 1]][0], False),
         # Not supported, basic indexing on the right of advanced indexing
@@ -792,10 +798,13 @@ def test_local_subtensor_of_adv_subtensor(original_fn, supported):
 
     out = original_fn(x)
     opt_out = rewrite_graph(
-        out, include=("canonicalize", "local_subtensor_of_adv_subtensor")
+        out,
+        include=("canonicalize", "local_subtensor_of_adv_subtensor"),
+        exclude=(
+            "local_advanced_read_of_write_constant_indices",
+            "local_adv_idx_to_slice",
+        ),
     )
-    # The graphs generated are too complicated to assert
-    # We simply check that the happens before the advanced subtensor
     toposort = FunctionGraph(outputs=[opt_out], clone=False).toposort()
     [idx_subtensor] = [
         i for i, node in enumerate(toposort) if isinstance(node.op, Subtensor)

--- a/tests/tensor/rewriting/test_subtensor_lift.py
+++ b/tests/tensor/rewriting/test_subtensor_lift.py
@@ -1045,7 +1045,7 @@ def test_local_subtensor_of_squeeze(original_fn, expected_fn, x_shape):
 class TestExtractDiagLiftPass:
     """Coverage for ``extract_diag_lift_pass`` and its constituent rewrites:
     ``local_extract_diag_of_alloc_diag``, ``local_extract_diag_of_eye``,
-    ``local_extract_diag_lift``.
+    ``local_extract_diag_lift``, and ``local_slice_read_of_write``.
     """
 
     rewrite_kw = dict(include=("ShapeOpt", "canonicalize", "specialize"))

--- a/tests/tensor/rewriting/test_subtensor_lift.py
+++ b/tests/tensor/rewriting/test_subtensor_lift.py
@@ -47,7 +47,7 @@ from pytensor.tensor.rewriting.subtensor_lift import (
     local_subtensor_of_batch_dims,
     local_subtensor_shape_constant,
 )
-from pytensor.tensor.shape import SpecifyShape, _shape
+from pytensor.tensor.shape import Shape_i, SpecifyShape, _shape
 from pytensor.tensor.special import softmax
 from pytensor.tensor.subtensor import (
     AdvancedSubtensor,
@@ -443,53 +443,212 @@ def test_local_subtensor_of_transpose(original_fn, expected_fn):
     )
 
 
-def test_local_subtensor_of_alloc():
-    # DebugMode should detect if something goes wrong.
-    # test shape combination of odd and event shape.
-    for s in [(3, 5), (4, 6), (3, 8), (4, 7), (1, 5), (5, 1)]:
-        x = tensor(
-            dtype=config.floatX,
-            shape=(1 if s[0] == 1 else None, 1 if s[1] == 1 else None),
+class TestSubtensorOfAlloc:
+    """Coverage for ``local_subtensor_of_alloc`` — basic and advanced indexing."""
+
+    rewrite_kw = dict(
+        include=("ShapeOpt", "canonicalize", "specialize"),
+        exclude=("local_replace_AdvancedSubtensor",),
+        clone=True,
+    )
+
+    def test_basic_subtensor(self):
+        for s in [(3, 5), (4, 6), (3, 8), (4, 7), (1, 5), (5, 1)]:
+            x = tensor(
+                dtype=config.floatX,
+                shape=(1 if s[0] == 1 else None, 1 if s[1] == 1 else None),
+            )
+
+            xval = np.zeros(s, dtype=config.floatX)
+            yval = np.arange(s[1], dtype=config.floatX)
+
+            for y in [shared(yval), pt.constant([1.0])]:
+                yx = pt.alloc(y, x.shape[0], x.shape[1])
+
+                slicess: list = []
+                if s[0] != 1:
+                    slicess.append((2, slice(None)))
+                if s[1] != 1:
+                    slicess.append((slice(None), 3))
+                slicess += [
+                    (slice(None), slice(3, None)),
+                    (slice(3, None),),
+                    (slice(3, None), slice(3, None)),
+                    (slice(1, 3), slice(None, -1)),
+                    (slice(None, None, 2)),
+                    (slice(1, None, 2)),
+                ]
+                for slices in slicess:
+                    z = yx.__getitem__(slices)
+                    f = function([x], z)
+                    if config.mode != "FAST_COMPILE":
+                        assert not isinstance(
+                            f.maker.fgraph.toposort()[-1].op, Subtensor
+                        )
+                    val = f(xval)
+                    assert xval.__getitem__(slices).shape == val.shape
+
+    @pytest.mark.parametrize("idx_ndim", (0, 1, 2))
+    def test_adv_int_indexing(self, idx_ndim):
+        v = pt.vector("v", shape=(7,))
+        # ``n`` is uint so the slice rewrite can prove non-negativity for the
+        # ``arange(n) -> slice(0, n)`` round-trip; ``uint32`` (not ``uint64``)
+        # because ``ShapeFeature`` rejects ``uint64`` shape dims.
+        n = pt.scalar("n", dtype="uint32")
+        idx = pt.tensor("idx", shape=(None,) * idx_ndim, dtype="int64")
+
+        # On broadcasted axis idx is a no-op, only contributes shape
+        out = pt.alloc(v, 5, 5, 7)[idx]
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        match idx_ndim:
+            case 0:
+                expected = pt.alloc(v, 5, 7)
+            case 1:
+                expected = pt.alloc(v, Shape_i(0)(idx), 5, 7)
+            case 2:
+                expected = pt.alloc(v, Shape_i(0)(idx), Shape_i(1)(idx), 5, 7)
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
+
+        # On real axis it could cause more work
+        out = pt.alloc(v, 5, 5, 7)[..., idx]
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        match idx_ndim:
+            case 0:
+                expected = pt.alloc(v[idx], 5, 5)
+            case 1 | 2:
+                expected = out
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
+
+        if idx_ndim == 0:
+            return
+
+        # But if we know it's less work, we're back on game
+        core_shape = (2,) * idx_ndim
+        out = pt.alloc(v, 5, 5, 7)[..., pt.specify_shape(idx, core_shape)]
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.alloc(v[pt.specify_shape(idx, core_shape)], 5, 5, *core_shape)
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
+
+        cast_n = n.astype("int64")
+        match idx_ndim:
+            case 1:
+                arange_idx = pt.arange(n)
+                # The lift's inner slice uses ``cast_n`` directly (slice clips
+                # at runtime), but the outer Alloc dim uses
+                # ``minimum(cast_n, dim_length)`` since arange-to-slice clamps
+                # against ``v.shape[0]`` to keep the gather in bounds.
+                expected_v_indexed = v[:cast_n]
+                index_shape = (pt.minimum(cast_n, v.type.shape[0]),)
+            case 2:
+                arange_idx = pt.arange(n).reshape((2, -1))
+                # The reshape-of-arange index isn't recognized by
+                # ``arange-to-slice``, so the lifted gather keeps its
+                # ``AdvancedSubtensor`` form. The outer Alloc shape uses
+                # ``cast_n // 2`` because ``arange`` casts the uint stop.
+                expected_v_indexed = v[arange_idx]
+                index_shape = (2, cast_n // 2)
+        out = pt.alloc(v, 5, 5, 7)[..., arange_idx]
+        expected = pt.alloc(expected_v_indexed, 5, 5, *index_shape)
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
+
+    def test_multiple_adv_int_indexing(self):
+        # Index on kept dims
+        val = pt.matrix("val", shape=(5, 7))
+        idx_a = pt.constant(np.array([0, 2], dtype=np.int64))
+        idx_b = pt.constant(np.array([1, 1], dtype=np.int64))
+
+        out = pt.alloc(val, 3, 4, 5, 7)[idx_a, idx_b, :, :]
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.alloc(val, 2, 5, 7)
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
+
+        out = pt.alloc(val, 3, 4, 5, 7)[:, idx_a, idx_b, :]
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.alloc(val[idx_b], 3, 2, 7)
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
+
+        out = pt.alloc(val, 3, 4, 5, 7)[:, :, idx_a, idx_b]
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.alloc(val[idx_a, idx_b], 3, 4, 2)
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
+
+        # Non-consecutive advanced indices make everything harder, we don't try
+        out = pt.alloc(val, 3, 4, 5, 7)[:, idx_a, :, idx_b]
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = out
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
+
+    def test_index_on_broadcast_val_dim(self):
+        v = pt.tensor("v", shape=(7, 1))
+
+        out = pt.alloc(v, 7, 5)[:3, :2]
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.alloc(v[:3], 3, 2)
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
+
+        out = pt.alloc(v, 7, 5)[:3, 2]
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = v[:3].squeeze(axis=1)
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
+
+        idx_a = pt.constant(np.array([0, 2], dtype=np.int64))
+        idx_b = pt.constant(np.array([0, 3], dtype=np.int64))
+
+        out = pt.alloc(v, 7, 5)[idx_a, idx_b]
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        rng = np.random.default_rng(0)
+        v_test = rng.normal(size=(7, 1))
+        np.testing.assert_allclose(
+            rewritten.eval({v: v_test}, mode=NO_OPTIMIZATION_MODE),
+            np.broadcast_to(v_test, (7, 5))[[0, 2], [0, 3]],
         )
 
-        xval = np.zeros(s, dtype=config.floatX)
-        yval = np.arange(s[1], dtype=config.floatX)
+        out = pt.alloc(v, 7, 5)[:3, idx_b]
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.alloc(v[:3], 3, 2)
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
 
-        for y in [shared(yval), pt.constant([1.0])]:
-            # The rows of yx are copies of y
-            yx = pt.alloc(y, x.shape[0], x.shape[1])
+    def test_boolean_idx_bails(self):
+        """A boolean mask on a non-broadcast val dim does not lift through Alloc."""
+        val = pt.vector("val", shape=(7,))
+        mask = pt.tensor("mask", shape=(None,), dtype="bool")
 
-            # Slice of each row
-            z_mat = yx[:, 3:]
-            assert z_mat.ndim == 2
+        out = pt.alloc(val, 5, 7)[:, mask]
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        assert_equal_computations([rewritten], [out], strict_dtype=False)
 
-            # Only one column
-            z_vec = yx[:, 3]
-            assert z_vec.ndim == 1
-            # results are vector
-            slicess = []
-            if s[0] != 1:
-                slicess.append((2, slice(None)))
-            if s[1] != 1:
-                slicess.append((slice(None), 3))
+    def test_const_idx_with_duplicates_bails(self):
+        """A constant integer index larger than the val dim does not lift through Alloc."""
+        val = pt.vector("val", shape=(3,))
+        idx = pt.constant(np.array([0, 0, 0, 0, 0], dtype=np.int64))
 
-            # results are matrix
-            slicess += [
-                (slice(None), slice(3, None)),
-                (slice(3, None),),
-                (slice(3, None), slice(3, None)),
-                (slice(1, 3), slice(None, -1)),
-                (slice(None, None, 2)),
-                (slice(1, None, 2)),
-            ]
-            for slices in slicess:
-                z = yx.__getitem__(slices)
-                f = function([x], z)
-                if config.mode != "FAST_COMPILE":
-                    # Subtensor can be in the input of Alloc
-                    assert not isinstance(f.maker.fgraph.toposort()[-1].op, Subtensor)
-                val = f(xval)
-                assert xval.__getitem__(slices).shape == val.shape
+        out = pt.alloc(val, 5, 3)[:, idx]
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        assert_equal_computations([rewritten], [out], strict_dtype=False)
+
+    def test_negative_step_idx_to_slice(self):
+        """Negative-step constant arange ``[7, 5, 3, 1]`` rewrites to ``x[7::-2]``."""
+        x = pt.vector("x", shape=(10,))
+        rng = np.random.default_rng(0)
+        x_test = rng.normal(size=10)
+
+        out = x[pt.constant(np.array([7, 5, 3, 1], dtype=np.int64))]
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        np.testing.assert_allclose(
+            rewritten.eval({x: x_test}, mode=NO_OPTIMIZATION_MODE),
+            x_test[7::-2],
+        )
+
+    def test_mixed_slice_and_adv_index(self):
+        """A mix of slice and adv index across alloc dims lifts each to its own dim."""
+        val = pt.matrix("val", shape=(4, 6))
+        idx = pt.constant(np.array([0, 1, 3], dtype=np.int64))
+
+        out = pt.alloc(val, 3, 4, 6)[:2, idx]
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.alloc(val[idx], 2, 3, 6)
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
 
 
 class TestLocalSubtensorSpecifyShapeLift:

--- a/tests/tensor/rewriting/test_subtensor_lift.py
+++ b/tests/tensor/rewriting/test_subtensor_lift.py
@@ -21,7 +21,7 @@ from pytensor.graph import (
     rewrite_graph,
 )
 from pytensor.graph.basic import equal_computations
-from pytensor.graph.rewriting.basic import check_stack_trace
+from pytensor.graph.rewriting.basic import check_stack_trace, out2in
 from pytensor.printing import debugprint
 from pytensor.tensor import (
     add,
@@ -44,7 +44,11 @@ from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.elemwise import DimShuffle, Elemwise
 from pytensor.tensor.math import Dot
 from pytensor.tensor.math import sum as pt_sum
+from pytensor.tensor.rewriting.subtensor import (
+    local_adv_idx_to_diagonal,
+)
 from pytensor.tensor.rewriting.subtensor_lift import (
+    _diag_indices,
     local_subtensor_make_vector,
     local_subtensor_of_batch_dims,
     local_subtensor_shape_constant,
@@ -1039,7 +1043,242 @@ def test_local_subtensor_of_squeeze(original_fn, expected_fn, x_shape):
 
 
 class TestExtractDiagLiftPass:
-    """Coverage for ``extract_diag_lift_pass`` and its constituent rewrites."""
+    """Coverage for ``extract_diag_lift_pass`` and its constituent rewrites:
+    ``local_extract_diag_of_alloc_diag``, ``local_extract_diag_of_eye``,
+    ``local_extract_diag_lift``.
+    """
+
+    rewrite_kw = dict(include=("ShapeOpt", "canonicalize", "specialize"))
+
+    @pytest.mark.parametrize(
+        "v_len, k_alloc, offset",
+        [(5, 0, 0), (4, 1, 1)],
+    )
+    def test_extract_diag_of_alloc_diag_match(self, v_len, k_alloc, offset):
+        v = pt.vector("v", shape=(v_len,))
+        out = pt.diagonal(pt.diag(v, k=k_alloc), offset=offset)
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        assert_equal_computations([rewritten], [v])
+
+    def test_extract_diag_of_alloc_diag_offset_mismatch(self):
+        """When offsets differ, the diagonals don't overlap, so the result is zeros."""
+        v = pt.vector("v", shape=(4,))
+        out = pt.diagonal(pt.diag(v, k=1), offset=0)
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.alloc(np.asarray(0.0, dtype=out.dtype), np.int64(5))
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
+
+    @pytest.mark.parametrize(
+        "n, m, k_eye, diag_offset, expected_val, expected_len",
+        [
+            (5, 5, 0, 0, 1, 5),
+            (3, 5, 0, 0, 1, 3),
+            (5, 5, 0, 1, 0, 4),
+        ],
+    )
+    def test_extract_diag_of_eye_static(
+        self, n, m, k_eye, diag_offset, expected_val, expected_len
+    ):
+        out = pt.diagonal(pt.eye(n, m, k_eye), offset=diag_offset)
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.as_tensor_variable(
+            np.full(expected_len, expected_val, dtype=out.dtype)
+        )
+        assert_equal_computations([rewritten], [expected])
+
+    def test_extract_diag_of_eye_symbolic(self):
+        n = pt.iscalar("n")
+        out = pt.diagonal(pt.eye(n, n, 0))
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.alloc(np.asarray(1.0, dtype=out.dtype), n)
+        assert_equal_computations([rewritten], [expected])
+
+    def test_extract_diag_of_eye_partial_static_n(self):
+        """Diagonal of ``eye(n, 5, 0)`` with symbolic ``n`` is ``alloc(1, min(n, 5))``."""
+        n = pt.iscalar("n")
+        out = pt.diagonal(pt.eye(n, 5, 0))
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.alloc(
+            np.asarray(1.0, dtype=out.dtype), pt.minimum(n, np.int64(5))
+        )
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
+
+    def test_extract_diag_of_eye_partial_static_m(self):
+        """Diagonal of ``eye(5, m, 0)`` with symbolic ``m`` is ``alloc(1, min(5, m))``."""
+        m = pt.iscalar("m")
+        out = pt.diagonal(pt.eye(5, m, 0))
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.alloc(
+            np.asarray(1.0, dtype=out.dtype), pt.minimum(np.int64(5), m)
+        )
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
+
+    def test_extract_diag_of_alloc_zeros(self):
+        n = pt.lscalar("n")
+        out = pt.diagonal(pt.alloc(np.float64(0.0), n, n))
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.alloc(np.float64(0.0), n)
+        assert_equal_computations([rewritten], [expected])
+
+    def test_extract_diag_of_alloc_ones(self):
+        n = pt.lscalar("n")
+        m = pt.lscalar("m")
+        out = pt.diagonal(pt.alloc(np.float64(1.0), n, m))
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.alloc(np.float64(1.0), pt.minimum(n, m))
+        assert_equal_computations([rewritten], [expected])
+
+    def test_extract_diag_of_alloc_symbolic_scalar(self):
+        v = pt.scalar("v")
+        out = pt.diagonal(pt.alloc(v, 5, 5))
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.alloc(v, 5)
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
+
+    def test_extract_diag_of_alloc_row_broadcast(self):
+        """Diagonal of a row-broadcast alloc reduces to a slice of the row."""
+        v = pt.vector("v", shape=(None,))
+        out = pt.diagonal(pt.alloc(v, 5, v.shape[0]))
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = v[:5]
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
+
+    def test_extract_diag_of_alloc_matrix(self):
+        """Diagonal lifts through Alloc onto the underlying matrix input."""
+        x = pt.matrix("x", shape=(None, None))
+        out = pt.diagonal(pt.alloc(x, 3, x.shape[0], x.shape[1]), axis1=-2, axis2=-1)
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        d = pt.minimum(Shape_i(0)(x), Shape_i(1)(x))
+        expected = pt.alloc(pt.diagonal(x), 3, d)
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
+
+    def test_extract_diag_of_eye_mul_matrix(self):
+        x = pt.matrix("x", shape=(5, 5))
+        out = pt.diagonal(pt.eye(5) * x)
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.diagonal(x)
+        assert_equal_computations([rewritten], [expected])
+
+    def test_extract_diag_of_eye_mul_scalar(self):
+        """Diagonal of ``eye(5) * s`` reduces to a length-5 broadcast of ``s``."""
+        s = pt.scalar("s")
+        out = pt.diagonal(pt.eye(5) * s)
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.alloc(s[None], 5)
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
+
+    def test_extract_diag_of_eye_mul_row(self):
+        v = pt.row("v", shape=(1, 5))
+        out = pt.diagonal(pt.eye(5) * v)
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = v.squeeze(axis=0)
+        assert_equal_computations([rewritten], [expected])
+
+    def test_extract_diag_of_eye_mul_col(self):
+        v = pt.col("v", shape=(5, 1))
+        out = pt.diagonal(pt.eye(5) * v)
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = v.squeeze(axis=1)
+        assert_equal_computations([rewritten], [expected])
+
+    def test_extract_diag_of_eye_mul_nonzero_offset(self):
+        """Off-diagonal of ``eye(5) * x`` is zero everywhere."""
+        x = pt.matrix("x", shape=(5, 5))
+        out = pt.diagonal(pt.eye(5) * x, offset=1)
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.alloc(np.asarray(0.0, dtype=out.dtype), 4)
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
+
+    def test_extract_diag_of_elemwise_unary(self):
+        x = pt.matrix("x", shape=(5, 4))
+        out = pt.diagonal(pt.exp(x))
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.exp(pt.diagonal(x))
+        assert_equal_computations([rewritten], [expected])
+
+    def test_extract_diag_of_elemwise_binary(self):
+        x = pt.matrix("x", shape=(5, 5))
+        y = pt.matrix("y", shape=(5, 5))
+        out = pt.diagonal(x + y)
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.diagonal(x) + pt.diagonal(y)
+        assert_equal_computations([rewritten], [expected])
+
+    @pytest.mark.parametrize(
+        "bcast_shape, squeeze_axis",
+        [
+            ((), None),
+            ((1, 5), 0),
+            ((5, 1), 1),
+        ],
+        ids=["scalar", "row", "col"],
+    )
+    def test_extract_diag_of_elemwise_broadcast(self, bcast_shape, squeeze_axis):
+        x = pt.matrix("x", shape=(5, 5))
+        b = pt.tensor("b", shape=bcast_shape)
+        out = pt.diagonal(x + b) if bcast_shape else pt.diagonal(x * b)
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        b_diag = b.squeeze(axis=squeeze_axis) if squeeze_axis is not None else b
+        expected = (pt.diagonal(x) + b_diag) if bcast_shape else (pt.diagonal(x) * b)
+        assert_equal_computations([rewritten], [expected])
+
+    def test_extract_diag_of_elemwise_row_broadcast_offset(self):
+        """Row-broadcast input with positive offset contributes ``r[:, offset:]``."""
+        x = pt.matrix("x", shape=(5, 5))
+        r = pt.row("r", shape=(1, 5))
+        out = pt.diagonal(x + r, offset=1)
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.diagonal(x, offset=1) + r[:, 1:].squeeze(axis=0)
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
+
+    def test_extract_diag_of_elemwise_unary_full_broadcast(self):
+        """Diagonal of a unary Elemwise on a fully-broadcast (1, 1) matrix is length-1."""
+        s = pt.scalar("s")
+        m = s.dimshuffle("x", "x")
+        out = pt.diagonal(-m)
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        rng = np.random.default_rng(0)
+        s_test = float(rng.normal())
+        np.testing.assert_allclose(rewritten.eval({s: s_test}), [-s_test])
+
+    def test_extract_diag_of_elemwise_binary_with_full_broadcast(self):
+        """Diagonal of a binary Elemwise mixing a matrix and a (1, 1) input."""
+        x = pt.matrix("x", shape=(4, 4))
+        s = pt.scalar("s")
+        m = s.dimshuffle("x", "x")
+        out = pt.diagonal(x + m)
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        rng = np.random.default_rng(0)
+        x_test = rng.normal(size=(4, 4))
+        s_test = float(rng.normal())
+        np.testing.assert_allclose(
+            rewritten.eval({x: x_test, s: s_test}),
+            np.diagonal(x_test + s_test),
+        )
+
+    @pytest.mark.parametrize("offset", [0, 2, -2])
+    def test_diag_indices_roundtrip(self, offset):
+        """``diagonal(x, k)`` -> ``_diag_indices`` -> rewrite back -> ``diagonal(x, k)``."""
+        x = pt.matrix("x", shape=(5, 5))
+        diag_form = pt.diagonal(x, offset=offset)
+
+        row_off, col_off = max(0, -offset), max(0, offset)
+        d = min(5 - row_off, 5 - col_off)
+        idxs = _diag_indices(2, 0, 1, d, row_off, col_off)
+        arange_form = x[tuple(idxs)]
+
+        ar = pt.arange(d, dtype="int64")
+        rows = ar + row_off if row_off else ar
+        cols = ar + col_off if col_off else ar
+        expected_lowered = x[rows, cols]
+        assert_equal_computations([arange_form], [expected_lowered])
+
+        folded = rewrite_graph(
+            arange_form,
+            include=(),
+            custom_rewrite=out2in(local_adv_idx_to_diagonal),
+        )
+        assert_equal_computations([folded], [diag_form])
 
     @pytest.mark.skipif(
         config.mode == "FAST_COMPILE", reason="Test requires specialization rewrites"

--- a/tests/tensor/rewriting/test_subtensor_lift.py
+++ b/tests/tensor/rewriting/test_subtensor_lift.py
@@ -1,3 +1,5 @@
+import random
+
 import numpy as np
 import pytest
 
@@ -50,6 +52,8 @@ from pytensor.tensor.rewriting.subtensor_lift import (
 from pytensor.tensor.shape import Shape_i, SpecifyShape, _shape
 from pytensor.tensor.special import softmax
 from pytensor.tensor.subtensor import (
+    AdvancedIncSubtensor,
+    AdvancedIncSubtensor1,
     AdvancedSubtensor,
     Subtensor,
 )
@@ -1032,3 +1036,52 @@ def test_local_subtensor_of_squeeze(original_fn, expected_fn, x_shape):
         opt_out.eval({x: x_test}, mode=NO_OPTIMIZATION_MODE),
         out.eval({x: x_test}, mode=NO_OPTIMIZATION_MODE),
     )
+
+
+class TestExtractDiagLiftPass:
+    """Coverage for ``extract_diag_lift_pass`` and its constituent rewrites."""
+
+    @pytest.mark.skipif(
+        config.mode == "FAST_COMPILE", reason="Test requires specialization rewrites"
+    )
+    def test_extract_diag_of_write(self):
+        """Diagonal reads collapse fully-covered diagonal writes and keep partial-coverage writes."""
+        A = pt.full((2, 6, 6), np.nan)
+        rows = pt.arange(A.shape[-2])
+        cols = pt.arange(A.shape[-1])
+        write_offsets = [-2, -1, 0, 1, 2]
+        random.shuffle(write_offsets)
+        for offset in write_offsets:
+            value = offset + 0.1 * offset
+            if offset == 0:
+                A = A[..., rows, cols].set(value)
+            elif offset > 0:
+                A = A[..., rows[:-offset], cols[offset:]].set(value)
+            else:
+                offset = -offset
+                A = A[..., rows[offset:], cols[:-offset]].set(value)
+        # Partial write along offset 3
+        A = A[..., rows[1:-3], cols[4:]].set(np.pi)
+
+        read_offsets = [-2, -1, 0, 1, 2, 3]
+        outs = [
+            A.diagonal(offset=offset, axis1=-2, axis2=-1) for offset in read_offsets
+        ]
+
+        f_on = function([], outs)
+        f_off = function(
+            [],
+            outs,
+            mode=get_default_mode().excluding("extract_diag_lift_pass"),
+        )
+
+        # The partial-coverage read at offset=3 keeps exactly one scatter write of pi.
+        on_topo = f_on.maker.fgraph.toposort()
+        n_writes = sum(
+            isinstance(n.op, AdvancedIncSubtensor | AdvancedIncSubtensor1)
+            for n in on_topo
+        )
+        assert n_writes == 1
+
+        for got, ref in zip(f_on(), f_off(), strict=True):
+            np.testing.assert_allclose(got, ref, equal_nan=True)

--- a/tests/tensor/rewriting/test_subtensor_lift.py
+++ b/tests/tensor/rewriting/test_subtensor_lift.py
@@ -49,7 +49,10 @@ from pytensor.tensor.rewriting.subtensor_lift import (
 )
 from pytensor.tensor.shape import SpecifyShape, _shape
 from pytensor.tensor.special import softmax
-from pytensor.tensor.subtensor import AdvancedSubtensor, Subtensor
+from pytensor.tensor.subtensor import (
+    AdvancedSubtensor,
+    Subtensor,
+)
 from tests.unittest_tools import assert_equal_computations
 
 
@@ -180,6 +183,25 @@ class TestLocalSubtensorOfBatchDims:
         # Otherwise it should work
         fgraph.remove_output(0)
         assert local_subtensor_of_batch_dims.transform(fgraph, out2.owner) is not None
+
+    def test_elemwise_adv_index_provably_smaller(self):
+        """An adv index provably smaller than the non-broadcast Elemwise inputs lifts through Elemwise."""
+        x = pt.matrix("x", shape=(10, 5))
+        y = pt.matrix("y", shape=(10, 5))
+        idx = pt.constant(np.array([0, 2, 5]), dtype="int64")
+        out = pt.add(x, y)[idx]
+        rewritten = rewrite_graph(out)
+        expected = pt.add(x[idx], y[idx])
+        assert_equal_computations([rewritten], [expected])
+
+    def test_elemwise_adv_index_not_provably_smaller_bails(self):
+        """An adv index whose size cannot be bounded does not lift through Elemwise."""
+        x = pt.matrix("x", shape=(10, 5))
+        y = pt.matrix("y", shape=(10, 5))
+        idx = pt.tensor("idx", shape=(None,), dtype="int64")
+        out = pt.add(x, y)[idx]
+        rewritten = rewrite_graph(out)
+        assert equal_computations([rewritten], [out])
 
     def test_blockwise(self):
         class CoreTestOp(Op):

--- a/tests/tensor/test_subtensor.py
+++ b/tests/tensor/test_subtensor.py
@@ -613,7 +613,11 @@ class TestSubtensor(utt.OptimizationTestMixin):
             (3, DimShuffle, np.index_exp[..., [0, 2, 3]]),
             (1, DimShuffle, np.index_exp[np.newaxis, ...]),
             (
-                4 if config.mode == "FAST_COMPILE" else 3,
+                # ``[1, 2]`` is folded to a basic slice by
+                # ``local_adv_idx_to_slice`` in canonicalize, so the
+                # AdvancedSubtensor never reaches the linker — toposort is the
+                # same shape regardless of FAST_RUN vs FAST_COMPILE.
+                3,
                 AdvancedSubtensor,
                 np.index_exp[..., np.newaxis, [1, 2]],
             ),
@@ -732,10 +736,15 @@ class TestSubtensor(utt.OptimizationTestMixin):
         # the boolean mask should have the correct shape
         # - too large, padded with True
         mask = np.array([True, False, True])
+        # Single-axis bool reads rewrite ``[T, F, T]`` -> ``[0, 2]`` ->
+        # ``[0:4:2]`` via ``local_adv_idx_to_slice`` (shape_unsafe),
+        # silently truncating the gather. Exclude it so the IndexError from
+        # the out-of-bounds gather still surfaces.
+        shape_safe_read_mode = get_default_mode().excluding("shape_unsafe")
         with pytest.raises(IndexError):
-            test_array[mask].eval()
+            test_array[mask].eval(mode=shape_safe_read_mode)
         with pytest.raises(IndexError):
-            test_array[mask, ...].eval()
+            test_array[mask, ...].eval(mode=shape_safe_read_mode)
         with pytest.raises(IndexError):
             inc_subtensor(test_array[mask], 1).eval()
         with pytest.raises(IndexError):
@@ -864,6 +873,10 @@ class TestSubtensor(utt.OptimizationTestMixin):
         assert np.allclose(gval, good), (gval, good)
 
     def test_ok_list(self):
+        # ``local_adv_idx_to_slice`` (shape_unsafe) rewrites
+        # constant-step gathers like ``[1, 0]`` to a basic slice — exclude it
+        # here so the AdvancedSubtensor1 op survives for inspection.
+        shape_safe_mode = self.mode.excluding("shape_unsafe")
         for data, idx in [
             (random(4), [1, 0]),
             (random(4, 5), [2, 3, -1]),
@@ -881,7 +894,9 @@ class TestSubtensor(utt.OptimizationTestMixin):
             n = self.shared(data)
             t = n[idx]
 
-            val = self.eval_output_and_check(t, op_type=AdvancedSubtensor1)
+            val = self.eval_output_and_check(
+                t, op_type=AdvancedSubtensor1, mode=shape_safe_mode
+            )
             if isinstance(idx, list):
                 good = data[idx]
             else:

--- a/tests/tensor/test_subtensor.py
+++ b/tests/tensor/test_subtensor.py
@@ -456,7 +456,11 @@ class TestSubtensor(utt.OptimizationTestMixin):
         assert isinstance(t.owner.op, Subtensor)
         self.eval_output_and_check(
             t,
-            mode=self.mode.excluding("local_useless_subtensor", "local_useless_slice"),
+            mode=self.mode.excluding(
+                "local_useless_subtensor",
+                "local_useless_slice",
+                "extract_diag_lift_pass",
+            ),
         )
 
     def test_err_invalid_2(self):


### PR DESCRIPTION
These came up when I was working on https://github.com/pymc-devs/pytensor/pull/2032. They're not related to that perse so I split them off. We're missing a lot of simple rewrites for ExtractDiag. I added:

- ExtractDiag(Eye) -> Ones or Zeros, depending on k
- ExtractDiag(Eye * x) -> Alloc(x) (new shape)
- ExtractDiag(Zeros / Ones) -> Zeros / Ones of new shape
- ExtractDiag(Alloc) -> Alloc (with new shape)
- ExtractDiag(Elemwise(a, b)) -> Elemwise(ExtractDiag(a), ExtractDiag(b)) (plus some broadcasting logic)
- ExtractDiag(Transpose(x), offset=k) -> ExtractDiag(X, offset=-k) (I understand transpose is just a free view but it removes a blocker to further rewrites that no longer need to see through the transpose)


## TODO
- [x] Split the lift_subtensor_through_alloc between shape_safe and shape_unsafe, only the former should be registered in `infer_shape` (we never want incorrect shape inference in this phase)
- [x] Split the new extract diag rewrites from the lower + lift
- [x] Split the subtensor of write? Shouldn't even be in subtensor_lift?
