### PR TITLE
Missing cxx_only tags

### DIFF
--- a/pytensor/sparse/rewriting.py
+++ b/pytensor/sparse/rewriting.py
@@ -917,7 +917,7 @@ local_usmm = PatternNodeRewriter(
     ),
     (spm.usmm, (neg, "alpha"), "x", "y", "z"),
 )
-register_specialize(local_usmm, name="local_usmm")
+register_specialize(local_usmm, "cxx_only", name="local_usmm")
 
 
 # register a specialization to replace usmm_csc_dense -> usmm_csc_dense_inplace

--- a/pytensor/tensor/rewriting/blas_c.py
+++ b/pytensor/tensor/rewriting/blas_c.py
@@ -56,7 +56,12 @@ def make_c_gemv_destructive(fgraph, node):
 
 
 blas_optdb.register(
-    "use_c_blas", dfs_rewriter(use_c_ger, use_c_gemv), "fast_run", "c_blas", position=20
+    "use_c_blas",
+    dfs_rewriter(use_c_ger, use_c_gemv),
+    "fast_run",
+    "c_blas",
+    "cxx_only",
+    position=20,
 )
 
 # this matches the InplaceBlasOpt defined in blas.py

--- a/tests/sparse/test_math.py
+++ b/tests/sparse/test_math.py
@@ -821,9 +821,10 @@ class TestUsmm:
         up = upcast(dtype1, dtype2, dtype3, dtype4)
 
         fast_compile = pytensor.config.mode == "FAST_COMPILE"
+        cxx_only_excluded = "cxx_only" in f_a.maker.linker.incompatible_rewrites
 
-        if not pytensor.config.blas__ldflags:
-            # Usmm should not be inserted, because it relies on BLAS
+        if not pytensor.config.blas__ldflags or cxx_only_excluded:
+            # Usmm should not be inserted, because it relies on BLAS / cxx
             assert len(topo) == 4, topo
             assert isinstance(topo[0].op, psm.Dot)
             assert isinstance(topo[1].op, DimShuffle)
@@ -837,7 +838,6 @@ class TestUsmm:
             y.type.dtype == up
             and format1 == "csc"
             and format2 == "dense"
-            and "cxx_only" not in f_a.maker.linker.incompatible_rewrites
             and up in ("float32", "float64")
         ):
             # The op UsmmCscDense should be inserted


### PR DESCRIPTION
Can trigger some blas/c compiler warnings because these rewrites/ops call into those lazy config flags.

Related to #1995