### PR TITLE
Remove complex objectmode in linalg Ops

### DIFF
--- a/pytensor/link/numba/dispatch/linalg/decomposition/dispatch.py
+++ b/pytensor/link/numba/dispatch/linalg/decomposition/dispatch.py
@@ -274,8 +274,6 @@ def numba_funcify_LU(op, node, **kwargs):
 @register_funcify_default_op_cache_key(LUFactor)
 def numba_funcify_LUFactor(op, node, **kwargs):
     inp_dtype = node.inputs[0].type.numpy_dtype
-    if inp_dtype.kind == "c":
-        return generate_fallback_impl(op, node=node, **kwargs)
     discrete_inp = inp_dtype.kind in "ibu"
     if discrete_inp and config.compiler_verbose:
         print("LUFactor requires casting discrete input to float")  # noqa: T201
@@ -298,7 +296,7 @@ def numba_funcify_LUFactor(op, node, **kwargs):
 
         return LU, piv
 
-    cache_version = 2
+    cache_version = 3
     return lu_factor, cache_version
 
 

--- a/pytensor/link/numba/dispatch/linalg/decomposition/dispatch.py
+++ b/pytensor/link/numba/dispatch/linalg/decomposition/dispatch.py
@@ -215,8 +215,6 @@ def pivot_to_permutation(op, node, **kwargs):
 @register_funcify_default_op_cache_key(LU)
 def numba_funcify_LU(op, node, **kwargs):
     inp_dtype = node.inputs[0].type.numpy_dtype
-    if inp_dtype.kind == "c":
-        return generate_fallback_impl(op, node=node, **kwargs)
     discrete_inp = inp_dtype.kind in "ibu"
     if discrete_inp and config.compiler_verbose:
         print("LU requires casting discrete input to float")  # noqa: T201
@@ -225,6 +223,10 @@ def numba_funcify_LU(op, node, **kwargs):
     permute_l = op.permute_l
     p_indices = op.p_indices
     overwrite_a = op.overwrite_a
+    # For the (P, L, U) case, P is real even when input is complex
+    p_dtype = (
+        node.outputs[0].type.numpy_dtype if not (permute_l or p_indices) else inp_dtype
+    )
 
     @numba_basic.numba_njit
     def lu(a):
@@ -237,7 +239,7 @@ def numba_funcify_LU(op, node, **kwargs):
                 P = np.zeros(a.shape[0], dtype="int32")
                 return P, L, U
             else:
-                P = np.zeros(a.shape, dtype=a.dtype)
+                P = np.zeros(a.shape, dtype=p_dtype)
                 return P, L, U
 
         if discrete_inp:
@@ -267,7 +269,7 @@ def numba_funcify_LU(op, node, **kwargs):
 
         return res
 
-    cache_version = 2
+    cache_version = 3
     return lu, cache_version
 
 

--- a/pytensor/link/numba/dispatch/linalg/decomposition/lu.py
+++ b/pytensor/link/numba/dispatch/linalg/decomposition/lu.py
@@ -3,13 +3,14 @@ from typing import Literal
 
 import numpy as np
 from numba.core.extending import overload
-from numba.core.types import Float
+from numba.core.types import Complex, Float
 from numba.np.linalg import ensure_lapack
 from scipy import linalg
 
 from pytensor.link.numba.dispatch import basic as numba_basic
 from pytensor.link.numba.dispatch.linalg.decomposition.lu_factor import _getrf
 from pytensor.link.numba.dispatch.linalg.utils import _check_linalg_matrix
+from pytensor.tensor.linalg.dtype_utils import linalg_real_output_dtype
 
 
 @numba_basic.numba_njit
