### PR TITLE
Make numba caching safe across internal name collisions

### DIFF
--- a/.github/workflows/numba-upper-bound.yml
+++ b/.github/workflows/numba-upper-bound.yml
@@ -1,0 +1,68 @@
+name: Bump numba upper bound
+
+# Watches PyPI for new numba releases. When one appears above our current
+# upper bound in pyproject.toml, opens a PR raising the cap so our normal
+# CI (Tests workflow) validates the new version before we ship it.
+
+on:
+  schedule:
+    # Every Monday at 08:00 UTC
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install packaging
+        run: python -m pip install --upgrade packaging
+
+      - name: Check PyPI and rewrite pin if needed
+        id: bump
+        run: python scripts/bump_numba_upper_bound.py
+
+      - name: Open PR with bumped pin
+        if: steps.bump.outputs.bumped == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LATEST: ${{ steps.bump.outputs.latest }}
+          NEW_CAP: ${{ steps.bump.outputs.new_cap }}
+        run: |
+          set -euo pipefail
+          branch="auto/bump-numba-${NEW_CAP}"
+
+          # The auto-bump may have already been opened in a prior run.
+          if gh pr list --head "$branch" --state open --json number --jq '.[0].number' | grep -q '.'; then
+            echo "PR for $branch already open; skipping."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$branch"
+          git add pyproject.toml
+          git commit -m "Bump numba upper bound to <=${NEW_CAP}"
+
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push "$remote" "$branch"
+
+          gh pr create \
+            --title "Bump numba upper bound to <=${NEW_CAP}" \
+            --body "numba ${LATEST} is available on PyPI. This PR raises the upper bound in \`pyproject.toml\` to \`<=${NEW_CAP}\` so the normal Tests workflow validates the new release. Merge after CI passes." \
+            --head "$branch" \
+            --base main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "setuptools>=59.0.0",
     "scipy>=1,<2",
     "numpy>=2.0",
-    "numba>0.57,<1",
+    "numba>=0.58,<0.66",
     "filelock>=3.15",
     "etuples",
     "logical-unification",
@@ -81,7 +81,7 @@ tests = [
 ]
 rtd = ["sphinx>=5.1.0,<6", "pygments", "pydot"]
 jax = ["jax", "jaxlib"]
-numba = ["numba>=0.57", "llvmlite"]
+numba = ["numba>=0.58,<0.66", "llvmlite"]
 
 [tool.setuptools.packages.find]
 include = ["pytensor*"]
@@ -158,6 +158,7 @@ lines-after-imports = 2
 "pytensor/bin/pytensor_cache.py" = ["T201"]
 "tests/compile/debug/test_monitormode.py" = ["T201"]
 "scripts/run_mypy.py" = ["T201"]
+"scripts/bump_numba_upper_bound.py" = ["T201"]
 # Test modules of optional backends that use `pytest.importorskip`, skip "E402"
 "tests/link/jax/**/test_*.py" = ["E402"]
 "tests/link/numba/**/test_*.py" = ["E402"]

--- a/pytensor/link/numba/cache.py
+++ b/pytensor/link/numba/cache.py
@@ -1,6 +1,4 @@
-import itertools
-import os
-import random
+import uuid
 from collections.abc import Callable
 from hashlib import sha256
 from pickle import dump
@@ -21,26 +19,34 @@ NUMBA_CACHE_PATH = config.base_compiledir / "numba"
 NUMBA_CACHE_PATH.mkdir(parents=True, exist_ok=True)
 CACHED_SRC_FUNCTIONS: WeakKeyDictionary[Callable, str] = WeakKeyDictionary()
 
