### PR TITLE
internal use of join/split dims 

### DIFF
--- a/pytensor/link/jax/dispatch/__init__.py
+++ b/pytensor/link/jax/dispatch/__init__.py
@@ -11,6 +11,7 @@ import pytensor.link.jax.dispatch.pad
 import pytensor.link.jax.dispatch.math
 import pytensor.link.jax.dispatch.linalg
 import pytensor.link.jax.dispatch.random
+import pytensor.link.jax.dispatch.reshape
 import pytensor.link.jax.dispatch.scalar
 import pytensor.link.jax.dispatch.scan
 import pytensor.link.jax.dispatch.shape

--- a/pytensor/link/jax/dispatch/reshape.py
+++ b/pytensor/link/jax/dispatch/reshape.py
@@ -1,0 +1,30 @@
+import jax.numpy as jnp
+
+from pytensor.link.jax.dispatch.basic import jax_funcify
+from pytensor.tensor.reshape import (
+    JoinDims,
+    SplitDims,
+)
+
+
+@jax_funcify.register(JoinDims)
+def jax_funcify_JoinDims(op, node, **kwargs):
+    start_axis = op.start_axis
+    n_axes = op.n_axes
+
+    def join_dims(x):
+        output_shape = (*x.shape[:start_axis], -1, *x.shape[start_axis + n_axes :])
+        return jnp.reshape(x, output_shape)
+
+    return join_dims
+
+
+@jax_funcify.register(SplitDims)
+def jax_funcify_SplitDims(op, node, **kwargs):
+    axis = op.axis
+
+    def split_dims(x, shape):
+        output_shape = (*x.shape[:axis], *shape, *x.shape[axis + 1 :])
+        return jnp.reshape(x, output_shape)
+
+    return split_dims

--- a/pytensor/link/jax/dispatch/shape.py
+++ b/pytensor/link/jax/dispatch/shape.py
@@ -4,7 +4,7 @@ from pytensor.graph import Constant
 from pytensor.graph.basic import Apply
 from pytensor.graph.op import Op
 from pytensor.link.jax.dispatch.basic import jax_funcify
-from pytensor.tensor.shape import Reshape, Shape, Shape_i, SpecifyShape
+from pytensor.tensor.shape import Reshape, Shape, Shape_i, SpecifyShape # JoinDims, SplitDims
 from pytensor.tensor.type import TensorType
 
 
@@ -104,3 +104,16 @@ def jax_funcify_SpecifyShape(op, node, **kwargs):
         return x
 
     return specifyshape
+
+
+@jax_funcify.register(JoinDims)
+def jax_funcify_JoinDims(op, node, **kwargs):
+    start_axis = op.start_axis
+    n_axes = op.n_axes
+    def join_dims(x):
+        if n_axes == 0:
+            expanded_x = jnp.expand_dims(x, axis=start_axis)
+            return expanded_x
+        if n_axes == 1:
+            return x
+    return join_dims

--- a/pytensor/link/jax/dispatch/shape.py
+++ b/pytensor/link/jax/dispatch/shape.py
@@ -4,7 +4,11 @@ from pytensor.graph import Constant
 from pytensor.graph.basic import Apply
 from pytensor.graph.op import Op
 from pytensor.link.jax.dispatch.basic import jax_funcify
-from pytensor.tensor.shape import Reshape, Shape, Shape_i, SpecifyShape # JoinDims, SplitDims
+from pytensor.tensor.reshape import (  # is the placement of joindims/splitdims under reshape instead of shape intentional?
+    JoinDims,
+    SplitDims,
+)
+from pytensor.tensor.shape import Reshape, Shape, Shape_i, SpecifyShape
 from pytensor.tensor.type import TensorType
 
 
@@ -110,10 +114,20 @@ def jax_funcify_SpecifyShape(op, node, **kwargs):
 def jax_funcify_JoinDims(op, node, **kwargs):
     start_axis = op.start_axis
     n_axes = op.n_axes
