### PR TITLE
JAX: fix Alloc failing under jax.jit when shape inputs are constants

### DIFF
--- a/pytensor/link/jax/dispatch/tensor_basic.py
+++ b/pytensor/link/jax/dispatch/tensor_basic.py
@@ -41,10 +41,32 @@ def jax_funcify_AllocEmpty(op, **kwargs):
 
 @jax_funcify.register(Alloc)
 def jax_funcify_Alloc(op, node, **kwargs):
-    def alloc(x, *shape):
-        res = jnp.broadcast_to(x, shape)
-        Alloc._check_runtime_broadcast(node, jnp.asarray(x), res.shape)
-        return res
+    # Extract concrete shape values at compile time where possible.
+    # Shape inputs that are constants must be baked in as Python ints so that
+    # jnp.broadcast_to receives a concrete tuple even when the surrounding
+    # function is traced by jax.jit / jax.value_and_grad (where JAX array
+    # constants would otherwise become JitTracers, which broadcast_to rejects).
+    static_shapes = []
+    for shape_input in node.inputs[1:]:
+        try:
+            static_shapes.append(int(get_scalar_constant_value(shape_input)))
+        except NotScalarConstantError:
+            static_shapes.append(None)
+
+    if all(s is not None for s in static_shapes):
+        concrete_shape = tuple(static_shapes)
+
+        def alloc(x, *shape):
+            res = jnp.broadcast_to(x, concrete_shape)
+            Alloc._check_runtime_broadcast(node, jnp.asarray(x), res.shape)
+            return res
+
+    else:
+
+        def alloc(x, *shape):
+            res = jnp.broadcast_to(x, shape)
+            Alloc._check_runtime_broadcast(node, jnp.asarray(x), res.shape)
+            return res
 
     return alloc
 

--- a/pytensor/link/jax/dispatch/tensor_basic.py
+++ b/pytensor/link/jax/dispatch/tensor_basic.py
@@ -52,7 +52,9 @@ def jax_funcify_Alloc(op, node, **kwargs):
         concrete_shape = tuple(static_shapes)
 
     def alloc(x, *shape):
-        res = jnp.broadcast_to(x, concrete_shape if concrete_shape is not None else shape)
+        res = jnp.broadcast_to(
+            x, concrete_shape if concrete_shape is not None else shape
+        )
         Alloc._check_runtime_broadcast(node, jnp.asarray(x), res.shape)
         return res
 

--- a/pytensor/link/jax/dispatch/tensor_basic.py
+++ b/pytensor/link/jax/dispatch/tensor_basic.py
@@ -41,32 +41,20 @@ def jax_funcify_AllocEmpty(op, **kwargs):
 
 @jax_funcify.register(Alloc)
 def jax_funcify_Alloc(op, node, **kwargs):
-    # Extract concrete shape values at compile time where possible.
-    # Shape inputs that are constants must be baked in as Python ints so that
-    # jnp.broadcast_to receives a concrete tuple even when the surrounding
-    # function is traced by jax.jit / jax.value_and_grad (where JAX array
-    # constants would otherwise become JitTracers, which broadcast_to rejects).
     static_shapes = []
     for shape_input in node.inputs[1:]:
         try:
             static_shapes.append(int(get_scalar_constant_value(shape_input)))
         except NotScalarConstantError:
-            static_shapes.append(None)
-
-    if all(s is not None for s in static_shapes):
+            concrete_shape = None
+            break
+    else:
         concrete_shape = tuple(static_shapes)
 
-        def alloc(x, *shape):
-            res = jnp.broadcast_to(x, concrete_shape)
-            Alloc._check_runtime_broadcast(node, jnp.asarray(x), res.shape)
-            return res
-
-    else:
-
-        def alloc(x, *shape):
-            res = jnp.broadcast_to(x, shape)
-            Alloc._check_runtime_broadcast(node, jnp.asarray(x), res.shape)
-            return res
+    def alloc(x, *shape):
+        res = jnp.broadcast_to(x, concrete_shape if concrete_shape is not None else shape)
+        Alloc._check_runtime_broadcast(node, jnp.asarray(x), res.shape)
+        return res
 
     return alloc
 


### PR DESCRIPTION
jax_funcify_Alloc returns a closure that receives shape dimensions as
JAX arrays at runtime. When the compiled pytensor function is
re-traced by an outer jax.jit or jax.value_and_grad call, as done by
downstream libraries that extract f.vm.jit_fn and differentiate through
it, those JAX arrays are promoted to JitTracers.  jnp.broadcast_to
requires a concrete tuple of Python ints for its shape argument and
raised:

TypeError: Shapes must be 1D sequences of concrete values of integer
	 type, got (JitTracer(int64[]),).

Fix: at compile time in jax_funcify_Alloc, attempt to resolve each
shape input to a concrete Python int using get_scalar_constant_value.
When all shape dimensions are constant (the common case), bake the
resulting tuple directly into the closure so that no JAX array is ever
passed as a shape argument at runtime.  Dynamic shape dimensions fall
back to the previous behaviour.

I came across this issue while using DADVI with @wrap_jax in PyMC.

Please note this was analyzed and patched using AI.

Minimal example showing the problem:
```python
import os

os.environ["JAX_PLATFORMS"] = "cpu"
os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=2"

import jax
import jax.numpy as jnp
import numpy as np
import pytensor.tensor as pt

jax.config.update("jax_enable_x64", True)

# Direct JAX reproduction of the core issue.
# (Reproduces the mechanism without going through pytensor.)
def unpatched_alloc(x, *shape):
    """Mimics the runtime closure returned by unpatched jax_funcify_Alloc."""
    return jnp.broadcast_to(x, shape)

@jax.jit
def objective_bug1(x):
    n = jnp.array(5, dtype=jnp.int64)  # JAX constant → JitTracer under jit
    return unpatched_alloc(x, n).sum()

print("Direct JAX demonstration:")
try:
    val, grad = jax.value_and_grad(objective_bug1)(np.float64(2.0))
    print(f"Result: val={val}, grad={grad}   (patch applied, no error)")
except TypeError as e:
    print(f"BUG — TypeError: {e}")

# pytensor round-trip: compile a function with Alloc and differentiate it.
# On unpatched pytensor this raises the same TypeError via f.vm.jit_fn.
# On patched pytensor, jax_funcify_Alloc bakes in a concrete Python int
# at compile time (using get_scalar_constant_value), so the closure
# never contains JAX arrays.
x_pt = pt.scalar("x")
loss = pt.sum(pt.alloc(x_pt, 5))  # constant shape (5,)
f_jax = pytensor.function([x_pt], loss, mode="JAX")
jit_fn = f_jax.vm.jit_fn

print("\nPytensor round-trip (wraps f.vm.jit_fn in jax.value_and_grad):")
try:
    val, grad = jax.jit(lambda v: jax.value_and_grad(lambda v: jit_fn(v)[0])(v))(
        np.float64(2.0)
    )
    print(f"Result: val={val:.1f}, grad={grad:.1f}   (patch applied, no error)")
except TypeError as e:
    print(f"BUG — TypeError: {e}")
```

## Related Issue
This mirrors the existing fix already applied to jax_funcify_ARange in
the same file for the same class of problem.
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [X] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [X] Included tests that prove the fix is effective or that the new feature works
- [X] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [X] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
