### PR TITLE
Centralize linalg output dtype inference 

### DIFF
--- a/pytensor/sparse/linalg.py
+++ b/pytensor/sparse/linalg.py
@@ -7,8 +7,8 @@ from pytensor.sparse import as_sparse_or_tensor_variable, matrix
 from pytensor.tensor import TensorVariable
 from pytensor.tensor.linalg.constructors import (
     BaseBlockDiagonal,
-    _largest_common_dtype,
 )
+from pytensor.tensor.linalg.dtype_utils import _largest_common_dtype
 
 
 class SparseBlockDiagonal(BaseBlockDiagonal):

--- a/pytensor/tensor/linalg/constructors.py
+++ b/pytensor/tensor/linalg/constructors.py
@@ -1,7 +1,3 @@
-from collections.abc import Sequence
-from functools import reduce
-
-import numpy as np
 import scipy.linalg as scipy_linalg
 
 import pytensor
@@ -10,12 +6,9 @@ from pytensor.graph.basic import Apply
 from pytensor.graph.op import Op
 from pytensor.tensor import basic as ptb
 from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.linalg.dtype_utils import _largest_common_dtype
 from pytensor.tensor.variable import TensorVariable
 from pytensor.utils import unzip
-
-
-def _largest_common_dtype(tensors: Sequence[TensorVariable]) -> np.dtype:
-    return reduce(lambda l, r: np.promote_types(l, r), [x.dtype for x in tensors])
 
 
 class BaseBlockDiagonal(Op):

--- a/pytensor/tensor/linalg/decomposition/cholesky.py
+++ b/pytensor/tensor/linalg/decomposition/cholesky.py
@@ -11,6 +11,7 @@ from pytensor.tensor import basic as ptb
 from pytensor.tensor import math as ptm
 from pytensor.tensor.basic import as_tensor_variable
 from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.linalg.dtype_utils import linalg_output_dtype
 from pytensor.tensor.type import tensor
 
 
@@ -41,8 +42,7 @@ class Cholesky(Op):
             raise TypeError(
                 f"Cholesky only allowed on matrix (2-D) inputs, got {x.type.ndim}-D input"
             )
-        # Call scipy to find output dtype
-        dtype = scipy_linalg.cholesky(np.eye(1, dtype=x.type.dtype)).dtype
+        dtype = linalg_output_dtype(x.type.dtype)
         return Apply(self, [x], [tensor(shape=x.type.shape, dtype=dtype)])
 
     def perform(self, node, inputs, outputs):

--- a/pytensor/tensor/linalg/decomposition/eigen.py
+++ b/pytensor/tensor/linalg/decomposition/eigen.py
@@ -11,6 +11,7 @@ from pytensor.graph.op import Op
 from pytensor.tensor import TensorLike
 from pytensor.tensor.basic import as_tensor_variable
 from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.linalg.dtype_utils import linalg_real_output_dtype
 from pytensor.tensor.type import Variable, matrix, tensor, vector
 from pytensor.tensor.type_other import NoneTypeT
 
@@ -112,12 +113,7 @@ class Eigh(Eig):
     def make_node(self, x):
         x = as_tensor_variable(x)
         assert x.ndim == 2
-        # Numpy's linalg.eigh may return either double or single
-        # presision eigenvalues depending on installed version of
-        # LAPACK.  Rather than trying to reproduce the (rather
-        # involved) logic, we just probe linalg.eigh with a trivial
-        # input.
-        w_dtype = np.linalg.eigh([[np.dtype(x.dtype).type()]])[0].dtype.name
+        w_dtype = linalg_real_output_dtype(x.type.dtype)
         w = vector(dtype=w_dtype)
         v = matrix(dtype=w_dtype)
         return Apply(self, [x], [w, v])

