### PR TITLE
Add ScalarOp mathematical props

### DIFF
--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -1331,8 +1331,6 @@ class UnaryScalarOp(ScalarOp):
     monotonic_increasing = False
     monotonic_decreasing = False
 
-    domain = (-np.inf, np.inf)
-
     def c_code_contiguous(self, node, name, inputs, outputs, sub):
         (x,) = inputs
         (z,) = outputs
@@ -1664,8 +1662,6 @@ switch = Switch()
 
 
 class UnaryBitOp(UnaryScalarOp):
-    monotonic_decreasing = True
-
     def output_types(self, *input_types):
         for i in input_types[0]:
             if i not in discrete_types:
@@ -1761,6 +1757,7 @@ and_ = AND()
 
 class Invert(UnaryBitOp):
     nfunc_spec = ("invert", 1, 1)
+    monotonic_decreasing = True
 
     def impl(self, x):
         return ~x

--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -1326,6 +1326,7 @@ class UnaryScalarOp(ScalarOp):
     nin = 1
     amd_float32: str | None = None
     amd_float64: str | None = None
+    preserves_zero = False
 
     def c_code_contiguous(self, node, name, inputs, outputs, sub):
         (x,) = inputs
@@ -2442,6 +2443,8 @@ second = Second(name="second")
 
 
 class Identity(UnaryScalarOp):
+    preserves_zero = True
+
     def impl(self, input):
         return input
 
@@ -2558,6 +2561,7 @@ def cast(x, dtype):
 
 
 class Abs(UnaryScalarOp):
+    preserves_zero = True
     nfunc_spec = ("abs", 1, 1)
 
     def make_node(self, x):
@@ -2608,6 +2612,7 @@ abs = Abs(same_out)
 
 
 class Sign(UnaryScalarOp):
+    preserves_zero = True
     nfunc_spec = ("sign", 1, 1)
 
     @staticmethod
@@ -2656,6 +2661,7 @@ sign = Sign(name="sign", output_types_preference=Sign._output_types_preference)
 
 
 class Ceil(UnaryScalarOp):
+    preserves_zero = True
     nfunc_spec = ("ceil", 1, 1)
 
     def impl(self, x):
@@ -2682,6 +2688,7 @@ ceil = Ceil(upgrade_to_float_no_complex, name="ceil")
 
 
 class Floor(UnaryScalarOp):
+    preserves_zero = True
     nfunc_spec = ("floor", 1, 1)
 
     def impl(self, x):
@@ -2708,6 +2715,7 @@ floor = Floor(upgrade_to_float_no_complex, name="floor")
 
 
 class Trunc(UnaryScalarOp):
+    preserves_zero = True
     nfunc_spec = ("trunc", 1, 1)
 
     def impl(self, x):
@@ -2728,6 +2736,7 @@ trunc = Trunc(upgrade_to_float_no_complex, name="trunc")
 
 
 class RoundHalfToEven(UnaryScalarOp):
+    preserves_zero = True
     """
     This function implement the same rounding than numpy: Round half to even.
 
@@ -2816,6 +2825,7 @@ def round_half_away_from_zero_vec(a):
 
 
 class RoundHalfAwayFromZero(UnaryScalarOp):
+    preserves_zero = True
     """
     Implement the same rounding algo as c round() fct.
 
@@ -2850,6 +2860,7 @@ round_half_away_from_zero = RoundHalfAwayFromZero(same_out_float_only)
 
 
 class Neg(UnaryScalarOp):
+    preserves_zero = True
     # We can use numpy.negative here, because even if it gives unexpected
     # results on Boolean arrays, it will be passed other dtypes as PyTensor
     # does not have a Boolean type for tensors.
@@ -3052,6 +3063,7 @@ log10 = Log10(upgrade_to_float, name="log10")
 
 
 class Log1p(UnaryScalarOp):
