### PR TITLE
Add empty input guards to numba linalg

### DIFF
--- a/pytensor/link/numba/dispatch/linalg/decomposition/dispatch.py
+++ b/pytensor/link/numba/dispatch/linalg/decomposition/dispatch.py
@@ -58,12 +58,14 @@ def numba_funcify_SVD(op, node, **kwargs):
     if discrete_input and config.compiler_verbose:
         print("SVD requires casting discrete input to float")  # noqa: T201
 
-    if compute_uv:
-        matrix_dtype = np.dtype(node.outputs[0].dtype)
-        s_dtype = np.dtype(node.outputs[1].dtype)
+    # np.linalg.svd always returns real-valued singular values, even for complex input.
+    # The Op may declare s as complex (matching input dtype), but numba returns the real
+    # component dtype, so we must match that to avoid type unification errors.
+    matrix_dtype = out_dtype
+    if out_dtype.kind == "c":
+        s_dtype = np.dtype(f"f{out_dtype.itemsize // 2}")
     else:
         s_dtype = out_dtype
-        matrix_dtype = out_dtype
 
     if not compute_uv:
 
@@ -85,17 +87,19 @@ def numba_funcify_SVD(op, node, **kwargs):
             if x.size == 0:
                 m, n = x.shape
                 k = min(m, n)
+                # The LAPACK dispatch returns matrices in fortran order. To match this for the empty cases,
+                # build flip the shape inputs to np.zeros and transpose.
                 if full_matrices:
                     return (
-                        np.zeros((m, m), dtype=matrix_dtype),
+                        np.zeros((m, m), dtype=matrix_dtype).T,
                         np.zeros((k,), dtype=s_dtype),
-                        np.zeros((n, n), dtype=matrix_dtype),
+                        np.zeros((n, n), dtype=matrix_dtype).T,
                     )
                 else:
                     return (
-                        np.zeros((m, k), dtype=matrix_dtype),
+                        np.zeros((k, m), dtype=matrix_dtype).T,
                         np.zeros((k,), dtype=s_dtype),
-                        np.zeros((k, n), dtype=matrix_dtype),
+                        np.zeros((n, k), dtype=matrix_dtype).T,
                     )
             if discrete_input:
                 x = x.astype(out_dtype)
@@ -330,22 +334,22 @@ def numba_funcify_QR(op, node, **kwargs):
                 R = np.zeros((k, n) if mode == "economic" else (m, n), dtype=out_dtype)
                 return Q, R
             elif mode == "r" and pivoting:
-                R = np.zeros((k, n), dtype=out_dtype)
+                R = np.zeros((m, n), dtype=out_dtype)
                 P = np.zeros(n, dtype=np.int32)
                 return R, P
             elif mode == "r" and not pivoting:
-                R = np.zeros((k, n), dtype=out_dtype)
+                R = np.zeros((m, n), dtype=out_dtype)
                 return R
             elif mode == "raw" and pivoting:
-                H = np.zeros((m, n), dtype=out_dtype).T
+                H = np.zeros((m, m), dtype=out_dtype)
                 tau = np.zeros(k, dtype=out_dtype)
-                R = np.zeros((k, n), dtype=out_dtype)
+                R = np.zeros((m, n), dtype=out_dtype)
                 P = np.zeros(n, dtype=np.int32)
                 return H, tau, R, P
             else:
-                H = np.zeros((m, n), dtype=out_dtype).T
+                H = np.zeros((m, m), dtype=out_dtype)
                 tau = np.zeros(k, dtype=out_dtype)
-                R = np.zeros((k, n), dtype=out_dtype)
+                R = np.zeros((m, n), dtype=out_dtype)
                 return H, tau, R
 
         if integer_input:

--- a/pytensor/link/numba/dispatch/linalg/decomposition/dispatch.py
+++ b/pytensor/link/numba/dispatch/linalg/decomposition/dispatch.py
@@ -310,12 +310,16 @@ def numba_funcify_QR(op, node, **kwargs):
             m, n = a.shape
             k = min(m, n)
             if (mode == "full" or mode == "economic") and pivoting:
-                Q = np.empty((m, k) if mode == "economic" else (m, m), dtype=out_dtype)
+                Q = np.empty(
+                    (k, m) if mode == "economic" else (m, m), dtype=out_dtype
+                ).T
                 R = np.empty((k, n) if mode == "economic" else (m, n), dtype=out_dtype)
                 P = np.empty(n, dtype=np.int32)
                 return Q, R, P
             elif (mode == "full" or mode == "economic") and not pivoting:
-                Q = np.empty((m, k) if mode == "economic" else (m, m), dtype=out_dtype)
+                Q = np.empty(
+                    (k, m) if mode == "economic" else (m, m), dtype=out_dtype
+                ).T
                 R = np.empty((k, n) if mode == "economic" else (m, n), dtype=out_dtype)
                 return Q, R
             elif mode == "r" and pivoting:
@@ -326,13 +330,13 @@ def numba_funcify_QR(op, node, **kwargs):
                 R = np.empty((k, n), dtype=out_dtype)
                 return R
             elif mode == "raw" and pivoting:
-                H = np.empty((n, m), dtype=out_dtype)
+                H = np.empty((m, n), dtype=out_dtype).T
                 tau = np.empty(k, dtype=out_dtype)
                 R = np.empty((k, n), dtype=out_dtype)
                 P = np.empty(n, dtype=np.int32)
                 return H, tau, R, P
             else:
-                H = np.empty((n, m), dtype=out_dtype)
+                H = np.empty((m, n), dtype=out_dtype).T
                 tau = np.empty(k, dtype=out_dtype)
                 R = np.empty((k, n), dtype=out_dtype)
                 return H, tau, R

--- a/pytensor/link/numba/dispatch/linalg/decomposition/dispatch.py
+++ b/pytensor/link/numba/dispatch/linalg/decomposition/dispatch.py
@@ -62,6 +62,10 @@ def numba_funcify_SVD(op, node, **kwargs):
 
         @numba_basic.numba_njit
         def svd(x):
+            if x.size == 0:
+                m, n = x.shape
+                k = min(m, n)
+                return np.empty((k,), dtype=out_dtype)
             if discrete_input:
                 x = x.astype(out_dtype)
             _, ret, _ = np.linalg.svd(x, full_matrices)
@@ -71,6 +75,21 @@ def numba_funcify_SVD(op, node, **kwargs):
 
         @numba_basic.numba_njit
         def svd(x):
+            if x.size == 0:
+                m, n = x.shape
+                k = min(m, n)
+                if full_matrices:
+                    return (
+                        np.empty((m, m), dtype=out_dtype),
+                        np.empty((k,), dtype=out_dtype),
+                        np.empty((n, n), dtype=out_dtype),
+                    )
+                else:
+                    return (
+                        np.empty((m, k), dtype=out_dtype),
+                        np.empty((k,), dtype=out_dtype),
+                        np.empty((k, n), dtype=out_dtype),
+                    )
             if discrete_input:
                 x = x.astype(out_dtype)
             return np.linalg.svd(x, full_matrices)
@@ -287,6 +306,37 @@ def numba_funcify_QR(op, node, **kwargs):
 
     @numba_basic.numba_njit
     def qr(a):
+        if a.size == 0:
+            m, n = a.shape
+            k = min(m, n)
+            if (mode == "full" or mode == "economic") and pivoting:
+                Q = np.empty((m, k) if mode == "economic" else (m, m), dtype=out_dtype)
+                R = np.empty((k, n) if mode == "economic" else (m, n), dtype=out_dtype)
+                P = np.empty(n, dtype=np.int32)
+                return Q, R, P
+            elif (mode == "full" or mode == "economic") and not pivoting:
+                Q = np.empty((m, k) if mode == "economic" else (m, m), dtype=out_dtype)
+                R = np.empty((k, n) if mode == "economic" else (m, n), dtype=out_dtype)
+                return Q, R
+            elif mode == "r" and pivoting:
+                R = np.empty((k, n), dtype=out_dtype)
+                P = np.empty(n, dtype=np.int32)
+                return R, P
+            elif mode == "r" and not pivoting:
+                R = np.empty((k, n), dtype=out_dtype)
+                return R
+            elif mode == "raw" and pivoting:
+                H = np.empty((n, m), dtype=out_dtype)
+                tau = np.empty(k, dtype=out_dtype)
+                R = np.empty((k, n), dtype=out_dtype)
+                P = np.empty(n, dtype=np.int32)
+                return H, tau, R, P
+            else:
+                H = np.empty((n, m), dtype=out_dtype)
+                tau = np.empty(k, dtype=out_dtype)
+                R = np.empty((k, n), dtype=out_dtype)
+                return H, tau, R
+
         if integer_input:
             a = a.astype(out_dtype)
 
