### PR TITLE
Update Eigh and Eigvalsh Ops

### DIFF
--- a/pytensor/link/jax/dispatch/linalg/decomposition.py
+++ b/pytensor/link/jax/dispatch/linalg/decomposition.py
@@ -31,11 +31,15 @@ def jax_funcify_Eig(op, **kwargs):
 
 
 @jax_funcify.register(Eigh)
-def jax_funcify_Eigh(op, **kwargs):
-    uplo = op.UPLO
+def jax_funcify_Eigh(op, node, **kwargs):
+    lower = op.lower
+    if len(node.inputs) == 2:
+        raise NotImplementedError(
+            "jax.scipy.linalg.eigh does not support generalized eigenvalue problems (b != None)"
+        )
 
-    def eigh(x, uplo=uplo):
-        return jax.numpy.linalg.eigh(x, UPLO=uplo)
+    def eigh(a):
+        return jax.scipy.linalg.eigh(a, lower=lower)
 
     return eigh
 

--- a/pytensor/link/mlx/dispatch/linalg/decomposition.py
+++ b/pytensor/link/mlx/dispatch/linalg/decomposition.py
@@ -85,12 +85,18 @@ def mlx_funcify_Eig(op, node, **kwargs):
 
 @mlx_funcify.register(Eigh)
 def mlx_funcify_Eigh(op, node, **kwargs):
-    uplo = op.UPLO
+    UPLO = "L" if op.lower else "U"
     X_dtype = getattr(mx, node.inputs[0].dtype)
 
-    def eigh(x):
+    if len(node.inputs) == 2:
+        raise NotImplementedError(
+            "mlx.core.linalg.eigh does not support generalized "
+            "eigenvalue problems (b != None)"
+        )
+
+    def eigh(a):
         return mx.linalg.eigh(
-            x.astype(dtype=X_dtype, stream=mx.cpu), UPLO=uplo, stream=mx.cpu
+            a.astype(dtype=X_dtype, stream=mx.cpu), UPLO=UPLO, stream=mx.cpu
         )
 
     return eigh

--- a/pytensor/link/numba/dispatch/linalg/_LAPACK.py
+++ b/pytensor/link/numba/dispatch/linalg/_LAPACK.py
@@ -1376,3 +1376,459 @@ class _LAPACK:
                 )
 
         return tgsen
+
+    @classmethod
+    def numba_xsyevd(cls, dtype) -> CPUDispatcher:
+        """
+        Compute all eigenvalues and eigenvectors of a real symmetric matrix
+        using a divide-and-conquer algorithm (LAPACK xSYEVD).
+        """
+        kind = get_blas_kind(dtype)
+        float_ptr = _get_nb_float_from_dtype(kind)
+        unique_func_name = f"scipy.lapack.{kind}syevd"
+
+        @numba_basic.numba_njit
+        def get_syevd_pointer():
+            with numba.objmode(ptr=types.intp):
+                ptr = get_lapack_ptr(dtype, "syevd")
+            return ptr
+
+        syevd_function_type = types.FunctionType(
+            types.void(
+                nb_i32p,  # JOBZ
+                nb_i32p,  # UPLO
+                nb_i32p,  # N
+                float_ptr,  # A
+                nb_i32p,  # LDA
+                float_ptr,  # W
+                float_ptr,  # WORK
+                nb_i32p,  # LWORK
+                nb_i32p,  # IWORK (int array passed as i32 ptr)
+                nb_i32p,  # LIWORK
+                nb_i32p,  # INFO
+            )
+        )
+
+        @numba_basic.numba_njit
+        def syevd(JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, IWORK, LIWORK, INFO):
+            fn = _call_cached_ptr(
+                get_ptr_func=get_syevd_pointer,
+                func_type_ref=syevd_function_type,
+                unique_func_name_lit=unique_func_name,
+            )
+            fn(JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, IWORK, LIWORK, INFO)
+
+        return syevd
+
+    @classmethod
+    def numba_xsygvd(cls, dtype) -> CPUDispatcher:
+        """
+        Compute all eigenvalues and eigenvectors of a generalized real symmetric
+        definite eigenproblem using a divide-and-conquer algorithm (LAPACK xSYGVD).
+
+        Solves A*v = w*B*v (ITYPE=1).
+        """
+        kind = get_blas_kind(dtype)
+        float_ptr = _get_nb_float_from_dtype(kind)
+        unique_func_name = f"scipy.lapack.{kind}sygvd"
+
+        @numba_basic.numba_njit
+        def get_sygvd_pointer():
+            with numba.objmode(ptr=types.intp):
+                ptr = get_lapack_ptr(dtype, "sygvd")
+            return ptr
+
+        sygvd_function_type = types.FunctionType(
+            types.void(
+                nb_i32p,  # ITYPE
+                nb_i32p,  # JOBZ
+                nb_i32p,  # UPLO
+                nb_i32p,  # N
+                float_ptr,  # A
+                nb_i32p,  # LDA
+                float_ptr,  # B
+                nb_i32p,  # LDB
+                float_ptr,  # W
+                float_ptr,  # WORK
+                nb_i32p,  # LWORK
+                nb_i32p,  # IWORK
+                nb_i32p,  # LIWORK
+                nb_i32p,  # INFO
+            )
+        )
+
+        @numba_basic.numba_njit
+        def sygvd(
+            ITYPE, JOBZ, UPLO, N, A, LDA, B, LDB, W, WORK, LWORK, IWORK, LIWORK, INFO
+        ):
+            fn = _call_cached_ptr(
+                get_ptr_func=get_sygvd_pointer,
+                func_type_ref=sygvd_function_type,
+                unique_func_name_lit=unique_func_name,
+            )
+            fn(
+                ITYPE,
+                JOBZ,
+                UPLO,
+                N,
+                A,
+                LDA,
+                B,
+                LDB,
+                W,
+                WORK,
+                LWORK,
+                IWORK,
+                LIWORK,
+                INFO,
+            )
+
+        return sygvd
+
+    @classmethod
+    def numba_xheevd(cls, dtype) -> CPUDispatcher:
+        """
+        Compute all eigenvalues and eigenvectors of a complex Hermitian matrix
+        using a divide-and-conquer algorithm (LAPACK xHEEVD).
+        """
+        kind = get_blas_kind(dtype)
+        float_ptr = _get_nb_float_from_dtype(kind)
+        real_ptr = nb_f64p if dtype is nb_c128 else nb_f32p
+        unique_func_name = f"scipy.lapack.{kind}heevd"
+
+        @numba_basic.numba_njit
+        def get_heevd_pointer():
+            with numba.objmode(ptr=types.intp):
+                ptr = get_lapack_ptr(dtype, "heevd")
+            return ptr
+
+        heevd_function_type = types.FunctionType(
+            types.void(
+                nb_i32p,  # JOBZ
+                nb_i32p,  # UPLO
+                nb_i32p,  # N
+                float_ptr,  # A (complex)
+                nb_i32p,  # LDA
+                real_ptr,  # W (real eigenvalues)
+                float_ptr,  # WORK (complex)
+                nb_i32p,  # LWORK
+                real_ptr,  # RWORK (real)
+                nb_i32p,  # LRWORK
+                nb_i32p,  # IWORK
+                nb_i32p,  # LIWORK
+                nb_i32p,  # INFO
+            )
+        )
+
+        @numba_basic.numba_njit
+        def heevd(
+            JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, RWORK, LRWORK, IWORK, LIWORK, INFO
+        ):
+            fn = _call_cached_ptr(
+                get_ptr_func=get_heevd_pointer,
+                func_type_ref=heevd_function_type,
+                unique_func_name_lit=unique_func_name,
+            )
+            fn(
+                JOBZ,
+                UPLO,
+                N,
+                A,
+                LDA,
+                W,
+                WORK,
+                LWORK,
+                RWORK,
+                LRWORK,
+                IWORK,
+                LIWORK,
+                INFO,
+            )
+
+        return heevd
+
+    @classmethod
+    def numba_xsyevr(cls, dtype) -> CPUDispatcher:
+        """
+        Compute eigenvalues and eigenvectors of a real symmetric matrix using the MRRR algorithm (LAPACK xSYEVR).
+        This is scipy's default driver for eigh.
+        """
+        kind = get_blas_kind(dtype)
+        float_ptr = _get_nb_float_from_dtype(kind)
+        unique_func_name = f"scipy.lapack.{kind}syevr"
+
+        @numba_basic.numba_njit
+        def get_syevr_pointer():
+            with numba.objmode(ptr=types.intp):
+                ptr = get_lapack_ptr(dtype, "syevr")
+            return ptr
+
+        syevr_function_type = types.FunctionType(
+            types.void(
+                nb_i32p,  # JOBZ
+                nb_i32p,  # RANGE
+                nb_i32p,  # UPLO
+                nb_i32p,  # N
+                float_ptr,  # A
+                nb_i32p,  # LDA
+                float_ptr,  # VL
+                float_ptr,  # VU
+                nb_i32p,  # IL
+                nb_i32p,  # IU
+                float_ptr,  # ABSTOL
+                nb_i32p,  # M
+                float_ptr,  # W
+                float_ptr,  # Z
+                nb_i32p,  # LDZ
+                nb_i32p,  # ISUPPZ
+                float_ptr,  # WORK
+                nb_i32p,  # LWORK
+                nb_i32p,  # IWORK
+                nb_i32p,  # LIWORK
+                nb_i32p,  # INFO
+            )
+        )
+
+        @numba_basic.numba_njit
+        def syevr(
+            JOBZ,
+            RANGE,
+            UPLO,
+            N,
+            A,
+            LDA,
+            VL,
+            VU,
+            IL,
+            IU,
+            ABSTOL,
+            M,
+            W,
+            Z,
+            LDZ,
+            ISUPPZ,
+            WORK,
+            LWORK,
+            IWORK,
+            LIWORK,
+            INFO,
+        ):
+            fn = _call_cached_ptr(
+                get_ptr_func=get_syevr_pointer,
+                func_type_ref=syevr_function_type,
+                unique_func_name_lit=unique_func_name,
+            )
+            fn(
+                JOBZ,
+                RANGE,
+                UPLO,
+                N,
+                A,
+                LDA,
+                VL,
+                VU,
+                IL,
+                IU,
+                ABSTOL,
+                M,
+                W,
+                Z,
+                LDZ,
+                ISUPPZ,
+                WORK,
+                LWORK,
+                IWORK,
+                LIWORK,
+                INFO,
+            )
+
+        return syevr
+
+    @classmethod
+    def numba_xheevr(cls, dtype) -> CPUDispatcher:
+        """
+        Compute eigenvalues and eigenvectors of a complex Hermitian matrix using the MRRR algorithm (LAPACK xHEEVR).
+        This is scipy's default driver for eigh with complex inputs.
+        """
+        kind = get_blas_kind(dtype)
+        float_ptr = _get_nb_float_from_dtype(kind)
+        real_ptr = nb_f64p if dtype is nb_c128 else nb_f32p
+        unique_func_name = f"scipy.lapack.{kind}heevr"
+
+        @numba_basic.numba_njit
+        def get_heevr_pointer():
+            with numba.objmode(ptr=types.intp):
+                ptr = get_lapack_ptr(dtype, "heevr")
+            return ptr
+
+        heevr_function_type = types.FunctionType(
+            types.void(
+                nb_i32p,  # JOBZ
+                nb_i32p,  # RANGE
+                nb_i32p,  # UPLO
+                nb_i32p,  # N
+                float_ptr,  # A (complex)
+                nb_i32p,  # LDA
+                real_ptr,  # VL
+                real_ptr,  # VU
+                nb_i32p,  # IL
+                nb_i32p,  # IU
+                real_ptr,  # ABSTOL
+                nb_i32p,  # M
+                real_ptr,  # W (real eigenvalues)
+                float_ptr,  # Z (complex eigenvectors)
+                nb_i32p,  # LDZ
+                nb_i32p,  # ISUPPZ
+                float_ptr,  # WORK (complex)
+                nb_i32p,  # LWORK
+                real_ptr,  # RWORK (real)
+                nb_i32p,  # LRWORK
+                nb_i32p,  # IWORK
+                nb_i32p,  # LIWORK
+                nb_i32p,  # INFO
+            )
+        )
+
+        @numba_basic.numba_njit
+        def heevr(
+            JOBZ,
+            RANGE,
+            UPLO,
+            N,
+            A,
+            LDA,
+            VL,
+            VU,
+            IL,
+            IU,
+            ABSTOL,
+            M,
+            W,
+            Z,
+            LDZ,
+            ISUPPZ,
+            WORK,
+            LWORK,
+            RWORK,
+            LRWORK,
+            IWORK,
+            LIWORK,
+            INFO,
+        ):
+            fn = _call_cached_ptr(
+                get_ptr_func=get_heevr_pointer,
+                func_type_ref=heevr_function_type,
+                unique_func_name_lit=unique_func_name,
+            )
+            fn(
+                JOBZ,
+                RANGE,
+                UPLO,
+                N,
+                A,
+                LDA,
+                VL,
+                VU,
+                IL,
+                IU,
+                ABSTOL,
+                M,
+                W,
+                Z,
+                LDZ,
+                ISUPPZ,
+                WORK,
+                LWORK,
+                RWORK,
+                LRWORK,
+                IWORK,
+                LIWORK,
+                INFO,
+            )
+
+        return heevr
+
+    @classmethod
+    def numba_xhegvd(cls, dtype) -> CPUDispatcher:
+        """
+        Compute all eigenvalues and eigenvectors of a generalized complex Hermitian
+        definite eigenproblem using a divide-and-conquer algorithm (LAPACK xHEGVD).
+
+        Solves A*v = w*B*v (ITYPE=1).
+        """
+        kind = get_blas_kind(dtype)
+        float_ptr = _get_nb_float_from_dtype(kind)
+        real_ptr = nb_f64p if dtype is nb_c128 else nb_f32p
+        unique_func_name = f"scipy.lapack.{kind}hegvd"
+
+        @numba_basic.numba_njit
+        def get_hegvd_pointer():
+            with numba.objmode(ptr=types.intp):
+                ptr = get_lapack_ptr(dtype, "hegvd")
+            return ptr
+
+        hegvd_function_type = types.FunctionType(
+            types.void(
+                nb_i32p,  # ITYPE
+                nb_i32p,  # JOBZ
+                nb_i32p,  # UPLO
+                nb_i32p,  # N
+                float_ptr,  # A (complex)
+                nb_i32p,  # LDA
+                float_ptr,  # B (complex)
+                nb_i32p,  # LDB
+                real_ptr,  # W (real eigenvalues)
+                float_ptr,  # WORK (complex)
+                nb_i32p,  # LWORK
+                real_ptr,  # RWORK (real)
+                nb_i32p,  # LRWORK
+                nb_i32p,  # IWORK
+                nb_i32p,  # LIWORK
+                nb_i32p,  # INFO
+            )
+        )
+
+        @numba_basic.numba_njit
+        def hegvd(
+            ITYPE,
+            JOBZ,
+            UPLO,
+            N,
+            A,
+            LDA,
+            B,
+            LDB,
+            W,
+            WORK,
+            LWORK,
+            RWORK,
+            LRWORK,
+            IWORK,
+            LIWORK,
+            INFO,
+        ):
+            fn = _call_cached_ptr(
+                get_ptr_func=get_hegvd_pointer,
+                func_type_ref=hegvd_function_type,
+                unique_func_name_lit=unique_func_name,
+            )
+            fn(
+                ITYPE,
+                JOBZ,
+                UPLO,
+                N,
+                A,
+                LDA,
+                B,
+                LDB,
+                W,
+                WORK,
+                LWORK,
+                RWORK,
+                LRWORK,
+                IWORK,
+                LIWORK,
+                INFO,
+            )
+
+        return hegvd