+    preserves_zero = True
     """
     log(1+x).
 
@@ -3167,6 +3179,7 @@ exp2 = Exp2(upgrade_to_float, name="exp2")
 
 
 class Expm1(UnaryScalarOp):
+    preserves_zero = True
     nfunc_spec = ("expm1", 1, 1)
 
     def impl(self, x):
@@ -3206,6 +3219,7 @@ expm1 = Expm1(upgrade_to_float, name="expm1")
 
 
 class Sqr(UnaryScalarOp):
+    preserves_zero = True
     nfunc_spec = ("square", 1, 1)
 
     def impl(self, x):
@@ -3234,6 +3248,7 @@ sqr = Sqr(same_out, name="sqr")
 
 
 class Sqrt(UnaryScalarOp):
+    preserves_zero = True
     nfunc_spec = ("sqrt", 1, 1)
 
     def impl(self, x):
@@ -3270,6 +3285,7 @@ sqrt = Sqrt(upgrade_to_float, name="sqrt")
 
 
 class Deg2Rad(UnaryScalarOp):
+    preserves_zero = True
     nfunc_spec = ("deg2rad", 1, 1)
 
     def impl(self, x):
@@ -3305,6 +3321,7 @@ deg2rad = Deg2Rad(upgrade_to_float, name="deg2rad")
 
 
 class Rad2Deg(UnaryScalarOp):
+    preserves_zero = True
     nfunc_spec = ("rad2deg", 1, 1)
 
     def impl(self, x):
@@ -3414,6 +3431,7 @@ arccos = ArcCos(upgrade_to_float, name="arccos")
 
 
 class Sin(UnaryScalarOp):
+    preserves_zero = True
     nfunc_spec = ("sin", 1, 1)
     amd_float32 = "amd_vrsa_sinf"
     amd_float64 = "amd_vrda_sin"
@@ -3452,6 +3470,7 @@ sin = Sin(upgrade_to_float, name="sin")
 
 
 class ArcSin(UnaryScalarOp):
+    preserves_zero = True
     nfunc_spec = ("arcsin", 1, 1)
 
     def impl(self, x):
@@ -3488,6 +3507,7 @@ arcsin = ArcSin(upgrade_to_float, name="arcsin")
 
 
 class Tan(UnaryScalarOp):
+    preserves_zero = True
     nfunc_spec = ("tan", 1, 1)
 
     def impl(self, x):
@@ -3524,6 +3544,7 @@ tan = Tan(upgrade_to_float, name="tan")
 
 
 class ArcTan(UnaryScalarOp):
+    preserves_zero = True
     nfunc_spec = ("arctan", 1, 1)
 
     def impl(self, x):
@@ -3683,6 +3704,7 @@ arccosh = ArcCosh(upgrade_to_float, name="arccosh")
 
 
 class Sinh(UnaryScalarOp):
+    preserves_zero = True
     """
     sinh(x) = (exp(x) - exp(-x)) / 2.
 
@@ -3724,6 +3746,7 @@ sinh = Sinh(upgrade_to_float, name="sinh")
 
 
 class ArcSinh(UnaryScalarOp):
+    preserves_zero = True
     nfunc_spec = ("arcsinh", 1, 1)
 
     def impl(self, x):
@@ -3760,6 +3783,7 @@ arcsinh = ArcSinh(upgrade_to_float, name="arcsinh")
 
 
 class Tanh(UnaryScalarOp):
+    preserves_zero = True
     """
     tanh(x) = sinh(x) / cosh(x)
             = (exp(2*x) - 1) / (exp(2*x) + 1).
@@ -3802,6 +3826,7 @@ tanh = Tanh(upgrade_to_float, name="tanh")
 
 
 class ArcTanh(UnaryScalarOp):
+    preserves_zero = True
     nfunc_spec = ("arctanh", 1, 1)
 
     def impl(self, x):
@@ -3838,6 +3863,7 @@ arctanh = ArcTanh(upgrade_to_float, name="arctanh")
 
 
 class Real(UnaryScalarOp):
+    preserves_zero = True
     """
     Extract the real coordinate of a complex number.
 
@@ -3862,6 +3888,7 @@ real = Real(real_out, name="real")
 
 
 class Imag(UnaryScalarOp):
+    preserves_zero = True
     nfunc_spec = ("imag", 1, 1)
 
     def impl(self, x):
@@ -3954,6 +3981,7 @@ complex = Complex(name="complex")
 
 
 class Conj(UnaryScalarOp):
+    preserves_zero = True
     nfunc_spec = ("conj", 1, 1)
 
     def impl(self, x):

--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -1326,7 +1326,12 @@ class UnaryScalarOp(ScalarOp):
     nin = 1
     amd_float32: str | None = None
     amd_float64: str | None = None
+
     preserves_zero = False
+    monotonic_increasing = False
+    monotonic_decreasing = False
+
+    domain = (-np.inf, np.inf)
 
     def c_code_contiguous(self, node, name, inputs, outputs, sub):
         (x,) = inputs
@@ -1659,6 +1664,8 @@ switch = Switch()
 
 
 class UnaryBitOp(UnaryScalarOp):