@@ -389,6 +439,8 @@ def numba_funcify_Schur(op, node, **kwargs):
 
         @numba_basic.numba_njit
         def schur(a):
+            if a.size == 0:
+                return a.copy().astype(out_dtype), np.empty((0, 0), dtype=out_dtype)
             if integer_input:
                 a = a.astype(out_dtype)
             elif needs_complex_cast:
@@ -399,6 +451,8 @@ def numba_funcify_Schur(op, node, **kwargs):
         # Real input with real output
         @numba_basic.numba_njit
         def schur(a):
+            if a.size == 0:
+                return a.copy().astype(out_dtype), np.empty((0, 0), dtype=out_dtype)
             if integer_input:
                 a = a.astype(out_dtype)
             T, Z = schur_real(a, lwork=None, overwrite_a=overwrite_a)
@@ -439,6 +493,8 @@ def numba_funcify_QZ(op, node, **kwargs):
     if (integer_input_a or integer_input_b) and config.compiler_verbose:
         print("QZ requires casting discrete input to float")  # noqa: T201
 
+    alpha_dtype = node.outputs[2].type.numpy_dtype if return_eigenvalues else out_dtype
+
     use_complex = complex_input or complex_output
     use_sort = sort is not None
 
@@ -469,6 +525,14 @@ def numba_funcify_QZ(op, node, **kwargs):
 
         @numba_basic.numba_njit
         def qz(a, b):
+            if a.size == 0:
+                n = a.shape[0]
+                e = np.empty((n, n), dtype=out_dtype)
+                if return_eigenvalues:
+                    alpha = np.empty((n,), dtype=alpha_dtype)
+                    beta = np.empty((n,), dtype=out_dtype)
+                    return e.copy(), e.copy(), alpha, beta, e.copy(), e.copy()
+                return e.copy(), e.copy(), e.copy(), e.copy()
             if integer_input_a:
                 a = a.astype(out_dtype)
             elif needs_complex_cast:
@@ -482,6 +546,14 @@ def numba_funcify_QZ(op, node, **kwargs):
 
         @numba_basic.numba_njit
         def qz(a, b):
+            if a.size == 0:
+                n = a.shape[0]
+                e = np.empty((n, n), dtype=out_dtype)
+                if return_eigenvalues:
+                    alpha = np.empty((n,), dtype=alpha_dtype)
+                    beta = np.empty((n,), dtype=out_dtype)
+                    return e.copy(), e.copy(), alpha, beta, e.copy(), e.copy()
+                return e.copy(), e.copy(), e.copy(), e.copy()
             if integer_input_a:
                 a = a.astype(out_dtype)
             elif needs_complex_cast:

--- a/pytensor/link/numba/dispatch/linalg/decomposition/dispatch.py
+++ b/pytensor/link/numba/dispatch/linalg/decomposition/dispatch.py
@@ -72,7 +72,7 @@ def numba_funcify_SVD(op, node, **kwargs):
             if x.size == 0:
                 m, n = x.shape
                 k = min(m, n)
-                return np.empty((k,), dtype=s_dtype)
+                return np.zeros((k,), dtype=s_dtype)
             if discrete_input:
                 x = x.astype(out_dtype)
             _, ret, _ = np.linalg.svd(x, full_matrices)