--- a/pytensor/tensor/linalg/decomposition/lu.py
+++ b/pytensor/tensor/linalg/decomposition/lu.py
@@ -12,6 +12,10 @@ from pytensor.tensor import TensorLike
 from pytensor.tensor import basic as ptb
 from pytensor.tensor.basic import as_tensor_variable
 from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.linalg.dtype_utils import (
+    linalg_output_dtype,
+    linalg_real_output_dtype,
+)
 from pytensor.tensor.type import matrix, tensor, vector
 from pytensor.tensor.variable import TensorVariable
 
@@ -55,13 +59,7 @@ class LU(Op):
                 f"LU only allowed on matrix (2-D) inputs, got {x.type.ndim}-D input"
             )
 
-        if x.type.numpy_dtype.kind in "ibu":
-            if x.type.numpy_dtype.itemsize <= 2:
-                out_dtype = "float32"
-            else:
-                out_dtype = "float64"
-        else:
-            out_dtype = x.type.dtype
+        out_dtype = linalg_output_dtype(x.type.dtype)
         L = tensor(shape=x.type.shape, dtype=out_dtype)
         U = tensor(shape=x.type.shape, dtype=out_dtype)
 
@@ -72,10 +70,7 @@ class LU(Op):
             p_indices = tensor(shape=(x.type.shape[0],), dtype="int32")
             return Apply(self, inputs=[x], outputs=[p_indices, L, U])
 
-        if out_dtype.startswith("complex"):
-            P_dtype = "float64" if out_dtype == "complex128" else "float32"
-        else:
-            P_dtype = out_dtype
+        P_dtype = linalg_real_output_dtype(x.type.dtype)
 
         P = tensor(shape=x.type.shape, dtype=P_dtype)
         return Apply(self, inputs=[x], outputs=[P, L, U])

--- a/pytensor/tensor/linalg/decomposition/qr.py
+++ b/pytensor/tensor/linalg/decomposition/qr.py
@@ -13,6 +13,7 @@ from pytensor.tensor import basic as ptb
 from pytensor.tensor import math as ptm
 from pytensor.tensor.basic import as_tensor_variable
 from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.linalg.dtype_utils import linalg_output_dtype
 from pytensor.tensor.type import tensor
 
 
@@ -71,13 +72,7 @@ class QR(Op):
         else:
             K = None
 
-        in_dtype = x.type.numpy_dtype
-        if in_dtype.kind in "ibu":
-            out_dtype = "float64" if in_dtype.itemsize > 2 else "float32"
-        elif in_dtype.kind == "c":
-            out_dtype = "complex128" if in_dtype.itemsize > 8 else "complex64"
-        else:
-            out_dtype = "float64" if in_dtype.itemsize > 4 else "float32"
+        out_dtype = linalg_output_dtype(x.type.dtype)
 
         match self.mode:
             case "full":

--- a/pytensor/tensor/linalg/decomposition/schur.py
+++ b/pytensor/tensor/linalg/decomposition/schur.py
@@ -9,6 +9,7 @@ from pytensor.graph import Apply, Op
 from pytensor.tensor import TensorLike
 from pytensor.tensor.basic import as_tensor_variable
 from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.linalg.dtype_utils import linalg_output_dtype
 from pytensor.tensor.type import matrix, vector
 from pytensor.tensor.variable import TensorVariable
 
@@ -78,13 +79,13 @@ class Schur(Op):
         A = as_tensor_variable(A)
         assert A.ndim == 2
 
-        out_dtype = A.dtype
-        complex_input = out_dtype in ("complex64", "complex128")
+        out_dtype = linalg_output_dtype(A.dtype)
+        complex_input = np.dtype(out_dtype).kind == "c"
 
         # Scipy behavior: output parameter only affects real inputs
         # Complex inputs always return complex output
         if self.output == "complex" and not complex_input:
-            out_dtype = "complex64" if A.dtype == "float32" else "complex128"
+            out_dtype = "complex64" if out_dtype == "float32" else "complex128"
 
         T = matrix(dtype=out_dtype, shape=A.type.shape)
         Z = matrix(dtype=out_dtype, shape=A.type.shape)