@@ -113,7 +114,7 @@ def lu_impl_1(
     False. Returns a tuple of (perm, L, U), where perm an integer array of row swaps, such that L[perm] @ U = A.
     """
     ensure_lapack()
-    _check_linalg_matrix(a, ndim=2, dtype=Float, func_name="lu")
+    _check_linalg_matrix(a, ndim=2, dtype=(Float, Complex), func_name="lu")
     dtype = a.dtype
 
     def impl(
@@ -141,7 +142,7 @@ def lu_impl_2(
     """
 
     ensure_lapack()
-    _check_linalg_matrix(a, ndim=2, dtype=Float, func_name="lu")
+    _check_linalg_matrix(a, ndim=2, dtype=(Float, Complex), func_name="lu")
     dtype = a.dtype
 
     def impl(
@@ -172,8 +173,10 @@ def lu_impl_3(
     False. Returns a tuple of (P, L, U), such that P @ L @ U = A.
     """
     ensure_lapack()
-    _check_linalg_matrix(a, ndim=2, dtype=Float, func_name="lu")
+    _check_linalg_matrix(a, ndim=2, dtype=(Float, Complex), func_name="lu")
     dtype = a.dtype
+    # scipy.linalg.lu returns P as a real permutation matrix even for complex input
+    p_dtype = np.dtype(linalg_real_output_dtype(str(dtype)))
 
     def impl(
         a: np.ndarray,
@@ -182,7 +185,7 @@ def lu_impl_3(
         overwrite_a: bool,
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         perm, L, U = _lu_factor_to_lu(a, dtype, overwrite_a)
-        P = np.eye(a.shape[-1], dtype=dtype)[perm]
+        P = np.eye(a.shape[-1], dtype=p_dtype)[perm]
 
         return P, L, U
 

--- a/pytensor/link/numba/dispatch/linalg/solvers/tridiagonal.py
+++ b/pytensor/link/numba/dispatch/linalg/solvers/tridiagonal.py
@@ -270,9 +270,6 @@ def _tridiagonal_solve_impl(
 
 @register_funcify_default_op_cache_key(LUFactorTridiagonal)
 def numba_funcify_LUFactorTridiagonal(op: LUFactorTridiagonal, node, **kwargs):
-    if any(i.type.numpy_dtype.kind == "c" for i in node.inputs):
-        return generate_fallback_impl(op, node=node)
-
     overwrite_dl = op.overwrite_dl
     overwrite_d = op.overwrite_d
     overwrite_du = op.overwrite_du
@@ -311,7 +308,7 @@ def numba_funcify_LUFactorTridiagonal(op: LUFactorTridiagonal, node, **kwargs):
         )
         return dl, d, du, du2, ipiv
 
-    cache_version = 2
+    cache_version = 3
     return lu_factor_tridiagonal, cache_version
 
 

--- a/pytensor/link/numba/dispatch/linalg/solvers/tridiagonal.py
+++ b/pytensor/link/numba/dispatch/linalg/solvers/tridiagonal.py
@@ -10,7 +10,6 @@ from scipy import linalg
 from pytensor import config
 from pytensor.link.numba.dispatch import basic as numba_basic
 from pytensor.link.numba.dispatch.basic import (
-    generate_fallback_impl,
     register_funcify_default_op_cache_key,
 )
 from pytensor.link.numba.dispatch.linalg._LAPACK import (
@@ -316,8 +315,6 @@ def numba_funcify_LUFactorTridiagonal(op: LUFactorTridiagonal, node, **kwargs):
 def numba_funcify_SolveLUFactorTridiagonal(
     op: SolveLUFactorTridiagonal, node, **kwargs
 ):
-    if any(i.type.numpy_dtype.kind == "c" for i in node.inputs):
-        return generate_fallback_impl(op, node=node)
     out_dtype = node.outputs[0].type.numpy_dtype
 
     b_ndim = op.b_ndim
@@ -367,5 +364,5 @@ def numba_funcify_SolveLUFactorTridiagonal(
 
         return x
 
-    cache_version = 2
+    cache_version = 3
     return solve_lu_factor_tridiagonal, cache_version

--- a/tests/link/numba/linalg/solvers/test_tridiagonal.py
+++ b/tests/link/numba/linalg/solvers/test_tridiagonal.py
@@ -12,17 +12,24 @@ from pytensor.tensor.linalg.solvers.tridiagonal import (
 from tests.link.numba.test_basic import compare_numba_and_py, numba_inplace_mode
 
 
+@pytest.mark.parametrize("complex", [False, True], ids=lambda x: f"complex={x}")
 @pytest.mark.parametrize("inplace", [False, True], ids=lambda x: f"inplace={x}")
-def test_tridiagonal_lu_factor(inplace):
-    dl = pt.vector("dl", shape=(4,))
-    d = pt.vector("d", shape=(5,))
-    du = pt.vector("du", shape=(4,))
+def test_tridiagonal_lu_factor(inplace, complex):
+    dtype = "complex128" if complex else "float64"
+    dl = pt.vector("dl", shape=(4,), dtype=dtype)
+    d = pt.vector("d", shape=(5,), dtype=dtype)
+    du = pt.vector("du", shape=(4,), dtype=dtype)
     lu_factor_outs = Blockwise(LUFactorTridiagonal())(dl, d, du)
 
     rng = np.random.default_rng(734)
-    dl_test = rng.random(dl.type.shape)
-    d_test = rng.random(d.type.shape)
-    du_test = rng.random(du.type.shape)
+    if complex:
+        dl_test = rng.random((*dl.type.shape, 2)).view(dtype).squeeze(-1)
+        d_test = rng.random((*d.type.shape, 2)).view(dtype).squeeze(-1)
+        du_test = rng.random((*du.type.shape, 2)).view(dtype).squeeze(-1)
+    else:
+        dl_test = rng.random(dl.type.shape)
+        d_test = rng.random(d.type.shape)
+        du_test = rng.random(du.type.shape)
 
     f, results = compare_numba_and_py(
         [

--- a/tests/link/numba/linalg/solvers/test_tridiagonal.py
+++ b/tests/link/numba/linalg/solvers/test_tridiagonal.py
@@ -68,30 +68,38 @@ def test_tridiagonal_lu_factor(inplace, complex):
     assert (du_test_not_contig == du_test).all()
 
 
+@pytest.mark.parametrize("complex", [False, True], ids=lambda x: f"complex={x}")
 @pytest.mark.parametrize("transposed", [False, True], ids=lambda x: f"transposed={x}")
 @pytest.mark.parametrize("inplace", [True, False], ids=lambda x: f"inplace={x}")
 @pytest.mark.parametrize("b_ndim", [1, 2], ids=lambda x: f"b_ndim={x}")
-def test_tridiagonal_lu_solve(b_ndim, transposed, inplace):
-    scipy_gttrf = scipy.linalg.get_lapack_funcs("gttrf")
+def test_tridiagonal_lu_solve(b_ndim, transposed, inplace, complex):
+    dtype = "complex128" if complex else "float64"
+    scipy_gttrf = scipy.linalg.get_lapack_funcs("gttrf", dtype=np.dtype(dtype))
 
-    dl = pt.tensor("dl", shape=(9,))
-    d = pt.tensor("d", shape=(10,))
-    du = pt.tensor("du", shape=(9,))
-    du2 = pt.tensor("du2", shape=(8,))
+    dl = pt.tensor("dl", shape=(9,), dtype=dtype)
+    d = pt.tensor("d", shape=(10,), dtype=dtype)
+    du = pt.tensor("du", shape=(9,), dtype=dtype)
+    du2 = pt.tensor("du2", shape=(8,), dtype=dtype)
     ipiv = pt.tensor("ipiv", shape=(10,), dtype="int32")
     diagonals = [dl, d, du, du2, ipiv]
-    b = pt.tensor("b", shape=(10, 25)[:b_ndim])
+    b = pt.tensor("b", shape=(10, 25)[:b_ndim], dtype=dtype)
 
     x = Blockwise(SolveLUFactorTridiagonal(b_ndim=b.type.ndim, transposed=transposed))(
         *diagonals, b
     )
 
     rng = np.random.default_rng(787)
-    A_test = rng.random((d.type.shape[0], d.type.shape[0]))
+    if complex:
+        A_test = (
+            rng.random((d.type.shape[0], d.type.shape[0], 2)).view(dtype).squeeze(-1)
+        )
+        b_test = rng.random((*b.type.shape, 2)).view(dtype).squeeze(-1)
+    else:
+        A_test = rng.random((d.type.shape[0], d.type.shape[0]))
+        b_test = rng.random(b.type.shape)
     *diagonals_test, _ = scipy_gttrf(
         *(np.diagonal(A_test, offset=o) for o in (-1, 0, 1))
     )
-    b_test = rng.random(b.type.shape)
 
     f, res = compare_numba_and_py(
         [

--- a/tests/link/numba/linalg/test_decomposition.py
+++ b/tests/link/numba/linalg/test_decomposition.py
@@ -299,12 +299,17 @@ class TestDecompositions:
     @pytest.mark.parametrize(
         "overwrite_a", [True, False], ids=["overwrite_a", "no_overwrite"]
     )
-    def test_lu_factor(self, overwrite_a):
+    @pytest.mark.parametrize("complex", (False, True))
+    def test_lu_factor(self, overwrite_a, complex):
         shape = (5, 5)
         rng = np.random.default_rng()
 
-        A = pt.tensor("A", shape=shape, dtype=config.floatX)
-        A_val = rng.normal(size=shape).astype(config.floatX)
+        dtype = "complex128" if complex else config.floatX
+        A = pt.tensor("A", shape=shape, dtype=dtype)
+        if complex:
+            A_val = rng.normal(size=(*shape, 2)).view(dtype=A.dtype).squeeze(-1)
+        else:
+            A_val = rng.normal(size=shape).astype(dtype)
 
         LU_out, piv = lu_factor(A)
 

--- a/tests/link/numba/linalg/test_decomposition.py
+++ b/tests/link/numba/linalg/test_decomposition.py
@@ -250,11 +250,16 @@ class TestDecompositions:
     @pytest.mark.parametrize(
         "overwrite_a", [True, False], ids=["overwrite_a", "no_overwrite"]
     )
-    def test_lu(self, permute_l, p_indices, overwrite_a):
+    @pytest.mark.parametrize("complex", (False, True))
+    def test_lu(self, permute_l, p_indices, overwrite_a, complex):
         shape = (5, 5)
         rng = np.random.default_rng()
-        A = pt.tensor("A", shape=shape, dtype=config.floatX)
-        A_val = rng.normal(size=shape).astype(config.floatX)
+        dtype = "complex128" if complex else config.floatX
+        A = pt.tensor("A", shape=shape, dtype=dtype)
+        if complex:
+            A_val = rng.normal(size=(*shape, 2)).view(dtype=A.dtype).squeeze(-1)
+        else:
+            A_val = rng.normal(size=shape).astype(dtype)
 
         lu_outputs = lu(A, permute_l=permute_l, p_indices=p_indices)
 


### PR DESCRIPTION
LU, LUFactor, TridiagonalLUFactor, and TridiagonalLUSove were all dropping back to object mode on complex inputs. There's no reason for this, they all have complex dispatches.