@@ -87,15 +87,15 @@ def numba_funcify_SVD(op, node, **kwargs):
                 k = min(m, n)
                 if full_matrices:
                     return (
-                        np.empty((m, m), dtype=matrix_dtype),
-                        np.empty((k,), dtype=s_dtype),
-                        np.empty((n, n), dtype=matrix_dtype),
+                        np.zeros((m, m), dtype=matrix_dtype),
+                        np.zeros((k,), dtype=s_dtype),
+                        np.zeros((n, n), dtype=matrix_dtype),
                     )
                 else:
                     return (
-                        np.empty((m, k), dtype=matrix_dtype),
-                        np.empty((k,), dtype=s_dtype),
-                        np.empty((k, n), dtype=matrix_dtype),
+                        np.zeros((m, k), dtype=matrix_dtype),
+                        np.zeros((k,), dtype=s_dtype),
+                        np.zeros((k, n), dtype=matrix_dtype),
                     )
             if discrete_input:
                 x = x.astype(out_dtype)
@@ -317,35 +317,35 @@ def numba_funcify_QR(op, node, **kwargs):
             m, n = a.shape
             k = min(m, n)
             if (mode == "full" or mode == "economic") and pivoting:
-                Q = np.empty(
+                Q = np.zeros(
                     (k, m) if mode == "economic" else (m, m), dtype=out_dtype
                 ).T
-                R = np.empty((k, n) if mode == "economic" else (m, n), dtype=out_dtype)
-                P = np.empty(n, dtype=np.int32)
+                R = np.zeros((k, n) if mode == "economic" else (m, n), dtype=out_dtype)
+                P = np.zeros(n, dtype=np.int32)
                 return Q, R, P
             elif (mode == "full" or mode == "economic") and not pivoting:
-                Q = np.empty(
+                Q = np.zeros(
                     (k, m) if mode == "economic" else (m, m), dtype=out_dtype
                 ).T
-                R = np.empty((k, n) if mode == "economic" else (m, n), dtype=out_dtype)
+                R = np.zeros((k, n) if mode == "economic" else (m, n), dtype=out_dtype)
                 return Q, R
             elif mode == "r" and pivoting:
-                R = np.empty((k, n), dtype=out_dtype)
-                P = np.empty(n, dtype=np.int32)
+                R = np.zeros((k, n), dtype=out_dtype)
+                P = np.zeros(n, dtype=np.int32)
                 return R, P
             elif mode == "r" and not pivoting:
-                R = np.empty((k, n), dtype=out_dtype)
+                R = np.zeros((k, n), dtype=out_dtype)
                 return R
             elif mode == "raw" and pivoting:
-                H = np.empty((m, n), dtype=out_dtype).T
-                tau = np.empty(k, dtype=out_dtype)
-                R = np.empty((k, n), dtype=out_dtype)
-                P = np.empty(n, dtype=np.int32)
+                H = np.zeros((m, n), dtype=out_dtype).T
+                tau = np.zeros(k, dtype=out_dtype)
+                R = np.zeros((k, n), dtype=out_dtype)
+                P = np.zeros(n, dtype=np.int32)
                 return H, tau, R, P
             else:
-                H = np.empty((m, n), dtype=out_dtype).T
-                tau = np.empty(k, dtype=out_dtype)
-                R = np.empty((k, n), dtype=out_dtype)
+                H = np.zeros((m, n), dtype=out_dtype).T
+                tau = np.zeros(k, dtype=out_dtype)
+                R = np.zeros((k, n), dtype=out_dtype)
                 return H, tau, R
 
         if integer_input:
@@ -451,7 +451,10 @@ def numba_funcify_Schur(op, node, **kwargs):
         @numba_basic.numba_njit
         def schur(a):
             if a.size == 0:
-                return a.copy().astype(out_dtype), np.empty((0, 0), dtype=out_dtype)
+                n = a.shape[0]
+                return np.zeros((n, n), dtype=out_dtype), np.zeros(
+                    (n, n), dtype=out_dtype
+                )
             if integer_input:
                 a = a.astype(out_dtype)
             elif needs_complex_cast:
@@ -463,7 +466,10 @@ def numba_funcify_Schur(op, node, **kwargs):
         @numba_basic.numba_njit
         def schur(a):
             if a.size == 0:
-                return a.copy().astype(out_dtype), np.empty((0, 0), dtype=out_dtype)
+                n = a.shape[0]
+                return np.zeros((n, n), dtype=out_dtype), np.zeros(
+                    (n, n), dtype=out_dtype
+                )
             if integer_input:
                 a = a.astype(out_dtype)
             T, Z = schur_real(a, lwork=None, overwrite_a=overwrite_a)
@@ -538,12 +544,21 @@ def numba_funcify_QZ(op, node, **kwargs):
         def qz(a, b):
             if a.size == 0:
                 n = a.shape[0]
-                e = np.empty((n, n), dtype=out_dtype)
                 if return_eigenvalues:
-                    alpha = np.empty((n,), dtype=alpha_dtype)
-                    beta = np.empty((n,), dtype=out_dtype)
-                    return e.copy(), e.copy(), alpha, beta, e.copy(), e.copy()
-                return e.copy(), e.copy(), e.copy(), e.copy()
+                    return (
+                        np.zeros((n, n), dtype=out_dtype),
+                        np.zeros((n, n), dtype=out_dtype),
+                        np.zeros((n,), dtype=alpha_dtype),
+                        np.zeros((n,), dtype=out_dtype),
+                        np.zeros((n, n), dtype=out_dtype),
+                        np.zeros((n, n), dtype=out_dtype),
+                    )
+                return (
+                    np.zeros((n, n), dtype=out_dtype),
+                    np.zeros((n, n), dtype=out_dtype),
+                    np.zeros((n, n), dtype=out_dtype),
+                    np.zeros((n, n), dtype=out_dtype),
+                )
             if integer_input_a:
                 a = a.astype(out_dtype)
             elif needs_complex_cast:
@@ -559,12 +574,21 @@ def numba_funcify_QZ(op, node, **kwargs):
         def qz(a, b):
             if a.size == 0:
                 n = a.shape[0]
-                e = np.empty((n, n), dtype=out_dtype)
                 if return_eigenvalues:
-                    alpha = np.empty((n,), dtype=alpha_dtype)
-                    beta = np.empty((n,), dtype=out_dtype)
-                    return e.copy(), e.copy(), alpha, beta, e.copy(), e.copy()
-                return e.copy(), e.copy(), e.copy(), e.copy()
+                    return (
+                        np.zeros((n, n), dtype=out_dtype),
+                        np.zeros((n, n), dtype=out_dtype),
+                        np.zeros((n,), dtype=alpha_dtype),
+                        np.zeros((n,), dtype=out_dtype),
+                        np.zeros((n, n), dtype=out_dtype),
+                        np.zeros((n, n), dtype=out_dtype),
+                    )
+                return (
+                    np.zeros((n, n), dtype=out_dtype),
+                    np.zeros((n, n), dtype=out_dtype),
+                    np.zeros((n, n), dtype=out_dtype),
+                    np.zeros((n, n), dtype=out_dtype),
+                )
             if integer_input_a:
                 a = a.astype(out_dtype)
             elif needs_complex_cast:

--- a/pytensor/link/numba/dispatch/linalg/decomposition/dispatch.py
+++ b/pytensor/link/numba/dispatch/linalg/decomposition/dispatch.py
@@ -58,6 +58,13 @@ def numba_funcify_SVD(op, node, **kwargs):
     if discrete_input and config.compiler_verbose:
         print("SVD requires casting discrete input to float")  # noqa: T201
 
+    if compute_uv:
+        matrix_dtype = np.dtype(node.outputs[0].dtype)
+        s_dtype = np.dtype(node.outputs[1].dtype)
+    else:
+        s_dtype = out_dtype
+        matrix_dtype = out_dtype
+
     if not compute_uv:
 
         @numba_basic.numba_njit
@@ -65,7 +72,7 @@ def numba_funcify_SVD(op, node, **kwargs):
             if x.size == 0:
                 m, n = x.shape
                 k = min(m, n)
-                return np.empty((k,), dtype=out_dtype)
+                return np.empty((k,), dtype=s_dtype)
             if discrete_input:
                 x = x.astype(out_dtype)
             _, ret, _ = np.linalg.svd(x, full_matrices)
@@ -80,15 +87,15 @@ def numba_funcify_SVD(op, node, **kwargs):
                 k = min(m, n)
                 if full_matrices:
                     return (
-                        np.empty((m, m), dtype=out_dtype),
-                        np.empty((k,), dtype=out_dtype),
-                        np.empty((n, n), dtype=out_dtype),
+                        np.empty((m, m), dtype=matrix_dtype),
+                        np.empty((k,), dtype=s_dtype),
+                        np.empty((n, n), dtype=matrix_dtype),
                     )
                 else:
                     return (
-                        np.empty((m, k), dtype=out_dtype),
-                        np.empty((k,), dtype=out_dtype),
-                        np.empty((k, n), dtype=out_dtype),
+                        np.empty((m, k), dtype=matrix_dtype),
+                        np.empty((k,), dtype=s_dtype),
+                        np.empty((k, n), dtype=matrix_dtype),
                     )
             if discrete_input:
                 x = x.astype(out_dtype)

--- a/pytensor/link/numba/dispatch/linalg/decomposition/schur.py
+++ b/pytensor/link/numba/dispatch/linalg/decomposition/schur.py
@@ -57,6 +57,9 @@ def schur_real_impl(A, lwork, overwrite_a):
 
     def real_schur_impl(A, lwork, overwrite_a):
         _N = np.int32(A.shape[-1])
+        if _N == 0:
+            return A.copy(), np.empty((0, 0), dtype=dtype)
+
         if lwork is None:
             lwork = -1
 
@@ -149,6 +152,9 @@ def schur_complex_impl(A, lwork, overwrite_a):
 
     def complex_schur_impl(A, lwork, overwrite_a):
         _N = np.int32(A.shape[-1])
+        if _N == 0:
+            return A.copy(), np.empty((0, 0), dtype=dtype)
+
         if lwork is None:
             lwork = -1
 

--- a/pytensor/link/numba/dispatch/linalg/decomposition/schur.py
+++ b/pytensor/link/numba/dispatch/linalg/decomposition/schur.py
@@ -57,9 +57,6 @@ def schur_real_impl(A, lwork, overwrite_a):
 
     def real_schur_impl(A, lwork, overwrite_a):
         _N = np.int32(A.shape[-1])
-        if _N == 0:
-            return A.copy(), np.empty((0, 0), dtype=dtype)
-
         if lwork is None:
             lwork = -1
 
@@ -152,9 +149,6 @@ def schur_complex_impl(A, lwork, overwrite_a):
 
     def complex_schur_impl(A, lwork, overwrite_a):
         _N = np.int32(A.shape[-1])
-        if _N == 0:
-            return A.copy(), np.empty((0, 0), dtype=dtype)
-
         if lwork is None:
             lwork = -1
 

--- a/pytensor/link/numba/dispatch/linalg/solvers/dispatch.py
+++ b/pytensor/link/numba/dispatch/linalg/solvers/dispatch.py
@@ -172,6 +172,8 @@ def numba_funcify_TRSYL(op, node, **kwargs):
 
     @numba_basic.numba_njit
     def trsyl(a, b, c):
+        if a.size == 0 or b.size == 0 or c.size == 0:
+            return np.empty(c.shape, dtype=out_dtype)
         if must_cast_a:
             a = a.astype(out_dtype)
         if must_cast_b:

--- a/pytensor/tensor/linalg/decomposition/qr.py
+++ b/pytensor/tensor/linalg/decomposition/qr.py
@@ -74,6 +74,8 @@ class QR(Op):
         in_dtype = x.type.numpy_dtype
         if in_dtype.kind in "ibu":
             out_dtype = "float64" if in_dtype.itemsize > 2 else "float32"
+        elif in_dtype.kind == "c":
+            out_dtype = "complex128" if in_dtype.itemsize > 8 else "complex64"
         else:
             out_dtype = "float64" if in_dtype.itemsize > 4 else "float32"
 


### PR DESCRIPTION
I was hitting this error in #2032; `tests/tensor/linalg/test_decomposition/test_schur.py::test_schur_empty` was failing because we didn't have any guard in place for an early return on empy inputs. I am a bit at a loss why the CI isnt' currently failing on v3. It might be a mac vs linux lapack thing? 

Anyway I fixed it, and also did an audit of the other linalg functions against empty inputs and found several decompositions that didn't have an appropriate guard, so I added those as well.

Related to: https://github.com/pymc-devs/pytensor/issues/1298