+    monotonic_decreasing = True
+
     def output_types(self, *input_types):
         for i in input_types[0]:
             if i not in discrete_types:
@@ -2444,6 +2451,7 @@ second = Second(name="second")
 
 class Identity(UnaryScalarOp):
     preserves_zero = True
+    monotonic_increasing = True
 
     def impl(self, input):
         return input
@@ -2613,6 +2621,8 @@ abs = Abs(same_out)
 
 class Sign(UnaryScalarOp):
     preserves_zero = True
+    monotonic_increasing = True
+
     nfunc_spec = ("sign", 1, 1)
 
     @staticmethod
@@ -2662,6 +2672,8 @@ sign = Sign(name="sign", output_types_preference=Sign._output_types_preference)
 
 class Ceil(UnaryScalarOp):
     preserves_zero = True
+    monotonic_increasing = True
+
     nfunc_spec = ("ceil", 1, 1)
 
     def impl(self, x):
@@ -2689,6 +2701,8 @@ ceil = Ceil(upgrade_to_float_no_complex, name="ceil")
 
 class Floor(UnaryScalarOp):
     preserves_zero = True
+    monotonic_increasing = True
+
     nfunc_spec = ("floor", 1, 1)
 
     def impl(self, x):
@@ -2716,6 +2730,8 @@ floor = Floor(upgrade_to_float_no_complex, name="floor")
 
 class Trunc(UnaryScalarOp):
     preserves_zero = True
+    monotonic_increasing = True
+
     nfunc_spec = ("trunc", 1, 1)
 
     def impl(self, x):
@@ -2737,6 +2753,8 @@ trunc = Trunc(upgrade_to_float_no_complex, name="trunc")
 
 class RoundHalfToEven(UnaryScalarOp):
     preserves_zero = True
+    monotonic_increasing = True
+
     """
     This function implement the same rounding than numpy: Round half to even.
 
@@ -2826,6 +2844,8 @@ def round_half_away_from_zero_vec(a):
 
 class RoundHalfAwayFromZero(UnaryScalarOp):
     preserves_zero = True
+    monotonic_increasing = True
+
     """
     Implement the same rounding algo as c round() fct.
 
@@ -2861,6 +2881,7 @@ round_half_away_from_zero = RoundHalfAwayFromZero(same_out_float_only)
 
 class Neg(UnaryScalarOp):
     preserves_zero = True
+    monotonic_decreasing = True
     # We can use numpy.negative here, because even if it gives unexpected
     # results on Boolean arrays, it will be passed other dtypes as PyTensor
     # does not have a Boolean type for tensors.
@@ -2936,6 +2957,7 @@ class Log(UnaryScalarOp):
 
     """
 
+    monotonic_increasing = True
     nfunc_spec = ("log", 1, 1)
     amd_float32 = "amd_vrsa_logf"
     amd_float64 = "amd_vrda_log"
@@ -2982,6 +3004,7 @@ class Log2(UnaryScalarOp):
 
     """
 
+    monotonic_increasing = True
     nfunc_spec = ("log2", 1, 1)
     amd_float32 = "amd_vrsa_log2f"
     amd_float64 = "amd_vrda_log2"
@@ -3025,6 +3048,7 @@ class Log10(UnaryScalarOp):
 
     """
 
+    monotonic_increasing = True
     nfunc_spec = ("log10", 1, 1)
     amd_float32 = "amd_vrsa_log10f"
     amd_float64 = "amd_vrda_log10"
@@ -3064,6 +3088,7 @@ log10 = Log10(upgrade_to_float, name="log10")
 
 class Log1p(UnaryScalarOp):
     preserves_zero = True
+    monotonic_increasing = True
     """
     log(1+x).
 
@@ -3105,6 +3130,7 @@ log1p = Log1p(upgrade_to_float, name="log1p")
 
 
 class Exp(UnaryScalarOp):
+    monotonic_increasing = True
     nfunc_spec = ("exp", 1, 1)
     amd_float32 = "amd_vrsa_expf"
     amd_float64 = "amd_vrda_exp"
@@ -3143,6 +3169,7 @@ exp = Exp(upgrade_to_float, name="exp")
 
 
 class Exp2(UnaryScalarOp):
+    monotonic_increasing = True
     nfunc_spec = ("exp2", 1, 1)
 
     def impl(self, x):
@@ -3180,6 +3207,7 @@ exp2 = Exp2(upgrade_to_float, name="exp2")
 
 class Expm1(UnaryScalarOp):
     preserves_zero = True