--- a/pytensor/link/numba/dispatch/linalg/decomposition/dispatch.py
+++ b/pytensor/link/numba/dispatch/linalg/decomposition/dispatch.py
@@ -1,16 +1,19 @@
-import warnings
-
-import numba
 import numpy as np
 
 from pytensor import config
 from pytensor.link.numba.dispatch import basic as numba_basic
 from pytensor.link.numba.dispatch.basic import (
     generate_fallback_impl,
-    get_numba_type,
     register_funcify_default_op_cache_key,
 )
 from pytensor.link.numba.dispatch.linalg.decomposition.cholesky import _cholesky
+from pytensor.link.numba.dispatch.linalg.decomposition.eigen import (
+    _eigh,
+    _eigh_evd,
+    _eigh_generalized,
+    _eigvalsh,
+    _eigvalsh_generalized,
+)
 from pytensor.link.numba.dispatch.linalg.decomposition.lu import (
     _lu_1,
     _lu_2,
@@ -41,7 +44,7 @@ from pytensor.link.numba.dispatch.linalg.decomposition.schur import (
     schur_real,
 )
 from pytensor.tensor.linalg.decomposition.cholesky import Cholesky
-from pytensor.tensor.linalg.decomposition.eigen import Eig, Eigh
+from pytensor.tensor.linalg.decomposition.eigen import Eig, Eigh, Eigvalsh
 from pytensor.tensor.linalg.decomposition.lu import LU, LUFactor, PivotToPermutations
 from pytensor.tensor.linalg.decomposition.qr import QR
 from pytensor.tensor.linalg.decomposition.schur import QZ, Schur
@@ -131,36 +134,105 @@ def numba_funcify_Eig(op, node, **kwargs):
 
 @register_funcify_default_op_cache_key(Eigh)
 def numba_funcify_Eigh(op, node, **kwargs):
-    uplo = op.UPLO
+    uplo_is_upper = not op.lower
+    generalized = len(node.inputs) == 2
+    driver = op.driver
 
-    if uplo != "L":
-        warnings.warn(
-            (
-                "Numba will use object mode to allow the "
-                "`UPLO` argument to `numpy.linalg.eigh`."
-            ),
-            UserWarning,
-        )
+    inp_dtype = node.inputs[0].type.numpy_dtype
+    discrete_inp = inp_dtype.kind in "ibu"
+    out_dtype = node.outputs[0].type.numpy_dtype
 
-        out_dtypes = tuple(o.type.numpy_dtype for o in node.outputs)
-        ret_sig = numba.types.Tuple(
-            [get_numba_type(node.outputs[0].type), get_numba_type(node.outputs[1].type)]
-        )
+    # Casting discrete input to float allocates a new buffer, so in-place is moot.
+    effective_overwrite_a = op.overwrite_a and not discrete_inp
+    effective_overwrite_b = op.overwrite_b and not discrete_inp
+
+    if generalized:
 
         @numba_basic.numba_njit
-        def eigh(x):
-            with numba.objmode(ret=ret_sig):
-                out = np.linalg.eigh(x, UPLO=uplo)
-                ret = (out[0].astype(out_dtypes[0]), out[1].astype(out_dtypes[1]))
-            return ret
+        def eigh(a, b):
+            if discrete_inp:
+                a = a.astype(out_dtype)
+                b = b.astype(out_dtype)
+            return _eigh_generalized(
+                a,
+                b,
+                np.int32(1) if uplo_is_upper else np.int32(0),
+                effective_overwrite_a,
+                effective_overwrite_b,
+            )
+
+    elif driver == "evd":
+
+        @numba_basic.numba_njit
+        def eigh(a):
+            if discrete_inp:
+                a = a.astype(out_dtype)
+            return _eigh_evd(
+                a,
+                np.int32(1) if uplo_is_upper else np.int32(0),
+                effective_overwrite_a,
+            )
 
     else:
 
         @numba_basic.numba_njit
-        def eigh(x):
-            return np.linalg.eigh(x)
+        def eigh(a):
+            if discrete_inp:
+                a = a.astype(out_dtype)
+            return _eigh(
+                a,
+                np.int32(1) if uplo_is_upper else np.int32(0),
+                effective_overwrite_a,
+            )
 
-    return eigh
+    cache_version = 1
+    return eigh, cache_version
+
+
+@register_funcify_default_op_cache_key(Eigvalsh)
+def numba_funcify_Eigvalsh(op, node, **kwargs):
+    uplo_is_upper = not op.lower
+    generalized = len(node.inputs) == 2
+    overwrite_a = op.overwrite_a
+    overwrite_b = op.overwrite_b
+
+    inp_dtype = node.inputs[0].type.numpy_dtype
+    discrete_inp = inp_dtype.kind in "ibu"
+    out_dtype = node.outputs[0].type.numpy_dtype
+
+    # Casting discrete input to float allocates a new buffer, so in-place is moot.
+    effective_overwrite_a = overwrite_a and not discrete_inp
+    effective_overwrite_b = overwrite_b and not discrete_inp
+
+    if generalized:
+
+        @numba_basic.numba_njit
+        def eigvalsh(a, b):
+            if discrete_inp:
+                a = a.astype(out_dtype)
+                b = b.astype(out_dtype)
+            return _eigvalsh_generalized(
+                a,
+                b,
+                np.int32(1) if uplo_is_upper else np.int32(0),
+                effective_overwrite_a,
+                effective_overwrite_b,
+            )
+
+    else:
+
+        @numba_basic.numba_njit
+        def eigvalsh(a):
+            if discrete_inp:
+                a = a.astype(out_dtype)
+            return _eigvalsh(
+                a,
+                np.int32(1) if uplo_is_upper else np.int32(0),
+                effective_overwrite_a,
+            )
+
+    cache_version = 1
+    return eigvalsh, cache_version
 
 
 @register_funcify_default_op_cache_key(Cholesky)

--- a/pytensor/link/numba/dispatch/linalg/decomposition/eigen.py
+++ b/pytensor/link/numba/dispatch/linalg/decomposition/eigen.py
@@ -1,0 +1,1052 @@
+import numpy as np
+from numba.core.extending import overload
+from numba.core.types import Complex, Float
+from numba.np.linalg import _copy_to_fortran_order, ensure_lapack
+from scipy import linalg
+
+from pytensor.link.numba.dispatch.linalg._LAPACK import (
+    _LAPACK,
+    _get_underlying_float,
+    int_ptr_to_val,
+    val_to_int_ptr,
+)
+from pytensor.link.numba.dispatch.linalg.utils import _check_linalg_matrix
+
+
+def _eigh(a, UPLO, overwrite_a=False):
+    """Placeholder for the overloaded eigh implementation."""
+    is_complex = np.issubdtype(a.dtype, np.complexfloating)
+    driver = "heevr" if is_complex else "syevr"
+    (syevr,) = linalg.get_lapack_funcs((driver,), (a,))
+    w, v, _m, _isuppz, info = syevr(
+        a, compute_v=1, lower=int(UPLO == 0), overwrite_a=int(overwrite_a)
+    )
+    if info != 0:
+        return np.full(a.shape[0], np.nan, dtype=w.dtype), np.full(
+            a.shape, np.nan, dtype=v.dtype
+        )
+    return w, v
+
+
+@overload(_eigh)
+def eigh_impl(A, UPLO, overwrite_a=False):
+    ensure_lapack()
+    _check_linalg_matrix(A, ndim=2, dtype=(Float, Complex), func_name="eigh")
+    dtype = A.dtype
+    is_complex = isinstance(dtype, Complex)
+
+    if is_complex:
+        numba_heevr = _LAPACK().numba_xheevr(dtype)
+        real_dtype = _get_underlying_float(dtype)
+
+        def impl(A, UPLO, overwrite_a=False):
+            _N = np.int32(A.shape[-1])
+            if A.shape[-2] != _N:
+                raise np.linalg.LinAlgError("Last 2 dimensions of A must be square")
+
+            # syevr/heevr scratch the input triangle of A (Householder reflectors) and read them back during the
+            # back-transform, so A and Z must remain distinct buffers. When A is donated and f-contig we reuse it as the
+            # LAPACK input/scratch buffer and still allocate Z separately.
+            if overwrite_a and A.flags.f_contiguous:
+                A_copy = A
+            else:
+                A_copy = _copy_to_fortran_order(A)
+
+            JOBZ = val_to_int_ptr(ord("V"))
+            RANGE = val_to_int_ptr(ord("A"))
+            UPLO_ptr = val_to_int_ptr(ord("L") if UPLO == 0 else ord("U"))
+            N = val_to_int_ptr(_N)
+            LDA = val_to_int_ptr(_N)
+            VL = np.empty(1, dtype=real_dtype)
+            VU = np.empty(1, dtype=real_dtype)
+            IL = val_to_int_ptr(np.int32(0))
+            IU = val_to_int_ptr(np.int32(0))
+            ABSTOL = np.empty(1, dtype=real_dtype)
+            ABSTOL[0] = 0.0
+            M = val_to_int_ptr(np.int32(0))
+            W = np.empty(_N, dtype=real_dtype)
+
+            Z = np.asfortranarray(np.empty((_N, _N), dtype=A_copy.dtype))
+
+            LDZ = val_to_int_ptr(max(np.int32(1), _N))
+            ISUPPZ = np.empty(2 * _N, dtype=np.int32)
+            INFO = val_to_int_ptr(0)
+
+            # Workspace query
+            LWORK = val_to_int_ptr(np.int32(-1))
+            LRWORK = val_to_int_ptr(np.int32(-1))
+            LIWORK = val_to_int_ptr(np.int32(-1))
+            WORK = np.empty(1, dtype=A_copy.dtype)
+            RWORK = np.empty(1, dtype=real_dtype)
+            IWORK = np.empty(1, dtype=np.int32)
+
+            numba_heevr(
+                JOBZ,
+                RANGE,
+                UPLO_ptr,
+                N,
+                A_copy.ctypes,
+                LDA,
+                VL.ctypes,
+                VU.ctypes,
+                IL,
+                IU,
+                ABSTOL.ctypes,
+                M,
+                W.ctypes,
+                Z.ctypes,
+                LDZ,
+                ISUPPZ.ctypes,
+                WORK.ctypes,
+                LWORK,
+                RWORK.ctypes,
+                LRWORK,
+                IWORK.ctypes,
+                LIWORK,
+                INFO,
+            )
+
+            lwork = np.int32(WORK[0].real)
+            lrwork = np.int32(RWORK[0])
+            liwork = IWORK[0]
+            WORK = np.empty(lwork, dtype=A_copy.dtype)
+            RWORK = np.empty(lrwork, dtype=real_dtype)
+            IWORK = np.empty(liwork, dtype=np.int32)
+            LWORK = val_to_int_ptr(lwork)
+            LRWORK = val_to_int_ptr(lrwork)
+            LIWORK = val_to_int_ptr(liwork)
+            INFO = val_to_int_ptr(0)
+
+            numba_heevr(
+                JOBZ,
+                RANGE,
+                UPLO_ptr,
+                N,
+                A_copy.ctypes,
+                LDA,
+                VL.ctypes,
+                VU.ctypes,
+                IL,
+                IU,
+                ABSTOL.ctypes,
+                M,
+                W.ctypes,
+                Z.ctypes,
+                LDZ,
+                ISUPPZ.ctypes,
+                WORK.ctypes,
+                LWORK,
+                RWORK.ctypes,
+                LRWORK,
+                IWORK.ctypes,
+                LIWORK,
+                INFO,
+            )
+
+            if int_ptr_to_val(INFO) != 0:
+                W[:] = np.nan
+                Z[:] = np.nan
+
+            return W, Z
+
+    else:
+        numba_syevr = _LAPACK().numba_xsyevr(dtype)
+
+        def impl(A, UPLO, overwrite_a=False):
+            _N = np.int32(A.shape[-1])
+            if A.shape[-2] != _N:
+                raise np.linalg.LinAlgError("Last 2 dimensions of A must be square")
+
+            # See the complex branch above for why A and Z must stay distinct.
+            # For real symmetric A, a c-contig buffer reinterpreted as f-contig equals A^T == A, so we can reuse a
+            # c-contig donated A by flipping UPLO. Z is allocated separately, so V lands in it correctly.
+            lower = UPLO == 0
+            if overwrite_a and (A.flags.f_contiguous or A.flags.c_contiguous):
+                A_copy = A
+                if A.flags.c_contiguous:
+                    lower = not lower
+            else:
+                A_copy = _copy_to_fortran_order(A)
+
+            JOBZ = val_to_int_ptr(ord("V"))
+            RANGE = val_to_int_ptr(ord("A"))
+            UPLO_ptr = val_to_int_ptr(ord("L") if lower else ord("U"))
+            N = val_to_int_ptr(_N)
+            LDA = val_to_int_ptr(_N)
+            VL = np.empty(1, dtype=A_copy.dtype)
+            VU = np.empty(1, dtype=A_copy.dtype)
+            IL = val_to_int_ptr(np.int32(0))
+            IU = val_to_int_ptr(np.int32(0))
+            ABSTOL = np.empty(1, dtype=A_copy.dtype)
+            ABSTOL[0] = 0.0
+            M = val_to_int_ptr(np.int32(0))
+            W = np.empty(_N, dtype=A_copy.dtype)
+
+            Z = np.asfortranarray(np.empty((_N, _N), dtype=A_copy.dtype))
+
+            LDZ = val_to_int_ptr(max(np.int32(1), _N))
+            ISUPPZ = np.empty(2 * _N, dtype=np.int32)
+            INFO = val_to_int_ptr(0)
+
+            # Workspace query
+            LWORK = val_to_int_ptr(np.int32(-1))
+            LIWORK = val_to_int_ptr(np.int32(-1))
+            WORK = np.empty(1, dtype=A_copy.dtype)
+            IWORK = np.empty(1, dtype=np.int32)
+
+            numba_syevr(
+                JOBZ,
+                RANGE,
+                UPLO_ptr,
+                N,
+                A_copy.ctypes,
+                LDA,
+                VL.ctypes,
+                VU.ctypes,
+                IL,
+                IU,
+                ABSTOL.ctypes,
+                M,
+                W.ctypes,
+                Z.ctypes,
+                LDZ,
+                ISUPPZ.ctypes,
+                WORK.ctypes,
+                LWORK,
+                IWORK.ctypes,
+                LIWORK,
+                INFO,
+            )
+
+            lwork = np.int32(WORK[0])
+            liwork = IWORK[0]
+            WORK = np.empty(lwork, dtype=A_copy.dtype)
+            IWORK = np.empty(liwork, dtype=np.int32)
+            LWORK = val_to_int_ptr(lwork)
+            LIWORK = val_to_int_ptr(liwork)
+            INFO = val_to_int_ptr(0)
+
+            numba_syevr(
+                JOBZ,
+                RANGE,
+                UPLO_ptr,
+                N,
+                A_copy.ctypes,
+                LDA,
+                VL.ctypes,
+                VU.ctypes,
+                IL,
+                IU,
+                ABSTOL.ctypes,
+                M,
+                W.ctypes,
+                Z.ctypes,
+                LDZ,
+                ISUPPZ.ctypes,
+                WORK.ctypes,
+                LWORK,
+                IWORK.ctypes,
+                LIWORK,
+                INFO,
+            )
+
+            if int_ptr_to_val(INFO) != 0:
+                W[:] = np.nan
+                Z[:] = np.nan
+
+            return W, Z
+
+    return impl
+
+
+def _eigh_evd(a, UPLO, overwrite_a=False):
+    """Placeholder for the overloaded eigh (divide-and-conquer) implementation."""
+    try:
+        return linalg.eigh(a, lower=(UPLO == 0), check_finite=False, driver="evd")
+    except np.linalg.LinAlgError:
+        if np.issubdtype(a.dtype, np.complexfloating):
+            real_dtype = np.finfo(a.dtype).dtype
+        else:
+            real_dtype = a.dtype
+        return (
+            np.full(a.shape[0], np.nan, dtype=real_dtype),
+            np.full(a.shape, np.nan, dtype=a.dtype),
+        )
+
+
+@overload(_eigh_evd)
+def eigh_evd_impl(A, UPLO, overwrite_a=False):
+    ensure_lapack()
+    _check_linalg_matrix(A, ndim=2, dtype=(Float, Complex), func_name="eigh")
+    dtype = A.dtype
+    is_complex = isinstance(dtype, Complex)
+
+    if is_complex:
+        numba_heevd = _LAPACK().numba_xheevd(dtype)
+        real_dtype = _get_underlying_float(dtype)
+
+        def impl(A, UPLO, overwrite_a=False):
+            _N = np.int32(A.shape[-1])
+            if A.shape[-2] != _N:
+                raise np.linalg.LinAlgError("Last 2 dimensions of A must be square")
+
+            if overwrite_a and A.flags.f_contiguous:
+                A_copy = A
+            else:
+                A_copy = _copy_to_fortran_order(A)
+
+            JOBZ = val_to_int_ptr(ord("V"))
+            UPLO_ptr = val_to_int_ptr(ord("L") if UPLO == 0 else ord("U"))
+            N = val_to_int_ptr(_N)
+            LDA = val_to_int_ptr(_N)
+            W = np.empty(_N, dtype=real_dtype)
+            INFO = val_to_int_ptr(0)
+
+            LWORK = val_to_int_ptr(np.int32(-1))
+            LRWORK = val_to_int_ptr(np.int32(-1))
+            LIWORK = val_to_int_ptr(np.int32(-1))
+            WORK = np.empty(1, dtype=A_copy.dtype)
+            RWORK = np.empty(1, dtype=real_dtype)
+            IWORK = np.empty(1, dtype=np.int32)
+
+            numba_heevd(
+                JOBZ,
+                UPLO_ptr,
+                N,
+                A_copy.ctypes,
+                LDA,
+                W.ctypes,
+                WORK.ctypes,
+                LWORK,
+                RWORK.ctypes,
+                LRWORK,
+                IWORK.ctypes,
+                LIWORK,
+                INFO,
+            )
+
+            lwork = np.int32(WORK[0].real)
+            lrwork = np.int32(RWORK[0])
+            liwork = IWORK[0]
+            WORK = np.empty(lwork, dtype=A_copy.dtype)
+            RWORK = np.empty(lrwork, dtype=real_dtype)
+            IWORK = np.empty(liwork, dtype=np.int32)
+            LWORK = val_to_int_ptr(lwork)
+            LRWORK = val_to_int_ptr(lrwork)
+            LIWORK = val_to_int_ptr(liwork)
+            INFO = val_to_int_ptr(0)
+
+            numba_heevd(
+                JOBZ,
+                UPLO_ptr,
+                N,
+                A_copy.ctypes,
+                LDA,
+                W.ctypes,
+                WORK.ctypes,
+                LWORK,
+                RWORK.ctypes,
+                LRWORK,
+                IWORK.ctypes,
+                LIWORK,
+                INFO,
+            )
+
+            if int_ptr_to_val(INFO) != 0:
+                W[:] = np.nan
+                A_copy[:] = np.nan
+
+            return W, A_copy
+
+    else:
+        numba_syevd = _LAPACK().numba_xsyevd(dtype)
+
+        def impl(A, UPLO, overwrite_a=False):
+            _N = np.int32(A.shape[-1])
+            if A.shape[-2] != _N:
+                raise np.linalg.LinAlgError("Last 2 dimensions of A must be square")
+
+            # syevd writes V back into A's buffer. For real symmetric A a c-contig buffer reinterpreted
+            # as f-contig equals A, so we can reuse a c-contig donated A by flipping UPLO. The eigenvectors
+            # LAPACK writes back are in column-major stride within the buffer; the numpy view is c-contig,
+            # so we transpose-on-return (zero-cost stride swap) to expose them as the f-order V the rest of the
+            # dispatch expects.
+            lower = UPLO == 0
+            if overwrite_a and (A.flags.f_contiguous or A.flags.c_contiguous):
+                A_copy = A
+                flip = A.flags.c_contiguous
+            else:
+                A_copy = _copy_to_fortran_order(A)
+                flip = False
+
+            if flip:
+                lower = not lower
+
+            JOBZ = val_to_int_ptr(ord("V"))
+            UPLO_ptr = val_to_int_ptr(ord("L") if lower else ord("U"))
+            N = val_to_int_ptr(_N)
+            LDA = val_to_int_ptr(_N)
+            W = np.empty(_N, dtype=A_copy.dtype)
+            INFO = val_to_int_ptr(0)
+
+            LWORK = val_to_int_ptr(np.int32(-1))
+            LIWORK = val_to_int_ptr(np.int32(-1))
+            WORK = np.empty(1, dtype=A_copy.dtype)
+            IWORK = np.empty(1, dtype=np.int32)
+
+            numba_syevd(
+                JOBZ,
+                UPLO_ptr,
+                N,
+                A_copy.ctypes,
+                LDA,
+                W.ctypes,
+                WORK.ctypes,
+                LWORK,
+                IWORK.ctypes,
+                LIWORK,
+                INFO,
+            )
+
+            lwork = np.int32(WORK[0])
+            liwork = IWORK[0]
+            WORK = np.empty(lwork, dtype=A_copy.dtype)
+            IWORK = np.empty(liwork, dtype=np.int32)
+            LWORK = val_to_int_ptr(lwork)
+            LIWORK = val_to_int_ptr(liwork)
+            INFO = val_to_int_ptr(0)
+
+            numba_syevd(
+                JOBZ,
+                UPLO_ptr,
+                N,
+                A_copy.ctypes,
+                LDA,
+                W.ctypes,
+                WORK.ctypes,
+                LWORK,
+                IWORK.ctypes,
+                LIWORK,
+                INFO,
+            )
+
+            if int_ptr_to_val(INFO) != 0:
+                W[:] = np.nan
+                A_copy[:] = np.nan
+
+            if flip:
+                return W, A_copy.T
+            return W, A_copy
+
+    return impl
+
+
+def _eigh_generalized(a, b, UPLO, overwrite_a=False, overwrite_b=False):
+    """Placeholder for the overloaded generalized eigh implementation."""
+    try:
+        return linalg.eigh(
+            a,
+            b=b,
+            lower=(UPLO == 0),
+            check_finite=False,
+            overwrite_a=bool(overwrite_a),
+            overwrite_b=bool(overwrite_b),
+        )
+    except np.linalg.LinAlgError:
+        w_dtype = np.result_type(a.dtype, b.dtype)
+        if np.issubdtype(w_dtype, np.complexfloating):
+            real_dtype = np.finfo(w_dtype).dtype
+        else:
+            real_dtype = w_dtype
+        return (
+            np.full(a.shape[0], np.nan, dtype=real_dtype),
+            np.full(a.shape, np.nan, dtype=w_dtype),
+        )
+
+
+@overload(_eigh_generalized)
+def eigh_generalized_impl(A, B, UPLO, overwrite_a=False, overwrite_b=False):
+    ensure_lapack()
+    _check_linalg_matrix(
+        A, ndim=2, dtype=(Float, Complex), func_name="eigh_generalized"
+    )
+    _check_linalg_matrix(
+        B, ndim=2, dtype=(Float, Complex), func_name="eigh_generalized"
+    )
+    dtype = A.dtype
+    is_complex = isinstance(dtype, Complex)
+
+    if is_complex:
+        numba_hegvd = _LAPACK().numba_xhegvd(dtype)
+        real_dtype = _get_underlying_float(dtype)
+
+        def impl(A, B, UPLO, overwrite_a=False, overwrite_b=False):
+            _N = np.int32(A.shape[-1])
+            if A.shape[-2] != _N:
+                raise np.linalg.LinAlgError("Last 2 dimensions of A must be square")
+            if B.shape[-1] != _N or B.shape[-2] != _N:
+                raise np.linalg.LinAlgError("A and B must have the same shape")
+
+            # hegvd writes eigenvectors back into A, so when overwrite_a is set and A is f-contig we route the
+            # LAPACK output into A's buffer directly. The c-contig flip from _eigvalsh_generalized doesn't
+            # apply here: returning eigenvectors of A^T (== conj(V) for Hermitian) would require a conjugate-on-return
+            # that defeats the alloc savings. B has no such issue since its post-call content is discarded scratch
+            # (Cholesky factor).
+            if overwrite_a and A.flags.f_contiguous:
+                A_copy = A
+            else:
+                A_copy = _copy_to_fortran_order(A)
+
+            if overwrite_b and B.flags.f_contiguous:
+                B_copy = B
+            else:
+                B_copy = _copy_to_fortran_order(B)
+
+            ITYPE = val_to_int_ptr(np.int32(1))
+            JOBZ = val_to_int_ptr(ord("V"))
+            UPLO_ptr = val_to_int_ptr(ord("L") if UPLO == 0 else ord("U"))
+            N = val_to_int_ptr(_N)
+            LDA = val_to_int_ptr(_N)
+            LDB = val_to_int_ptr(_N)
+            W = np.empty(_N, dtype=real_dtype)
+            INFO = val_to_int_ptr(0)
+
+            # scipy's f2py wrapper skips the workspace query for the *gvd family and uses the LAPACK-documented
+            # minima; MKL's hegvd workspace query can leave WORK[0] unset, so we do the same here.
+            lwork = np.int32(max(np.int32(1), 2 * _N + _N * _N))
+            lrwork = np.int32(max(np.int32(1), 1 + 5 * _N + 2 * _N * _N))
+            liwork = np.int32(max(np.int32(1), 3 + 5 * _N))
+            WORK = np.empty(lwork, dtype=A_copy.dtype)
+            RWORK = np.empty(lrwork, dtype=real_dtype)
+            IWORK = np.empty(liwork, dtype=np.int32)
+            LWORK = val_to_int_ptr(lwork)
+            LRWORK = val_to_int_ptr(lrwork)
+            LIWORK = val_to_int_ptr(liwork)
+
+            numba_hegvd(
+                ITYPE,
+                JOBZ,
+                UPLO_ptr,
+                N,
+                A_copy.ctypes,
+                LDA,
+                B_copy.ctypes,
+                LDB,
+                W.ctypes,
+                WORK.ctypes,
+                LWORK,
+                RWORK.ctypes,
+                LRWORK,
+                IWORK.ctypes,
+                LIWORK,
+                INFO,
+            )
+
+            if int_ptr_to_val(INFO) != 0:
+                W[:] = np.nan
+                A_copy[:] = np.nan
+
+            return W, A_copy
+
+    else:
+        numba_sygvd = _LAPACK().numba_xsygvd(dtype)
+
+        def impl(A, B, UPLO, overwrite_a=False, overwrite_b=False):
+            _N = np.int32(A.shape[-1])
+            if A.shape[-2] != _N:
+                raise np.linalg.LinAlgError("Last 2 dimensions of A must be square")
+            if B.shape[-1] != _N or B.shape[-2] != _N:
+                raise np.linalg.LinAlgError("A and B must have the same shape")
+
+            # Real symmetric: c-contig A reinterpreted as f-contig equals A, so a c-contig donated A can be reused via
+            # a UPLO flip. sygvd writes V back into A's buffer in column-major stride; the numpy view is still c-contig
+            # labeled, so we transpose-on-return (zero-cost stride swap) to expose V in f-order. B's matched
+            # layout requirement (c-contig when A flipped, f-contig otherwise) lets B also stay in-place; B's post-call
+            # content is discarded scratch (Cholesky factor) so its layout doesn't propagate.
+            lower = UPLO == 0
+            if overwrite_a and (A.flags.f_contiguous or A.flags.c_contiguous):
+                A_copy = A
+                flip = A.flags.c_contiguous
+            else:
+                A_copy = _copy_to_fortran_order(A)
+                flip = False
+
+            if overwrite_b and (
+                (flip and B.flags.c_contiguous) or (not flip and B.flags.f_contiguous)
+            ):
+                B_copy = B
+            else:
+                B_copy = _copy_to_fortran_order(B)
+
+            if flip:
+                lower = not lower
+
+            ITYPE = val_to_int_ptr(np.int32(1))
+            JOBZ = val_to_int_ptr(ord("V"))
+            UPLO_ptr = val_to_int_ptr(ord("L") if lower else ord("U"))
+            N = val_to_int_ptr(_N)
+            LDA = val_to_int_ptr(_N)
+            LDB = val_to_int_ptr(_N)
+            W = np.empty(_N, dtype=A_copy.dtype)
+            INFO = val_to_int_ptr(0)
+
+            # scipy's f2py wrapper skips the workspace query for the *gvd family
+            # and uses the LAPACK-documented minima; MKL's sygvd workspace query
+            # can leave WORK[0] unset, so we do the same here.
+            lwork = np.int32(max(np.int32(1), 1 + 6 * _N + 2 * _N * _N))
+            liwork = np.int32(max(np.int32(1), 3 + 5 * _N))
+            WORK = np.empty(lwork, dtype=A_copy.dtype)
+            IWORK = np.empty(liwork, dtype=np.int32)
+            LWORK = val_to_int_ptr(lwork)
+            LIWORK = val_to_int_ptr(liwork)
+
+            numba_sygvd(
+                ITYPE,
+                JOBZ,
+                UPLO_ptr,
+                N,
+                A_copy.ctypes,
+                LDA,
+                B_copy.ctypes,
+                LDB,
+                W.ctypes,
+                WORK.ctypes,
+                LWORK,
+                IWORK.ctypes,
+                LIWORK,
+                INFO,
+            )
+
+            if int_ptr_to_val(INFO) != 0:
+                W[:] = np.nan
+                A_copy[:] = np.nan
+
+            if flip:
+                return W, A_copy.T
+            return W, A_copy
+
+    return impl
+
+
+def _eigvalsh(a, UPLO, overwrite_a=False):
+    """Placeholder for the overloaded eigvalsh implementation (JOBZ='N')."""
+    is_complex = np.issubdtype(a.dtype, np.complexfloating)
+    driver = "heevr" if is_complex else "syevr"
+    (syevr,) = linalg.get_lapack_funcs((driver,), (a,))
+    w, _v, _m, _isuppz, info = syevr(
+        a, compute_v=0, lower=int(UPLO == 0), overwrite_a=int(overwrite_a)
+    )
+    if info != 0:
+        return np.full(a.shape[0], np.nan, dtype=w.dtype)
+    return w
+
+
+@overload(_eigvalsh)
+def eigvalsh_impl(A, UPLO, overwrite_a=False):
+    ensure_lapack()
+    _check_linalg_matrix(A, ndim=2, dtype=(Float, Complex), func_name="eigvalsh")
+    dtype = A.dtype
+    is_complex = isinstance(dtype, Complex)
+
+    if is_complex:
+        numba_heevr = _LAPACK().numba_xheevr(dtype)
+        real_dtype = _get_underlying_float(dtype)
+
+        def impl(A, UPLO, overwrite_a=False):
+            _N = np.int32(A.shape[-1])
+            if A.shape[-2] != _N:
+                raise np.linalg.LinAlgError("Last 2 dimensions of A must be square")
+
+            # For c-contig Hermitian A, LAPACK sees conj(A) if we reuse the
+            # memory. Eigenvalues of conj(A) equal those of A (both real), so
+            # only W is returned — no output fixup, just flip UPLO to read
+            # the user's valid triangle.
+            lower = UPLO == 0
+            if overwrite_a and (A.flags.f_contiguous or A.flags.c_contiguous):
+                A_copy = A
+                if A.flags.c_contiguous:
+                    lower = not lower
+            else:
+                A_copy = _copy_to_fortran_order(A)
+
+            JOBZ = val_to_int_ptr(ord("N"))
+            RANGE = val_to_int_ptr(ord("A"))
+            UPLO_ptr = val_to_int_ptr(ord("L") if lower else ord("U"))
+            N = val_to_int_ptr(_N)
+            LDA = val_to_int_ptr(_N)
+            VL = np.empty(1, dtype=real_dtype)
+            VU = np.empty(1, dtype=real_dtype)
+            IL = val_to_int_ptr(np.int32(0))
+            IU = val_to_int_ptr(np.int32(0))
+            ABSTOL = np.empty(1, dtype=real_dtype)
+            ABSTOL[0] = 0.0
+            M = val_to_int_ptr(np.int32(0))
+            W = np.empty(_N, dtype=real_dtype)
+
+            # JOBZ='N': Z and ISUPPZ are not referenced, but still need valid pointers.
+            Z = np.empty(1, dtype=A_copy.dtype)
+            LDZ = val_to_int_ptr(np.int32(1))
+            ISUPPZ = np.empty(1, dtype=np.int32)
+            INFO = val_to_int_ptr(0)
+
+            # Workspace query
+            LWORK = val_to_int_ptr(np.int32(-1))
+            LRWORK = val_to_int_ptr(np.int32(-1))
+            LIWORK = val_to_int_ptr(np.int32(-1))
+            WORK = np.empty(1, dtype=A_copy.dtype)
+            RWORK = np.empty(1, dtype=real_dtype)
+            IWORK = np.empty(1, dtype=np.int32)
+
+            numba_heevr(
+                JOBZ,
+                RANGE,
+                UPLO_ptr,
+                N,
+                A_copy.ctypes,
+                LDA,
+                VL.ctypes,
+                VU.ctypes,
+                IL,
+                IU,
+                ABSTOL.ctypes,
+                M,
+                W.ctypes,
+                Z.ctypes,
+                LDZ,
+                ISUPPZ.ctypes,
+                WORK.ctypes,
+                LWORK,
+                RWORK.ctypes,
+                LRWORK,
+                IWORK.ctypes,
+                LIWORK,
+                INFO,
+            )
+
+            lwork = np.int32(WORK[0].real)
+            lrwork = np.int32(RWORK[0])
+            liwork = IWORK[0]
+            WORK = np.empty(lwork, dtype=A_copy.dtype)
+            RWORK = np.empty(lrwork, dtype=real_dtype)
+            IWORK = np.empty(liwork, dtype=np.int32)
+            LWORK = val_to_int_ptr(lwork)
+            LRWORK = val_to_int_ptr(lrwork)
+            LIWORK = val_to_int_ptr(liwork)
+            INFO = val_to_int_ptr(0)
+
+            numba_heevr(
+                JOBZ,
+                RANGE,
+                UPLO_ptr,
+                N,
+                A_copy.ctypes,
+                LDA,
+                VL.ctypes,
+                VU.ctypes,
+                IL,
+                IU,
+                ABSTOL.ctypes,
+                M,
+                W.ctypes,
+                Z.ctypes,
+                LDZ,
+                ISUPPZ.ctypes,
+                WORK.ctypes,
+                LWORK,
+                RWORK.ctypes,
+                LRWORK,
+                IWORK.ctypes,
+                LIWORK,
+                INFO,
+            )
+
+            if int_ptr_to_val(INFO) != 0:
+                W[:] = np.nan
+
+            return W
+
+    else:
+        numba_syevr = _LAPACK().numba_xsyevr(dtype)
+
+        def impl(A, UPLO, overwrite_a=False):
+            _N = np.int32(A.shape[-1])
+            if A.shape[-2] != _N:
+                raise np.linalg.LinAlgError("Last 2 dimensions of A must be square")
+
+            # A c-contiguous symmetric matrix is identical to its f-contiguous
+            # transpose, which equals itself with UPLO swapped.
+            lower = UPLO == 0
+            if overwrite_a and (A.flags.f_contiguous or A.flags.c_contiguous):
+                A_copy = A
+                if A.flags.c_contiguous:
+                    lower = not lower
+            else:
+                A_copy = _copy_to_fortran_order(A)
+
+            JOBZ = val_to_int_ptr(ord("N"))
+            RANGE = val_to_int_ptr(ord("A"))
+            UPLO_ptr = val_to_int_ptr(ord("L") if lower else ord("U"))
+            N = val_to_int_ptr(_N)
+            LDA = val_to_int_ptr(_N)
+            VL = np.empty(1, dtype=A_copy.dtype)
+            VU = np.empty(1, dtype=A_copy.dtype)
+            IL = val_to_int_ptr(np.int32(0))
+            IU = val_to_int_ptr(np.int32(0))
+            ABSTOL = np.empty(1, dtype=A_copy.dtype)
+            ABSTOL[0] = 0.0
+            M = val_to_int_ptr(np.int32(0))
+            W = np.empty(_N, dtype=A_copy.dtype)
+
+            # JOBZ='N': Z and ISUPPZ are not referenced, but still need valid pointers.
+            Z = np.empty(1, dtype=A_copy.dtype)
+            LDZ = val_to_int_ptr(np.int32(1))
+            ISUPPZ = np.empty(1, dtype=np.int32)
+            INFO = val_to_int_ptr(0)
+
+            LWORK = val_to_int_ptr(np.int32(-1))
+            LIWORK = val_to_int_ptr(np.int32(-1))
+            WORK = np.empty(1, dtype=A_copy.dtype)
+            IWORK = np.empty(1, dtype=np.int32)
+
+            numba_syevr(
+                JOBZ,
+                RANGE,
+                UPLO_ptr,
+                N,
+                A_copy.ctypes,
+                LDA,
+                VL.ctypes,
+                VU.ctypes,
+                IL,
+                IU,
+                ABSTOL.ctypes,
+                M,
+                W.ctypes,
+                Z.ctypes,
+                LDZ,
+                ISUPPZ.ctypes,
+                WORK.ctypes,
+                LWORK,
+                IWORK.ctypes,
+                LIWORK,
+                INFO,
+            )
+
+            lwork = np.int32(WORK[0])
+            liwork = IWORK[0]
+            WORK = np.empty(lwork, dtype=A_copy.dtype)
+            IWORK = np.empty(liwork, dtype=np.int32)
+            LWORK = val_to_int_ptr(lwork)
+            LIWORK = val_to_int_ptr(liwork)
+            INFO = val_to_int_ptr(0)
+
+            numba_syevr(
+                JOBZ,
+                RANGE,
+                UPLO_ptr,
+                N,
+                A_copy.ctypes,
+                LDA,
+                VL.ctypes,
+                VU.ctypes,
+                IL,
+                IU,
+                ABSTOL.ctypes,
+                M,
+                W.ctypes,
+                Z.ctypes,
+                LDZ,
+                ISUPPZ.ctypes,
+                WORK.ctypes,
+                LWORK,
+                IWORK.ctypes,
+                LIWORK,
+                INFO,
+            )
+
+            if int_ptr_to_val(INFO) != 0:
+                W[:] = np.nan
+
+            return W
+
+    return impl
+
+
+def _eigvalsh_generalized(a, b, UPLO, overwrite_a=False, overwrite_b=False):
+    """Placeholder for the overloaded generalized eigvalsh implementation (JOBZ='N')."""
+    try:
+        return linalg.eigvalsh(
+            a,
+            b=b,
+            lower=(UPLO == 0),
+            check_finite=False,
+            overwrite_a=bool(overwrite_a),
+            overwrite_b=bool(overwrite_b),
+        )
+    except np.linalg.LinAlgError:
+        w_dtype = np.result_type(a.dtype, b.dtype)
+        if np.issubdtype(w_dtype, np.complexfloating):
+            real_dtype = np.finfo(w_dtype).dtype
+        else:
+            real_dtype = w_dtype
+        return np.full(a.shape[0], np.nan, dtype=real_dtype)
+
+
+@overload(_eigvalsh_generalized)
+def eigvalsh_generalized_impl(A, B, UPLO, overwrite_a=False, overwrite_b=False):
+    ensure_lapack()
+    _check_linalg_matrix(
+        A, ndim=2, dtype=(Float, Complex), func_name="eigvalsh_generalized"
+    )
+    _check_linalg_matrix(
+        B, ndim=2, dtype=(Float, Complex), func_name="eigvalsh_generalized"
+    )
+    dtype = A.dtype
+    is_complex = isinstance(dtype, Complex)
+
+    if is_complex:
+        numba_hegvd = _LAPACK().numba_xhegvd(dtype)
+        real_dtype = _get_underlying_float(dtype)
+
+        def impl(A, B, UPLO, overwrite_a=False, overwrite_b=False):
+            _N = np.int32(A.shape[-1])
+            if A.shape[-2] != _N:
+                raise np.linalg.LinAlgError("Last 2 dimensions of A must be square")
+            if B.shape[-1] != _N or B.shape[-2] != _N:
+                raise np.linalg.LinAlgError("A and B must have the same shape")
+
+            # A (Hermitian/symmetric) c-contig stored is equivalent to f-contig stored
+            # with UPLO flipped. The same flip must apply to B so we only reuse B if
+            # its layout matches whichever direction A picks.
+            lower = UPLO == 0
+            if overwrite_a and (A.flags.f_contiguous or A.flags.c_contiguous):
+                A_copy = A
+                flip = A.flags.c_contiguous
+            else:
+                A_copy = _copy_to_fortran_order(A)
+                flip = False
+
+            if overwrite_b and (
+                (flip and B.flags.c_contiguous) or (not flip and B.flags.f_contiguous)
+            ):
+                B_copy = B
+            else:
+                B_copy = _copy_to_fortran_order(B)
+
+            if flip:
+                lower = not lower
+
+            ITYPE = val_to_int_ptr(np.int32(1))
+            JOBZ = val_to_int_ptr(ord("N"))
+            UPLO_ptr = val_to_int_ptr(ord("L") if lower else ord("U"))
+            N = val_to_int_ptr(_N)
+            LDA = val_to_int_ptr(_N)
+            LDB = val_to_int_ptr(_N)
+            W = np.empty(_N, dtype=real_dtype)
+            INFO = val_to_int_ptr(0)
+
+            # hegvd JOBZ='N' has documented fixed minimum workspace; scipy uses this instead
+            # of a workspace call (bug in some LAPACKs)
+            lwork = np.int32(max(np.int32(1), _N + 1))
+            lrwork = np.int32(max(np.int32(1), _N))
+            liwork = np.int32(1)
+            WORK = np.empty(lwork, dtype=A_copy.dtype)
+            RWORK = np.empty(lrwork, dtype=real_dtype)
+            IWORK = np.empty(liwork, dtype=np.int32)
+            LWORK = val_to_int_ptr(lwork)
+            LRWORK = val_to_int_ptr(lrwork)
+            LIWORK = val_to_int_ptr(liwork)
+
+            numba_hegvd(
+                ITYPE,
+                JOBZ,
+                UPLO_ptr,
+                N,
+                A_copy.ctypes,
+                LDA,
+                B_copy.ctypes,
+                LDB,
+                W.ctypes,
+                WORK.ctypes,
+                LWORK,
+                RWORK.ctypes,
+                LRWORK,
+                IWORK.ctypes,
+                LIWORK,
+                INFO,
+            )
+
+            if int_ptr_to_val(INFO) != 0:
+                W[:] = np.nan
+
+            return W
+
+    else:
+        numba_sygvd = _LAPACK().numba_xsygvd(dtype)
+
+        def impl(A, B, UPLO, overwrite_a=False, overwrite_b=False):
+            _N = np.int32(A.shape[-1])
+            if A.shape[-2] != _N:
+                raise np.linalg.LinAlgError("Last 2 dimensions of A must be square")
+            if B.shape[-1] != _N or B.shape[-2] != _N:
+                raise np.linalg.LinAlgError("A and B must have the same shape")
+
+            lower = UPLO == 0
+            if overwrite_a and (A.flags.f_contiguous or A.flags.c_contiguous):
+                A_copy = A
+                flip = A.flags.c_contiguous
+            else:
+                A_copy = _copy_to_fortran_order(A)
+                flip = False
+
+            if overwrite_b and (
+                (flip and B.flags.c_contiguous) or (not flip and B.flags.f_contiguous)
+            ):
+                B_copy = B
+            else:
+                B_copy = _copy_to_fortran_order(B)
+
+            if flip:
+                lower = not lower
+
+            ITYPE = val_to_int_ptr(np.int32(1))
+            JOBZ = val_to_int_ptr(ord("N"))
+            UPLO_ptr = val_to_int_ptr(ord("L") if lower else ord("U"))
+            N = val_to_int_ptr(_N)
+            LDA = val_to_int_ptr(_N)
+            LDB = val_to_int_ptr(_N)
+            W = np.empty(_N, dtype=A_copy.dtype)
+            INFO = val_to_int_ptr(0)
+
+            # sygvd JOBZ='N' doc minima; see _eigh_generalized for why we skip
+            # the workspace query for the *gvd family.
+            lwork = np.int32(max(np.int32(1), 2 * _N + 1))
+            liwork = np.int32(1)
+            WORK = np.empty(lwork, dtype=A_copy.dtype)
+            IWORK = np.empty(liwork, dtype=np.int32)
+            LWORK = val_to_int_ptr(lwork)
+            LIWORK = val_to_int_ptr(liwork)
+
+            numba_sygvd(
+                ITYPE,
+                JOBZ,
+                UPLO_ptr,
+                N,
+                A_copy.ctypes,
+                LDA,
+                B_copy.ctypes,
+                LDB,
+                W.ctypes,
+                WORK.ctypes,
+                LWORK,
+                IWORK.ctypes,
+                LIWORK,
+                INFO,
+            )
+
+            if int_ptr_to_val(INFO) != 0:
+                W[:] = np.nan
+
+            return W
+
+    return impl

--- a/pytensor/link/pytorch/dispatch/linalg/decomposition.py
+++ b/pytensor/link/pytorch/dispatch/linalg/decomposition.py
@@ -1,7 +1,7 @@
 import torch
 
 from pytensor.link.pytorch.dispatch import pytorch_funcify
-from pytensor.tensor.linalg.decomposition.eigen import Eig, Eigh
+from pytensor.tensor.linalg.decomposition.eigen import Eig, Eigh, Eigvalsh
 from pytensor.tensor.linalg.decomposition.qr import QR
 from pytensor.tensor.linalg.decomposition.svd import SVD
 
@@ -41,6 +41,21 @@ def pytorch_funcify_Eigh(op, node, **kwargs):
         return torch.linalg.eigh(a, UPLO=UPLO)
 
     return eigh
+
+
+@pytorch_funcify.register(Eigvalsh)
+def pytorch_funcify_Eigvalsh(op, node, **kwargs):
+    UPLO = "L" if op.lower else "U"
+
+    if len(node.inputs) == 2:
+        raise NotImplementedError(
+            "torch.linalg.eigvalsh does not support generalized eigenvalue problems (b != None)"
+        )
+
+    def eigvalsh(a):
+        return torch.linalg.eigvalsh(a, UPLO=UPLO)
+
+    return eigvalsh
 
 
 @pytorch_funcify.register(QR)

--- a/pytensor/link/pytorch/dispatch/linalg/decomposition.py
+++ b/pytensor/link/pytorch/dispatch/linalg/decomposition.py
@@ -29,11 +29,16 @@ def pytorch_funcify_Eig(op, **kwargs):
 
 
 @pytorch_funcify.register(Eigh)
-def pytorch_funcify_Eigh(op, **kwargs):
-    uplo = op.UPLO
+def pytorch_funcify_Eigh(op, node, **kwargs):
+    UPLO = "L" if op.lower else "U"
 
-    def eigh(x, uplo=uplo):
-        return torch.linalg.eigh(x, UPLO=uplo)
+    if len(node.inputs) == 2:
+        raise NotImplementedError(
+            "torch.linalg.eigh does not support generalized eigenvalue problems (b != None)"
+        )
+
+    def eigh(a):
+        return torch.linalg.eigh(a, UPLO=UPLO)
 
     return eigh
 

--- a/pytensor/tensor/linalg/__init__.py
+++ b/pytensor/tensor/linalg/__init__.py
@@ -10,7 +10,6 @@ from pytensor.tensor.linalg.decomposition.cholesky import (
 from pytensor.tensor.linalg.decomposition.eigen import (
     Eig,
     Eigh,
-    EighGrad,
     Eigvalsh,
     EigvalshGrad,
     eig,

--- a/pytensor/tensor/linalg/__init__.py
+++ b/pytensor/tensor/linalg/__init__.py
@@ -11,7 +11,6 @@ from pytensor.tensor.linalg.decomposition.eigen import (
     Eig,
     Eigh,
     Eigvalsh,
-    EigvalshGrad,
     eig,
     eigh,
     eigvalsh,

--- a/pytensor/tensor/linalg/decomposition/eigen.py
+++ b/pytensor/tensor/linalg/decomposition/eigen.py
@@ -1,4 +1,5 @@
-from functools import partial
+import warnings
+from typing import cast
 
 import numpy as np
 import scipy.linalg as scipy_linalg
@@ -9,10 +10,11 @@ from pytensor.gradient import DisconnectedType
 from pytensor.graph.basic import Apply
 from pytensor.graph.op import Op
 from pytensor.tensor import TensorLike
-from pytensor.tensor.basic import as_tensor_variable
+from pytensor.tensor.basic import as_tensor_variable, diag, eye, tril, triu
 from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.linalg.dtype_utils import linalg_real_output_dtype
 from pytensor.tensor.type import Variable, matrix, tensor, vector
+from pytensor.tensor.math import sub, switch
 from pytensor.tensor.type_other import NoneTypeT
 
 
@@ -99,128 +101,265 @@ def eig(x: TensorLike):
     return Blockwise(Eig())(x)
 
 
-class Eigh(Eig):
+class Eigh(Op):
     """
     Return the eigenvalues and eigenvectors of a Hermitian or symmetric matrix.
+
+    Optionally solves the generalized eigenvalue problem ``A @ v = w * B @ v``
+    when a second matrix *b* is provided (delegated to ``scipy.linalg.eigh``).
     """
 
-    __props__ = ("UPLO",)
+    __props__ = ("lower", "overwrite_a", "overwrite_b", "driver")
 
-    def __init__(self, UPLO="L"):
-        assert UPLO in ("L", "U")
-        self.UPLO = UPLO
+    def __init__(
+        self,
+        lower: bool = True,
+        UPLO: str | None = None,
+        overwrite_a: bool = False,
+        overwrite_b: bool = False,
+        driver: str = "evr",
+    ):
+        if UPLO is not None:
+            warnings.warn(
+                "UPLO is deprecated and will be removed in a future version. Use the ``lower`` argument "
+                "instead.",
+                stacklevel=2,
+                category=DeprecationWarning,
+            )
+            lower = UPLO == "L"
 
-    def make_node(self, x):
-        x = as_tensor_variable(x)
-        assert x.ndim == 2
-        w_dtype = linalg_real_output_dtype(x.type.dtype)
-        w = vector(dtype=w_dtype)
-        v = matrix(dtype=w_dtype)
-        return Apply(self, [x], [w, v])
+        if driver not in ("evr", "evd"):
+            raise ValueError(
+                f"Invalid driver: {driver!r}. Must be one of 'evr', 'evd'."
+            )
+
+        if overwrite_a and overwrite_b:
+            raise ValueError(
+                "overwrite_a and overwrite_b are mutually exclusive: pytensor "
+                "tracks at most one destroyed input per output."
+            )
+
+        self.lower = lower
+        self.overwrite_a = overwrite_a
+        self.overwrite_b = overwrite_b
+        self.driver = driver
+
+        # Output 1 (eigenvectors) is the one that lands in the destroyed buffer.
+        if self.overwrite_a:
+            self.destroy_map = {1: [0]}
+        elif self.overwrite_b:
+            self.destroy_map = {1: [1]}
+
+    def make_node(self, a, b=None):
+        a = as_tensor_variable(a)
+        assert a.ndim == 2
+        M, N = a.type.shape
+
+        if M is not None and N is not None and M != N:
+            raise ValueError(
+                f"Input to Eigh must be a square matrix, got static shape: ({M}, {N})"
+            )
+
+        has_b = b is not None and not (
+            isinstance(b, Variable) and isinstance(b.type, NoneTypeT)
+        )
+
+        if has_b:
+            b = as_tensor_variable(b)
+            inputs = [a, b]
+        else:
+            inputs = [a]
+
+        w_dtype = linalg_real_output_dtype(*[x.type.dtype for x in inputs])
+
+        w = tensor(dtype=w_dtype, shape=(M,))
+        v = tensor(dtype=w_dtype, shape=(M, N))
+
+        return Apply(self, inputs, [w, v])
 
     def perform(self, node, inputs, outputs):
-        (x,) = inputs
         (w, v) = outputs
-        w[0], v[0] = np.linalg.eigh(x, self.UPLO)
+        if len(inputs) == 2:
+            # Generalized eigenproblem: scipy doesn't accept driver= with b
+            w[0], v[0] = scipy_linalg.eigh(
+                inputs[0],
+                b=inputs[1],
+                lower=self.lower,
+                overwrite_a=self.overwrite_a,
+                overwrite_b=self.overwrite_b,
+            )
+        else:
+            w[0], v[0] = scipy_linalg.eigh(
+                inputs[0],
+                lower=self.lower,
+                overwrite_a=self.overwrite_a,
+                driver=self.driver,
+            )
+
+    def inplace_on_inputs(self, allowed_inplace_inputs: list[int]) -> "Op":
+        # overwrite_a and overwrite_b are mutually exclusive; prefer overwrite_a
+        # arbitrarily (memory savings are identical)
+        new_props = self._props_dict()  # type: ignore
+        if 0 in allowed_inplace_inputs:
+            new_props["overwrite_a"] = True
+        elif 1 in allowed_inplace_inputs:
+            new_props["overwrite_b"] = True
+        else:
+            return self
+        return type(self)(**new_props)
+
+    def infer_shape(self, fgraph, node, shapes):
+        n = shapes[0][0]
+        return [(n,), (n, n)]
 
     def pullback(self, inputs, outputs, output_grads):
-        r"""The gradient function should return
+        r"""Symbolic gradient of ``eigh``.
 
-           .. math:: \sum_n\left(W_n\frac{\partial\,w_n}
-                           {\partial a_{ij}} +
-                     \sum_k V_{nk}\frac{\partial\,v_{nk}}
-                           {\partial a_{ij}}\right),
+        For the standard symmetric problem,
 
-        where [:math:`W`, :math:`V`] corresponds to ``g_outputs``,
-        :math:`a` to ``inputs``, and  :math:`(w, v)=\mbox{eig}(a)`.
+        .. math::
 
-        Analytic formulae for eigensystem gradients are well-known in
-        perturbation theory:
+            A V = V \operatorname{diag}(w), \qquad V^T V = I,
 
-           .. math:: \frac{\partial\,w_n}
-                          {\partial a_{ij}} = v_{in}\,v_{jn}
+        define
 
+        .. math::
 
-           .. math:: \frac{\partial\,v_{kn}}
-                          {\partial a_{ij}} =
-                \sum_{m\ne n}\frac{v_{km}v_{jn}}{w_n-w_m}
+            F_{ij} =
+            \begin{cases}
+                \frac{1}{w_j - w_i}, & i \ne j, \\
+                0, & i = j .
+            \end{cases}
 
+        Then the pullback is
+
+        .. math::
+
+            C = V^T g_V,
+            \qquad
+            M = \operatorname{diag}(g_w) + F \odot C,
+            \qquad
+            g_A = V M V^T.
+
+        For the generalized symmetric-definite problem,
+
+        .. math::
+
+            A V = B V \operatorname{diag}(w), \qquad V^T B V = I,
+
+        the pullback is
+
+        .. math::
+
+            C = V^T g_V,
+            \qquad
+            M = \operatorname{diag}(g_w) + F \odot C,
+
+        .. math::
+
+            g_A = V M V^T,
+
+        .. math::
+
+            g_B =
+            -V \left(M \operatorname{diag}(w)\right) V^T
+            - \frac12 V \operatorname{diag}(\operatorname{diag}(C)) V^T.
+
+        The gradients are symmetrized on return to match the triangular storage
+        specified by ``UPLO``.
+
+        These formulas assume distinct eigenvalues. When eigenvalues are repeated,
+        the factors ``1 / (w_j - w_i)`` are singular and the eigenvector gradient is
+        not uniquely defined.
         """
-        (x,) = inputs
         w, v = outputs
         gw, gv = _zero_disconnected([w, v], output_grads)
 
-        return [EighGrad(self.UPLO)(x, w, v, gw, gv)]
+        # F_ij = 1/(w_j - w_i) for i != j, 0 on diagonal
+        w_diff = sub.outer(w, w).T
+        F = switch(eye(w.shape[0], dtype="bool"), 0.0, 1.0 / w_diff)
 
+        if len(inputs) == 1:
+            inner = diag(gw) + F * (v.T @ gv)
+            g = v @ inner @ v.T
 
-class EighGrad(Op):
-    """
-    Gradient of an eigensystem of a Hermitian matrix.
-
-    """
-
-    __props__ = ("UPLO",)
-
-    def __init__(self, UPLO="L"):
-        assert UPLO in ("L", "U")
-        self.UPLO = UPLO
-        if UPLO == "L":
-            self.tri0 = np.tril
-            self.tri1 = partial(np.triu, k=1)
+            if self.lower:
+                out = tril(g) + triu(g, k=1).T
+            else:
+                out = triu(g) + tril(g, k=-1).T
+            return [out]
         else:
-            self.tri0 = np.triu
-            self.tri1 = partial(np.tril, k=-1)
+            C = v.T @ gv
+            inner = diag(gw) + F * C
 
-    def make_node(self, x, w, v, gw, gv):
-        x, w, v, gw, gv = map(as_tensor_variable, (x, w, v, gw, gv))
-        assert x.ndim == 2
-        assert w.ndim == 1
-        assert v.ndim == 2
-        assert gw.ndim == 1
-        assert gv.ndim == 2
-        out_dtype = ps.upcast(x.dtype, w.dtype, v.dtype, gw.dtype, gv.dtype)
-        out = matrix(dtype=out_dtype)
-        return Apply(self, [x, w, v, gw, gv], [out])
+            ga = v @ inner @ v.T
+            gb = -v @ (inner * w[None, :]) @ v.T
+            gb = gb - 0.5 * v @ diag(diag(C)) @ v.T
 
-    def perform(self, node, inputs, outputs):
-        """
-        Implements the "reverse-mode" gradient for the eigensystem of
-        a square matrix.
-
-        """
-        x, w, v, W, V = inputs
-        N = x.shape[0]
-        outer = np.outer
-
-        def G(n):
-            return sum(
-                v[:, m] * V.T[n].dot(v[:, m]) / (w[n] - w[m])
-                for m in range(N)
-                if m != n
-            )
-
-        g = sum(outer(v[:, n], v[:, n] * W[n] + G(n)) for n in range(N))
-
-        # Numpy's eigh(a, 'L') (eigh(a, 'U')) is a function of tril(a)
-        # (triu(a)) only.  This means that partial derivative of
-        # eigh(a, 'L') (eigh(a, 'U')) with respect to a[i,j] is zero
-        # for i < j (i > j).  At the same time, non-zero components of
-        # the gradient must account for the fact that variation of the
-        # opposite triangle contributes to variation of two elements
-        # of Hermitian (symmetric) matrix. The following line
-        # implements the necessary logic.
-        out = self.tri0(g) + self.tri1(g).T
-
-        # Make sure we return the right dtype even if NumPy performed
-        # upcasting in self.tri0.
-        outputs[0][0] = np.asarray(out, dtype=node.outputs[0].dtype)
-
-    def infer_shape(self, fgraph, node, shapes):
-        return [shapes[0]]
+            if self.lower:
+                ga_sym = tril(ga) + triu(ga, k=1).T
+                gb_sym = tril(gb) + triu(gb, k=1).T
+            else:
+                ga_sym = triu(ga) + tril(ga, k=-1).T
+                gb_sym = triu(gb) + tril(gb, k=-1).T
+            return [ga_sym, gb_sym]
 
 
-def eigh(a, UPLO="L"):
-    return Eigh(UPLO)(a)
+def eigh(
+    a: TensorLike,
+    b: TensorLike | None = None,
+    lower: bool = True,
+    UPLO: str | None = None,
+    driver: str = "evr",
+) -> list[Variable]:
+    """
+    Return the eigenvalues and eigenvectors of a symmetric/Hermitian matrix.
+
+    Parameters
+    ----------
+    a : TensorLike
+        Symmetric/Hermitian matrix (or batch thereof).
+    b : TensorLike, optional
+        Second matrix for the generalized eigenvalue problem ``A v = w B v``.
+        Must be positive-definite. If ``None``, the standard eigenvalue
+        problem is solved.
+    lower : bool
+        Whether to use the lower or upper triangle of a (and b, if provided). Default is True
+    UPLO : {'L', 'U'}, optional
+        Whether to use the lower or upper triangle of a (and b, if provided). Default is 'L' (lower).
+        UPLO is deprecated and will be removed in a future version. Use the ``lower`` argument instead.
+    driver : {'evr', 'evd'}, optional
+        LAPACK driver to use. ``'evr'`` (default) uses the MRRR algorithm, the fastest general-purpose driver.
+        This is the default used by Scipy. ``'evd'`` uses divide-and-conquer, matching NumPy, JAX, and MLX.
+
+    Returns
+    -------
+    w : Variable
+        Eigenvalues of the system, in ascending order.
+    v : Variable
+        Eigenvectors of the system, in ascending order.
+    """
+    if UPLO is not None:
+        warnings.warn(
+            "UPLO is deprecated and will be removed in a future version. ",
+            stacklevel=2,
+            category=DeprecationWarning,
+        )
+        lower = UPLO == "L"
+
+    if b is None:
+        signature = "(m,m)->(m),(m,m)"
+        return cast(
+            list[Variable],
+            Blockwise(Eigh(lower=lower, driver=driver), signature=signature)(a),
+        )
+
+    # Generalized eigenproblem always uses divide-and-conquer
+    signature = "(m,m),(m,m)->(m),(m,m)"
+    return cast(
+        list[Variable],
+        Blockwise(Eigh(lower=lower, driver="evd"), signature=signature)(a, b),
+    )
 
 
 class Eigvalsh(Op):

--- a/pytensor/tensor/linalg/decomposition/eigen.py
+++ b/pytensor/tensor/linalg/decomposition/eigen.py
@@ -4,8 +4,6 @@ from typing import cast
 import numpy as np
 import scipy.linalg as scipy_linalg
 
-import pytensor
-from pytensor import scalar as ps
 from pytensor.gradient import DisconnectedType
 from pytensor.graph.basic import Apply
 from pytensor.graph.op import Op
@@ -13,8 +11,8 @@ from pytensor.tensor import TensorLike
 from pytensor.tensor.basic import as_tensor_variable, diag, eye, tril, triu
 from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.linalg.dtype_utils import linalg_real_output_dtype
-from pytensor.tensor.type import Variable, matrix, tensor, vector
 from pytensor.tensor.math import sub, switch
+from pytensor.tensor.type import Variable, tensor, vector
 from pytensor.tensor.type_other import NoneTypeT
 
 
@@ -368,100 +366,153 @@ class Eigvalsh(Op):
 
     """
 
-    __props__ = ("lower",)
+    __props__ = ("lower", "overwrite_a", "overwrite_b")
 
-    def __init__(self, lower=True):
+    def __init__(self, lower=True, overwrite_a=False, overwrite_b=False):
         assert lower in [True, False]
+        if overwrite_a and overwrite_b:
+            raise ValueError(
+                "overwrite_a and overwrite_b are mutually exclusive: pytensor "
+                "tracks at most one destroyed input per output. "
+            )
         self.lower = lower
+        self.overwrite_a = overwrite_a
+        self.overwrite_b = overwrite_b
+
+        if overwrite_a:
+            self.destroy_map = {0: [0]}
+        elif overwrite_b:
+            self.destroy_map = {0: [1]}
 
     def make_node(self, a, b=None):
         a = as_tensor_variable(a)
         assert a.ndim == 2
 
+        M, N = a.type.shape
+
+        if M is not None and N is not None and M != N:
+            raise ValueError(
+                f"Input to eigvalsh must be square, got {a} with shape ({M}, {N})"
+            )
+
         if b is None or (isinstance(b, Variable) and isinstance(b.type, NoneTypeT)):
-            w = vector(dtype=a.dtype)
-            return Apply(self, [a], [w])
+            if self.overwrite_b:
+                raise ValueError(
+                    "overwrite_b=True requires the generalized form with a second input"
+                )
+            inputs = [a]
+            probe_dtype = a.type.dtype
         else:
             b = as_tensor_variable(b)
             assert a.ndim == 2
             assert b.ndim == 2
+            probe_dtype = np.result_type(a.type.dtype, b.type.dtype)
+            inputs = [a, b]
 
-            out_dtype = pytensor.scalar.upcast(a.dtype, b.dtype)
-            w = vector(dtype=out_dtype)
-            return Apply(self, [a, b], [w])
+        # Probe scipy for the output dtype (eigenvalues are always real)
+        probe = np.zeros((1, 1), dtype=probe_dtype)
+        out_dtype = scipy_linalg.eigvalsh(probe).dtype.name
+
+        w = vector(dtype=out_dtype, shape=(N,))
+        return Apply(self, inputs, [w])
+
+    def infer_shape(self, fgraph, node, shapes):
+        n = shapes[0][0]
+        return [
+            (n,),
+        ]
 
     def perform(self, node, inputs, outputs):
         (w,) = outputs
         if len(inputs) == 2:
-            w[0] = scipy_linalg.eigvalsh(a=inputs[0], b=inputs[1], lower=self.lower)
+            w[0] = scipy_linalg.eigvalsh(
+                a=inputs[0],
+                b=inputs[1],
+                lower=self.lower,
+                overwrite_a=self.overwrite_a,
+                overwrite_b=self.overwrite_b,
+            )
         else:
-            w[0] = scipy_linalg.eigvalsh(a=inputs[0], b=None, lower=self.lower)
+            w[0] = scipy_linalg.eigvalsh(
+                a=inputs[0],
+                b=None,
+                lower=self.lower,
+                overwrite_a=self.overwrite_a,
+            )
 
     def pullback(self, inputs, outputs, g_outputs):
-        a, b = inputs
         (gw,) = g_outputs
-        return EigvalshGrad(self.lower)(a, b, gw)
 
-    def infer_shape(self, fgraph, node, shapes):
-        n = shapes[0][0]
-        return [(n,)]
+        if len(inputs) == 1:
+            (a,) = inputs
+            w, v = eigh(a, lower=self.lower)
+            gA = v @ diag(gw) @ v.T
 
+            if self.lower:
+                gA = tril(gA) + triu(gA, k=1).T
+            else:
+                gA = triu(gA) + tril(gA, k=-1).T
 
-class EigvalshGrad(Op):
-    """
-    Gradient of generalized eigenvalues of a Hermitian positive definite
-    eigensystem.
+            return [gA]
 
-    """
-
-    # Note: This Op (EigvalshGrad), should be removed and replaced with a graph
-    # of pytensor ops that is constructed directly in Eigvalsh.grad.
-    # But this can only be done once scipy.linalg.eigh is available as an Op
-    # (currently the Eigh uses numpy.linalg.eigh, which doesn't let you
-    # pass the right-hand-side matrix for a generalized eigenproblem.) See the
-    # discussion on GitHub at
-    # https://github.com/Theano/Theano/pull/1846#discussion-diff-12486764
-
-    __props__ = ("lower",)
-
-    def __init__(self, lower=True):
-        assert lower in [True, False]
-        self.lower = lower
-        if lower:
-            self.tri0 = np.tril
-            self.tri1 = lambda a: np.triu(a, 1)
         else:
-            self.tri0 = np.triu
-            self.tri1 = lambda a: np.tril(a, -1)
+            a, b = inputs
+            w, v = eigh(a, b, lower=self.lower)
+            gA = v @ diag(gw) @ v.T
+            gB = -v @ diag(gw * w) @ v.T
 
-    def make_node(self, a, b, gw):
-        a = as_tensor_variable(a)
-        b = as_tensor_variable(b)
-        gw = as_tensor_variable(gw)
-        assert a.ndim == 2
-        assert b.ndim == 2
-        assert gw.ndim == 1
+            if self.lower:
+                gA = tril(gA) + triu(gA, k=1).T
+                gB = tril(gB) + triu(gB, k=1).T
+            else:
+                gA = triu(gA) + tril(gA, k=-1).T
+                gB = triu(gB) + tril(gB, k=-1).T
 
-        out_dtype = pytensor.scalar.upcast(a.dtype, b.dtype, gw.dtype)
-        out1 = matrix(dtype=out_dtype)
-        out2 = matrix(dtype=out_dtype)
-        return Apply(self, [a, b, gw], [out1, out2])
+            return [gA, gB]
 
-    def perform(self, node, inputs, outputs):
-        (a, b, gw) = inputs
-        w, v = scipy_linalg.eigh(a, b, lower=self.lower)
-        gA = v.dot(np.diag(gw).dot(v.T))
-        gB = -v.dot(np.diag(gw * w).dot(v.T))
-
-        # See EighGrad comments for an explanation of these lines
-        out1 = self.tri0(gA) + self.tri1(gA).T
-        out2 = self.tri0(gB) + self.tri1(gB).T
-        outputs[0][0] = np.asarray(out1, dtype=node.outputs[0].dtype)
-        outputs[1][0] = np.asarray(out2, dtype=node.outputs[1].dtype)
-
-    def infer_shape(self, fgraph, node, shapes):
-        return [shapes[0], shapes[1]]
+    def inplace_on_inputs(self, allowed_inplace_inputs: list[int]) -> "Op":
+        # overwrite_a and overwrite_b are mutually exclusive (PyTensor tracks at most one destroyed
+        # input per output). When both can be destroyed, we prefer overwrite_a.
+        new_props = self._props_dict()  # type: ignore
+        if 0 in allowed_inplace_inputs:
+            new_props["overwrite_a"] = True
+        elif 1 in allowed_inplace_inputs:
+            new_props["overwrite_b"] = True
+        else:
+            return self
+        return type(self)(**new_props)
 
 
-def eigvalsh(a, b, lower=True):
-    return Eigvalsh(lower)(a, b)
+def eigvalsh(
+    a: TensorLike,
+    b: TensorLike | None = None,
+    lower: bool = True,
+) -> Variable:
+    """
+    Compute the eigenvalues of a symmetric/Hermitian matrix.
+
+    This is identical to ``eigh(a, b, lower)[0]``, but more efficient when only the eigenvalues are needed.
+
+    Parameters
+    ----------
+    a : TensorLike
+        Symmetric/Hermitian matrix (or batch thereof).
+    b : TensorLike, optional
+        Second matrix for the generalized eigenvalue problem ``A v = w B v``.
+        Must be positive-definite. If ``None``, the standard eigenvalue
+        problem is solved.
+    lower : bool, optional
+        Whether to use the lower or upper triangle of a (and b). Default True.
+
+    Returns
+    -------
+    w : TensorVariable
+        Eigenvalues of the system, in ascending order.
+    """
+    op = Eigvalsh(lower=lower)
+    if b is None:
+        signature = "(m,m)->(m)"
+        return cast(Variable, Blockwise(op, signature=signature)(a))
+
+    signature = "(m,m),(m,m)->(m)"
+    return cast(Variable, Blockwise(op, signature=signature)(a, b))

--- a/tests/link/jax/linalg/test_decomposition.py
+++ b/tests/link/jax/linalg/test_decomposition.py
@@ -12,7 +12,6 @@ from pytensor.tensor.linalg.inverse import matrix_inverse
 from pytensor.tensor.linalg.summary import det, slogdet
 from pytensor.tensor.math import clip, cosh
 from pytensor.tensor.type import matrix, vector
-from pytensor.tensor.type_other import NoneConst
 from tests.link.jax.test_basic import compare_jax_and_py
 
 
@@ -135,7 +134,7 @@ def test_jax_basic_multiout():
 
     compare_jax_and_py([x], outs, [X.astype(config.floatX)], assert_fn=assert_fn)
 
-    outs = eigh(x)
+    outs = eigh(x, driver="evd")
     compare_jax_and_py([x], outs, [X.astype(config.floatX)], assert_fn=assert_fn)
 
     outs = svd.svd(x)
@@ -165,7 +164,8 @@ def test_jax_eigvalsh(lower):
                 ).astype(config.floatX),
             ],
         )
-    out_no_b = eigvalsh(A, NoneConst, lower=lower)
+
+    out_no_b = eigvalsh(A, None, lower=lower)
     compare_jax_and_py(
         [A],
         [out_no_b],

--- a/tests/link/mlx/linalg/test_decomposition.py
+++ b/tests/link/mlx/linalg/test_decomposition.py
@@ -8,7 +8,6 @@ import pytensor.tensor as pt
 from pytensor import config
 from pytensor.tensor.linalg.decomposition import lu, svd
 from pytensor.tensor.linalg.decomposition.cholesky import cholesky
-from pytensor.tensor.type_other import NoneConst
 from tests.link.mlx.test_basic import compare_mlx_and_py, mlx_mode
 
 
@@ -32,15 +31,15 @@ def test_mlx_eig():
     compare_mlx_and_py([A], outs, [A_val])
 
 
-@pytest.mark.parametrize("UPLO", ["L", "U"])
-def test_mlx_eigh(UPLO):
+@pytest.mark.parametrize("lower", [True, False])
+def test_mlx_eigh(lower):
     rng = np.random.default_rng(15)
 
     M = rng.normal(size=(3, 3))
     A_val = (M @ M.T).astype(config.floatX)
 
     A = pt.matrix(name="A")
-    outs = pt.linalg.eigh(A, UPLO=UPLO)
+    outs = pt.linalg.eigh(A, lower=lower, driver="evd")
 
     compare_mlx_and_py([A], outs, [A_val])
 
@@ -115,7 +114,9 @@ def test_mlx_eigvalsh(lower):
     with pytest.raises(NotImplementedError):
         compare_mlx_and_py([A, B], [out_with_b], [A_val, A_val])
 
-    out_no_b = pt.linalg.eigvalsh(A, NoneConst, lower=lower)
+    out_no_b = pt.linalg.eigvalsh(A, None, lower=lower)
+
+    # Pytensor uses d
     compare_mlx_and_py([A], [out_no_b], [A_val])
 
 

--- a/tests/link/numba/linalg/test_decomposition.py
+++ b/tests/link/numba/linalg/test_decomposition.py
@@ -1,5 +1,3 @@
-import contextlib
-
 import numpy as np
 import pytest
 import scipy
@@ -31,9 +29,6 @@ floatX = config.floatX
 rng = np.random.default_rng(42849)
 
 
-# --- From test_nlinalg.py ---
-
-
 @pytest.mark.parametrize("input_dtype", ["int64", "float64", "complex128"])
 @pytest.mark.parametrize("symmetric", [True, False], ids=["symmetric", "general"])
 def test_Eig(input_dtype, symmetric):
@@ -47,7 +42,7 @@ def test_Eig(input_dtype, symmetric):
         x_val = x_val + x_val.T
 
     def assert_fn(x, y):
-        # eig can return equivalent values with some sign flips depending on impl, allow for that
+        # eig can return equivalent values with some sign flips depending on impl
         np.testing.assert_allclose(np.abs(x), np.abs(y), strict=True)
 
     g = eig(x)
@@ -66,93 +61,82 @@ def test_Eig(input_dtype, symmetric):
     )
 
 
+@pytest.mark.parametrize("lower", [True, False], ids=lambda x: f"lower={x}")
 @pytest.mark.parametrize(
-    "x, uplo, exc",
+    "overwrite_a", [False, True], ids=["no_overwrite", "overwrite_a"]
+)
+@pytest.mark.parametrize("driver", ["evr", "evd"], ids=lambda x: f"driver={x}")
+def test_Eigh(lower, overwrite_a, driver):
+    x = pt.dmatrix()
+    test_x = (lambda x: x.T.dot(x))(rng.random(size=(3, 3)).astype("float64"))
+    g = Eigh(lower=lower, overwrite_a=overwrite_a, driver=driver)(x)
+
+    # The numba c-contig overwrite_a path uses an UPLO flip that scipy's
+    # python implementation doesn't, so eigenvector signs may differ per
+    # column (both are valid). Compare W exactly and |V| element-wise.
+    def eigh_assert(numba_out, py_out):
+        if numba_out.ndim == 1:
+            np.testing.assert_allclose(numba_out, py_out, rtol=1e-4)
+        else:
+            np.testing.assert_allclose(np.abs(numba_out), np.abs(py_out), rtol=1e-4)
+
+    fn, _ = compare_numba_and_py(
+        [In(x, mutable=overwrite_a)],
+        g,
+        [test_x],
+        numba_mode=numba_inplace_mode,
+        inplace=True,
+        assert_fn=eigh_assert,
+    )
+
+    op = fn.maker.fgraph.outputs[0].owner.op
+    assert isinstance(op, Eigh)
+    if overwrite_a:
+        assert op.destroy_map == {1: [0]}
+    else:
+        assert op.destroy_map == {}
+
+    # Eigenvector signs are not unique, so check the eigenvalue equation
+    # A v = w v per call rather than comparing V matrices across calls.
+    def assert_reconstruction(val, expect_mutation):
+        snapshot = np.array(val)
+        w, v = fn(val)
+        np.testing.assert_allclose(test_x @ v, v * w, atol=1e-10)
+        np.testing.assert_allclose(np.sort(w), np.sort(np.linalg.eigvalsh(test_x)))
+        if expect_mutation:
+            assert not np.allclose(val, snapshot)
+        else:
+            np.testing.assert_allclose(val, snapshot)
+
+    # Real symmetric c-contig inputs are reused via UPLO flip when overwrite_a,
+    # so both f- and c-contig get mutated. Non-contig falls back to a copy.
+    assert_reconstruction(np.copy(test_x, order="F"), expect_mutation=overwrite_a)
+    assert_reconstruction(np.copy(test_x, order="C"), expect_mutation=overwrite_a)
+    assert_reconstruction(np.repeat(test_x, 2, axis=0)[::2], expect_mutation=False)
+
+
+def test_Eigh_integer_input():
+    x = pt.lmatrix()
+    test_x = np.array([[2, 1], [1, 3]], dtype="int64")
+    g = Eigh(lower=True)(x)
+    compare_numba_and_py([x], g, [test_x])
+
+
+@pytest.mark.parametrize(
+    "x, full_matrices, compute_uv",
     [
-        (
-            (
-                pt.dmatrix(),
-                (lambda x: x.T.dot(x))(rng.random(size=(3, 3)).astype("float64")),
-            ),
-            "L",
-            None,
-        ),
-        (
-            (
-                pt.lmatrix(),
-                (lambda x: x.T.dot(x))(
-                    rng.integers(1, 10, size=(3, 3)).astype("int64")
-                ),
-            ),
-            "U",
-            UserWarning,
-        ),
+        ((pt.dmatrix(), rng.random(size=(3, 3)).astype("float64")), True, True),
+        ((pt.dmatrix(), rng.random(size=(3, 3)).astype("float64")), False, True),
+        ((pt.lmatrix(), rng.integers(1, 10, size=(3, 3)).astype("int64")), True, True),
+        ((pt.lmatrix(), rng.integers(1, 10, size=(3, 3)).astype("int64")), True, False),
     ],
 )
-def test_Eigh(x, uplo, exc):
+def test_SVD(x, full_matrices, compute_uv):
     x, test_x = x
-    g = Eigh(uplo)(x)
-
-    cm = contextlib.suppress() if exc is None else pytest.warns(exc)
-    with cm:
-        compare_numba_and_py([x], g, [test_x])
-
-
-@pytest.mark.parametrize(
-    "x, full_matrices, compute_uv, exc",
-    [
-        (
-            (
-                pt.dmatrix(),
-                (lambda x: x.T.dot(x))(rng.random(size=(3, 3)).astype("float64")),
-            ),
-            True,
-            True,
-            None,
-        ),
-        (
-            (
-                pt.dmatrix(),
-                (lambda x: x.T.dot(x))(rng.random(size=(3, 3)).astype("float64")),
-            ),
-            False,
-            True,
-            None,
-        ),
-        (
-            (
-                pt.lmatrix(),
-                (lambda x: x.T.dot(x))(
-                    rng.integers(1, 10, size=(3, 3)).astype("int64")
-                ),
-            ),
-            True,
-            True,
-            None,
-        ),
-        (
-            (
-                pt.lmatrix(),
-                (lambda x: x.T.dot(x))(
-                    rng.integers(1, 10, size=(3, 3)).astype("int64")
-                ),
-            ),
-            True,
-            False,
-            None,
-        ),
-    ],
-)
-def test_SVD(x, full_matrices, compute_uv, exc):
-    x, test_x = x
+    test_x = test_x.T @ test_x
     g = svd.SVD(full_matrices, compute_uv)(x)
 
-    cm = contextlib.suppress() if exc is None else pytest.warns(exc)
-    with cm:
-        compare_numba_and_py([x], g, [test_x])
-
-
-# --- From test_slinalg.py TestDecompositions ---
+    compare_numba_and_py([x], g, [test_x])
 
 
 class TestDecompositions:

--- a/tests/link/pytorch/linalg/test_decomposition.py
+++ b/tests/link/pytorch/linalg/test_decomposition.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from pytensor.tensor.linalg.decomposition import qr, svd
-from pytensor.tensor.linalg.decomposition.eigen import eig, eigh
+from pytensor.tensor.linalg.decomposition.eigen import eig, eigh, eigvalsh
 from pytensor.tensor.linalg.inverse import inv
 from pytensor.tensor.linalg.summary import SLogDet, det
 from tests.link.pytorch.test_basic import compare_pytorch_and_py
@@ -14,8 +14,8 @@ def assert_fn(x, y):
 
 @pytest.mark.parametrize(
     "func",
-    (lambda x: eigh(x, driver="evd"), SLogDet(), inv, det),
-    ids=["eigh", "slogdet", "inv", "det"],
+    (lambda x: eigh(x, driver="evd"), eigvalsh, SLogDet(), inv, det),
+    ids=["eigh", "eigvalsh", "slogdet", "inv", "det"],
 )
 def test_lin_alg_no_params(func, matrix_test):
     x, test_value = matrix_test

--- a/tests/link/pytorch/linalg/test_decomposition.py
+++ b/tests/link/pytorch/linalg/test_decomposition.py
@@ -14,7 +14,8 @@ def assert_fn(x, y):
 
 @pytest.mark.parametrize(
     "func",
-    (eigh, SLogDet(), inv, det),
+    (lambda x: eigh(x, driver="evd"), SLogDet(), inv, det),
+    ids=["eigh", "slogdet", "inv", "det"],
 )
 def test_lin_alg_no_params(func, matrix_test):
     x, test_value = matrix_test

--- a/tests/tensor/linalg/test_decomposition/test_eigen.py
+++ b/tests/tensor/linalg/test_decomposition/test_eigen.py
@@ -1,44 +1,12 @@
 import numpy as np
+import pytest
 import scipy
 
 import pytensor.tensor as pt
 from pytensor import function
-from pytensor.tensor.linalg import Eig, eig, eigh, eigvalsh
-from pytensor.tensor.type import dmatrix, matrix
+from pytensor.tensor.linalg import Eig, Eigh, Eigvalsh, eig, eigh, eigvalsh
+from pytensor.tensor.type import matrix
 from tests import unittest_tools as utt
-
-
-def test_eigvalsh():
-    A = dmatrix("a")
-    B = dmatrix("b")
-    f = function([A, B], eigvalsh(A, B))
-
-    rng = np.random.default_rng(utt.fetch_seed())
-    a = rng.standard_normal((5, 5))
-    a = a + a.T
-    for b in [10 * np.eye(5, 5) + rng.standard_normal((5, 5))]:
-        w = f(a, b)
-        refw = scipy.linalg.eigvalsh(a, b)
-        np.testing.assert_array_almost_equal(w, refw)
-
-    # We need to test None separately, as otherwise DebugMode will
-    # complain, as this isn't a valid ndarray.
-    b = None
-    B = pt.NoneConst
-    f = function([A], eigvalsh(A, B))
-    w = f(a)
-    refw = scipy.linalg.eigvalsh(a, b)
-    np.testing.assert_array_almost_equal(w, refw)
-
-
-def test_eigvalsh_grad():
-    rng = np.random.default_rng(utt.fetch_seed())
-    a = rng.standard_normal((5, 5))
-    a = a + a.T
-    b = 10 * np.eye(5, 5) + rng.standard_normal((5, 5))
-    utt.verify_grad(
-        lambda a, b: eigvalsh(a, b).dot([1, 2, 3, 4, 5]), [a, b], rng=np.random
-    )
 
 
 class TestEig(utt.InferShapeTester):
@@ -51,7 +19,7 @@ class TestEig(utt.InferShapeTester):
 
         self.rng = np.random.default_rng(utt.fetch_seed())
         self.A = matrix(dtype=self.dtype)
-        self.X = np.asarray(self.rng.random((5, 5)), dtype=self.dtype)
+        self.X = self.rng.normal(size=(5, 5)).astype(self.dtype)
         self.S = self.X.dot(self.X.T)
 
     def test_infer_shape(self):
@@ -100,24 +68,121 @@ class TestEig(utt.InferShapeTester):
 
 class TestEigh(TestEig):
     op = staticmethod(eigh)
+    op_class = Eigh
 
-    def test_eval(self):
-        A = matrix(dtype=self.dtype)
+    @pytest.mark.parametrize("is_complex", [True, False], ids=["complex", "real"])
+    def test_eval(self, is_complex):
+        if is_complex:
+            dtype = "complex128" if self.dtype == "float64" else "complex64"
+        else:
+            dtype = self.dtype
+
+        A = matrix(dtype=dtype)
         fn = function([A], self.op(A))
 
-        # Symmetric input (real eigenvalues)
-        A_val = self.rng.normal(size=(5, 5)).astype(self.dtype)
-        A_val = A_val + A_val.T
+        A_val = self.rng.normal(size=(5, 5)).astype(dtype)
+        if is_complex:
+            A_val = A_val + 1j * self.rng.normal(size=(5, 5)).astype(dtype)
+            A_val = A_val + A_val.T.conj()  # Hermitian
+        else:
+            A_val = A_val + A_val.T
 
         w, v = fn(A_val)
         w_np, v_np = np.linalg.eigh(A_val)
-        rtol = 1e-2 if self.dtype == "float32" else 1e-7
+        rtol = 1e-2 if np.finfo(dtype).bits <= 32 else 1e-7
         np.testing.assert_allclose(np.dot(A_val, v), w * v, rtol=rtol)
 
         np.testing.assert_allclose(np.abs(w), np.abs(w_np), rtol=rtol)
         np.testing.assert_allclose(np.abs(v), np.abs(v_np), rtol=rtol)
 
-    def test_uplo(self):
+    @pytest.mark.parametrize("is_complex", [True, False], ids=["complex", "real"])
+    def test_eval_generalized(self, is_complex):
+        if is_complex:
+            dtype = "complex128" if self.dtype == "float64" else "complex64"
+        else:
+            dtype = self.dtype
+
+        A = matrix(dtype=dtype)
+        B = matrix(dtype=dtype)
+        fn = function([A, B], self.op(A, B))
+
+        A_val = self.rng.normal(size=(5, 5)).astype(dtype)
+        if is_complex:
+            A_val = A_val + 1j * self.rng.normal(size=(5, 5)).astype(dtype)
+            A_val = A_val + A_val.T.conj()
+        else:
+            A_val = A_val + A_val.T
+
+        # Posdef input (add diagonal for better conditioning)
+        B_val = self.rng.normal(size=(5, 5)).astype(dtype)
+        if is_complex:
+            B_val = B_val + 1j * self.rng.normal(size=(5, 5)).astype(dtype)
+        B_val = B_val @ B_val.T.conj() + 50 * np.eye(5, dtype=dtype)
+
+        w, v = fn(A_val, B_val)
+        w_np, v_np = scipy.linalg.eigh(A_val, B_val)
+        rtol = 5e-2 if np.finfo(dtype).bits <= 32 else 1e-7
+        np.testing.assert_allclose(np.dot(A_val, v), B_val @ (w * v), rtol=rtol)
+
+        np.testing.assert_allclose(np.abs(w), np.abs(w_np), rtol=rtol)
+        np.testing.assert_allclose(np.abs(v), np.abs(v_np), rtol=rtol)
+
+    @pytest.mark.parametrize("lower", [True, False], ids=["lower", "upper"])
+    def test_grad_basic(self, lower):
+        rng = self.rng
+
+        def make_spd(x):
+            return x @ x.T + 10 * pt.eye(x.shape[0])
+
+        x_val = rng.normal(size=(5, 5)).astype(self.dtype)
+
+        # Eigenvalue gradient
+        utt.verify_grad(
+            lambda x: self.op(make_spd(x), lower=lower)[0], [x_val], rng=rng
+        )
+        # Eigenvector gradient: use sign-invariant cost (v**2) because
+        # eigenvector signs can flip under finite-difference perturbation
+        utt.verify_grad(
+            lambda x: self.op(make_spd(x), lower=lower)[1] ** 2, [x_val], rng=rng
+        )
+
+    @pytest.mark.parametrize("lower", [True, False], ids=["lower", "upper"])
+    def test_grad_generalized(self, lower):
+        rng = self.rng
+
+        def make_spd(x):
+            return x @ x.T + 50 * pt.eye(x.shape[0])
+
+        a_val = rng.normal(size=(5, 5)).astype(self.dtype)
+        b_val = rng.normal(size=(5, 5)).astype(self.dtype)
+
+        # Gradients w.r.t. A
+        # Eigenvalues
+        utt.verify_grad(
+            lambda a, b: eigh(a + a.T, make_spd(b), lower=lower)[0],
+            [a_val, b_val],
+            rng=rng,
+        )
+        # Eigenvectors
+        utt.verify_grad(
+            lambda a, b: eigh(a + a.T, make_spd(b), lower=lower)[1],
+            [a_val, b_val],
+            rng=rng,
+        )
+
+        # Gradients w.r.t B
+        # Eigenvalues
+        utt.verify_grad(
+            lambda a, b: eigh(a + a.T, make_spd(b), lower=lower)[1],
+            [a_val, b_val],
+            rng=rng,
+        )
+        # Eigenvectors
+        utt.verify_grad(
+            lambda a, b: eigh(a + a.T, make_spd(b), lower=lower)[1],
+            [a_val, b_val],
+            rng=rng,
+        )
         S = self.S
         a = matrix(dtype=self.dtype)
         wu, vu = (out.eval({a: S}) for out in self.op(a, "U"))

--- a/tests/tensor/linalg/test_decomposition/test_eigen.py
+++ b/tests/tensor/linalg/test_decomposition/test_eigen.py
@@ -183,30 +183,98 @@ class TestEigh(TestEig):
             [a_val, b_val],
             rng=rng,
         )