@@ -318,11 +319,9 @@ class QZ(Op):
         assert A.ndim == 2
         assert B.ndim == 2
 
-        out_dtype = pytensor.scalar.upcast(A.dtype, B.dtype)
-        if np.dtype(out_dtype).kind in "ibu":
-            out_dtype = "float64" if np.dtype(out_dtype).itemsize > 2 else "float32"
+        out_dtype = linalg_output_dtype(A.dtype, B.dtype)
 
-        complex_input = out_dtype in ("complex64", "complex128")
+        complex_input = np.dtype(out_dtype).kind == "c"
 
         # Scipy behavior: output parameter only affects real inputs
         # Complex inputs always return complex output

--- a/pytensor/tensor/linalg/decomposition/svd.py
+++ b/pytensor/tensor/linalg/decomposition/svd.py
@@ -9,6 +9,10 @@ from pytensor.tensor import basic as ptb
 from pytensor.tensor import math as ptm
 from pytensor.tensor.basic import as_tensor_variable
 from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.linalg.dtype_utils import (
+    linalg_output_dtype,
+    linalg_real_output_dtype,
+)
 from pytensor.tensor.type import matrix, vector
 
 
@@ -48,12 +52,10 @@ class SVD(Op):
         assert x.ndim == 2, "The input of svd function should be a matrix."
 
         in_dtype = x.type.numpy_dtype
-        if in_dtype.name.startswith("int"):
-            out_dtype = np.dtype(f"f{in_dtype.itemsize}")
-        else:
-            out_dtype = in_dtype
+        out_dtype = linalg_output_dtype(in_dtype)
+        s_dtype = linalg_real_output_dtype(in_dtype)
 
-        s = vector(dtype=out_dtype)
+        s = vector(dtype=s_dtype)
 
         if self.compute_uv:
             u = matrix(dtype=out_dtype)

--- a/pytensor/tensor/linalg/dtype_utils.py
+++ b/pytensor/tensor/linalg/dtype_utils.py
@@ -1,13 +1,22 @@
 import numpy as np
 
 
+_float32 = np.dtype("float32")
+_float64 = np.dtype("float64")
+_complex64 = np.dtype("complex64")
+_complex128 = np.dtype("complex128")
+
+
 def _to_lapack_dtype(dt: np.dtype) -> np.dtype:
     """Map a single numpy dtype to the nearest LAPACK-supported dtype."""
     if dt.kind == "c":
-        return np.dtype("complex64") if dt.itemsize <= 8 else np.dtype("complex128")
+        return _complex64 if dt.itemsize <= 8 else _complex128
     if (dt.kind == "f" and dt.itemsize > 4) or (dt.kind in "ibu" and dt.itemsize > 2):
-        return np.dtype("float64")
-    return np.dtype("float32")
+        return _float64
+    return _float32
+
+
+_COMPLEX_TO_REAL = {_complex64: _float32, _complex128: _float64}
 
 
 def linalg_output_dtype(*input_dtypes: np.dtype | str) -> str:
@@ -16,6 +25,8 @@ def linalg_output_dtype(*input_dtypes: np.dtype | str) -> str:
     Matches ``scipy.linalg.lapack.find_best_lapack_type``: each input is mapped to its nearest LAPACK type
     independently, then the results are combined via ``numpy.result_type``.
     """
+    if len(input_dtypes) == 1:
+        return _to_lapack_dtype(np.dtype(input_dtypes[0])).name
     lapack_dtypes = [_to_lapack_dtype(np.dtype(dt)) for dt in input_dtypes]
     return np.result_type(*lapack_dtypes).name
 
@@ -26,4 +37,5 @@ def linalg_real_output_dtype(*input_dtypes: np.dtype | str) -> str:
     Use for outputs that are mathematically real regardless of input type: singular values (SVD), eigenvalues of
     hermitian matrices (eigh), log-determinant (slogdet), norms, etc.
     """