+    monotonic_increasing = True
     nfunc_spec = ("expm1", 1, 1)
 
     def impl(self, x):
@@ -3249,6 +3277,8 @@ sqr = Sqr(same_out, name="sqr")
 
 class Sqrt(UnaryScalarOp):
     preserves_zero = True
+    monotonic_increasing = True
+
     nfunc_spec = ("sqrt", 1, 1)
 
     def impl(self, x):
@@ -3286,6 +3316,8 @@ sqrt = Sqrt(upgrade_to_float, name="sqrt")
 
 class Deg2Rad(UnaryScalarOp):
     preserves_zero = True
+    monotonic_increasing = True
+
     nfunc_spec = ("deg2rad", 1, 1)
 
     def impl(self, x):
@@ -3322,6 +3354,8 @@ deg2rad = Deg2Rad(upgrade_to_float, name="deg2rad")
 
 class Rad2Deg(UnaryScalarOp):
     preserves_zero = True
+    monotonic_increasing = True
+
     nfunc_spec = ("rad2deg", 1, 1)
 
     def impl(self, x):
@@ -3395,6 +3429,7 @@ cos = Cos(upgrade_to_float, name="cos")
 
 
 class ArcCos(UnaryScalarOp):
+    monotonic_decreasing = True
     nfunc_spec = ("arccos", 1, 1)
 
     def impl(self, x):
@@ -3471,6 +3506,7 @@ sin = Sin(upgrade_to_float, name="sin")
 
 class ArcSin(UnaryScalarOp):
     preserves_zero = True
+    monotonic_increasing = True
     nfunc_spec = ("arcsin", 1, 1)
 
     def impl(self, x):
@@ -3545,6 +3581,7 @@ tan = Tan(upgrade_to_float, name="tan")
 
 class ArcTan(UnaryScalarOp):
     preserves_zero = True
+    monotonic_increasing = True
     nfunc_spec = ("arctan", 1, 1)
 
     def impl(self, x):
@@ -3668,6 +3705,7 @@ cosh = Cosh(upgrade_to_float, name="cosh")
 
 
 class ArcCosh(UnaryScalarOp):
+    monotonic_increasing = True
     nfunc_spec = ("arccosh", 1, 1)
 
     def impl(self, x):
@@ -3705,6 +3743,7 @@ arccosh = ArcCosh(upgrade_to_float, name="arccosh")
 
 class Sinh(UnaryScalarOp):
     preserves_zero = True
+    monotonic_increasing = True
     """
     sinh(x) = (exp(x) - exp(-x)) / 2.
 
@@ -3747,6 +3786,7 @@ sinh = Sinh(upgrade_to_float, name="sinh")
 
 class ArcSinh(UnaryScalarOp):
     preserves_zero = True
+    monotonic_increasing = True
     nfunc_spec = ("arcsinh", 1, 1)
 
     def impl(self, x):
@@ -3784,6 +3824,7 @@ arcsinh = ArcSinh(upgrade_to_float, name="arcsinh")
 
 class Tanh(UnaryScalarOp):
     preserves_zero = True
+    monotonic_increasing = True
     """
     tanh(x) = sinh(x) / cosh(x)
             = (exp(2*x) - 1) / (exp(2*x) + 1).
@@ -3827,6 +3868,7 @@ tanh = Tanh(upgrade_to_float, name="tanh")
 
 class ArcTanh(UnaryScalarOp):
     preserves_zero = True
+    monotonic_increasing = True
     nfunc_spec = ("arctanh", 1, 1)
 
     def impl(self, x):

--- a/pytensor/scalar/math.py
+++ b/pytensor/scalar/math.py
@@ -50,6 +50,7 @@ C_CODE_PATH = Path(__file__).parent / "c_code"
 
 class Erf(UnaryScalarOp):
     preserves_zero = True
+    monotonic_increasing = True
     nfunc_spec = ("scipy.special.erf", 1, 1)
 
     def impl(self, x):
@@ -84,6 +85,7 @@ erf = Erf(upgrade_to_float, name="erf")
 
 
 class Erfc(UnaryScalarOp):
+    monotonic_decreasing = True
     nfunc_spec = ("scipy.special.erfc", 1, 1)
 
     def impl(self, x):
@@ -133,6 +135,7 @@ class Erfcx(UnaryScalarOp):
 
     """
 
+    monotonic_decreasing = True
     nfunc_spec = ("scipy.special.erfcx", 1, 1)
 
     def impl(self, x):
@@ -179,6 +182,7 @@ erfcx = Erfcx(upgrade_to_float_no_complex, name="erfcx")
 
 class Erfinv(UnaryScalarOp):
     preserves_zero = True
+    monotonic_increasing = True
     """
     Implements the inverse error function.
 
