### PR TITLE
Rewrites for consecutive advanced read-write operations

### DIFF
--- a/pytensor/tensor/rewriting/shape.py
+++ b/pytensor/tensor/rewriting/shape.py
@@ -44,7 +44,13 @@ from pytensor.tensor.shape import (
     SpecifyShape,
     specify_shape,
 )
-from pytensor.tensor.subtensor import Subtensor, get_idx_list
+from pytensor.tensor.subtensor import (
+    AdvancedIncSubtensor,
+    AdvancedIncSubtensor1,
+    IncSubtensor,
+    Subtensor,
+    get_idx_list,
+)
 from pytensor.tensor.type import TensorType, discrete_dtypes, integer_dtypes
 from pytensor.tensor.type_other import NoneTypeT
 from pytensor.tensor.variable import TensorVariable
@@ -1191,7 +1197,7 @@ def local_Shape_of_SpecifyShape(fgraph, node):
 @register_canonicalize
 @register_specialize
 @node_rewriter([SpecifyShape])
-def local_specify_shape_lift(fgraph, node):
+def local_lift_specify_shape_elemwise(fgraph, node):
     """Lift SpecifyShape of Elemwise towards the inputs."""
     inp, *shape = node.inputs
     if inp.owner and isinstance(inp.owner.op, Elemwise):
@@ -1234,6 +1240,26 @@ def local_specify_shape_lift(fgraph, node):
         new_out = inp.owner.op.make_node(*new_elem_inps).outputs
         copy_stack_trace(node.outputs, new_out)
         return new_out
+
+
+@register_canonicalize
+@register_specialize
+@node_rewriter([SpecifyShape])
+def local_lift_specify_shape_inc_subtensor(fgraph, node):
+    """specify_shape(x[idx].inc(y)) -> specify_shape(x)[idx].inc(y).
+
+    IncSubtensor always preserves the shape of the buffer
+    """
+    inc_x, *specified_shape = node.inputs
+    if isinstance(
+        (inc_op := inc_x.owner_op),
+        IncSubtensor | AdvancedIncSubtensor1 | AdvancedIncSubtensor,
+    ):
+        x, y, *idx_vars = inc_x.owner.inputs
+        new_x = specify_shape(x, *specified_shape)
+        new_out = inc_op(new_x, y, *idx_vars)
+        copy_stack_trace(node.outputs[0], new_out)
+        return [new_out]
 
 
 @register_infer_shape

--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -1267,6 +1267,12 @@ def local_read_of_write_same_indices(fgraph, node):
     are trivially unique, while integer-array indices must be constant with
     no repeated entries (mixing positive and negative values counts as
     potentially duplicated since they may alias).
+
+    Companion rewrites:
+
+    - ``local_advanced_read_of_write_constant_indices`` handles the multi-axis
+      case when read and write indices differ but are both constant.
+    - ``local_write_of_write_same_indices`` folds nested write chains.
     """
     if isinstance(node.op, Subtensor):
         write_type = IncSubtensor
@@ -1333,6 +1339,12 @@ def local_advanced_read_of_write_constant_indices(fgraph, node):
     Fires only when all advanced indices on both sides are 1-D integer
     constants with matching ``idx_list``.  The inc case additionally requires
     unique joint write coords so each read coord matches at most one write.
+
+    Companion rewrites:
+
+    - ``local_read_of_write_same_indices`` handles the identity-check case
+      (symbolic indices allowed) for basic and advanced subtensors.
+    - ``local_write_of_write_same_indices`` folds nested write chains.
     """
     inner = node.inputs[0]
     if not (inner.owner and isinstance(inner.owner.op, AdvancedIncSubtensor)):
@@ -1492,6 +1504,97 @@ def local_advanced_read_of_write_constant_indices(fgraph, node):
 
     copy_stack_trace(node.outputs[0], out)
     return [out]
+
+
+@register_canonicalize
+@register_stabilize
+@register_specialize
+@node_rewriter([IncSubtensor, AdvancedIncSubtensor1, AdvancedIncSubtensor])
+def local_write_of_write_same_indices(fgraph, node):
+    """Fold nested write ops that share the same indices.
+
+    .. code::
+
+        x[idx].set/inc(a)[idx].set(b) -> x[idx].set(b)
+        x[idx].inc(a)[idx].inc(b)     -> x[idx].inc(a + b)
+        x[idx].set(a)[idx].inc(b)     -> x[idx].set(a + b)   [unique idx]
+
+    Outer-set always applies (it shadows the inner write).  Inc+inc is safe
+    because addition is associative.  Inc-of-set requires duplicate-free
+    indices: slices are trivially unique, advanced indices are checked
+    per-axis (conservative — joint-tuple uniqueness would be exact).
+
+    If the inc-of-set base is zero-filled the result is emitted as an
+    ``inc`` so downstream zero-aware rewrites can still fire.
+
+    Typically arises from gradient accumulation or user code that writes
+    then updates the same slice (e.g. Scan updates).
+
+    Companion rewrites:
+
+    - ``local_read_of_write_same_indices`` simplifies a read following a
+      write at the same indices.
+    - ``local_advanced_read_of_write_constant_indices`` handles multi-axis
+      reads with differing constant indices.
+    """
+    # AdvancedIncSubtensor.ignore_duplicates is not a concern here:
+    # the outer-set and inc+inc cases are valid regardless of duplicates,
+    # and the inc-of-set case requires verified-unique indices so there
+    # are no duplicates for the flag to affect.
+    inner_x, b, *outer_idx_vars = node.inputs
+    if not (inner_x.owner and isinstance(inner_x.owner.op, type(node.op))):
+        return
+
+    base, a, *inner_idx_vars = inner_x.owner.inputs
+
+    # Same indices: idx_list (slice specs) must match and all index
+    # variables must be identical.  AdvancedIncSubtensor1 has a fixed
+    # class-level idx_list = (0,) so the comparison is trivially true.
+    if node.op.idx_list != inner_x.owner.op.idx_list:
+        return
+    if not all(o is i for o, i in zip(outer_idx_vars, inner_idx_vars, strict=True)):
+        return
+
+    outer_is_set = node.op.set_instead_of_inc
+    inner_is_set = inner_x.owner.op.set_instead_of_inc
+
+    if outer_is_set:
+        # Outer set shadows inner completely.
+        new_val = b
+        use_set = True
+    elif inner_is_set:
+        # x[idx].set(a)[idx].inc(b) — needs unique indices.
+        # Basic indexing (slices/scalars) is always duplicate-free.
+        # For advanced indexing, per-axis uniqueness is conservative but
+        # sufficient: it guarantees no duplicates in the joint cross-product
+        # after broadcasting.
+        if not isinstance(node.op, IncSubtensor):
+            if not all(_constant_has_unique_indices(v) for v in outer_idx_vars):
+                return
+        new_val = a + b
+        if (
+            get_underlying_scalar_constant_value(
+                base, elemwise=False, raise_not_constant=False
+            )
+            == 0
+        ):
+            use_set = False
+        else:
+            use_set = True
+    else:
+        # x[idx].inc(a)[idx].inc(b) — always safe (addition is associative).
+        new_val = a + b
+        use_set = False
+
+    if isinstance(node.op, AdvancedIncSubtensor1):
+        new_op = AdvancedIncSubtensor1(set_instead_of_inc=use_set)
+    else:
+        # ignore_duplicates is deliberately not propagated: the merged op
+        # should use the safe np.add.at path (the default).
+        new_op = type(node.op)(idx_list=node.op.idx_list, set_instead_of_inc=use_set)
+    r = new_op(base, new_val, *outer_idx_vars)
+    copy_stack_trace(node.outputs[0], r)
+    return [r]
 
 
 @register_specialize

--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -54,7 +54,6 @@ from pytensor.tensor.math import (
     or_,
     variadic_add,
 )