-    return np.finfo(np.dtype(linalg_output_dtype(*input_dtypes))).dtype.name
+    dt = np.dtype(linalg_output_dtype(*input_dtypes))
+    return _COMPLEX_TO_REAL.get(dt, dt).name

--- a/pytensor/tensor/linalg/dtype_utils.py
+++ b/pytensor/tensor/linalg/dtype_utils.py
@@ -1,19 +1,9 @@
+from collections.abc import Sequence
+from functools import reduce
+
 import numpy as np
 
-
-def _to_lapack_dtype(dt: np.dtype) -> np.dtype:
-    """Map a single numpy dtype to the nearest LAPACK-supported dtype."""
-    if dt.kind == "c":
-        return np.dtype("complex64") if dt.itemsize <= 8 else np.dtype("complex128")
-    if (dt.kind == "f" and dt.itemsize > 4) or (dt.kind in "ibu" and dt.itemsize > 2):
-        return np.dtype("float64")
-    return np.dtype("float32")
-
-
-_COMPLEX_TO_REAL: dict[np.dtype, np.dtype] = {
-    np.dtype("complex64"): np.dtype("float32"),
-    np.dtype("complex128"): np.dtype("float64"),
-}
+from pytensor.tensor.variable import TensorVariable
 
 
 def linalg_output_dtype(*input_dtypes: np.dtype | str) -> str:
@@ -22,10 +12,18 @@ def linalg_output_dtype(*input_dtypes: np.dtype | str) -> str:
     Matches ``scipy.linalg.lapack.find_best_lapack_type``: each input is mapped to its nearest LAPACK type
     independently, then the results are combined via ``numpy.result_type``.
     """
-    if len(input_dtypes) == 1:
-        return _to_lapack_dtype(np.dtype(input_dtypes[0])).name
-    lapack_dtypes = [_to_lapack_dtype(np.dtype(dt)) for dt in input_dtypes]
-    return np.result_type(*lapack_dtypes).name
+
+    def _to_lapack_dtype(dt: np.dtype) -> np.dtype:
+        """Map a single numpy dtype to the nearest LAPACK-supported dtype."""
+        if dt.kind == "c":
+            return np.dtype("complex64") if dt.itemsize <= 8 else np.dtype("complex128")
+        if (dt.kind == "f" and dt.itemsize > 4) or (
+            dt.kind in "ibu" and dt.itemsize > 2
+        ):
+            return np.dtype("float64")
+        return np.dtype("float32")
+
+    return np.result_type(*(_to_lapack_dtype(np.dtype(dt)) for dt in input_dtypes)).name
 
 
 def linalg_real_output_dtype(*input_dtypes: np.dtype | str) -> str:
@@ -35,6 +33,10 @@ def linalg_real_output_dtype(*input_dtypes: np.dtype | str) -> str:
     hermitian matrices (eigh), log-determinant (slogdet), norms, etc.
     """
     dt = np.dtype(linalg_output_dtype(*input_dtypes))
-    if dt in _COMPLEX_TO_REAL:
-        return _COMPLEX_TO_REAL[dt].name
+    if dt.kind == "c":
+        return np.finfo(dt).dtype.name
     return dt.name
+
+
+def _largest_common_dtype(tensors: Sequence[TensorVariable]) -> np.dtype:
+    return reduce(lambda l, r: np.promote_types(l, r), [x.dtype for x in tensors])