@@ -225,6 +229,7 @@ erfinv = Erfinv(upgrade_to_float_no_complex, name="erfinv")
 
 
 class Erfcinv(UnaryScalarOp):
+    monotonic_decreasing = True
     nfunc_spec = ("scipy.special.erfcinv", 1, 1)
 
     def impl(self, x):
@@ -1078,6 +1083,7 @@ j0 = J0(upgrade_to_float, name="j0")
 
 class I1(UnaryScalarOp):
     preserves_zero = True
+    monotonic_increasing = True
     """
     Modified Bessel function of the first kind of order 1.
     """
@@ -1181,6 +1187,7 @@ class Sigmoid(UnaryScalarOp):
     Logistic sigmoid function (1 / (1 + exp(-x)), also known as expit or inverse logit
     """
 
+    monotonic_increasing = True
     nfunc_spec = ("scipy.special.expit", 1, 1)
 
     def impl(self, x):
@@ -1234,6 +1241,8 @@ class Softplus(UnaryScalarOp):
     .. [Machler2012] Martin Mächler (2012).
         "Accurately computing `\log(1-\exp(- \mid a \mid))` Assessed by the Rmpfr package"
     """
+
+    monotonic_increasing = True
 
     def impl(self, x):
         # If x is an int8 or uint8, numpy.exp will compute the result in
@@ -1315,6 +1324,8 @@ class Log1mexp(UnaryScalarOp):
     .. [Machler2012] Martin Mächler (2012).
         "Accurately computing `\log(1-\exp(- \mid a \mid))` Assessed by the Rmpfr package"
     """
+
+    monotonic_decreasing = True
 
     def impl(self, x):
         if x < np.log(0.5):

--- a/pytensor/scalar/math.py
+++ b/pytensor/scalar/math.py
@@ -49,6 +49,7 @@ C_CODE_PATH = Path(__file__).parent / "c_code"
 
 
 class Erf(UnaryScalarOp):
+    preserves_zero = True
     nfunc_spec = ("scipy.special.erf", 1, 1)
 
     def impl(self, x):
@@ -177,6 +178,7 @@ erfcx = Erfcx(upgrade_to_float_no_complex, name="erfcx")
 
 
 class Erfinv(UnaryScalarOp):
+    preserves_zero = True
     """
     Implements the inverse error function.
 
@@ -1020,6 +1022,7 @@ jv = Jv(upgrade_to_float, name="jv")
 
 
 class J1(UnaryScalarOp):
+    preserves_zero = True
     """
     Bessel function of the first kind of order 1.
     """
@@ -1074,6 +1077,7 @@ j0 = J0(upgrade_to_float, name="j0")
 
 
 class I1(UnaryScalarOp):
+    preserves_zero = True
     """
     Modified Bessel function of the first kind of order 1.
     """

--- a/pytensor/tensor/rewriting/linalg/inverse.py
+++ b/pytensor/tensor/rewriting/linalg/inverse.py
@@ -160,4 +160,4 @@ def lift_linalg_of_expanded_matrices(fgraph: FunctionGraph, node: Apply):
         case (Blockwise(BlockDiagonal()), *inner_matrices):
             return [block_diag(*(outer_op(m) for m in inner_matrices))]
         case (KroneckerProduct(), *inner_matrices):
-            return [kron(*(outer_op(m) for m in inner_matrices))]  # type: ignore[unreachable]
+            return [kron(*(outer_op(m) for m in inner_matrices))]

--- a/pytensor/tensor/rewriting/linalg/solvers.py
+++ b/pytensor/tensor/rewriting/linalg/solvers.py
@@ -222,7 +222,7 @@ def _split_decomp_and_solve_steps(
             case (DimShuffle(is_left_expand_dims=True), root_a):  # type: ignore[misc]
                 transposed = False
             case (DimShuffle(is_left_expanded_matrix_transpose=True), root_a):  # type: ignore[misc]
-                transposed = True  # type: ignore[unreachable]
+                transposed = True
 
         return root_a, transposed
 


### PR DESCRIPTION
Closes #2052

Adds props for UnaryScalarOps tagging some useful math properties:

- perserves_zero if f(0) = 0
- monotonic_increasing if f(x+a) >= f(x) for all x, a > 0
- monotonic_decreasing if f(x+a) <= f(x) for all x, a > 0