-# Re-seed numba's FunctionIdentity._unique_ids counter on first use and
-# after every os.fork() to avoid LLVM symbol collisions between sibling
-# forks. See https://github.com/numba/numba/issues/10486
-_numba_uid_needs_reseed: bool = True
+
+class _RandomUidIter:
+    """Iterator yielding cryptographically random 128-bit integers.
+
+    Replaces numba's default ``FunctionIdentity._unique_ids`` sequential
+    counter so that sibling forks — which inherit the counter state verbatim —
+    cannot allocate identical uids to same-qualname functions they
+    fresh-compile next. Identical uids produce byte-identical LLVM mangled
+    symbols with different bodies; a later process that loads both hits LLVM's
+    weak-merge and dispatches into the wrong body, segfaulting.
+
+    Numba only consumes ``_unique_ids`` via ``next(cls._unique_ids)`` (see
+    ``numba.core.bytecode.FunctionIdentity.from_function``), so any iterator
+    of unique ints is a drop-in replacement. ``uuid.uuid4`` pulls fresh
+    entropy from the OS on every call, making this generator fork-safe
+    without any re-seed hook.
+
+    See https://github.com/numba/numba/issues/10486.
+    """
+
+    def __iter__(self) -> "_RandomUidIter":
+        return self
+
+    def __next__(self) -> int:
+        return uuid.uuid4().int
 
 
-def _mark_numba_uid_needs_reseed() -> None:
-    global _numba_uid_needs_reseed
-    _numba_uid_needs_reseed = True
-
-
-os.register_at_fork(after_in_child=_mark_numba_uid_needs_reseed)
-
-
-def reseed_numba_uid_counter() -> None:
-    """Re-seed numba's UID counter if needed (after fork or first use)."""
-    global _numba_uid_needs_reseed
-    if _numba_uid_needs_reseed:
-        _numba_uid_needs_reseed = False
-        FunctionIdentity._unique_ids = itertools.count(random.getrandbits(48) | 1)
+FunctionIdentity._unique_ids = _RandomUidIter()
 
 
 class NumbaPyTensorCacheLocator(_CacheLocator):
@@ -92,7 +98,6 @@ class NumbaPyTensorCacheLocator(_CacheLocator):
     def from_function(cls, py_func, py_file):
         """Create a locator instance for functions stored in CACHED_SRC_FUNCTIONS."""
         if py_func in CACHED_SRC_FUNCTIONS and config.numba__cache:
-            reseed_numba_uid_counter()
             return cls(py_func, py_file, CACHED_SRC_FUNCTIONS[py_func])
 
 

--- a/pytensor/link/numba/cache.py
+++ b/pytensor/link/numba/cache.py
@@ -1,3 +1,6 @@
+import itertools
+import os
+import random
 from collections.abc import Callable
 from hashlib import sha256
 from pickle import dump
@@ -8,6 +11,7 @@ from weakref import WeakKeyDictionary
 import numba
 from llvmlite import ir
 from numba.core import cgutils
+from numba.core.bytecode import FunctionIdentity
 from numba.core.caching import CacheImpl, _CacheLocator
 
 from pytensor.configdefaults import config
@@ -16,6 +20,27 @@ from pytensor.configdefaults import config
 NUMBA_CACHE_PATH = config.base_compiledir / "numba"
 NUMBA_CACHE_PATH.mkdir(parents=True, exist_ok=True)
 CACHED_SRC_FUNCTIONS: WeakKeyDictionary[Callable, str] = WeakKeyDictionary()
+
+# Re-seed numba's FunctionIdentity._unique_ids counter on first use and
+# after every os.fork() to avoid LLVM symbol collisions between sibling
+# forks. See https://github.com/numba/numba/issues/10486
+_numba_uid_needs_reseed: bool = True
+
+
+def _mark_numba_uid_needs_reseed() -> None:
+    global _numba_uid_needs_reseed
+    _numba_uid_needs_reseed = True
+
+
+os.register_at_fork(after_in_child=_mark_numba_uid_needs_reseed)
+
+
+def reseed_numba_uid_counter() -> None:
+    """Re-seed numba's UID counter if needed (after fork or first use)."""
+    global _numba_uid_needs_reseed
+    if _numba_uid_needs_reseed:
+        _numba_uid_needs_reseed = False
+        FunctionIdentity._unique_ids = itertools.count(random.getrandbits(48) | 1)
 
 
 class NumbaPyTensorCacheLocator(_CacheLocator):
@@ -67,6 +92,7 @@ class NumbaPyTensorCacheLocator(_CacheLocator):
     def from_function(cls, py_func, py_file):
         """Create a locator instance for functions stored in CACHED_SRC_FUNCTIONS."""
         if py_func in CACHED_SRC_FUNCTIONS and config.numba__cache:
+            reseed_numba_uid_counter()
             return cls(py_func, py_file, CACHED_SRC_FUNCTIONS[py_func])
 
 

--- a/pytensor/link/numba/dispatch/basic.py
+++ b/pytensor/link/numba/dispatch/basic.py
@@ -1,4 +1,3 @@
-import re
 import warnings
 from collections.abc import Callable
 from functools import singledispatch, wraps
@@ -450,20 +449,12 @@ def numba_funcify_ensure_cache(op, *args, **kwargs) -> tuple[Callable, str | Non
             print(f"{op} of type {type(op)} will not be cached by PyTensor.\n")  # noqa: T201
         return jitable_func, None
     else:
-        full_cache_key = f"{cache_key}_fastmath{int(config.numba__fastmath)}"
-        # Include cache_key in the wrapper name to ensure unique LLVM symbol names.
-        # Without this, functions with the same __name__ but different behavior
-        # (e.g. all DimShuffle ops produce "dimshuffle")
-        # get identical mangled names when numba's UID counter overlaps after os.fork().
-        # This could cause compilation errors or silent bugs.
-        # See https://github.com/numba/numba/issues/10486
-        safe_key = re.sub(r"[^a-zA-Z0-9_]", "_", full_cache_key)
-        op_name = f"{jitable_func.__name__}_{safe_key}"
+        op_name = jitable_func.__name__
         cached_func = compile_numba_function_src(
             src=f"def {op_name}(*args): return jitable_func(*args)",
             function_name=op_name,
             global_env=globals() | {"jitable_func": jitable_func},
-            cache_key=full_cache_key,
+            cache_key=f"{cache_key}_fastmath{int(config.numba__fastmath)}",
         )
         return numba_njit(cached_func, cache=True), cache_key
 

--- a/scripts/bump_numba_upper_bound.py
+++ b/scripts/bump_numba_upper_bound.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+"""Bump the numba upper bound in pyproject.toml when a new numba release is out.
+
+Queries PyPI for the latest stable numba release and compares it against the
+current ``<=`` cap pinned in pyproject.toml. The pin is rewritten to the
+canonical ``"numba>=X.Y,<=A.B.C"`` form whenever:
+
+* the latest release is newer than the cap; or
+* the existing pin is in a non-canonical shape (``<`` instead of ``<=``, or
+  no upper bound at all). Form drift triggers a PR so the inconsistency is
+  surfaced for review rather than silently smoothed over.
+
+Exit code:
+    0  - no bump needed (pin is canonical and at the latest release)
+    0  - bump written (emits GITHUB_OUTPUT for the workflow)
+    1  - unexpected state (no pin found, inconsistent pins, etc.)
+"""
+
+import json
+import os
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+from packaging.version import Version
+
+
+PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+# Match any quoted numba spec: the bare name, or numba followed by a version
+# operator. The spec body (group "spec") is what we re-parse and rewrite.
+PIN_RE = re.compile(r'"numba(?P<spec>(?:[<>=!~][^"]*)?)"')
+LOWER_RE = re.compile(r">=\d+\.\d+(?:\.\d+)?")
+UPPER_RE = re.compile(r"<(=?)(\d+\.\d+(?:\.\d+)?)")
+DEFAULT_LOWER = ">=0.58"
+PYPI_URL = "https://pypi.org/pypi/numba/json"
+
+
+def fetch_latest_numba() -> Version:
+    with urllib.request.urlopen(PYPI_URL, timeout=30) as resp:
+        data = json.load(resp)
+    candidates: list[Version] = []
+    for raw, files in data["releases"].items():
+        if not files:
+            continue
+        v = Version(raw)
+        if v.is_prerelease or v.is_devrelease:
+            continue
+        candidates.append(v)
+    if not candidates:
+        raise RuntimeError("no stable numba release found on PyPI")
+    return max(candidates)
+
+
+def emit_output(key: str, value: str) -> None:
+    out = os.environ.get("GITHUB_OUTPUT")
+    if not out:
+        return
+    with Path(out).open("a") as f:
+        f.write(f"{key}={value}\n")
+
+
+def parse_spec(spec: str) -> tuple[str, str | None, Version | None]:
+    """Return ``(lower_clause, upper_op, upper_cap)`` for a numba pin body.
+
+    ``upper_op`` is ``"<"``, ``"<="``, or ``None`` when no upper bound is
+    present. A missing lower bound falls back to ``DEFAULT_LOWER`` so the
+    rewritten pin still constrains both sides.
+    """
+    lower_m = LOWER_RE.search(spec)
+    lower = lower_m.group(0) if lower_m else DEFAULT_LOWER
+    upper_m = UPPER_RE.search(spec)
+    if upper_m is None:
+        return lower, None, None
+    op = "<=" if upper_m.group(1) == "=" else "<"
+    return lower, op, Version(upper_m.group(2))
+
+
+def main() -> int:
+    text = PYPROJECT.read_text()
+    matches = list(PIN_RE.finditer(text))
+    if not matches:
+        print(f"no numba pin found in {PYPROJECT}", file=sys.stderr)
+        return 1
+
+    parsed = [parse_spec(m.group("spec")) for m in matches]
+    if len(set(parsed)) != 1:
+        print(f"inconsistent numba pins: {parsed}", file=sys.stderr)
+        return 1
+    lower, upper_op, current_cap = parsed[0]
+
+    latest = fetch_latest_numba()
+    latest_str = f"{latest.major}.{latest.minor}.{latest.micro}"
+    print(f"current pin spec: numba{matches[0].group('spec')}")
+    print(f"latest numba release: {latest}")
+
+    if upper_op == "<=" and current_cap == latest:
+        print("no bump needed")
+        emit_output("bumped", "false")
+        return 0
+
+    new_spec = f"{lower},<={latest_str}"
+    new_text = PIN_RE.sub(f'"numba{new_spec}"', text)
+    PYPROJECT.write_text(new_text)
+
+    if upper_op is None:
+        reason = "pin had no upper bound"
+    elif upper_op != "<=":
+        reason = "pin used '<' instead of '<='"
+    else:
+        reason = f"upper bound was {current_cap}, latest is {latest}"
+    print(f"rewrote pin ({reason}); new spec: numba{new_spec}")
+    emit_output("bumped", "true")
+    emit_output("latest", str(latest))
+    emit_output("new_cap", latest_str)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/link/numba/test_basic.py
+++ b/tests/link/numba/test_basic.py
@@ -1,6 +1,7 @@
 import contextlib
 import copy
 import os
+import pickle
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any
 from unittest import mock
@@ -25,6 +26,7 @@ from pytensor.graph.fg import FunctionGraph
 from pytensor.graph.op import Op
 from pytensor.graph.rewriting.db import RewriteDatabaseQuery
 from pytensor.graph.type import Type
+from pytensor.link.numba import cache as numba_cache
 from pytensor.link.numba.dispatch import basic as numba_basic
 from pytensor.link.numba.dispatch.basic import (
     _filter_numba_warnings,
@@ -773,57 +775,125 @@ class TestFgraphCacheKey:
         )
 
 
-@pytest.mark.skipif(not hasattr(os, "fork"), reason="Test requires os.fork (Unix only)")
-def test_fork_cache_no_type_mismatch(tmp_path, monkeypatch):
-    """Regression test for fork-safety of the numba disk cache.
+class TestNumbaCacheMuliprocessSafe:
+    @pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
+    def test_case1(self, tmp_path, monkeypatch):
+        """Regression test for fork-safety of the numba disk cache.
 
-    After os.fork(), numba's internal UID counter (FunctionIdentity._unique_ids)
-    is shared between parent and child. If two exec()-created wrapper functions
-    with the same qualname get the same UID in different processes, their LLVM
-    mangled names collide. When they have different return types (e.g. 3D vs 4D
-    array), this causes a ValueError during LLVM lowering.
+        After os.fork(), numba's internal UID counter (FunctionIdentity._unique_ids)
+        is shared between parent and child. If two exec()-created wrapper functions
+        with the same qualname get the same UID in different processes, their LLVM
+        mangled names collide. When they have different return types (e.g. 3D vs 4D
+        array), this causes a ValueError during LLVM lowering.
 
-    PyTensor prevents this by including the cache key in the wrapper function
-    name, ensuring unique LLVM symbols even when UIDs overlap after fork.
+        PyTensor prevents this by re-seeding numba's UID counter with a large random
+        offset after every fork, ensuring unique LLVM symbols across sibling processes.
 
-    See: https://github.com/numba/numba/issues/10486
-    """
-    import pytensor.link.numba.cache as cache_mod
+        See https://github.com/numba/numba/issues/10486
+        """
+        # Use a temporary cache for this test
+        monkeypatch.setattr(numba_cache, "NUMBA_CACHE_PATH", tmp_path)
 
-    # Use a temporary cache for this test
-    monkeypatch.setattr(cache_mod, "NUMBA_CACHE_PATH", tmp_path)
+        def run_in_fork(func):
+            pid = os.fork()
+            if pid == 0:
+                try:
+                    func()
+                    os._exit(0)
+                except BaseException:
+                    os._exit(1)
+            else:
+                _, status = os.waitpid(pid, 0)
+                return os.WEXITSTATUS(status)
 
-    def run_in_fork(func):
-        pid = os.fork()
-        if pid == 0:
-            try:
-                func()
-                os._exit(0)
-            except BaseException:
-                os._exit(1)
+        def graph_a():
+            x = pt.tensor3("x")
+            fn = function([x], x.transpose(2, 0, 1), mode="NUMBA")
+            assert fn(np.zeros((2, 3, 4))).shape == (4, 2, 3)
+
+        def graph_b():
+            x = pt.tensor3("x")
+            fn = function([x], [x.transpose(2, 0, 1), x[None]], mode="NUMBA")
+            r1, r2 = fn(np.zeros((2, 3, 4)))
+            assert r1.shape == (4, 2, 3)
+            assert r2.shape == (1, 2, 3, 4)
+
+        # Fork child compiles graph_a (transpose only)
+        assert run_in_fork(graph_a) == 0, "Fork child failed"
+
+        # Parent compiles graph_b (transpose + expand dims)
+        # This loads fork's cache and also compiles fresh ops
+        graph_b()
+
+        # Running in another fork is also fine
+        assert run_in_fork(graph_a) == 0, "Fork child 1 failed"
+        assert run_in_fork(graph_b) == 0, "Fork child 2 failed"
+
+    @pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
+    @pytest.mark.parametrize("pickled_in_parent", [False, True])
+    def test_case2(self, tmp_path, monkeypatch, pickled_in_parent):
+        """Regression test: sibling forks compiling/loading cached numba functions
+        must not segfault due to LLVM symbol collisions.
+
+        The 3-fork pattern (fork 0 runs fn_a only; forks 1 and 2 run
+        fn_a + fn_b) reproduces with:
+            fn_a = [x + 1, x * 2]  - two-output elemwise.
+            fn_b = x[:4] + 1       - elemwise over a Subtensor.
+        Dropping fn_a's second output, dropping fn_b's Subtensor, or
+        running fn_b in fork 0 as well all defuse the repro.
+
+        Two compilation patterns are covered:
+            pickled_in_parent=False - child compiles the function itself.
+            pickled_in_parent=True  - parent lazily compiles and pickles;
+                child's unpickle re-runs NumbaLinker, where the reseed
+                guard fires.
+
+        See https://github.com/numba/numba/issues/10486
+        """
+        monkeypatch.setattr(numba_cache, "NUMBA_CACHE_PATH", tmp_path)
+        raw_numba = Mode(linker=NumbaLinker(), optimizer=None)
+
+        def make_fn_a():
+            x = pt.vector("x")
+            return function([x], [x + 1.0, x * 2.0], mode=raw_numba)
+
+        def make_fn_b():
+            x = pt.vector("x")
+            return function([x], x[:4] + 1.0, mode=raw_numba)
+
+        if pickled_in_parent:
+            fn_a_blob = pickle.dumps(make_fn_a())
+            fn_b_blob = pickle.dumps(make_fn_b())
+
+            def get_fn_a():
+                return pickle.loads(fn_a_blob)
+
+            def get_fn_b():
+                return pickle.loads(fn_b_blob)
         else:
-            _, status = os.waitpid(pid, 0)
-            return os.WEXITSTATUS(status)
+            get_fn_a = make_fn_a
+            get_fn_b = make_fn_b
 
-    def graph_a():
-        x = pt.tensor3("x")
-        fn = function([x], x.transpose(2, 0, 1), mode="NUMBA")
-        assert fn(np.zeros((2, 3, 4))).shape == (4, 2, 3)
+        def run_in_child(with_fn_b, result_file):
+            a_add, a_mul = get_fn_a()(np.zeros(5))
+            out_b = get_fn_b()(np.zeros(5)) if with_fn_b else np.array([])
+            np.savez(result_file, a_add=a_add, a_mul=a_mul, b=out_b)
 
-    def graph_b():
-        x = pt.tensor3("x")
-        fn = function([x], [x.transpose(2, 0, 1), x[None]], mode="NUMBA")
-        r1, r2 = fn(np.zeros((2, 3, 4)))
-        assert r1.shape == (4, 2, 3)
-        assert r2.shape == (1, 2, 3, 4)
+        for i, with_fn_b in enumerate((False, True, True)):
+            result_file = tmp_path / f"child_{i}.npz"
+            pid = os.fork()
+            if pid == 0:
+                try:
+                    run_in_child(with_fn_b, result_file)
+                    os._exit(0)
+                except BaseException:
+                    os._exit(1)
+            _, st = os.waitpid(pid, 0)
+            assert not os.WIFSIGNALED(st), f"child {i} segfaulted ({os.WTERMSIG(st)})"
+            assert os.WEXITSTATUS(st) == 0
 
-    # Fork child compiles graph_a (transpose only)
-    assert run_in_fork(graph_a) == 0, "Fork child failed"
-
-    # Parent compiles graph_b (transpose + expand dims)
-    # This loads fork's cache and also compiles fresh ops
-    graph_b()
-
-    # Running in another fork is also fine
-    assert run_in_fork(graph_a) == 0, "Fork child 1 failed"
-    assert run_in_fork(graph_b) == 0, "Fork child 2 failed"
+            data = np.load(result_file)
+            np.testing.assert_allclose(data["a_add"], [1.0] * 5)
+            np.testing.assert_allclose(data["a_mul"], [0.0] * 5)
+            if with_fn_b:
+                np.testing.assert_allclose(data["b"], [1.0] * 4)

--- a/tests/link/numba/test_basic.py
+++ b/tests/link/numba/test_basic.py
@@ -786,8 +786,8 @@ class TestNumbaCacheMuliprocessSafe:
         mangled names collide. When they have different return types (e.g. 3D vs 4D
         array), this causes a ValueError during LLVM lowering.
 
-        PyTensor prevents this by re-seeding numba's UID counter with a large random
-        offset after every fork, ensuring unique LLVM symbols across sibling processes.
+        PyTensor prevents this by replacing numba's UID counter with a random
+        128-bit UUID iterator, ensuring unique LLVM symbols across sibling processes.
 
         See https://github.com/numba/numba/issues/10486
         """
@@ -845,8 +845,8 @@ class TestNumbaCacheMuliprocessSafe:
         Two compilation patterns are covered:
             pickled_in_parent=False - child compiles the function itself.
             pickled_in_parent=True  - parent lazily compiles and pickles;
-                child's unpickle re-runs NumbaLinker, where the reseed
-                guard fires.
+                child's unpickle re-runs NumbaLinker, which pulls fresh
+                UUIDs from the replacement iterator.
 
         See https://github.com/numba/numba/issues/10486
         """


### PR DESCRIPTION
The patch #1992 turned out not to be sufficient. It depends on whether numba decides to inline our customly-cached disk functions or not. The underlying issue is still https://github.com/numba/numba/issues/10486

Which means pytensor custom caching machinery is not safe inside multiprocessing. This hasn't proven to be such a big deal in PyMC, as we opt to first compile then multiprocess (fine... as long as we do an early call to actually trigger numba cache/compile).

But it's all fragile. We went down #1992 because of #1988. ASV defaults to launching each job on a fork process. It sounded like spawn was immune to this mangling, but seems to be just an accident from numba using a set of flags for the naming, and the set is random across spawns (I don't think the set is that big that it would be hard to see problems).

 So the current solution is to hack numba's internal counter for generating unique function ids, the first time and at each subsequent fork. This helper was stable for a while, but maybe it's time to start pinning range of numba versions manually.

