### PR TITLE
Special case v3->v2 in workflows

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -3,11 +3,11 @@ on:
   push:
     branches:
       - main
-      - v3
+      - v2
   pull_request:
     branches:
       - main
-      - v3
+      - v2
   release:
     types: [published]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - main
-      - v3
+      - v2
   pull_request:
     branches:
       - main
-      - v3
+      - v2
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:


### PR DESCRIPTION
Keeping v2 for a while in case we need to back-port critical fixes?