+
     def join_dims(x):
-        if n_axes == 0:
-            expanded_x = jnp.expand_dims(x, axis=start_axis)
-            return expanded_x
-        if n_axes == 1:
-            return x
+        output_shape = (*x.shape[:start_axis], -1, *x.shape[start_axis + n_axes :])
+        return jnp.reshape(x, output_shape)
+
     return join_dims
+
+
+@jax_funcify.register(SplitDims)
+def jax_funcify_SplitDims(op, node, **kwargs):
+    axis = op.axis
+
+    def split_dims(x, shape):
+        output_shape = (*x.shape[:axis], *shape, *x.shape[axis + 1 :])
+        return jnp.reshape(x, output_shape)
+
+    return split_dims

--- a/pytensor/link/jax/dispatch/shape.py
+++ b/pytensor/link/jax/dispatch/shape.py
@@ -4,10 +4,6 @@ from pytensor.graph import Constant
 from pytensor.graph.basic import Apply
 from pytensor.graph.op import Op
 from pytensor.link.jax.dispatch.basic import jax_funcify
-from pytensor.tensor.reshape import (  # is the placement of joindims/splitdims under reshape instead of shape intentional?
-    JoinDims,
-    SplitDims,
-)
 from pytensor.tensor.shape import Reshape, Shape, Shape_i, SpecifyShape
 from pytensor.tensor.type import TensorType
 
@@ -108,26 +104,3 @@ def jax_funcify_SpecifyShape(op, node, **kwargs):
         return x
 
     return specifyshape
-
-
-@jax_funcify.register(JoinDims)
-def jax_funcify_JoinDims(op, node, **kwargs):
-    start_axis = op.start_axis
-    n_axes = op.n_axes
-
-    def join_dims(x):
-        output_shape = (*x.shape[:start_axis], -1, *x.shape[start_axis + n_axes :])
-        return jnp.reshape(x, output_shape)
-
-    return join_dims
-
-
-@jax_funcify.register(SplitDims)
-def jax_funcify_SplitDims(op, node, **kwargs):
-    axis = op.axis
-
-    def split_dims(x, shape):
-        output_shape = (*x.shape[:axis], *shape, *x.shape[axis + 1 :])
-        return jnp.reshape(x, output_shape)
-
-    return split_dims

--- a/pytensor/link/numba/dispatch/__init__.py
+++ b/pytensor/link/numba/dispatch/__init__.py
@@ -8,6 +8,7 @@ import pytensor.link.numba.dispatch.elemwise
 import pytensor.link.numba.dispatch.extra_ops
 import pytensor.link.numba.dispatch.linalg
 import pytensor.link.numba.dispatch.random
+import pytensor.link.numba.dispatch.reshape
 import pytensor.link.numba.dispatch.scan
 import pytensor.link.numba.dispatch.scalar
 import pytensor.link.numba.dispatch.shape

--- a/pytensor/link/numba/dispatch/reshape.py
+++ b/pytensor/link/numba/dispatch/reshape.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from pytensor.link.numba.dispatch import basic as numba_basic
+from pytensor.link.numba.dispatch.basic import register_funcify_default_op_cache_key
+from pytensor.tensor.reshape import JoinDims, SplitDims
+
+
+@register_funcify_default_op_cache_key(JoinDims)
+def numba_funcify_JoinDims(op, node, **kwargs):
+    start_axis = op.start_axis
+    n_axes = op.n_axes
+
+    @numba_basic.numba_njit
+    def join_dims(x):
+        output_shape = (*x.shape[:start_axis], -1, *x.shape[start_axis + n_axes :])
+        return np.reshape(x, output_shape)
+
+    return join_dims
+
+
+@register_funcify_default_op_cache_key(SplitDims)
+def numba_funcify_SplitDims(op, node, **kwargs):
+    axis = op.axis
+
+    @numba_basic.numba_njit
+    def split_dims(x, shape):
+        output_shape = (*x.shape[:axis], *shape, *x.shape[axis + 1 :])
+        return np.reshape(x, output_shape)
+
+    return split_dims