+
+
+class TestEigvalsh(TestEig):
+    op = staticmethod(eigvalsh)
+    op_class = Eigvalsh
+
+    def test_infer_shape(self):
+        A = self.A
         S = self.S
-        a = matrix(dtype=self.dtype)
-        wu, vu = (out.eval({a: S}) for out in self.op(a, "U"))
-        wl, vl = (out.eval({a: S}) for out in self.op(a, "L"))
-        atol = 1e-14 if np.dtype(self.dtype).itemsize == 8 else 1e-5
-        rtol = 1e-14 if np.dtype(self.dtype).itemsize == 8 else 1e-3
-        np.testing.assert_allclose(wu, wl, atol=atol, rtol=rtol)
-        np.testing.assert_allclose(
-            vu * np.sign(vu[0, :]), vl * np.sign(vl[0, :]), atol=atol, rtol=rtol
+        self._compile_and_check(
+            [A],
+            [self.op(A)],
+            [S],
+            self.op_class,
+            warn=False,
         )
 
-    def test_grad(self):
+    @pytest.mark.parametrize("is_complex", [True, False], ids=["complex", "real"])
+    def test_eval(self, is_complex):
+        if is_complex:
+            dtype = "complex128" if self.dtype == "float64" else "complex64"
+        else:
+            dtype = self.dtype
+
+        A = matrix(dtype=dtype)
+        fn = function([A], self.op(A))
+
+        A_val = self.rng.normal(size=(5, 5)).astype(dtype)
+        if is_complex:
+            A_val = A_val + 1j * self.rng.normal(size=(5, 5)).astype(dtype)
+            A_val = A_val + A_val.T.conj()
+        else:
+            A_val = A_val + A_val.T
+
+        w = fn(A_val)
+        w_np = scipy.linalg.eigvalsh(A_val)
+        rtol = 1e-2 if np.finfo(dtype).bits <= 32 else 1e-7
+        np.testing.assert_allclose(np.abs(w), np.abs(w_np), rtol=rtol)
+
+    @pytest.mark.parametrize("is_complex", [True, False], ids=["complex", "real"])
+    def test_eval_generalized(self, is_complex):
+        if is_complex:
+            dtype = "complex128" if self.dtype == "float64" else "complex64"
+        else:
+            dtype = self.dtype
+
+        A = matrix(dtype=dtype)
+        B = matrix(dtype=dtype)
+        fn = function([A, B], self.op(A, B))
+
+        A_val = self.rng.normal(size=(5, 5)).astype(dtype)
+        if is_complex:
+            A_val = A_val + 1j * self.rng.normal(size=(5, 5)).astype(dtype)
+            A_val = A_val + A_val.T.conj()
+        else:
+            A_val = A_val + A_val.T
+
+        B_val = self.rng.normal(size=(5, 5)).astype(dtype)
+        if is_complex:
+            B_val = B_val + 1j * self.rng.normal(size=(5, 5)).astype(dtype)
+        B_val = B_val @ B_val.T.conj() + 50 * np.eye(5, dtype=dtype)
+
+        w = fn(A_val, B_val)
+        w_np = scipy.linalg.eigvalsh(A_val, B_val)
+        rtol = 5e-2 if np.finfo(dtype).bits <= 32 else 1e-7
+        np.testing.assert_allclose(np.abs(w), np.abs(w_np), rtol=rtol)
+
+    @pytest.mark.parametrize("lower", [True, False], ids=["lower", "upper"])
+    def test_grad_basic(self, lower):
         X = self.X
-        utt.verify_grad(lambda x: self.op(x.dot(x.T))[0], [X], rng=self.rng)
-        utt.verify_grad(lambda x: self.op(x.dot(x.T))[1], [X], rng=self.rng)
-        utt.verify_grad(lambda x: self.op(x.dot(x.T), "U")[0], [X], rng=self.rng)
-        utt.verify_grad(lambda x: self.op(x.dot(x.T), "U")[1], [X], rng=self.rng)
+        utt.verify_grad(lambda x: self.op(x.dot(x.T), lower=lower), [X], rng=self.rng)
 
+    @pytest.mark.parametrize("lower", [True, False], ids=["lower", "upper"])
+    def test_grad_generalized(self, lower):
+        rng = self.rng
 
-class TestEighFloat32(TestEigh):
-    dtype = "float32"
+        def make_spd(x):
+            return x @ x.T + 50 * pt.eye(x.shape[0])
 
-    def test_uplo(self):
-        super().test_uplo()
+        a_val = rng.normal(size=(5, 5)).astype(self.dtype)
+        b_val = rng.normal(size=(5, 5)).astype(self.dtype)
 
-    def test_grad(self):
-        super().test_grad()
+        # Gradients w.r.t. A
+        utt.verify_grad(
+            lambda a, b: eigh(a + a.T, make_spd(b), lower=lower)[0],
+            [a_val, b_val],
+            rng=rng,
+        )
+
+        # Gradients w.r.t B
+        utt.verify_grad(
+            lambda a, b: eigh(a + a.T, make_spd(b), lower=lower)[1],
+            [a_val, b_val],
+            rng=rng,
+        )


### PR DESCRIPTION
- Make Eigh and Eigvalsh fully symbolic
- Deprecate UPLO argument in favor of lower (matches API of other linalg ops)
- Add numba dispatch to underlying LAPACK routines for generalized eigenvalue and complex support

This is another in my "decompositions nobody asked for" series. Actually this one is useful, eigh/eigvalsh get used here and there in logp of multivariate normal, see [here](https://github.com/pymc-devs/pymc/blob/6182801c7a7b82345423d7db1f0f070e872c16a0/pymc/distributions/multivariate.py#L2028) for example. Now the *generalized* problem I have no idea :) But I was sick of looking at the separate Grad ops that were doing nothing special at all. 