--- a/pytensor/tensor/linalg/dtype_utils.py
+++ b/pytensor/tensor/linalg/dtype_utils.py
@@ -1,0 +1,29 @@
+import numpy as np
+
+
+def _to_lapack_dtype(dt: np.dtype) -> np.dtype:
+    """Map a single numpy dtype to the nearest LAPACK-supported dtype."""
+    if dt.kind == "c":
+        return np.dtype("complex64") if dt.itemsize <= 8 else np.dtype("complex128")
+    if (dt.kind == "f" and dt.itemsize > 4) or (dt.kind in "ibu" and dt.itemsize > 2):
+        return np.dtype("float64")
+    return np.dtype("float32")
+
+
+def linalg_output_dtype(*input_dtypes: np.dtype | str) -> str:
+    """Map one or more input dtypes to the working dtype LAPACK would use.
+
+    Matches ``scipy.linalg.lapack.find_best_lapack_type``: each input is mapped to its nearest LAPACK type
+    independently, then the results are combined via ``numpy.result_type``.
+    """
+    lapack_dtypes = [_to_lapack_dtype(np.dtype(dt)) for dt in input_dtypes]
+    return np.result_type(*lapack_dtypes).name
+
+
+def linalg_real_output_dtype(*input_dtypes: np.dtype | str) -> str:
+    """Companion to ``linalg_output_dtype`` for functions that map C -> R.
+
+    Use for outputs that are mathematically real regardless of input type: singular values (SVD), eigenvalues of
+    hermitian matrices (eigh), log-determinant (slogdet), norms, etc.
+    """
+    return np.finfo(np.dtype(linalg_output_dtype(*input_dtypes))).dtype.name

--- a/pytensor/tensor/linalg/dtype_utils.py
+++ b/pytensor/tensor/linalg/dtype_utils.py
@@ -16,7 +16,10 @@ def _to_lapack_dtype(dt: np.dtype) -> np.dtype:
     return _float32
 
 
-_COMPLEX_TO_REAL = {_complex64: _float32, _complex128: _float64}
+_COMPLEX_TO_REAL: dict[np.dtype, np.dtype] = {
+    _complex64: _float32,
+    _complex128: _float64,
+}
 
 
 def linalg_output_dtype(*input_dtypes: np.dtype | str) -> str:
@@ -38,4 +41,6 @@ def linalg_real_output_dtype(*input_dtypes: np.dtype | str) -> str:
     hermitian matrices (eigh), log-determinant (slogdet), norms, etc.
     """
     dt = np.dtype(linalg_output_dtype(*input_dtypes))
-    return _COMPLEX_TO_REAL.get(dt, dt).name
+    if dt in _COMPLEX_TO_REAL:
+        return _COMPLEX_TO_REAL[dt].name
+    return dt.name

--- a/pytensor/tensor/linalg/dtype_utils.py
+++ b/pytensor/tensor/linalg/dtype_utils.py
@@ -1,24 +1,18 @@
 import numpy as np
 
 
-_float32 = np.dtype("float32")
-_float64 = np.dtype("float64")
-_complex64 = np.dtype("complex64")
-_complex128 = np.dtype("complex128")
-
-
 def _to_lapack_dtype(dt: np.dtype) -> np.dtype:
     """Map a single numpy dtype to the nearest LAPACK-supported dtype."""
     if dt.kind == "c":
-        return _complex64 if dt.itemsize <= 8 else _complex128
+        return np.dtype("complex64") if dt.itemsize <= 8 else np.dtype("complex128")
     if (dt.kind == "f" and dt.itemsize > 4) or (dt.kind in "ibu" and dt.itemsize > 2):
-        return _float64
-    return _float32
+        return np.dtype("float64")
+    return np.dtype("float32")
 
 
 _COMPLEX_TO_REAL: dict[np.dtype, np.dtype] = {
-    _complex64: _float32,
-    _complex128: _float64,
+    np.dtype("complex64"): np.dtype("float32"),
+    np.dtype("complex128"): np.dtype("float64"),
 }
 
 

--- a/pytensor/tensor/linalg/inverse.py
+++ b/pytensor/tensor/linalg/inverse.py
@@ -7,6 +7,7 @@ from pytensor.tensor import basic as ptb
 from pytensor.tensor import math as ptm
 from pytensor.tensor.basic import as_tensor_variable
 from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.linalg.dtype_utils import linalg_output_dtype
 from pytensor.tensor.type import matrix
 
 
@@ -20,10 +21,7 @@ class MatrixPinv(Op):
     def make_node(self, x):
         x = as_tensor_variable(x)
         assert x.ndim == 2
-        if x.type.numpy_dtype.kind in "ibu":
-            out_dtype = "float64"
-        else:
-            out_dtype = x.dtype
+        out_dtype = linalg_output_dtype(x.type.dtype)
         return Apply(
             self,
             [x],
@@ -110,10 +108,7 @@ class MatrixInverse(Op):
     def make_node(self, x):
         x = as_tensor_variable(x)
         assert x.ndim == 2
-        if x.type.numpy_dtype.kind in "ibu":
-            out_dtype = "float64"
-        else:
-            out_dtype = x.dtype
+        out_dtype = linalg_output_dtype(x.type.dtype)
         return Apply(self, [x], [matrix(shape=x.type.shape, dtype=out_dtype)])
 
     def perform(self, node, inputs, outputs):

--- a/pytensor/tensor/linalg/solvers/core.py
+++ b/pytensor/tensor/linalg/solvers/core.py
@@ -1,13 +1,11 @@
 import logging
 
-import numpy as np
-import scipy.linalg as scipy_linalg
-
 import pytensor.tensor.math as ptm
 from pytensor import tensor as pt
 from pytensor.graph.basic import Apply
 from pytensor.graph.op import Op
 from pytensor.tensor.basic import as_tensor_variable
+from pytensor.tensor.linalg.dtype_utils import linalg_output_dtype
 from pytensor.tensor.type import tensor
 
 
@@ -69,11 +67,7 @@ class SolveBase(Op):
         if b.ndim != self.b_ndim:
             raise ValueError(f"`b` must have {self.b_ndim} dims; got {b.type} instead.")
 
-        # Infer dtype by solving the most simple case with 1x1 matrices
-        o_dtype = scipy_linalg.solve(
-            np.ones((1, 1), dtype=A.dtype),
-            np.ones((1,), dtype=b.dtype),
-        ).dtype
+        o_dtype = linalg_output_dtype(A.dtype, b.dtype)
         x = tensor(dtype=o_dtype, shape=b.type.shape)
         return Apply(self, [A, b], [x])
 

--- a/pytensor/tensor/linalg/solvers/psd.py
+++ b/pytensor/tensor/linalg/solvers/psd.py
@@ -1,11 +1,11 @@
 import numpy as np
-import scipy.linalg as scipy_linalg
 from scipy.linalg import get_lapack_funcs
 
 from pytensor.graph.basic import Apply
 from pytensor.graph.op import Op
 from pytensor.tensor import TensorLike
 from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.linalg.dtype_utils import linalg_output_dtype
 from pytensor.tensor.linalg.solvers.core import SolveBase, _default_b_ndim
 from pytensor.tensor.type import tensor
 
@@ -27,11 +27,7 @@ class CholeskySolve(SolveBase):
         super_apply = super().make_node(*inputs)
         A, b = super_apply.inputs
         [super_out] = super_apply.outputs
-        # The dtype of chol_solve does not match solve, which the base class checks
-        dtype = scipy_linalg.cho_solve(
-            (np.ones((1, 1), dtype=A.dtype), False),
-            np.ones((1,), dtype=b.dtype),
-        ).dtype
+        dtype = linalg_output_dtype(A.dtype, b.dtype)
         out = tensor(dtype=dtype, shape=super_out.type.shape)
         return Apply(self, [A, b], [out])
 

--- a/pytensor/tensor/linalg/summary.py
+++ b/pytensor/tensor/linalg/summary.py
@@ -13,6 +13,10 @@ from pytensor.tensor import math as ptm
 from pytensor.tensor.basic import as_tensor_variable, diagonal
 from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.linalg.decomposition.svd import svd
+from pytensor.tensor.linalg.dtype_utils import (
+    linalg_output_dtype,
+    linalg_real_output_dtype,
+)
 from pytensor.tensor.type import scalar
 
 
@@ -48,10 +52,7 @@ class Det(Op):
             raise ValueError(
                 f"Determinant not defined for non-square matrix inputs. Shape received is {x.type.shape}"
             )
-        if x.type.numpy_dtype.kind in "ibu":
-            out_dtype = "float64"
-        else:
-            out_dtype = x.dtype
+        out_dtype = linalg_output_dtype(x.type.dtype)
         o = scalar(dtype=out_dtype)
         return Apply(self, [x], [o])
 
@@ -92,12 +93,9 @@ class SLogDet(Op):
     def make_node(self, x):
         x = as_tensor_variable(x)
         assert x.ndim == 2
-        if x.type.numpy_dtype.kind in "ibu":
-            out_dtype = "float64"
-        else:
-            out_dtype = x.dtype
+        out_dtype = linalg_output_dtype(x.type.dtype)
         sign = scalar(dtype=out_dtype)
-        det = scalar(dtype=out_dtype)
+        det = scalar(dtype=linalg_real_output_dtype(x.type.dtype))
         return Apply(self, [x], [sign, det])
 
     def perform(self, node, inputs, outputs):

--- a/tests/sparse/test_math.py
+++ b/tests/sparse/test_math.py
@@ -358,6 +358,7 @@ class TestStructuredDot:
         verify_grad_sparse(buildgraph_T, [spmat, mat], structured=True)
 
     def test_upcast(self):
+        rng = np.random.default_rng(sum(map(ord, "test_upcast")))
         typenames = (
             "float32",
             "int64",
@@ -381,9 +382,7 @@ class TestStructuredDot:
                 M, N, K, nnz = (4, 3, 5, 3)
                 spmat = scipy_sparse.csc_matrix(random_lil((M, N), sparse_dtype, nnz))
                 spmat.dtype = np.dtype(sparse_dtype)
-                mat = np.asarray(
-                    np.random.standard_normal((N, K)) * 9, dtype=dense_dtype
-                )
+                mat = np.asarray(rng.standard_normal((N, K)) * 9, dtype=dense_dtype)
                 pytensor_result = f(spmat, mat)
                 scipy_result = spmat * mat
                 assert pytensor_result.shape == scipy_result.shape


### PR DESCRIPTION
Handling of output dtype logic was inconsistent between Ops, and I was running into bugs in QR and SVD during development. I also never liked the hack in Solve/Cholesky to just call the scipy function with the input dtypes and check. I know it was never very expensive, but it's like come on dude, these are deterministic maps. While working on this PR, I found more bugs in complex dtype handling for slogdet.

This PR adds two helper functions in a new file (`tensor/linalg/dtype_utils.py`) that copy in the logic from helper function in numpy/scipy. We could also just wrap those functions directly, but I really don't think we have to worry about drift on this.  

AI summary of what was changed:

**Bugs fixed**
- QR: complex64/128 inputs mapped to float64, causing numba TypingError (node said float64, LAPACK returned complex).
- SVD: singular values s typed as complex for complex input. Should be real.
- SLogDet: logdet typed as complex for complex input. Should be real.

**What changed**
LAPACK only has 4 types (float32/float64/complex64/complex128). Added two utilities in dtype_utils.py that encode this mapping:

- linalg_output_dtype(*dtypes) — matches scipy.linalg.lapack.find_best_lapack_type
- linalg_real_output_dtype(*dtypes) — for mathematically-real outputs (singular values, eigenvalues of hermitian matrices, log-determinants, permutation matrices)

- 
- Replaced all ad-hoc dtype inference across linalg: QR, SVD, LU, Cholesky, Eigh, Schur, QZ, Det, SLogDet, MatrixInverse, MatrixPinv, Solve, CholeskySolve. This removes the pattern of calling scipy on dummy inputs to discover output dtypes at graph-build time.