-from pytensor.tensor.math import all as pt_all
 from pytensor.tensor.rewriting.basic import (
     register_canonicalize,
     register_specialize,
@@ -501,48 +500,6 @@ def local_subtensor_remove_broadcastable_index(fgraph, node):
         all_dim = range(node.inputs[0].ndim)
         remain_dim = [x for x in all_dim if x not in remove_dim]
         return [node.inputs[0].dimshuffle(tuple(remain_dim))]
-
-
-@register_specialize
-@register_canonicalize
-@node_rewriter([Subtensor])
-def local_subtensor_inc_subtensor(fgraph, node):
-    """
-    Subtensor(SetSubtensor(x, y, idx), idx) -> y
-
-    """
-    if isinstance(node.op, Subtensor):
-        x = node.inputs[0]
-        if not (x.owner and isinstance(x.owner.op, IncSubtensor)):
-            return
-        if not x.owner.op.set_instead_of_inc:
-            return
-
-        x_inc, y_inc, *inc_index_variables = x.owner.inputs
-        _sub_x, *sub_index_variables = node.inputs
-
-        if (
-            inc_index_variables == sub_index_variables
-            and x.owner.op.idx_list == node.op.idx_list
-        ):
-            out = node.outputs[0]
-            # If the dtypes differ, cast y into x.dtype
-            if x.dtype != y_inc.dtype:
-                y_inc = y_inc.astype(x.dtype)
-            if (
-                out.type.dtype == y_inc.type.dtype
-                and out.type.broadcastable == y_inc.type.broadcastable
-            ):
-                # if x[idx] and y have the same type, directly return y
-                return [y_inc]
-            else:
-                # The difference is related to broadcasting pattern
-                assert out.broadcastable != y_inc.broadcastable
-                # We have to alloc y to the shape of x[idx]
-                x_subtensor = node.op(x_inc, *inc_index_variables)
-                return [alloc(y_inc, *x_subtensor.shape)]
-        else:
-            return
 
 
 @register_canonicalize
@@ -1209,74 +1166,92 @@ def local_setsubtensor_of_constants(fgraph, node):
             return False
 
 
-@register_canonicalize
-@register_specialize
-@node_rewriter([AdvancedSubtensor1])
-def local_adv_sub1_adv_inc_sub1(fgraph, node):
-    """Rewrite graphs like ``AdvancedSubtensor1(AdvancedSetSubtensor1(...), ...)``.
+def _constant_has_unique_indices(idx) -> bool:
+    """Check whether a constant index has no duplicate entries.
+
+    Boolean indices, scalars, and single-element arrays are trivially unique.
+    For larger integer arrays, indices that mix positive and negative values
+    may alias, so those are treated as potentially duplicated.  The result
+    is cached on ``idx.tag``.
+    """
+    if not isinstance(idx, Constant):
+        return False
+    cached = getattr(idx.tag, "unique_indices", None)
+    if cached is not None:
+        return bool(cached)
+    idx_val = np.asarray(idx.data)
+    if idx_val.dtype == bool:
+        result = True
+    elif idx_val.size <= 1:
+        result = True
+    else:
+        has_pos = (idx_val >= 0).any()
+        has_neg = (idx_val < 0).any()
+        result = not (has_pos and has_neg) and np.unique(idx_val).size == idx_val.size
+    idx.tag.unique_indices = result
+    return result
+
+
+@register_canonicalize("shape_unsafe")
+@register_specialize("shape_unsafe")
+@node_rewriter([Subtensor, AdvancedSubtensor1, AdvancedSubtensor])
+def local_read_of_write_same_indices(fgraph, node):
+    """Read of a write at the same indices: ``x[idx].set/inc(v)[idx]``.
 
     .. code::
 
-        AdvancedSubtensor1(AdvancedSetSubtensor1(x, y, idx), idx) -> y
+        x[idx].set(v)[idx] -> v
+        x[idx].inc(v)[idx] -> x[idx] + v   (idx must be duplicate-free)
 
-
-    Notes
-    -----
-    This rewrite adds an `AssertOp`; otherwise, it would remove shape and index
-    error. If you want to get rid of them, see the :ref:`unsafe_rewrites`
-    section.
-
-    A previous version of this rewrite also matched
-    ``AdvancedSubtensor1(AdvancedIncSubtensor1(x, y, idx), idx)``.
-    This is incorrect when there are duplicate indices.
-    The current version warns the user about potential issues.
-
+    Applies when the outer read and inner write share identical index
+    variables (``is`` check) and the same ``idx_list``.  The inc case
+    additionally requires duplicate-free indices: slices and scalar indices
+    are trivially unique, while integer-array indices must be constant with
+    no repeated entries (mixing positive and negative values counts as
+    potentially duplicated since they may alias).
     """
-    if not isinstance(node.op, AdvancedSubtensor1):
-        return
-    inp = node.inputs[0]
-    if not (inp.owner and isinstance(inp.owner.op, AdvancedIncSubtensor1)):
-        return
-    idx = node.inputs[1]
-    idx2 = inp.owner.inputs[2]
-    x = inp.owner.inputs[0]
-    y = inp.owner.inputs[1]
-    if idx is not idx2:
-        return
-    if (
-        not inp.owner.op.set_instead_of_inc
-        and
-        # Don't use only_process_constants=True. We need to
-        # investigate Alloc of 0s but with non constant shape.
-        get_underlying_scalar_constant_value(
-            x, elemwise=False, raise_not_constant=False
-        )
-        != 0
-    ):
-        return
+    if isinstance(node.op, Subtensor):
+        write_type = IncSubtensor
+    elif isinstance(node.op, AdvancedSubtensor1):
+        write_type = AdvancedIncSubtensor1
+    else:
+        write_type = AdvancedIncSubtensor
 
-    if not inp.owner.op.set_instead_of_inc:
-        return
+    inner = node.inputs[0]
+    if not (inner.owner and isinstance(inner.owner.op, write_type)):
+        return None
 
-    cond = [pt_all(and_(lt(idx, x.shape[0]), ge(idx, -x.shape[0])))]
-    if not fgraph.shape_feature.same_shape(idx, y, 0, 0):
-        cond.append(eq(idx.shape[0], y.shape[0]))
-    r = Assert(
-        "Bad indexing or shapes in a AdvancedIncSubtensor1 that was optimized away"
-    )(y, *cond)
-    copy_stack_trace(y, r)
+    if node.op.idx_list != inner.owner.op.idx_list:
+        return None
 
-    if r.dtype == node.outputs[0].dtype:
+    x, v, *inner_idx_vars = inner.owner.inputs
+    outer_idx_vars = node.inputs[1:]
+
+    if not all(o is i for o, i in zip(outer_idx_vars, inner_idx_vars, strict=True)):
+        return None
+
+    out = node.outputs[0]
+
+    if inner.owner.op.set_instead_of_inc:
+        r = cast(v, out.dtype)
+        if not r.type.is_super(out.type):
+            r = alloc(r, *out.shape)
+        copy_stack_trace(out, r)
         return [r]
-    # It is possible that y is upcast or downcast to x.dtype.
-    # In all case, as we set or add with 0, we can just cast y.
-    r2 = cast(r, node.outputs[0].dtype)
+    else:
+        # Inc case: advanced integer-array indices must be duplicate-free;
+        # slices and scalar indices are trivially unique.
+        indices = indices_from_subtensor(outer_idx_vars, node.op.idx_list)
+        for idx in indices:
+            if isinstance(idx, TensorVariable) and idx.type.ndim > 0:
+                if not _constant_has_unique_indices(idx):
+                    return None
 
-    # Copy over stacktrace from before casting, since
-    # we don't expect problems in the casting operation,
-    # and any problems in the indexing would have been spotted above.
-    copy_stack_trace(r, r2)
-    return [r2]
+        x_at_idx = x[tuple(indices)]
+        copy_stack_trace(out, x_at_idx)
+        r = x_at_idx + v
+        copy_stack_trace(out, r)
+        return [r]
 
 
 @register_specialize

--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -1312,6 +1312,188 @@ def local_read_of_write_same_indices(fgraph, node):
         return [r]
 
 
+@register_canonicalize("shape_unsafe")
+@register_specialize("shape_unsafe")
+@node_rewriter([AdvancedSubtensor])
+def local_advanced_read_of_write_constant_indices(fgraph, node):
+    """Read of a write at possibly-different constant indices.
+
+    .. code::
+
+        x[w_idx].set(v)[r_idx] ->
+            v[lookup]                     (full coverage — base irrelevant)
+            x[r_idx]                      (no coverage — set irrelevant)
+            x[r_idx].set(v[k])[...]       (partial — mix base and v)
+
+        x[w_idx].inc(v)[r_idx] ->
+            x[r_idx] + v[lookup]          (full coverage, unique writes)
+            x[r_idx]                      (no coverage)
+            x[r_idx].inc(v[k])[...]       (partial, unique writes)
+
+    Fires only when all advanced indices on both sides are 1-D integer
+    constants with matching ``idx_list``.  The inc case additionally requires
+    unique joint write coords so each read coord matches at most one write.
+    """
+    inner = node.inputs[0]
+    if not (inner.owner and isinstance(inner.owner.op, AdvancedIncSubtensor)):
+        return None
+
+    inner_op = inner.owner.op
+    is_set = inner_op.set_instead_of_inc
+
+    # Both must have the same idx_list structure (same axes advanced-indexed).
+    if node.op.idx_list != inner_op.idx_list:
+        return None
+
+    base, v, *write_idx_inputs = inner.owner.inputs
+    read_idx_inputs = node.inputs[1:]
+
+    write_indices = indices_from_subtensor(write_idx_inputs, inner_op.idx_list)
+    read_indices = indices_from_subtensor(read_idx_inputs, node.op.idx_list)
+
+    # Collect advanced (integer) axes; other axes must be identical slices.
+    # Cross-sign indices are rejected since negatives can alias positives
+    # (a normalisation rewrite handles those separately).
+    write_arrs = []
+    read_arrs = []
+    for w, r in zip(write_indices, read_indices, strict=True):
+        if isinstance(w, TensorVariable) and isinstance(r, TensorVariable):
+            if not (isinstance(w, TensorConstant) and isinstance(r, TensorConstant)):
+                return None
+            # Require proper 1-D array indices, not broadcastable length-1.
+            if w.type.broadcastable != (False,) or r.type.broadcastable != (False,):
+                return None
+            w_arr = np.asarray(w.data)
+            r_arr = np.asarray(r.data)
+            # Reject only cross-sign within an axis — negatives can alias
+            # positives on the same axis, but uniformly negative (or
+            # uniformly non-negative) indices compare correctly as raw values.
+            # Short-circuit so the common all-non-negative case skips most checks.
+            if ((w_arr < 0).any() or (r_arr < 0).any()) and (
+                (w_arr >= 0).any() or (r_arr >= 0).any()
+            ):
+                return None
+            write_arrs.append(w_arr)
+            read_arrs.append(r_arr)
+        elif isinstance(w, slice) and isinstance(r, slice):
+            if w != r:
+                return None
+        else:
+            return None
+
+    if not write_arrs:
+        return None
+
+    n_write = len(write_arrs[0])
+
+    # Extend indices with implicit trailing slices so axis bookkeeping is
+    # uniform regardless of whether the subtensor indexed all base dims.
+    n_trailing = base.type.ndim - len(write_indices)
+    full_write = list(write_indices) + [slice(None)] * n_trailing
+
+    # Compute where the advanced axis lands in the result of x[indices], per
+    # numpy semantics: hoisted to position 0 if the adv indices are split by
+    # slices, otherwise kept in place at the position of the first adv axis
+    # (counting only slice axes that come before it, since collapsed adv
+    # axes share one output dim).
+    adv_axes = [
+        i for i, idx in enumerate(full_write) if isinstance(idx, TensorVariable)
+    ]
+    if _non_consecutive_adv_indexing(full_write):
+        adv_pos = 0
+        slice_shapes = [
+            base.shape[i] for i in range(base.type.ndim) if i not in set(adv_axes)
+        ]
+    else:
+        first_adv = min(adv_axes)
+        last_adv = max(adv_axes)
+        pre = [
+            base.shape[i] for i in range(first_adv) if isinstance(full_write[i], slice)
+        ]
+        post = [
+            base.shape[i]
+            for i in range(last_adv + 1, base.type.ndim)
+            if isinstance(full_write[i], slice)
+        ]
+        adv_pos = len(pre)
+        slice_shapes = pre + post
+
+    # Bring v to its full natural shape so we can index the adv axis directly.
+    natural_shape_v = [*slice_shapes[:adv_pos], n_write, *slice_shapes[adv_pos:]]
+    v = alloc(v, *natural_shape_v)
+    # set_subtensor/inc_subtensor cast v to the buffer dtype internally; we need
+    # to do it explicitly so v[lookup] (and subsequent ops) match the output dtype.
+    out_dtype = node.outputs[0].type.dtype
+    if v.type.dtype != out_dtype:
+        v = cast(v, out_dtype)
+
+    write_coords = np.column_stack(write_arrs)  # (n_write, n_axes)
+    read_coords = np.column_stack(read_arrs)  # (n_read, n_axes)
+
+    if is_set:
+        # Set: last-write-wins; uncovered positions need the base.
+        write_dict: dict[tuple, int] = {}
+        for k in range(len(write_coords)):
+            write_dict[tuple(write_coords[k])] = k
+    else:
+        # Inc: require unique write coords so each read matches at most one
+        # write.  With duplicates we'd need a scatter-add at write positions,
+        # which generally isn't simpler than the original inc.
+        write_dict = {}
+        for k in range(len(write_coords)):
+            coord = tuple(write_coords[k])
+            if coord in write_dict:
+                return None
+            write_dict[coord] = k
+
+    lookup = np.array(
+        [write_dict.get(tuple(rc), -1) for rc in read_coords], dtype=np.int64
+    )
+    covered = lookup >= 0
+
+    def index_adv(t, positions):
+        # Index axis `adv_pos` of t with `positions`. Skip if identity.
+        if len(positions) == n_write and np.array_equal(positions, np.arange(n_write)):
+            return t
+        indexer = [slice(None)] * t.type.ndim
+        indexer[adv_pos] = tensor_constant(positions)
+        return t[tuple(indexer)]
+
+    if is_set:
+        if covered.all():
+            # Every read position is overwritten; base is irrelevant.
+            out = index_adv(v, lookup)
+        elif not covered.any():
+            # No read position is overwritten; the set is irrelevant.
+            out = base[tuple(read_indices)]
+        else:
+            # Mix: read base, then overwrite covered positions with v values.
+            base_part = base[tuple(read_indices)]
+            covered_read = np.flatnonzero(covered)
+            covered_write = lookup[covered]
+            indexer = [slice(None)] * base_part.type.ndim
+            indexer[adv_pos] = tensor_constant(covered_read)
+            out = base_part[tuple(indexer)].set(index_adv(v, covered_write))
+    else:
+        # Inc case (write coords are unique by construction above).
+        base_part = base[tuple(read_indices)]
+        copy_stack_trace(node.outputs[0], base_part)
+        if not covered.any():
+            return [base_part]
+
+        if covered.all():
+            out = base_part + index_adv(v, lookup)
+        else:
+            covered_read = np.flatnonzero(covered)
+            covered_write = lookup[covered]
+            indexer = [slice(None)] * base_part.type.ndim
+            indexer[adv_pos] = tensor_constant(covered_read)
+            out = base_part[tuple(indexer)].inc(index_adv(v, covered_write))
+
+    copy_stack_trace(node.outputs[0], out)
+    return [out]
+
+
 @register_specialize
 @register_stabilize
 @register_canonicalize

--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -369,8 +369,13 @@ def local_useless_slice(fgraph, node):
         new_idx_list, new_flat_vars = flatten_index_variables(new_idxs)
         props = op._props_dict() | {"idx_list": new_idx_list}
         if is_inc_subtensor:
-            # We let local_useless_inc_subtensor handle empty new_idx_list
-            out = type(op)(**props)(x, y, *new_flat_vars)
+            new_node = type(op)(**props)(x, y, *new_flat_vars).owner
+            if not new_idx_list:
+                ret = local_useless_inc_subtensor.fn(fgraph, new_node)
+                if ret:
+                    copy_stack_trace(node.outputs, ret)
+                    return ret
+            out = new_node.outputs[0]
         else:
             out = type(op)(**props)(x, *new_flat_vars) if new_idx_list else x
         copy_stack_trace(node.outputs, out)
@@ -546,26 +551,17 @@ def local_subtensor_inc_subtensor(fgraph, node):
 def local_useless_inc_subtensor(fgraph, node):
     r"""Remove redundant `IncSubtensor`\s.
 
-    Replace set_subtensor (or inc_subtensor on zero) that overwrite their whole buffers
-    by the written value (perhaps broadcasted and/or reversed).
+    - ``x[full_slices].set(y)`` → ``y``  (broadcast/cast to x's shape)
+    - ``zeros[full_slices].inc(y)`` → ``y``  (broadcast/cast to x's shape)
+    - ``x[full_slices].inc(y)`` → ``x + y``
     """
 
     x, y, *index_vars = node.inputs
 
-    if node.op.set_instead_of_inc is False:
-        # This is an increment operation, so the array being incremented must
-        # consist of all zeros in order for the entire operation to be useless
-        try:
-            c = get_underlying_scalar_constant_value(x)
-            if c != 0:
-                return
-        except NotScalarConstantError:
-            return
-
     indices = indices_from_subtensor(index_vars, node.op.idx_list)
 
     # Check that all indices are full slices or full reversals
-    if all(
+    if not all(
         isinstance(e, slice)
         and e.start is None
         and e.stop is None
@@ -578,30 +574,42 @@ def local_useless_inc_subtensor(fgraph, node):
         )
         for e in indices
     ):
-        # IncSubtensor casts y to x's dtype and broadcasts y onto x's shape
-        out_dtype = node.outputs[0].type.dtype
+        return
 
-        # Check shapes before casting, as cast creates a new node not in the fgraph
-        static_same = x.type.shape == y.type.shape and all(
-            s is not None for s in x.type.shape
-        )
-        if not static_same:
-            if hasattr(fgraph, "shape_feature") and fgraph.shape_feature.same_shape(
-                x, y
-            ):
-                static_same = True
+    is_inc = not node.op.set_instead_of_inc
+    x_is_zero = False
+    if is_inc:
+        try:
+            x_is_zero = get_underlying_scalar_constant_value(x) == 0
+        except NotScalarConstantError:
+            pass
 
-        if y.type.dtype != out_dtype:
-            y = cast(y, out_dtype)
+    # IncSubtensor casts y to x's dtype and broadcasts y onto x's shape
+    out_dtype = node.outputs[0].type.dtype
 
-        if not static_same:
-            y = alloc(y, *x.shape)
-            copy_stack_trace(node.outputs[0], y)
+    static_same = x.type.shape == y.type.shape and all(
+        s is not None for s in x.type.shape
+    )
+    if not static_same:
+        if hasattr(fgraph, "shape_feature") and fgraph.shape_feature.same_shape(x, y):
+            static_same = True
 
-        if not all(e.step is None for e in node.op.idx_list):
-            y = Subtensor(node.op.idx_list)(y, *index_vars)
+    if y.type.dtype != out_dtype:
+        y = cast(y, out_dtype)
 
+    if not static_same:
+        y = alloc(y, *x.shape)
+        copy_stack_trace(node.outputs[0], y)
+
+    if not all(e.step is None for e in node.op.idx_list):
+        y = Subtensor(node.op.idx_list)(y, *index_vars)
+
+    if not is_inc or x_is_zero:
         return [y]
+
+    r = add(x, y)
+    copy_stack_trace(node.outputs[0], r)
+    return [r]
 
 
 @register_canonicalize

--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -614,6 +614,64 @@ def local_set_to_inc_subtensor(fgraph, node):
 
 
 @register_canonicalize
+@register_stabilize
+@register_specialize
+@node_rewriter([add])
+def local_add_of_sparse_write(fgraph, node):
+    """Absorb a sparse write into a surrounding add: ``x + zeros[idx].set(v) -> x[idx].inc(v)``.
+
+    A set into a zero-filled base is just the dense form of a sparse update.
+    Adding it to another tensor is equivalent to incrementing in place, which
+    avoids materialising the dense sparse representation.
+
+    Also handles ``zeros[idx].inc(v)`` when ``idx`` is duplicate-free, since
+    with unique indices inc is semantically equivalent to set.
+    """
+    for i, sparse_candidate in enumerate(node.inputs):
+        if not (
+            sparse_candidate.owner
+            and isinstance(
+                sparse_candidate.owner.op,
+                IncSubtensor | AdvancedIncSubtensor1 | AdvancedIncSubtensor,
+            )
+        ):
+            continue
+
+        inner_op = sparse_candidate.owner.op
+        base, v, *idx_vars = sparse_candidate.owner.inputs
+
+        if (
+            get_underlying_scalar_constant_value(
+                base, elemwise=False, raise_not_constant=False
+            )
+            != 0
+        ):
+            continue
+
+        # An inc into zeros is only equivalent to a set when indices are
+        # duplicate-free. Basic (slice/scalar) indexing is always unique;
+        # advanced integer-array indices must be checked.
+        if not inner_op.set_instead_of_inc and not isinstance(inner_op, IncSubtensor):
+            if not all(_constant_has_unique_indices(idx) for idx in idx_vars):
+                continue
+
+        others = [node.inputs[j] for j in range(len(node.inputs)) if j != i]
+        other = variadic_add(*others)
+
+        if inner_op.set_instead_of_inc:
+            new_op = type(inner_op)(
+                **(inner_op._props_dict() | {"set_instead_of_inc": False})
+            )
+        else:
+            new_op = inner_op
+        r = new_op(other, v, *idx_vars)
+        copy_stack_trace(node.outputs[0], r)
+        return [r]
+
+    return None
+
+
+@register_canonicalize
 @register_specialize
 @node_rewriter([Subtensor])
 def local_useless_subtensor(fgraph, node):

--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -1463,12 +1463,24 @@ def local_advanced_read_of_write_constant_indices(fgraph, node):
     )
     covered = lookup >= 0
 
+    def constant_idx(idx, merge_feature=getattr(fgraph, "merge_feature", None)):
+        # Build (or reuse) the TensorConstant that indexes the adv axis.
+        # Read-write graphs on the same idx require structural identity
+        # To not be at the mercy of MergeOptimizer firing in time,
+        # we eagerly reuse index variables if they already exist in the graph
+        # (which is the case in which those rewrites would need)
+        idx = tensor_constant(idx)
+        if merge_feature is None:
+            return idx
+        else:
+            return merge_feature.atomic_sig_inv.get(idx.signature(), idx)
+
     def index_adv(t, positions):
         # Index axis `adv_pos` of t with `positions`. Skip if identity.
         if len(positions) == n_write and np.array_equal(positions, np.arange(n_write)):
             return t
         indexer = [slice(None)] * t.type.ndim
-        indexer[adv_pos] = tensor_constant(positions)
+        indexer[adv_pos] = constant_idx(positions)
         return t[tuple(indexer)]
 
     if is_set:
@@ -1484,7 +1496,7 @@ def local_advanced_read_of_write_constant_indices(fgraph, node):
             covered_read = np.flatnonzero(covered)
             covered_write = lookup[covered]
             indexer = [slice(None)] * base_part.type.ndim
-            indexer[adv_pos] = tensor_constant(covered_read)
+            indexer[adv_pos] = constant_idx(covered_read)
             out = base_part[tuple(indexer)].set(index_adv(v, covered_write))
     else:
         # Inc case (write coords are unique by construction above).
@@ -1499,7 +1511,7 @@ def local_advanced_read_of_write_constant_indices(fgraph, node):
             covered_read = np.flatnonzero(covered)
             covered_write = lookup[covered]
             indexer = [slice(None)] * base_part.type.ndim
-            indexer[adv_pos] = tensor_constant(covered_read)
+            indexer[adv_pos] = constant_idx(covered_read)
             out = base_part[tuple(indexer)].inc(index_adv(v, covered_write))
 
     copy_stack_trace(node.outputs[0], out)

--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -29,7 +29,6 @@ from pytensor.tensor.basic import (
     cast,
     concatenate,
     expand_dims,
-    full,
     get_scalar_constant_value,
     get_underlying_scalar_constant_value,
     moveaxis,
@@ -2143,95 +2142,73 @@ optdb["specialize"].register(
 )
 
 
-@register_canonicalize
-@register_stabilize
-@register_specialize
+@register_stabilize("shape_unsafe")
+@register_specialize("shape_unsafe")
 @node_rewriter([ExtractDiag])
-def extract_diag_of_diagonal_set_subtensor(fgraph, node):
-    """Undo extract diagonal from a set diagonal
+def local_extract_diag_of_write(fgraph, node):
+    """Delegate ``extract_diag(advanced_inc_subtensor(...))`` to the constant-indices rewrite.
 
-    This rewrites the following pattern:
-        y = write_diagonal*(x, x_diag, offset=k1)
-        z = extract_diag(y, offset=k2)
+    Rewrites ``extract_diag(x, offset=k)`` as the equivalent
+    ``x[..., arange(d) + max(0, -k), arange(d) + max(0, k), ...]`` and
+    calls ``local_advanced_read_of_write_constant_indices`` to do the
+    work.  Since ``extract_diag`` is a zero-copy view, we only commit the
+    replacement when the downstream rewrite eliminates the gather.
 
-    as:
-        z = diag_x, if k1 == k2
-        z = x if k1 != k2
-
-    * write_diagonal is not an atomic operation, but a sequence of Arange/SetSubtensor operations.
-
+    Requires statically-known sizes on the two diagonal axes.
     """
-
-    def is_cosntant_arange(var) -> bool:
-        if not (isinstance(var, TensorConstant) and var.type.ndim == 1):
-            return False
-
-        data = var.data
-        start, stop = data[0], data[-1] + 1
-        return data.size == (stop - start) and (data == np.arange(start, stop)).all()  # type: ignore
-
-    [diag_x] = node.inputs
-    if not (
-        diag_x.owner is not None
-        and isinstance(diag_x.owner.op, AdvancedIncSubtensor)
-        and diag_x.owner.op.set_instead_of_inc
-    ):
-        return None
-
-    x, y, *idx_variables = diag_x.owner.inputs
-    idxs = indices_from_subtensor(idx_variables, diag_x.owner.op.idx_list)
-
-    if not (
-        x.type.ndim >= 2
-        and None not in x.type.shape[-2:]
-        and x.type.shape[-2] == x.type.shape[-1]
-    ):
-        # TODO: for now we only support rewrite with static square shape for x
-        return None
-
     op = node.op
-    if op.axis2 > len(idxs):
+
+    inner = node.inputs[0]
+    # AdvancedIncSubtensor1 is intentionally not accepted: it writes whole
+    # rows/slices on a single axis, not specific (i, j) positions, so it
+    # can't express "write the diagonal" the way two paired index arrays can.
+    if not (inner.owner and isinstance(inner.owner.op, AdvancedIncSubtensor)):
         return None
 
-    # Check all non-axis indices are full slices
-    axis = {op.axis1, op.axis2}
-    if not all(idx == slice(None) for i, idx in enumerate(idxs) if i not in axis):
+    # Need static sizes on the two diagonal axes to build constant indices.
+    dim_a = inner.type.shape[op.axis1]
+    dim_b = inner.type.shape[op.axis2]
+    if dim_a is None or dim_b is None:
         return None
 
-    # Check axis indices are arange we would expect from setting on the diagonal
-    axis1_idx = idxs[op.axis1]
-    axis2_idx = idxs[op.axis2]
-    if not (is_cosntant_arange(axis1_idx) and is_cosntant_arange(axis2_idx)):
+    k = op.offset
+    row_offset = max(0, -k)
+    col_offset = max(0, k)
+    d = min(dim_a - row_offset, dim_b - col_offset)
+    if d <= 0:
         return None
 
-    dim_length = x.type.shape[-1]
-    offset = op.offset
-    start_stop1 = (axis1_idx.data[0], axis1_idx.data[-1] + 1)
-    start_stop2 = (axis2_idx.data[0], axis2_idx.data[-1] + 1)
-    orig_start1, orig_start2 = start_stop1[0], start_stop2[0]
+    # Build equivalent AdvancedSubtensor: inner[..., arange(d) + row_offset, ..., arange(d) + col_offset, ...]
+    base_arange = np.arange(d, dtype=np.int64)
+    rows = pytensor.tensor.as_tensor_variable(base_arange + row_offset)
+    cols = pytensor.tensor.as_tensor_variable(base_arange + col_offset)
+    idxs = [slice(None)] * inner.type.ndim
+    idxs[op.axis1] = rows
+    idxs[op.axis2] = cols
+    equiv = inner[tuple(idxs)]
 
-    if offset < 0:
-        # The logic for checking if we are selecting or not a diagonal for negative offset is the same
-        # as the one with positive offset but swapped axis
-        start_stop1, start_stop2 = start_stop2, start_stop1
-        offset = -offset
+    if not (equiv.owner and isinstance(equiv.owner.op, AdvancedSubtensor)):
+        return None
 
-    start1, stop1 = start_stop1
-    start2, stop2 = start_stop2
+    # Delegate to the general read-after-write rewrite.
+    result = local_advanced_read_of_write_constant_indices.fn(fgraph, equiv.owner)
+    if not result:
+        return None
+
+    # Stay zero-copy where possible: when the simplification reduced to a
+    # gather of the inner write's base at our diagonal-arange pattern (i.e.
+    # the no-coverage case where the write is irrelevant for this read),
+    # re-emit as ExtractDiag so we keep the view semantics of the original.
+    base = inner.owner.inputs[0]
+    [result_var] = result
     if (
-        start1 == 0
-        and start2 == offset
-        and stop1 == dim_length - offset
-        and stop2 == dim_length
+        result_var.owner
+        and isinstance(result_var.owner.op, AdvancedSubtensor)
+        and result_var.owner.inputs[0] is base
     ):
-        # We are extracting the just written diagonal
-        if y.type.ndim == 0 or y.type.shape[-1] == 1:
-            # We may need to broadcast y
-            y = full((*x.shape[:-2], dim_length - offset), y, dtype=x.type.dtype)
-        return [y]
-    elif (orig_start2 - orig_start1) != op.offset:
-        # Some other diagonal was written, ignore it
-        return [op(x)]
-    else:
-        # A portion, but no the whole diagonal was written, don't do anything
-        return None
+        out = base.diagonal(offset=k, axis1=op.axis1, axis2=op.axis2)
+        copy_stack_trace(node.outputs[0], out)
+        return [out]
+
+    copy_stack_trace(node.outputs[0], result)
+    return result

--- a/tests/tensor/rewriting/test_elemwise.py
+++ b/tests/tensor/rewriting/test_elemwise.py
@@ -1095,14 +1095,6 @@ class TestFusion:
         assert not any(len(node.inputs) > 31 for node in composite_nodes)
 
     @pytest.mark.skipif(not config.cxx, reason="No cxx compiler")
-    @pytest.mark.xfail(
-        reason="Elemwise.perform doesn't support >32 operands. "
-        "local_useless_inc_subtensor now triggers get_underlying_scalar_constant_value "
-        "on large fused Add nodes, exposing a pre-existing bug where prepare_node "
-        "refuses to create a ufunc for >32 inputs but perform falls through to the "
-        "ufunc code path anyway (missing return after super().perform()).",
-        raises=AttributeError,
-    )
     def test_big_fusion(self):
         # Make sure that C compilation is used
         mode = Mode("cvm", self.rewrites)

--- a/tests/tensor/rewriting/test_shape.py
+++ b/tests/tensor/rewriting/test_shape.py
@@ -650,12 +650,23 @@ def test_local_Shape_of_SpecifyShape_partial(s1):
     assert not any(isinstance(apply.op, SpecifyShape) for apply in fgraph.apply_nodes)
 
 
-def test_local_specify_shape_lift():
+def test_local_lift_specify_shape_elemwise():
     x = vector("x")
     out = specify_shape([1.0] + x, shape=(5,))  # noqa: RUF005
 
     new_out = rewrite_graph(out)
     assert equal_computations([new_out], [[1.0] + specify_shape(x, shape=(5,))])  # noqa: RUF005
+
+
+def test_local_lift_specify_shape_inc_subtensor():
+    x = vector("x")
+    y = vector("y")
+    out = specify_shape(set_subtensor(x[1:4], y), shape=(5,))
+
+    new_out = rewrite_graph(out)
+    assert equal_computations(
+        [new_out], [set_subtensor(specify_shape(x, shape=(5,))[1:4], y)]
+    )
 
 
 def test_local_Shape_i_ground():

--- a/tests/tensor/rewriting/test_subtensor.py
+++ b/tests/tensor/rewriting/test_subtensor.py
@@ -1397,6 +1397,149 @@ class TestReadOfWriteSameIndices:
         utt.assert_equal_computations([rewritten], [x[:stop] + v])
 
 
+class TestReadOfWriteConstantIndices:
+    def setup_method(self):
+        mode = get_default_mode()
+        self.mode = mode.including(
+            "local_replace_AdvancedSubtensor",
+            "local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1",
+            "local_advanced_read_of_write_constant_indices",
+        ).excluding("fusion")
+
+    def test_inc_multi_axis_unique_const(self):
+        """Multi-axis ``x[idx_a, idx_b].inc(v)[idx_a, idx_b]`` with
+        unique-per-axis constant indices collapses to ``x[idx] + v``."""
+        x = matrix("x", dtype="float64")
+        v = vector("v", dtype="float64")
+        cidx_a = pt.constant(np.array([0, 2, 3], dtype="int32"))
+        cidx_b = pt.constant(np.array([1, 2, 4], dtype="int32"))
+
+        out = inc_subtensor(x[cidx_a, cidx_b], v)[cidx_a, cidx_b]
+        f = function([x, v], out, self.mode)
+
+        topo = f.maker.fgraph.toposort()
+        assert not any(
+            isinstance(n.op, AdvancedIncSubtensor | AdvancedIncSubtensor1) for n in topo
+        )
+
+        dx = np.random.random((4, 5))
+        dv = np.random.random((3,))
+        expected = dx.copy()
+        expected[[0, 2, 3], [1, 2, 4]] += dv
+        np.testing.assert_allclose(f(dx, dv), expected[[0, 2, 3], [1, 2, 4]])
+
+    def test_non_leading_adv(self):
+        """The constant-indices rewrite must place the advanced axis correctly
+        for non-leading layouts: ``x[:, a, b]`` (consecutive non-leading,
+        adv stays at axis 1) and ``x[a, :, b]`` (non-consecutive, numpy
+        hoists adv to axis 0).
+        """
+        x = pt.tensor3("x", dtype="float64")
+        v = matrix("v", dtype="float64")
+        ca = pt.constant(np.array([0, 1], dtype="int64"))
+        cb = pt.constant(np.array([2, 3], dtype="int64"))
+
+        np.random.seed(0)
+        dx = np.random.random((3, 4, 5))
+        dv = np.random.random((3, 2))  # matches numpy x[:, ca, cb].shape
+
+        # Consecutive non-leading: result shape (3, 2), adv at axis 1
+        for op, expected_fn in (
+            (set_subtensor, lambda dx, dv: dv),
+            (inc_subtensor, lambda dx, dv: dx[:, [0, 1], [2, 3]] + dv),
+        ):
+            out = op(x[:, ca, cb], v)[:, ca, cb]
+            f = function([x, v], out, self.mode)
+            topo = f.maker.fgraph.toposort()
+            assert not any(
+                isinstance(n.op, AdvancedIncSubtensor | AdvancedIncSubtensor1)
+                for n in topo
+            )
+            np.testing.assert_allclose(f(dx, dv), expected_fn(dx, dv))
+
+        # Non-consecutive: numpy hoists adv to axis 0 → result shape (2, 4)
+        dv2 = np.random.random((2, 4))
+        for op, expected_fn in (
+            (set_subtensor, lambda dx, dv: dv),
+            (inc_subtensor, lambda dx, dv: dx[[0, 1], :, [2, 3]] + dv),
+        ):
+            out = op(x[ca, :, cb], v)[ca, :, cb]
+            f = function([x, v], out, self.mode)
+            topo = f.maker.fgraph.toposort()
+            assert not any(
+                isinstance(n.op, AdvancedIncSubtensor | AdvancedIncSubtensor1)
+                for n in topo
+            )
+            np.testing.assert_allclose(f(dx, dv2), expected_fn(dx, dv2))
+
+    def test_partial_coverage_set(self):
+        """Partial-coverage set: read indices overlap only some write indices.
+        Covered positions come from ``v``; uncovered positions are read from
+        the base.  Works for both constant-fill and non-constant bases.
+
+        The rewrite transforms a multi-axis write into a 1-axis write on a
+        gathered slice; the marker is that no multi-axis
+        ``AdvancedIncSubtensor`` remains (single-axis ``...1`` variants are
+        the target state).
+        """
+        v = vector("v", dtype="float64")
+        write_a = pt.constant(np.array([0, 1, 2], dtype="int64"))
+        write_b = pt.constant(np.array([0, 1, 2], dtype="int64"))
+        # Read positions: (0,0) covered (=v[0]), (1,2) uncovered (=base), (2,2) covered (=v[2])
+        read_a = pt.constant(np.array([0, 1, 2], dtype="int64"))
+        read_b = pt.constant(np.array([0, 2, 2], dtype="int64"))
+
+        dv = np.array([10.0, 20.0, 30.0])
+
+        # Constant-fill base (zeros).
+        out_zeros = set_subtensor(pt.zeros((4, 4))[write_a, write_b], v)[read_a, read_b]
+        f_zeros = function([v], out_zeros, self.mode)
+        assert not any(
+            isinstance(n.op, AdvancedIncSubtensor)
+            for n in f_zeros.maker.fgraph.toposort()
+        )
+        np.testing.assert_allclose(f_zeros(dv), [10.0, 0.0, 30.0])
+
+        # Non-constant base: uncovered positions must read from the base.
+        x = matrix("x", dtype="float64")
+        out_x = set_subtensor(x[write_a, write_b], v)[read_a, read_b]
+        f_x = function([x, v], out_x, self.mode)
+        assert not any(
+            isinstance(n.op, AdvancedIncSubtensor) for n in f_x.maker.fgraph.toposort()
+        )
+        np.random.seed(0)
+        dx = np.random.random((4, 4))
+        # Expected: covered → v values; uncovered (1,2) → dx[1,2]
+        np.testing.assert_allclose(f_x(dx, dv), [10.0, dx[1, 2], 30.0])
+
+    def test_partial_coverage_inc(self):
+        """Partial-coverage inc: works with any base since we read base and
+        add v only at covered positions.  Same marker as
+        ``test_partial_coverage_set``: no multi-axis ``AdvancedIncSubtensor``.
+        """
+        x = matrix("x", dtype="float64")
+        v = vector("v", dtype="float64")
+        write_a = pt.constant(np.array([0, 1, 2], dtype="int64"))
+        write_b = pt.constant(np.array([0, 1, 2], dtype="int64"))
+        # (0,0) covered, (1,2) uncovered, (2,2) covered
+        read_a = pt.constant(np.array([0, 1, 2], dtype="int64"))
+        read_b = pt.constant(np.array([0, 2, 2], dtype="int64"))
+
+        out = inc_subtensor(x[write_a, write_b], v)[read_a, read_b]
+        f = function([x, v], out, self.mode)
+
+        topo = f.maker.fgraph.toposort()
+        assert not any(isinstance(n.op, AdvancedIncSubtensor) for n in topo)
+
+        np.random.seed(0)
+        dx = np.random.random((4, 4))
+        dv = np.array([10.0, 20.0, 30.0])
+        expected = dx[[0, 1, 2], [0, 2, 2]].copy()
+        expected[0] += dv[0]  # (0,0) covered by write index 0
+        expected[2] += dv[2]  # (2,2) covered by write index 2
+        np.testing.assert_allclose(f(dx, dv), expected)
+
+
 class TestSubtensorAllocRewrites:
     def setup_method(self):
         mode = get_default_mode()

--- a/tests/tensor/rewriting/test_subtensor.py
+++ b/tests/tensor/rewriting/test_subtensor.py
@@ -2513,7 +2513,7 @@ def test_cholesky_unconstrain_grad(exp_before_materialize):
         AdvancedIncSubtensor,
     )
     n_idx = sum(1 for n in f.maker.fgraph.toposort() if isinstance(n.op, idx_types))
-    assert n_idx == 7
+    assert n_idx == 6
 
     x = np.array([1.0, 0.5, 2.0, 0.3, 0.1, 1.5])
     # Expected values were computed once by running ``f(x)``.

--- a/tests/tensor/rewriting/test_subtensor.py
+++ b/tests/tensor/rewriting/test_subtensor.py
@@ -2427,12 +2427,19 @@ class TestUselessSlice:
         )
 
 
-def test_extract_diag_of_diagonal_set_subtensor():
+@pytest.mark.skipif(
+    config.mode == "FAST_COMPILE", reason="Test requires specialization rewrites"
+)
+def test_extract_diag_of_write():
+    """``extract_diag`` of a chain of diagonal writes should simplify away
+    the writes when the read overlaps a (fully or partially) written diagonal,
+    and otherwise reduce to ``extract_diag`` of the original base.
+    """
     A = pt.full((2, 6, 6), np.nan)
     rows = pt.arange(A.shape[-2])
     cols = pt.arange(A.shape[-1])
     write_offsets = [-2, -1, 0, 1, 2]
-    # Randomize order of write operations, to make sure rewrite is not sensitive to it
+    # Randomize write order to make sure the rewrite is not sensitive to it
     random.shuffle(write_offsets)
     for offset in write_offsets:
         value = offset + 0.1 * offset
@@ -2443,22 +2450,28 @@ def test_extract_diag_of_diagonal_set_subtensor():
         else:
             offset = -offset
             A = A[..., rows[offset:], cols[:-offset]].set(value)
-    # Add a partial diagonal along offset 3
+    # Partial write along offset 3
     A = A[..., rows[1:-3], cols[4:]].set(np.pi)
 
     read_offsets = [-2, -1, 0, 1, 2, 3]
     outs = [A.diagonal(offset=offset, axis1=-2, axis2=-1) for offset in read_offsets]
-    rewritten_outs = rewrite_graph(outs, include=("ShapeOpt", "canonicalize"))
 
-    # Every output should just be an Alloc with value
-    expected_outs = []
-    for offset in read_offsets[:-1]:
-        value = np.asarray(offset + 0.1 * offset, dtype=A.type.dtype)
-        expected_outs.append(pt.full((np.int64(2), np.int8(6 - abs(offset))), value))
-    # The partial diagonal shouldn't be rewritten
-    expected_outs.append(outs[-1])
+    f_on = function([], outs)
+    f_off = function(
+        [],
+        outs,
+        mode=get_default_mode().excluding("local_extract_diag_of_write"),
+    )
 
-    assert equal_computations(rewritten_outs, expected_outs)
+    # All AdvancedIncSubtensor writes should be eliminated by the rewrite.
+    on_topo = f_on.maker.fgraph.toposort()
+    assert not any(
+        isinstance(n.op, AdvancedIncSubtensor | AdvancedIncSubtensor1) for n in on_topo
+    )
+
+    # Numerical equivalence with the unrewritten reference.
+    for got, ref in zip(f_on(), f_off(), strict=True):
+        np.testing.assert_allclose(got, ref, equal_nan=True)
 
 
 @pytest.mark.skipif(

--- a/tests/tensor/rewriting/test_subtensor.py
+++ b/tests/tensor/rewriting/test_subtensor.py
@@ -125,27 +125,33 @@ def test_local_replace_AdvancedSubtensor(indexer, is_none):
 
 
 @pytest.mark.parametrize("s", [slice(None), slice(None, None, -1)])
-def test_local_useless_inc_subtensor(s):
+@pytest.mark.parametrize("op", [set_subtensor, inc_subtensor], ids=["set", "inc"])
+def test_local_useless_inc_subtensor(op, s):
     x = matrix("x")
     y = matrix("y")
 
     mode = get_default_mode().including("local_useless_inc_subtensor")
 
+    dx = np.asarray([[2, 3]], dtype=config.floatX)
+    dy = np.asarray([[3, 4]], dtype=config.floatX)
+    # inc(x[:, s], y) writes y into the s-view of x, so when the result is
+    # viewed normally the y values appear at positions y[:, s] (e.g. reversed
+    # for s=::-1).  Set is the same, sans the base.
+    expected = (dx + dy[:, s]) if op is inc_subtensor else dy[:, s]
+
     # Without shape info: rewrite fires but inserts alloc to handle broadcast
-    o = set_subtensor(x[:, s], y)
+    o = op(x[:, s], y)
     f = function([x, y], o, mode=mode)
     topo = f.maker.fgraph.toposort()
     assert not any(isinstance(n.op, IncSubtensor) for n in topo)
-    out = f([[2, 3]], [[3, 4]])
-    assert np.array_equal(out, np.asarray([[3, 4]])[::, s])
+    np.testing.assert_array_equal(f(dx, dy), expected)
 
     # With shape info: rewrite fires without alloc
-    o_shape = set_subtensor(x[:, s], specify_shape(y, x.shape))
+    o_shape = op(x[:, s], specify_shape(y, x.shape))
     f_shape = function([x, y], o_shape, mode=mode)
     topo = f_shape.maker.fgraph.toposort()
     assert not any(isinstance(n.op, IncSubtensor | Alloc) for n in topo)
-    out = f_shape([[2, 3]], [[3, 4]])
-    assert np.array_equal(out, np.asarray([[3, 4]])[::, s])
+    np.testing.assert_array_equal(f_shape(dx, dy), expected)
 
 
 def test_local_useless_setsubtensor_alloc_empty():
@@ -196,23 +202,29 @@ def test_local_useless_inc_subtensor_no_opt():
     out = f_shape([[2, 3, 6, 7]], [[8, 9]])
     assert np.array_equal(out, np.asarray([[8, 3, 9, 7]]))
 
-    # This is an increment with a non-constant target array
+    # Increment with a non-constant target array, full slices collapse to x + y.
     s = x[:, :]
     o_shape = inc_subtensor(s, specify_shape(y, s.shape))
 
     f_shape = function([x, y], o_shape, mode=mode)
 
     topo = f_shape.maker.fgraph.toposort()
-    assert any(isinstance(n.op, IncSubtensor) for n in topo)
+    assert not any(isinstance(n.op, IncSubtensor) for n in topo)
 
-    # This is an increment with a non-zero target array
+    out = f_shape([[1, 2], [3, 4]], [[10, 20], [30, 40]])
+    assert np.array_equal(out, np.asarray([[11, 22], [33, 44]]))
+
+    # Increment with a non-zero constant target array, same collapse to x + y.
     s = pt.ones((2, 2))[:, :]
     o_shape = inc_subtensor(s, specify_shape(y, s.shape))
 
     f_shape = function([y], o_shape, mode=mode)
 
     topo = f_shape.maker.fgraph.toposort()
-    assert any(isinstance(n.op, IncSubtensor) for n in topo)
+    assert not any(isinstance(n.op, IncSubtensor) for n in topo)
+
+    out = f_shape([[10, 20], [30, 40]])
+    assert np.array_equal(out, np.asarray([[11, 21], [31, 41]]))
 
 
 class TestLocalUselessSubtensor:

--- a/tests/tensor/rewriting/test_subtensor.py
+++ b/tests/tensor/rewriting/test_subtensor.py
@@ -1540,6 +1540,76 @@ class TestReadOfWriteConstantIndices:
         np.testing.assert_allclose(f(dx, dv), expected)
 
 
+class TestWriteOfWriteSameIndices:
+    def test_set_of_set_basic_slice(self):
+        """Outer set shadows inner write: ``x[sl].set(a)[sl].set(b) -> x[sl].set(b)``."""
+        x = matrix("x")
+        a = matrix("a")
+        b = matrix("b")
+        stop = iscalar("stop")
+
+        out = set_subtensor(set_subtensor(x[:stop], a)[:stop], b)
+        rewritten = rewrite_graph(out, include=("canonicalize", "specialize"))
+        utt.assert_equal_computations([rewritten], [set_subtensor(x[:stop], b)])
+
+    def test_inc_of_inc_basic_slice(self):
+        """Inc+inc folds the increments: ``x[sl].inc(a)[sl].inc(b) -> x[sl].inc(a + b)``."""
+        x = matrix("x")
+        a = matrix("a")
+        b = matrix("b")
+        stop = iscalar("stop")
+
+        out = inc_subtensor(inc_subtensor(x[:stop], a)[:stop], b)
+        rewritten = rewrite_graph(out, include=("canonicalize", "specialize"))
+        utt.assert_equal_computations([rewritten], [inc_subtensor(x[:stop], a + b)])
+
+    def test_inc_of_set_basic_slice(self):
+        """Inc-of-set with slices (trivially unique):
+        ``x[sl].set(a)[sl].inc(b) -> x[sl].set(a + b)``."""
+        x = matrix("x")
+        a = matrix("a")
+        b = matrix("b")
+        stop = iscalar("stop")
+
+        out = inc_subtensor(set_subtensor(x[:stop], a)[:stop], b)
+        rewritten = rewrite_graph(out, include=("canonicalize", "specialize"))
+        utt.assert_equal_computations([rewritten], [set_subtensor(x[:stop], a + b)])
+
+    def test_inc_of_set_zero_base_emits_inc(self):
+        """When the set base is zero, inc-of-set becomes an inc so that
+        downstream zero-aware rewrites keep firing."""
+        a = matrix("a")
+        b = matrix("b")
+        stop = iscalar("stop")
+        zeros = pt.zeros((5, 5))
+
+        out = inc_subtensor(set_subtensor(zeros[:stop], a)[:stop], b)
+        rewritten = rewrite_graph(out, include=("canonicalize", "specialize"))
+        utt.assert_equal_computations([rewritten], [inc_subtensor(zeros[:stop], a + b)])
+
+    def test_inc_of_set_advanced_non_unique_not_rewritten(self):
+        """Inc-of-set requires unique indices; duplicate constant indices
+        on advanced axes block the rewrite."""
+        x = matrix("x", dtype="float64")
+        a = matrix("a", dtype="float64")
+        b = matrix("b", dtype="float64")
+        cidx = pt.constant(np.array([1, 3, 3], dtype="int32"))
+
+        out = inc_subtensor(set_subtensor(x[cidx], a)[cidx], b)
+        f = function([x, a, b], out)
+
+        topo = f.maker.fgraph.toposort()
+        # Both writes must remain; rewrite can't prove uniqueness.
+        assert (
+            sum(
+                1
+                for n in topo
+                if isinstance(n.op, AdvancedIncSubtensor | AdvancedIncSubtensor1)
+            )
+            == 2
+        )
+
+
 class TestSubtensorAllocRewrites:
     def setup_method(self):
         mode = get_default_mode()
@@ -2443,7 +2513,7 @@ def test_cholesky_unconstrain_grad(exp_before_materialize):
         AdvancedIncSubtensor,
     )
     n_idx = sum(1 for n in f.maker.fgraph.toposort() if isinstance(n.op, idx_types))
-    assert n_idx == 8
+    assert n_idx == 7
 
     x = np.array([1.0, 0.5, 2.0, 0.3, 0.1, 1.5])
     # Expected values were computed once by running ``f(x)``.

--- a/tests/tensor/rewriting/test_subtensor.py
+++ b/tests/tensor/rewriting/test_subtensor.py
@@ -2118,6 +2118,71 @@ def test_extract_diag_of_diagonal_set_subtensor():
     assert equal_computations(rewritten_outs, expected_outs)
 
 
+@pytest.mark.skipif(
+    config.mode == "FAST_COMPILE", reason="Test requires specialization rewrites"
+)
+@pytest.mark.parametrize("exp_before_materialize", [True, False])
+def test_cholesky_unconstrain_grad(exp_before_materialize):
+    """Integration test: gradient of a Cholesky-based log-density.
+
+    Builds a lower-triangular ``L`` from a packed vector via
+    ``set_subtensor``, exponentiates the diagonal, and computes
+    ``sum(log(diag(L))) + sum(L @ L.T)``.  The gradient produces nested
+    inc/set chains at the diagonal indices and diag-of-scatter patterns;
+    the subtensor rewrites should collapse redundant indexing ops.
+    """
+    n = 3
+
+    packed = pt.vector("packed")
+    if exp_before_materialize:
+        # We test the same optimized result regardless of whether
+        # the diagonals are updated before or after materialization
+        packed_diag_indices = pt.arange(n + 1).cumsum()[1:] - 1
+        log_diag = packed[packed_diag_indices]
+        packed_update = packed[packed_diag_indices].set(pt.exp(log_diag))
+    else:
+        packed_update = packed
+
+    tril_r, tril_c = np.tril_indices(n)
+    L = pt.zeros((n, n))
+    L = pt.set_subtensor(L[tril_r, tril_c], packed_update)
+
+    if not exp_before_materialize:
+        diag_indices = np.diag_indices(n)
+        log_diag = L[diag_indices]
+        L = L[diag_indices].set(pt.exp(log_diag))
+
+    Sigma = L @ L.T
+    # log-det via diag(L), not diag(Sigma) — the actual Wishart pattern
+
+    loss = pt.sum(pt.log(pt.diagonal(L))) + pt.sum(Sigma)
+    grad = pt.grad(loss, packed)
+
+    f = function([packed], [loss, grad])
+    f.dprint(print_shape=True)
+
+    idx_types = (
+        Subtensor,
+        AdvancedSubtensor1,
+        AdvancedSubtensor,
+        IncSubtensor,
+        AdvancedIncSubtensor1,
+        AdvancedIncSubtensor,
+    )
+    n_idx = sum(1 for n in f.maker.fgraph.toposort() if isinstance(n.op, idx_types))
+    assert n_idx == 8
+
+    x = np.array([1.0, 0.5, 2.0, 0.3, 0.1, 1.5])
+    # Expected values were computed once by running ``f(x)``.
+    expected_loss = 93.04980520058317
+    expected_grad = np.array(
+        [20.12736312, 7.03656366, 111.67411129, 7.03656366, 14.9781122, 41.17107385]
+    )
+    loss_out, grad_out = f(x)
+    np.testing.assert_allclose(loss_out, expected_loss)
+    np.testing.assert_allclose(grad_out, expected_grad)
+
+
 def test_local_convert_negative_indices():
     x = pt.tensor("x", shape=(None, 3, 1))
 

--- a/tests/tensor/rewriting/test_subtensor.py
+++ b/tests/tensor/rewriting/test_subtensor.py
@@ -15,7 +15,6 @@ from pytensor.graph import rewrite_graph, vectorize_graph
 from pytensor.graph.basic import Constant, Variable, equal_computations
 from pytensor.graph.rewriting.basic import check_stack_trace
 from pytensor.graph.traversal import ancestors
-from pytensor.raise_op import Assert
 from pytensor.tensor import as_tensor
 from pytensor.tensor.basic import Alloc, _convert_to_int8
 from pytensor.tensor.blockwise import Blockwise
@@ -535,7 +534,7 @@ class TestSubtensorIncSubtensor:
     def setup_class(cls):
         cls.rng = np.random.default_rng(utt.fetch_seed())
         cls.mode = get_default_mode().including(
-            "local_subtensor_inc_subtensor",
+            "local_read_of_write_same_indices",
             "local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1",
             "local_replace_AdvancedSubtensor",
         )
@@ -1180,103 +1179,168 @@ class TestLocalSubtensorMerge:
                         f(x_val, *i_val)
 
 
-class TestLocalAdvSub1AdvIncSub1:
+class TestReadOfWriteSameIndices:
     def setup_method(self):
         mode = get_default_mode()
         self.mode = mode.including(
             "local_replace_AdvancedSubtensor",
             "local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1",
-            "local_adv_sub1_adv_inc_sub1",
+            "local_read_of_write_same_indices",
         ).excluding("fusion")
-        self.mode_no_assert = self.mode.including("local_remove_all_assert")
 
-    def test_basic(self):
-        for dtype1, dtype2 in [
+    @pytest.mark.parametrize(
+        "dtype1, dtype2",
+        [
             ("float32", "float32"),
             ("float32", "float64"),
             ("float64", "float32"),
             ("float64", "float64"),
-        ]:
-            x = matrix(dtype=dtype1)
-            y = matrix(dtype=dtype2)
-            idx = ivector()
+        ],
+    )
+    def test_set(self, dtype1, dtype2):
+        x = matrix(dtype=dtype1)
+        y = matrix(dtype=dtype2)
+        idx = ivector()
 
-            dx = np.random.random((4, 5)).astype(dtype1)
-            dy = np.random.random((2, 5)).astype(dtype2)
-            # Duplicate the last row of dy
-            dy = np.vstack([dy, dy[-1:]])
-            # Use the same index twice, with the same corresponding value.
-            # That makes set_subtensor well-defined, and tests
-            # duplication for inc_subtensor.
-            didx = np.asarray([1, 3, 3], "int32")
+        dx = np.random.random((4, 5)).astype(dtype1)
+        dy = np.random.random((2, 5)).astype(dtype2)
+        dy = np.vstack([dy, dy[-1:]])
+        didx = np.asarray([1, 3, 3], "int32")
 
-            # set_subtensor
-            inc = set_subtensor(x[idx], y)
-            o = inc[idx]
-            f = function([x, y, idx], o, self.mode_no_assert)
+        inc = set_subtensor(x[idx], y)
+        o = inc[idx]
+        f = function([x, y, idx], o, self.mode)
 
-            res = f(dx, dy, didx)
-            utt.assert_allclose(dy, res)
-            topo = f.maker.fgraph.toposort()
-            assert len(topo) == 1
-            assert isinstance(topo[0].op, DeepCopyOp | Elemwise)
+        res = f(dx, dy, didx)
+        np.testing.assert_allclose(dy, res)
+        topo = f.maker.fgraph.toposort()
+        assert not any(
+            isinstance(n.op, AdvancedIncSubtensor | AdvancedIncSubtensor1) for n in topo
+        )
 
-            # inc_subtensor(data[idx], y)
-            inc = inc_subtensor(x[idx], y)
-            o = inc[idx]
-            f = function([x, y, idx], o, self.mode_no_assert)
+    def test_inc_unique_constant_idx(self):
+        x = matrix(dtype="float64")
+        y = matrix(dtype="float64")
+        cidx = pt.constant(np.array([0, 2, 3], dtype="int32"))
 
-            res = f(dx, dy, didx)
-            _dx = dx.copy()
-            np.add.at(_dx, didx, dy)
-            utt.assert_allclose(_dx[didx], res)
-            topo = f.maker.fgraph.toposort()
-            len(topo) == 2
+        dx = np.random.random((4, 5))
+        dy = np.random.random((3, 5))
 
-            # inc_subtensor(0[idx], y)
-            inc = inc_subtensor(x.zeros_like()[idx], y)
-            o = inc[idx]
-            f = function([x, y, idx], o, self.mode_no_assert)
+        inc = inc_subtensor(x[cidx], y)
+        o = inc[cidx]
+        f = function([x, y], o, self.mode)
 
-            res = f(dx, dy, didx)
-            utt.assert_allclose(np.vstack([dy[0], 2 * dy[1], 2 * dy[2]]), res)
+        expected = dx.copy()
+        np.add.at(expected, [0, 2, 3], dy)
+        np.testing.assert_allclose(expected[[0, 2, 3]], f(dx, dy))
+        topo = f.maker.fgraph.toposort()
+        assert not any(
+            isinstance(n.op, AdvancedIncSubtensor | AdvancedIncSubtensor1) for n in topo
+        )
+        assert check_stack_trace(f, ops_to_check=(AdvancedSubtensor1, Elemwise))
 
-    def test_assert(self):
+    @pytest.mark.parametrize(
+        "cidx_values, n_rows",
+        [
+            pytest.param([1, 3, 3], 4, id="duplicate"),
+            # Positive and negative indices that alias in a 2-row buffer
+            # (0 and -2 both refer to row 0).
+            pytest.param([0, -2], 2, id="mixed_sign"),
+        ],
+    )
+    def test_inc_non_unique_constant_idx(self, cidx_values, n_rows):
+        """Inc with constant indices that may alias must not be rewritten."""
+        x = matrix(dtype="float64")
+        y = matrix(dtype="float64")
+        cidx = pt.constant(np.array(cidx_values, dtype="int32"))
+
+        dx = np.random.random((n_rows, 5))
+        dy = np.random.random((len(cidx_values), 5))
+
+        inc = inc_subtensor(x[cidx], y)
+        o = inc[cidx]
+        f = function([x, y], o, self.mode)
+
+        expected = dx.copy()
+        np.add.at(expected, cidx_values, dy)
+        np.testing.assert_allclose(expected[cidx_values], f(dx, dy))
+        topo = f.maker.fgraph.toposort()
+        assert any(
+            isinstance(n.op, AdvancedIncSubtensor | AdvancedIncSubtensor1) for n in topo
+        )
+
+    def test_inc_symbolic_idx_not_rewritten(self):
+        """Non-constant indices cannot be checked, so inc must not be rewritten."""
+        x = matrix(dtype="float64")
+        y = matrix(dtype="float64")
+        idx = ivector()
+
+        inc = inc_subtensor(x[idx], y)
+        o = inc[idx]
+        f = function([x, y, idx], o, self.mode)
+
+        dx = np.random.random((4, 5))
+        dy = np.random.random((3, 5))
+        didx = np.array([0, 2, 3], dtype="int32")
+
+        expected = dx.copy()
+        np.add.at(expected, didx, dy)
+        np.testing.assert_allclose(expected[didx], f(dx, dy, didx))
+        topo = f.maker.fgraph.toposort()
+        assert any(
+            isinstance(n.op, AdvancedIncSubtensor | AdvancedIncSubtensor1) for n in topo
+        )
+
+    def test_shape_unsafe_excluded(self):
+        """When shape_unsafe is excluded the rewrite must not fire, so
+        out-of-bounds and shape errors are still caught at runtime."""
+        mode = self.mode.excluding("shape_unsafe")
         x = matrix("x")
         y = matrix("y")
         idx = ivector()
 
+        inc = set_subtensor(x[idx], y)
+        o = inc[idx]
+        f = function([x, y, idx], o, mode)
+
+        topo = f.maker.fgraph.toposort()
+        assert any(
+            isinstance(n.op, AdvancedIncSubtensor1 | AdvancedIncSubtensor) for n in topo
+        )
+
         dx = np.random.random((4, 5)).astype(config.floatX)
         dy = np.random.random((2, 5)).astype(config.floatX)
 
-        # set_subtensor
-        inc = set_subtensor(x[idx], y)
-        o = inc[idx]
-        f = function([x, y, idx], o, self.mode)
-        # test wrong index
-        for i in [dx.shape[0], -dx.shape[0] - 1]:
-            with pytest.raises((AssertionError, IndexError)):
-                f(dx, dy, [i, i])
-        # test wrong shape
-        with pytest.raises((AssertionError, IndexError)):
+        # Out-of-bounds index
+        with pytest.raises((IndexError, ValueError)):
+            f(dx, dy, [dx.shape[0]])
+        with pytest.raises((IndexError, ValueError)):
+            f(dx, dy, [-dx.shape[0] - 1])
+        # Shape mismatch between y and idx
+        with pytest.raises((IndexError, ValueError)):
             f(dx, dy, [1])
 
-    def test_stack_trace(self):
-        x = matrix("x")
-        # test cases with y.dtype
-        # - equal to x.dtype
-        # - different from x.dtype (to trigger the cast in
-        #   local_adv_sub1_adv_inc_sub1)
-        ys = [matrix("y"), dmatrix("y")]
-        idx = ivector()
+    def test_set_multi_axis_symbolic(self):
+        """Multi-axis ``x[idx_a, idx_b].set(v)[idx_a, idx_b]`` with symbolic
+        indices collapses to ``v``."""
+        x = matrix("x", dtype="float64")
+        v = vector("v", dtype="float64")
+        idx_a = ivector("idx_a")
+        idx_b = ivector("idx_b")
 
-        # set_subtensor and then subtensor with both ys
-        incs = [set_subtensor(x[idx], y) for y in ys]
-        outs = [inc[idx] for inc in incs]
+        out = set_subtensor(x[idx_a, idx_b], v)[idx_a, idx_b]
+        rewritten = rewrite_graph(out, include=("canonicalize", "specialize"))
+        utt.assert_equal_computations([rewritten], [v])
 
-        for y, out in zip(ys, outs, strict=True):
-            f = function([x, y, idx], out, self.mode)
-            assert check_stack_trace(f, ops_to_check=(Assert, ps.Cast))
+    def test_inc_basic_slice(self):
+        """Basic ``x[slice].inc(v)[slice]`` collapses to ``x[slice] + v``."""
+        x = matrix("x", dtype="float64")
+        v = matrix("v", dtype="float64")
+        stop = iscalar("stop")
+
+        out = inc_subtensor(x[:stop], v)[:stop]
+        rewritten = rewrite_graph(out, include=("canonicalize", "specialize"))
+        utt.assert_equal_computations([rewritten], [x[:stop] + v])
 
 
 class TestSubtensorAllocRewrites:

--- a/tests/tensor/rewriting/test_subtensor.py
+++ b/tests/tensor/rewriting/test_subtensor.py
@@ -13,7 +13,7 @@ from pytensor.compile.ops import DeepCopyOp
 from pytensor.configdefaults import config
 from pytensor.graph import rewrite_graph, vectorize_graph
 from pytensor.graph.basic import Constant, Variable, equal_computations
-from pytensor.graph.rewriting.basic import check_stack_trace
+from pytensor.graph.rewriting.basic import check_stack_trace, in2out
 from pytensor.graph.traversal import ancestors
 from pytensor.tensor import as_tensor
 from pytensor.tensor.basic import Alloc, _convert_to_int8
@@ -21,6 +21,7 @@ from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.math import Dot, dot, exp, sqr
 from pytensor.tensor.rewriting.subtensor import (
+    local_add_of_sparse_write,
     local_replace_AdvancedSubtensor,
 )
 from pytensor.tensor.shape import (
@@ -224,6 +225,59 @@ def test_local_useless_inc_subtensor_no_opt():
 
     out = f_shape([[10, 20], [30, 40]])
     assert np.array_equal(out, np.asarray([[11, 21], [31, 41]]))
+
+
+def test_local_add_of_sparse_write():
+    """``x + set(zeros, v, idx) -> inc(x, v, idx)``: avoid materialising
+    the dense sparse representation when adding a sparse set into a base.
+
+    Also covers ``x + inc(zeros, v, idx)`` when ``idx`` is duplicate-free,
+    since then inc-into-zeros is equivalent to set-into-zeros.
+    """
+    sparse_rewriter = in2out(local_add_of_sparse_write, name="add_of_sparse_write")
+
+    x = vector("x")
+    v = vector("v")
+    idx = ivector("idx")
+
+    # set-into-zeros is always rewritten.
+    out = x + pt.zeros(x.shape)[idx].set(v)
+    expected = x[idx].inc(v)
+    rewritten = rewrite_graph(out)
+    utt.assert_equal_computations([rewritten], [expected], strict_dtype=False)
+
+    f = function([x, v, idx], out)
+    f_ref = function([x, v, idx], out, mode=Mode(linker="py", optimizer=None))
+    dx = np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=config.floatX)
+    dv = np.array([10.0, 20.0], dtype=config.floatX)
+    didx = np.array([1, 3], dtype="int32")
+    np.testing.assert_allclose(f(dx, dv, didx), f_ref(dx, dv, didx))
+
+    # inc-into-zeros with unique constant indices is rewritten.
+    out_inc = x + pt.zeros(x.shape)[np.array([1, 3])].inc(v)
+    rewritten_inc = rewrite_graph(out_inc)
+    utt.assert_equal_computations(
+        [rewritten_inc], [x[np.array([1, 3])].inc(v)], strict_dtype=False
+    )
+
+    # inc-into-zeros with a non-constant (potentially duplicated) index is
+    # left alone.  Run the rewrite in isolation so other simplifications
+    # don't obscure what happens.
+    out_unsafe = x + pt.zeros(x.shape)[idx].inc(v)
+    rewritten_unsafe = rewrite_graph(
+        out_unsafe, include=[], custom_rewrite=sparse_rewriter
+    )
+    utt.assert_equal_computations([rewritten_unsafe], [out_unsafe])
+
+    # Basic (scalar) inc-into-zeros is trivially unique and should be rewritten.
+    s = iscalar("s")
+    out_basic = x + pt.zeros(x.shape)[s].inc(v[0])
+    rewritten_basic = rewrite_graph(
+        out_basic, include=[], custom_rewrite=sparse_rewriter
+    )
+    utt.assert_equal_computations(
+        [rewritten_basic], [x[s].inc(v[0])], strict_dtype=False
+    )
 
 
 class TestLocalUselessSubtensor:


### PR DESCRIPTION
Handling simplifications that show up in "sparse"-like graphs (lower triangular with exponentiated diagonals). The gradient / logp can end up with reading entries from a latent vector that was written/updated into a matrix. The rewrites in this PR not materializing the intermediate matrix, by mapping the reads/updates directly into the original latent vector.

* Generalizes symbolic x[idx].set/inc(y)[idx] -> y (or x[idx] + y) to AdvancedIncSubtensor, not just basic and AdvancedSubtensor1 like before
* Constant read of constant write like x[const_idx1].set/inc(y)[const_idx2], get's converted into a read of y (when no entry of uwritten x was kept), or a read of x (when no entry of written y was kept) or a mix read of x with some entries still updated by y. Overlap / translation of indices needed, so only applicable to constant indices.
* Apply the last rewrite to x[idx].set/inc(y).diagonal() (i.e., ExtractDiagonal), by converting to advanced indexing and calling the rewrite
* Flatten successive writes into the same indices x[idx].set/inc(y)[idx].set/inc(z) -> x[idx].set(y) or (x[idx].inc(y + z))
* x + zeros()[idx].set(y) -> x[idx].inc(y). Don't materialize the zeros + wasteful addition, update directly into x.
 