--- a/pytensor/link/numba/dispatch/shape.py
+++ b/pytensor/link/numba/dispatch/shape.py
@@ -7,7 +7,6 @@ from pytensor.link.numba.dispatch import basic as numba_basic
 from pytensor.link.numba.dispatch.basic import register_funcify_default_op_cache_key
 from pytensor.link.utils import compile_function_src
 from pytensor.tensor import NoneConst
-from pytensor.tensor.reshape import JoinDims, SplitDims
 from pytensor.tensor.shape import Reshape, Shape, Shape_i, SpecifyShape
 
 
@@ -78,28 +77,3 @@ def numba_funcify_Reshape(op, **kwargs):
             )
 
     return reshape
-
-
-@register_funcify_default_op_cache_key(JoinDims)
-def numba_funcify_JoinDims(op, node, **kwargs):
-    start_axis = op.start_axis
-    n_axes = op.n_axes
-
-    @numba_basic.numba_njit
-    def join_dims(x):
-        output_shape = (*x.shape[:start_axis], -1, *x.shape[start_axis + n_axes :])
-        return np.reshape(x, output_shape)
-
-    return join_dims
-
-
-@register_funcify_default_op_cache_key(SplitDims)
-def numba_funcify_SplitDims(op, node, **kwargs):
-    axis = op.axis
-
-    @numba_basic.numba_njit
-    def split_dims(x, shape):
-        output_shape = (*x.shape[:axis], *shape, *x.shape[axis + 1 :])
-        return np.reshape(x, output_shape)
-
-    return split_dims

--- a/pytensor/link/numba/dispatch/shape.py
+++ b/pytensor/link/numba/dispatch/shape.py
@@ -7,7 +7,8 @@ from pytensor.link.numba.dispatch import basic as numba_basic
 from pytensor.link.numba.dispatch.basic import register_funcify_default_op_cache_key
 from pytensor.link.utils import compile_function_src
 from pytensor.tensor import NoneConst
-from pytensor.tensor.shape import Reshape, Shape, Shape_i, SpecifyShape # JoinDims, SplitDims
+from pytensor.tensor.reshape import JoinDims, SplitDims
+from pytensor.tensor.shape import Reshape, Shape, Shape_i, SpecifyShape
 
 
 @register_funcify_default_op_cache_key(Shape)
@@ -78,15 +79,27 @@ def numba_funcify_Reshape(op, **kwargs):
 
     return reshape
 
+
 @register_funcify_default_op_cache_key(JoinDims)
 def numba_funcify_JoinDims(op, node, **kwargs):
     start_axis = op.start_axis
     n_axes = op.n_axes
+
     @numba_basic.numba_njit
     def join_dims(x):
-        if n_axes == 0:
-            expanded_x = np.expand_dims(x, axis=start_axis)
-            return expanded_x
-        if n_axes == 1:
-            return x
+        output_shape = (*x.shape[:start_axis], -1, *x.shape[start_axis + n_axes :])
+        return np.reshape(x, output_shape)
+
     return join_dims
+
+
+@register_funcify_default_op_cache_key(SplitDims)
+def numba_funcify_SplitDims(op, node, **kwargs):
+    axis = op.axis
+
+    @numba_basic.numba_njit
+    def split_dims(x, shape):
+        output_shape = (*x.shape[:axis], *shape, *x.shape[axis + 1 :])
+        return np.reshape(x, output_shape)
+
+    return split_dims

--- a/pytensor/link/numba/dispatch/shape.py
+++ b/pytensor/link/numba/dispatch/shape.py
@@ -7,7 +7,7 @@ from pytensor.link.numba.dispatch import basic as numba_basic
 from pytensor.link.numba.dispatch.basic import register_funcify_default_op_cache_key
 from pytensor.link.utils import compile_function_src
 from pytensor.tensor import NoneConst
-from pytensor.tensor.shape import Reshape, Shape, Shape_i, SpecifyShape
+from pytensor.tensor.shape import Reshape, Shape, Shape_i, SpecifyShape # JoinDims, SplitDims
 
 
 @register_funcify_default_op_cache_key(Shape)
@@ -70,9 +70,23 @@ def numba_funcify_Reshape(op, **kwargs):
         @numba_basic.numba_njit
         def reshape(x, shape):
             # TODO: Use this until https://github.com/numba/numba/issues/7353 is closed.
+            # the above issue is closed, what to do instead?
             return np.reshape(
                 np.ascontiguousarray(np.asarray(x)),
                 numba_ndarray.to_fixed_tuple(shape, ndim),
             )
 
     return reshape
+
+@register_funcify_default_op_cache_key(JoinDims)
+def numba_funcify_JoinDims(op, node, **kwargs):
+    start_axis = op.start_axis
+    n_axes = op.n_axes
+    @numba_basic.numba_njit
+    def join_dims(x):
+        if n_axes == 0:
+            expanded_x = np.expand_dims(x, axis=start_axis)
+            return expanded_x
+        if n_axes == 1:
+            return x
+    return join_dims

--- a/pytensor/tensor/math.py
+++ b/pytensor/tensor/math.py
@@ -2762,6 +2762,7 @@ def median(x: TensorLike, axis=None) -> TensorVariable:
         None means all axes (like numpy).
     """
     from pytensor.ifelse import ifelse
+    from pytensor.tensor.reshape import join_dims
 
     x = as_tensor_variable(x)
     x_ndim = x.type.ndim
@@ -2776,7 +2777,9 @@ def median(x: TensorLike, axis=None) -> TensorVariable:
     # Put axis at the end and unravel them
     x_raveled = x.transpose(*non_axis, *axis)
     if len(axis) > 1:
-        x_raveled = x_raveled.reshape((*non_axis_shape, -1))
+        x_raveled = join_dims(
+            x_raveled, start_axis=len(non_axis_shape), n_axes=len(axis)
+        )
     raveled_size = x_raveled.shape[-1]
     k = raveled_size // 2
 

--- a/pytensor/tensor/reshape.py
+++ b/pytensor/tensor/reshape.py
@@ -152,7 +152,7 @@ def join_dims(
     return JoinDims(start_axis, n_axes)(x)  # type: ignore[return-value]
 
 
-class SplitDims(Op):
+class SplitDims(COp):
     __props__ = ("axis",)
     view_map = {0: [0]}
 
@@ -217,6 +217,12 @@ class SplitDims(Op):
             disconnected_type(),
         ]
 
+    def pushforward() # is this needed?
+
+    def c_code_cache_version(self):
+        return (10,)
+
+    def c_code():
 
 @_vectorize_node.register(SplitDims)
 def _vectorize_splitdims(op, node, x, shape):

--- a/pytensor/tensor/shape.py
+++ b/pytensor/tensor/shape.py
@@ -1017,3 +1017,14 @@ def specify_broadcastable(x, *axes):
     axes = normalize_axis_tuple(axes, x.type.ndim)
     shape_info = [1 if i in axes else s for i, s in enumerate(x.type.shape)]
     return specify_shape(x, shape_info)
+
+
+Class JoinDims(COp):
+    
+    def __init__
+    
+    def c_code_cache_version(self):
+        return (10,)
+
+    def c_code(self, node, name, inputs, outputs, sub):
+


### PR DESCRIPTION
TODO:

- [ ] joindims/splitdims COp
- [ ] numba test_reshape
- [ ] jax test_reshape

This is a follow-up of #1843. After adding the special cases to join/split dims, the next step is to identify places that reshape can be replaced by join/split dims to reduce rounds of rewriting and enhance efficiency.
Will be making slow and small progress one at a time!