### PR TITLE
Improve Feature hook API and pickle round-trip 

### DIFF
--- a/pytensor/compile/aliasing.py
+++ b/pytensor/compile/aliasing.py
@@ -97,7 +97,7 @@ class Supervisor(Feature):
         fgraph._supervisor = self
         self.fgraph = fgraph
 
-    def validate(self, fgraph):
+    def on_validate(self, fgraph):
         if config.cycle_detection == "fast" and hasattr(fgraph, "has_destroyers"):
             if fgraph.has_destroyers(self.protected):
                 raise InconsistencyError("Trying to destroy protected variables.")

--- a/pytensor/compile/debug/debugmode.py
+++ b/pytensor/compile/debug/debugmode.py
@@ -26,7 +26,7 @@ from pytensor.compile.ops import ViewOp
 from pytensor.configdefaults import config
 from pytensor.graph.basic import Variable
 from pytensor.graph.destroyhandler import DestroyHandler
-from pytensor.graph.features import AlreadyThere, BadOptimization
+from pytensor.graph.features import AlreadyThere, BadOptimization, Feature
 from pytensor.graph.fg import Output
 from pytensor.graph.op import HasInnerGraph, Op
 from pytensor.graph.traversal import io_toposort
@@ -1146,7 +1146,7 @@ class _FunctionGraphEvent:
         return not (self == other)
 
 
-class _VariableEquivalenceTracker:
+class _VariableEquivalenceTracker(Feature):
     """
     A FunctionGraph Feature that keeps tabs on an FunctionGraph and
     tries to detect problems.

--- a/pytensor/graph/destroyhandler.py
+++ b/pytensor/graph/destroyhandler.py
@@ -180,7 +180,7 @@ def _build_droot_impact(destroy_handler):
     impact = {}  # destroyed nonview variable -> it + all views of it
     root_destroyer = {}  # root -> destroyer apply
 
-    for app in destroy_handler.destroyers:
+    for app in destroy_handler._destroying_apps:
         for input_idx_list in app.op.destroy_map.values():
             if len(input_idx_list) != 1:
                 raise NotImplementedError()
@@ -321,7 +321,7 @@ class DestroyHandler(Bookkeeper):
 
     """
 
-    pickle_rm_attr = ["destroyers", "has_destroyers"]
+    provides = ("destroyers", "has_destroyers")
 
     def __init__(self, do_imports_on_attach=True, algo=None):
         self.fgraph = None
@@ -378,7 +378,9 @@ class DestroyHandler(Bookkeeper):
 
         """
 
-        if any(hasattr(fgraph, attr) for attr in ("destroyers", "destroy_handler")):
+        if "destroyers" in fgraph._feature_methods or hasattr(
+            fgraph, "destroy_handler"
+        ):
             raise AlreadyThere("DestroyHandler feature is already present")
 
         if self.fgraph is not None and self.fgraph != fgraph:
@@ -386,66 +388,50 @@ class DestroyHandler(Bookkeeper):
                 "A DestroyHandler instance can only serve one FunctionGraph"
             )
 
-        # Annotate the FunctionGraph #
-        self.unpickle(fgraph)
         fgraph.destroy_handler = self
-
         self.fgraph = fgraph
-        self.destroyers = (
-            OrderedSet()
-        )  # set of Apply instances with non-null destroy_map
-        self.view_i = {}  # variable -> variable used in calculation
-        self.view_o = {}  # variable -> set of variables that use this one as a direct input
-        # clients: how many times does an apply use a given variable
-        self.clients = {}  # variable -> apply -> ninputs
+        self._destroying_apps = OrderedSet()
+        self.view_i = {}
+        self.view_o = {}
+        self.clients = {}
         self.stale_droot = True
-
         self.debug_all_apps = set()
         if self.do_imports_on_attach:
             Bookkeeper.on_attach(self, fgraph)
 
-    def unpickle(self, fgraph):
-        def get_destroyers_of(r):
+    def destroyers(self, fgraph, r):
+        droot, _, root_destroyer = self.refresh_droot_impact()
+        try:
+            return [root_destroyer[droot[r]]]
+        except Exception:
+            return []
+
+    def has_destroyers(self, fgraph, protected_list):
+        if self.algo != "fast":
             droot, _, root_destroyer = self.refresh_droot_impact()
-            try:
-                return [root_destroyer[droot[r]]]
-            except Exception:
-                return []
-
-        fgraph.destroyers = get_destroyers_of
-
-        def has_destroyers(protected_list):
-            if self.algo != "fast":
-                droot, _, root_destroyer = self.refresh_droot_impact()
-                for protected_var in protected_list:
-                    try:
-                        root_destroyer[droot[protected_var]]
-                        return True
-                    except KeyError:
-                        pass
-                return False
-
-            def recursive_destroys_finder(protected_var):
-                # protected_var is the idx'th input of app.
-                for app, idx in fgraph.clients[protected_var]:
-                    destroy_maps = app.op.destroy_map.values()
-                    # If True means that the apply node, destroys the protected_var.
-                    if idx in [dmap for sublist in destroy_maps for dmap in sublist]:
-                        return True
-                    for var_idx in app.op.view_map:
-                        if idx in app.op.view_map[var_idx]:
-                            # We need to recursively check the destroy_map of all the
-                            # outputs that we have a view_map on.
-                            if recursive_destroys_finder(app.outputs[var_idx]):
-                                return True
-                return False
-
             for protected_var in protected_list:
-                if recursive_destroys_finder(protected_var):
+                try:
+                    root_destroyer[droot[protected_var]]
                     return True
+                except KeyError:
+                    pass
             return False
 
-        fgraph.has_destroyers = has_destroyers
+        def recursive_destroys_finder(protected_var):
+            for app, idx in fgraph.clients[protected_var]:
+                destroy_maps = app.op.destroy_map.values()
+                if idx in [dmap for sublist in destroy_maps for dmap in sublist]:
+                    return True
+                for var_idx in app.op.view_map:
+                    if idx in app.op.view_map[var_idx]:
+                        if recursive_destroys_finder(app.outputs[var_idx]):
+                            return True
+            return False
+
+        for protected_var in protected_list:
+            if recursive_destroys_finder(protected_var):
+                return True
+        return False
 
     def refresh_droot_impact(self):
         """
@@ -461,14 +447,12 @@ class DestroyHandler(Bookkeeper):
     def on_detach(self, fgraph):
         if fgraph is not self.fgraph:
             raise Exception("detaching wrong fgraph", fgraph)
-        del self.destroyers
+        del self._destroying_apps
         del self.view_i
         del self.view_o
         del self.clients
         del self.stale_droot
-        assert self.fgraph.destroyer_handler is self
-        delattr(self.fgraph, "destroyers")
-        delattr(self.fgraph, "has_destroyers")
+        assert self.fgraph.destroy_handler is self
         delattr(self.fgraph, "destroy_handler")
         self.fgraph = None
 
@@ -535,7 +519,7 @@ class DestroyHandler(Bookkeeper):
         dmap = app.op.destroy_map
         vmap = app.op.view_map
         if dmap:
-            self.destroyers.add(app)
+            self._destroying_apps.add(app)
             if self.algo == "fast":
                 self.fast_destroy(fgraph, app, reason)
 
@@ -574,7 +558,7 @@ class DestroyHandler(Bookkeeper):
             del self.clients[input][app]
 
         if app.op.destroy_map:
-            self.destroyers.remove(app)
+            self._destroying_apps.remove(app)
 
         # Note: leaving empty client dictionaries in the struct.
         # Why? It's a pain to remove them. I think they aren't doing any harm, they will be
@@ -653,7 +637,7 @@ class DestroyHandler(Bookkeeper):
         b) orderings cannot be topologically sorted.
 
         """
-        if self.destroyers:
+        if self._destroying_apps:
             if self.algo == "fast":
                 if self.fail_validate:
                     app_err_pairs = self.fail_validate
@@ -702,7 +686,7 @@ class DestroyHandler(Bookkeeper):
         set_type = OrderedSet if ordered else set
         rval = {}
 
-        if self.destroyers:
+        if self._destroying_apps:
             # BUILD DATA STRUCTURES
             # CHECK for multiple destructions during construction of variables
 
@@ -720,7 +704,7 @@ class DestroyHandler(Bookkeeper):
                 )
 
             # add destroyed variable clients as computational dependencies
-            for app in self.destroyers:
+            for app in self._destroying_apps:
                 # keep track of clients that should run before the current Apply
                 root_clients = set_type()
                 # for each destroyed input...

--- a/pytensor/graph/destroyhandler.py
+++ b/pytensor/graph/destroyhandler.py
@@ -321,7 +321,7 @@ class DestroyHandler(Bookkeeper):
 
     """
 
-    provides = ("destroyers", "has_destroyers")
+    provides: tuple[str, ...] = ("destroyers", "has_destroyers")
 
     def __init__(self, do_imports_on_attach=True, algo=None):
         self.fgraph = None

--- a/pytensor/graph/destroyhandler.py
+++ b/pytensor/graph/destroyhandler.py
@@ -644,7 +644,7 @@ class DestroyHandler(Bookkeeper):
                 self.fast_destroy(fgraph, app, reason)
         self.stale_droot = True
 
-    def validate(self, fgraph):
+    def on_validate(self, fgraph):
         """
         Return None.
 

--- a/pytensor/graph/features.py
+++ b/pytensor/graph/features.py
@@ -2,8 +2,9 @@ import inspect
 import sys
 import time
 import warnings
+from dataclasses import dataclass
 from io import StringIO
-from typing import Any, NamedTuple
+from typing import Any
 
 import numpy as np
 
@@ -14,11 +15,17 @@ from pytensor.graph.traversal import toposort
 from pytensor.graph.utils import InconsistencyError
 
 
-class HistoryEntry(NamedTuple):
+@dataclass(slots=True)
+class HistoryEntry:
     """A recorded edit to a `FunctionGraph` input.
 
     Used by `History` and `FullHistory` to remember a ``change_node_input``
     that can later be replayed (forward) or undone (backward).
+
+    Not ``frozen=True`` despite being a logical record: the frozen-dataclass
+    ``__init__`` routes through ``object.__setattr__`` to bypass the immutability
+    check, which is ~4x slower to construct. We allocate one of these per
+    ``change_node_input``, so we rely on convention for "don't mutate".
     """
 
     node: Any
@@ -620,22 +627,30 @@ class FullHistory(Feature):
 
         # Go backwards
         while pointer > checkpoint - 1:
-            node, i, r, reason = self.bw[pointer]
+            entry = self.bw[pointer]
             if verbose:
-                print(reason)  # noqa: T201
+                print(entry.reason)  # noqa: T201
             self.fg.change_node_input(
-                node, i, r, reason=("Revert", reason), check=False
+                entry.node,
+                entry.i,
+                entry.var,
+                reason=("Revert", entry.reason),
+                check=False,
             )
             pointer -= 1
 
         # Go forward
         while pointer < checkpoint - 1:
             pointer += 1
-            node, i, r, reason = self.fw[pointer]
+            entry = self.fw[pointer]
             if verbose:
-                print(reason)  # noqa: T201
+                print(entry.reason)  # noqa: T201
             self.fg.change_node_input(
-                node, i, r, reason=("Revert", reason), check=False
+                entry.node,
+                entry.i,
+                entry.var,
+                reason=("Revert", entry.reason),
+                check=False,
             )
 
         # Remove history changes caused by the foward/backward!

--- a/pytensor/graph/features.py
+++ b/pytensor/graph/features.py
@@ -26,6 +26,20 @@ class HistoryEntry(NamedTuple):
     var: Any
     reason: Any
 
+    def __reduce__(self):
+        # `reason` is typically a rewriter instance passed by
+        # `replace_all_validate(..., reason=node_rewriter)`. Decorated
+        # rewriters (`@graph_rewriter` / `@node_rewriter`) aren't picklable
+        # — the decorator rebinds the module attribute to the wrapper, so
+        # pickle can't resolve the inner function back to itself by qualname.
+        # Since `reason` is only used for display in verbose revert, drop
+        # the live object and keep a string at pickle time.
+        reason = self.reason
+        if reason is not None and not isinstance(reason, str):
+            name = getattr(reason, "__name__", None)
+            reason = name if isinstance(name, str) else str(reason)
+        return type(self), (self.node, self.i, self.var, reason)
+
 
 class AlreadyThere(Exception):
     """

--- a/pytensor/graph/features.py
+++ b/pytensor/graph/features.py
@@ -256,11 +256,18 @@ class Feature:
     by various operations on FunctionGraphs. It can be used to enforce
     graph properties at all stages of graph optimization.
 
+    A Feature may also expose callables on the FunctionGraph itself by
+    listing their names in ``provides``. A name listed there becomes callable
+    as ``fgraph.<name>(...)``, dispatched through ``FunctionGraph.__getattr__``
+    to ``feature.<name>(fgraph, ...)``.
+
     See Also
     --------
     pytensor.graph.features : for common extensions.
 
     """
+
+    provides: tuple[str, ...] = ()
 
     def on_attach(self, fgraph):
         """

--- a/pytensor/graph/features.py
+++ b/pytensor/graph/features.py
@@ -624,12 +624,12 @@ class Validator(Feature):
         # Don't call unpickle here, as ReplaceValidate.on_attach()
         # call to History.on_attach() will call the
         # ReplaceValidate.unpickle and not History.unpickle
-        fgraph.validate = partial(self.validate_, fgraph)
-        fgraph.consistent = partial(self.consistent_, fgraph)
+        fgraph.validate = partial(self.validate, fgraph)
+        fgraph.consistent = partial(self.consistent, fgraph)
 
     def unpickle(self, fgraph):
-        fgraph.validate = partial(self.validate_, fgraph)
-        fgraph.consistent = partial(self.consistent_, fgraph)
+        fgraph.validate = partial(self.validate, fgraph)
+        fgraph.consistent = partial(self.consistent, fgraph)
 
     def on_detach(self, fgraph):
         """
@@ -639,7 +639,7 @@ class Validator(Feature):
         del fgraph.validate
         del fgraph.consistent
 
-    def validate_(self, fgraph):
+    def validate(self, fgraph):
         """
         If the caller is replace_all_validate, just raise the
         exception. replace_all_validate will print out the
@@ -647,7 +647,7 @@ class Validator(Feature):
         """
         t0 = time.perf_counter()
         try:
-            ret = fgraph.execute_callbacks("validate")
+            ret = fgraph.execute_callbacks("on_validate")
         except Exception as e:
             cf = inspect.currentframe()
             uf = cf.f_back
@@ -671,7 +671,7 @@ class Validator(Feature):
             fgraph.profile.validate_time += t1 - t0
         return ret
 
-    def consistent_(self, fgraph):
+    def consistent(self, fgraph):
         try:
             fgraph.validate()
             return True
@@ -828,7 +828,7 @@ class ReplaceValidate(History, Validator):
         if node in self._nodes_removed:
             self.fail_validate = True
 
-    def validate(self, fgraph):
+    def on_validate(self, fgraph):
         if self.fail_validate:
             self.fail_validate = False
             raise InconsistencyError("Trying to reintroduce a removed node")
@@ -865,7 +865,7 @@ class NoOutputFromInplace(Feature):
     def clone(self):
         return type(self)(self.protected_out_ids)
 
-    def validate(self, fgraph):
+    def on_validate(self, fgraph):
         if not hasattr(fgraph, "destroyers"):
             return True
 

--- a/pytensor/graph/features.py
+++ b/pytensor/graph/features.py
@@ -465,6 +465,7 @@ class History(Feature):
         """
         h = self.history[fgraph]
         self.history[fgraph] = None
+        # Reject stale tokens: only the most recent checkpoint can be reverted to.
         assert self._checkpoint_counters[fgraph] == checkpoint
         while h:
             entry = h.pop()

--- a/pytensor/graph/features.py
+++ b/pytensor/graph/features.py
@@ -425,7 +425,7 @@ class History(Feature):
 
     """
 
-    provides = ("checkpoint", "revert")
+    provides: tuple[str, ...] = ("checkpoint", "revert")
 
     def __init__(self):
         self.history: dict = {}
@@ -638,7 +638,7 @@ class FullHistory(Feature):
 
 
 class Validator(Feature):
-    provides = ("validate", "consistent")
+    provides: tuple[str, ...] = ("validate", "consistent")
 
     def on_attach(self, fgraph):
         if "validate" in fgraph._feature_methods:
@@ -688,7 +688,7 @@ class Validator(Feature):
 
 
 class ReplaceValidate(History, Validator):
-    provides = (
+    provides: tuple[str, ...] = (
         *History.provides,
         *Validator.provides,
         "replace_validate",

--- a/pytensor/graph/features.py
+++ b/pytensor/graph/features.py
@@ -247,18 +247,38 @@ class BadOptimization(Exception):
         return sio.getvalue()
 
 
+def register_feature_callback(method):
+    """Mark a Feature method as dispatched by ``execute_callbacks``.
+
+    The decorated method's name is collected into the owning class's
+    ``_feature_callbacks`` set at class-definition time. Subclasses inherit
+    the registration via the MRO walk in ``Feature.__init_subclass__`` —
+    they can override the method without re-decorating; the override will
+    still be invoked by ``execute_callbacks``.
+    """
+    method._is_feature_callback = True
+    return method
+
+
 class Feature:
     """
     Base class for FunctionGraph extensions.
 
-    A Feature is an object with several callbacks that are triggered
-    by various operations on FunctionGraphs. It can be used to enforce
-    graph properties at all stages of graph optimization.
+    A Feature has two ways to integrate with a ``FunctionGraph``:
 
-    A Feature may also expose callables on the FunctionGraph itself by
-    listing their names in ``provides``. A name listed there becomes callable
-    as ``fgraph.<name>(...)``, dispatched through ``FunctionGraph.__getattr__``
-    to ``feature.<name>(fgraph, ...)``.
+    1. **Callbacks.** Methods decorated with ``@register_feature_callback``
+       are invoked by ``FunctionGraph.execute_callbacks`` (or
+       ``collect_callbacks``) at well-defined points in the graph's lifecycle
+       — attach/detach, import/prune, input change, validation, and toposort
+       ordering queries. The registered name is what ``execute_callbacks``
+       dispatches by.
+
+    2. **Provided methods.** Names listed in ``provides`` become callable
+       as ``fgraph.<name>(...)``, dispatched through
+       ``FunctionGraph.__getattr__`` to ``feature.<name>(fgraph, ...)``.
+
+    A name cannot appear in both ``provides`` and the callback registry —
+    ``__init_subclass__`` enforces this at import time.
 
     See Also
     --------
@@ -267,7 +287,24 @@ class Feature:
     """
 
     provides: tuple[str, ...] = ()
+    _feature_callbacks: frozenset[str] = frozenset()
 
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        callbacks: set[str] = set()
+        for base in cls.__mro__:
+            for name, val in vars(base).items():
+                if getattr(val, "_is_feature_callback", False):
+                    callbacks.add(name)
+        cls._feature_callbacks = frozenset(callbacks)
+        clash = set(cls.provides) & callbacks
+        if clash:
+            raise TypeError(
+                f"{cls.__name__}: names {sorted(clash)} appear in both "
+                "`provides` and as callbacks; pick one role per name"
+            )
+
+    @register_feature_callback
     def on_attach(self, fgraph):
         """
         Called by `FunctionGraph.attach_feature`, the method that attaches the
@@ -280,11 +317,9 @@ class Feature:
         implementing the same functionality is already attached to the
         `FunctionGraph`.
 
-        The feature has great freedom in what it can do with the `fgraph`: it
-        may, for example, add methods to it dynamically.
-
         """
 
+    @register_feature_callback
     def on_detach(self, fgraph):
         """
         Called by `FunctionGraph.remove_feature`.  Should remove any
@@ -292,6 +327,7 @@ class Feature:
 
         """
 
+    @register_feature_callback
     def on_import(self, fgraph, node, reason):
         """
         Called whenever a node is imported into `fgraph`, which is just before
@@ -303,6 +339,7 @@ class Feature:
 
         """
 
+    @register_feature_callback
     def on_change_input(self, fgraph, node, i, var, new_var, reason=None):
         """
         Called whenever ``node.inputs[i]`` is changed from `var` to `new_var`.
@@ -313,6 +350,7 @@ class Feature:
 
         """
 
+    @register_feature_callback
     def on_prune(self, fgraph, node, reason):
         """
         Called whenever a node is pruned (removed) from the `fgraph`, after it
@@ -320,6 +358,16 @@ class Feature:
 
         """
 
+    @register_feature_callback
+    def on_validate(self, fgraph):
+        """
+        Called by ``Validator.validate`` to give each Feature a chance to
+        veto the current graph state. Implementations should raise
+        ``InconsistencyError`` if the graph is invalid.
+
+        """
+
+    @register_feature_callback
     def orderings(self, fgraph):
         """
         Called by `FunctionGraph.toposort`. It should return a dictionary of

--- a/pytensor/graph/features.py
+++ b/pytensor/graph/features.py
@@ -3,6 +3,7 @@ import sys
 import time
 import warnings
 from io import StringIO
+from typing import Any, NamedTuple
 
 import numpy as np
 
@@ -11,6 +12,19 @@ from pytensor.configdefaults import config
 from pytensor.graph.basic import Variable
 from pytensor.graph.traversal import toposort
 from pytensor.graph.utils import InconsistencyError
+
+
+class HistoryEntry(NamedTuple):
+    """A recorded edit to a `FunctionGraph` input.
+
+    Used by `History` and `FullHistory` to remember a ``change_node_input``
+    that can later be replayed (forward) or undone (backward).
+    """
+
+    node: Any
+    i: int
+    var: Any
+    reason: Any
 
 
 class AlreadyThere(Exception):
@@ -402,20 +416,6 @@ class Bookkeeper(Feature):
             self.on_prune(fgraph, node, "Bookkeeper.detach")
 
 
-class LambdaExtract:
-    def __init__(self, fgraph, node, i, r, reason=None):
-        self.fgraph = fgraph
-        self.node = node
-        self.i = i
-        self.r = r
-        self.reason = reason
-
-    def __call__(self):
-        return self.fgraph.change_node_input(
-            self.node, self.i, self.r, reason=("Revert", self.reason), check=False
-        )
-
-
 class History(Feature):
     """Keep an history of changes to an FunctionGraph.
 
@@ -447,9 +447,10 @@ class History(Feature):
         del self._checkpoint_counters[fgraph]
 
     def on_change_input(self, fgraph, node, i, r, new_r, reason=None):
-        if self.history[fgraph] is None:
+        h = self.history[fgraph]
+        if h is None:
             return
-        self.history[fgraph].append(LambdaExtract(fgraph, node, i, r, reason))
+        h.append(HistoryEntry(node, i, r, reason))
 
     def checkpoint(self, fgraph):
         self.history[fgraph] = []
@@ -466,8 +467,14 @@ class History(Feature):
         self.history[fgraph] = None
         assert self._checkpoint_counters[fgraph] == checkpoint
         while h:
-            f = h.pop()
-            f()
+            entry = h.pop()
+            fgraph.change_node_input(
+                entry.node,
+                entry.i,
+                entry.var,
+                reason=("Revert", entry.reason),
+                check=False,
+            )
         self.history[fgraph] = h
 
 
@@ -578,8 +585,8 @@ class FullHistory(Feature):
         self.fg = fgraph
 
     def on_change_input(self, fgraph, node, i, r, new_r, reason=None):
-        self.bw.append(LambdaExtract(fgraph, node, i, r, reason))
-        self.fw.append(LambdaExtract(fgraph, node, i, new_r, reason))
+        self.bw.append(HistoryEntry(node, i, r, reason))
+        self.fw.append(HistoryEntry(node, i, new_r, reason))
         self.pointer += 1
         if self.callback:
             self.callback()
@@ -598,19 +605,23 @@ class FullHistory(Feature):
 
         # Go backwards
         while pointer > checkpoint - 1:
-            reverse_fn = self.bw[pointer]
+            node, i, r, reason = self.bw[pointer]
             if verbose:
-                print(reverse_fn.reason)  # noqa: T201
-            reverse_fn()
+                print(reason)  # noqa: T201
+            self.fg.change_node_input(
+                node, i, r, reason=("Revert", reason), check=False
+            )
             pointer -= 1
 
         # Go forward
         while pointer < checkpoint - 1:
             pointer += 1
-            forward_fn = self.fw[pointer]
+            node, i, r, reason = self.fw[pointer]
             if verbose:
-                print(forward_fn.reason)  # noqa: T201
-            forward_fn()
+                print(reason)  # noqa: T201
+            self.fg.change_node_input(
+                node, i, r, reason=("Revert", reason), check=False
+            )
 
         # Remove history changes caused by the foward/backward!
         self.bw = self.bw[:history_len]

--- a/pytensor/graph/features.py
+++ b/pytensor/graph/features.py
@@ -2,7 +2,6 @@ import inspect
 import sys
 import time
 import warnings
-from functools import partial
 from io import StringIO
 
 import numpy as np
@@ -355,18 +354,6 @@ class Bookkeeper(Feature):
             self.on_prune(fgraph, node, "Bookkeeper.detach")
 
 
-class GetCheckpoint:
-    def __init__(self, history, fgraph):
-        self.h = history
-        self.fgraph = fgraph
-        self.nb = 0
-
-    def __call__(self):
-        self.h.history[self.fgraph] = []
-        self.nb += 1
-        return self.nb
-
-
 class LambdaExtract:
     def __init__(self, fgraph, node, i, r, reason=None):
         self.fgraph = fgraph
@@ -390,55 +377,46 @@ class History(Feature):
 
     """
 
-    pickle_rm_attr = ["checkpoint", "revert"]
+    provides = ("checkpoint", "revert")
 
     def __init__(self):
-        self.history = {}
+        self.history: dict = {}
+        self._checkpoint_counters: dict = {}
 
     def on_attach(self, fgraph):
-        if hasattr(fgraph, "checkpoint") or hasattr(fgraph, "revert"):
+        if "checkpoint" in fgraph._feature_methods:
             raise AlreadyThere(
                 "History feature is already present or in conflict with another plugin."
             )
         self.history[fgraph] = []
-        # Don't call unpickle here, as ReplaceValidate.on_attach()
-        # call to History.on_attach() will call the
-        # ReplaceValidate.unpickle and not History.unpickle
-        fgraph.checkpoint = GetCheckpoint(self, fgraph)
-        fgraph.revert = partial(self.revert, fgraph)
+        self._checkpoint_counters[fgraph] = 0
 
     def clone(self):
         return type(self)()
 
-    def unpickle(self, fgraph):
-        fgraph.checkpoint = GetCheckpoint(self, fgraph)
-        fgraph.revert = partial(self.revert, fgraph)
-
     def on_detach(self, fgraph):
-        """
-        Should remove any dynamically added functionality
-        that it installed into the function_graph
-        """
-        del fgraph.checkpoint
-        del fgraph.revert
         del self.history[fgraph]
+        del self._checkpoint_counters[fgraph]
 
     def on_change_input(self, fgraph, node, i, r, new_r, reason=None):
         if self.history[fgraph] is None:
             return
-        h = self.history[fgraph]
-        h.append(LambdaExtract(fgraph, node, i, r, reason))
+        self.history[fgraph].append(LambdaExtract(fgraph, node, i, r, reason))
+
+    def checkpoint(self, fgraph):
+        self.history[fgraph] = []
+        self._checkpoint_counters[fgraph] += 1
+        return self._checkpoint_counters[fgraph]
 
     def revert(self, fgraph, checkpoint):
         """
         Reverts the graph to whatever it was at the provided
-        checkpoint (undoes all replacements). A checkpoint at any
-        given time can be obtained using self.checkpoint().
+        checkpoint (undoes all replacements).
 
         """
         h = self.history[fgraph]
         self.history[fgraph] = None
-        assert fgraph.checkpoint.nb == checkpoint
+        assert self._checkpoint_counters[fgraph] == checkpoint
         while h:
             f = h.pop()
             f()
@@ -612,32 +590,14 @@ class FullHistory(Feature):
 
 
 class Validator(Feature):
-    pickle_rm_attr = ["validate", "consistent"]
+    provides = ("validate", "consistent")
 
     def on_attach(self, fgraph):
-        for attr in ("validate", "validate_time"):
-            if hasattr(fgraph, attr):
-                raise AlreadyThere(
-                    "Validator feature is already present or in"
-                    " conflict with another plugin."
-                )
-        # Don't call unpickle here, as ReplaceValidate.on_attach()
-        # call to History.on_attach() will call the
-        # ReplaceValidate.unpickle and not History.unpickle
-        fgraph.validate = partial(self.validate, fgraph)
-        fgraph.consistent = partial(self.consistent, fgraph)
-
-    def unpickle(self, fgraph):
-        fgraph.validate = partial(self.validate, fgraph)
-        fgraph.consistent = partial(self.consistent, fgraph)
-
-    def on_detach(self, fgraph):
-        """
-        Should remove any dynamically added functionality
-        that it installed into the function_graph
-        """
-        del fgraph.validate
-        del fgraph.consistent
+        if "validate" in fgraph._feature_methods:
+            raise AlreadyThere(
+                "Validator feature is already present or in"
+                " conflict with another plugin."
+            )
 
     def validate(self, fgraph):
         """
@@ -680,54 +640,36 @@ class Validator(Feature):
 
 
 class ReplaceValidate(History, Validator):
-    pickle_rm_attr = [
+    provides = (
+        *History.provides,
+        *Validator.provides,
         "replace_validate",
         "replace_all_validate",
         "replace_all_validate_remove",
-        *History.pickle_rm_attr,
-        *Validator.pickle_rm_attr,
-    ]
+    )
+
+    def __init__(self):
+        super().__init__()
+        self._nodes_removed: set = set()
+        self.fail_validate: bool = False
 
     def on_attach(self, fgraph):
-        for attr in (
-            "replace_validate",
-            "replace_all_validate",
-            "replace_all_validate_remove",
-        ):
-            if hasattr(fgraph, attr):
-                raise AlreadyThere(
-                    "ReplaceValidate feature is already present"
-                    " or in conflict with another plugin."
-                )
+        if "replace_validate" in fgraph._feature_methods:
+            raise AlreadyThere(
+                "ReplaceValidate feature is already present"
+                " or in conflict with another plugin."
+            )
         self._nodes_removed = set()
         self.fail_validate = False
         History.on_attach(self, fgraph)
         Validator.on_attach(self, fgraph)
-        self.unpickle(fgraph)
 
     def clone(self):
         return type(self)()
 
-    def unpickle(self, fgraph):
-        History.unpickle(self, fgraph)
-        Validator.unpickle(self, fgraph)
-        fgraph.replace_validate = partial(self.replace_validate, fgraph)
-        fgraph.replace_all_validate = partial(self.replace_all_validate, fgraph)
-        fgraph.replace_all_validate_remove = partial(
-            self.replace_all_validate_remove, fgraph
-        )
-
     def on_detach(self, fgraph):
-        """
-        Should remove any dynamically added functionality
-        that it installed into the function_graph
-        """
         History.on_detach(self, fgraph)
         Validator.on_detach(self, fgraph)
-        del self._nodes_removed
-        del fgraph.replace_validate
-        del fgraph.replace_all_validate
-        del fgraph.replace_all_validate_remove
 
     def replace_validate(self, fgraph, r, new_r, reason=None, **kwargs):
         self.replace_all_validate(fgraph, [(r, new_r)], reason=reason, **kwargs)
@@ -817,12 +759,6 @@ class ReplaceValidate(History, Validator):
                         f"{reason}: {replacements}",
                     )
                 raise ReplacementDidNotRemoveError()
-
-    def __getstate__(self):
-        d = self.__dict__.copy()
-        if "history" in d:
-            del d["history"]
-        return d
 
     def on_import(self, fgraph, node, reason):
         if node in self._nodes_removed:

--- a/pytensor/graph/fg.py
+++ b/pytensor/graph/fg.py
@@ -905,12 +905,11 @@ class FunctionGraph(AbstractFunctionGraph):
         aren't picklable); the property re-creates it transparently.
         """
         d = self.__dict__
-        try:
-            return d["_execute_callbacks_times_dict"]
-        except KeyError:
-            cbt: dict[Feature, float] = defaultdict(float)
+        cbt: dict[Feature, float] | None = d.get("_execute_callbacks_times_dict")
+        if cbt is None:
+            cbt = defaultdict(float)
             d["_execute_callbacks_times_dict"] = cbt
-            return cbt
+        return cbt
 
     def __getstate__(self):
         d = self.__dict__.copy()

--- a/pytensor/graph/fg.py
+++ b/pytensor/graph/fg.py
@@ -721,37 +721,30 @@ class FunctionGraph(AbstractFunctionGraph):
     def execute_callbacks(self, name: str, *args, **kwargs) -> None:
         """Execute callbacks.
 
-        Calls ``getattr(feature, name)(*args)`` for each feature which has
-        a method called after name.
-
+        For each attached feature whose class registered ``name`` via
+        ``@register_feature_callback``, call ``feature.<name>(self, *args)``.
         """
         t0 = time.perf_counter()
         for feature in self._features:
-            try:
-                fn = getattr(feature, name)
-            except AttributeError:
-                # this is safe because there is no work done inside the
-                # try; the AttributeError really must come from feature.${name}
-                # not existing
+            if name not in type(feature)._feature_callbacks:
                 continue
             tf0 = time.perf_counter()
-            fn(self, *args, **kwargs)
+            getattr(feature, name)(self, *args, **kwargs)
             self.execute_callbacks_times[feature] += time.perf_counter() - tf0
         self.execute_callbacks_time += time.perf_counter() - t0
 
     def collect_callbacks(self, name: str, *args) -> dict[Feature, Any]:
-        """Collects callbacks
+        """Collect callback return values.
 
-        Returns a dictionary d such that ``d[feature] == getattr(feature, name)(*args)``
-        For each feature which has a method called after name.
+        Returns a dict mapping each attached feature whose class registered
+        ``name`` via ``@register_feature_callback`` to the result of
+        ``feature.<name>(*args)``.
         """
         d = {}
         for feature in self._features:
-            try:
-                fn = getattr(feature, name)
-            except AttributeError:
+            if name not in type(feature)._feature_callbacks:
                 continue
-            d[feature] = fn(*args)
+            d[feature] = getattr(feature, name)(*args)
         return d
 
     def toposort(self) -> list[Apply]:

--- a/pytensor/graph/fg.py
+++ b/pytensor/graph/fg.py
@@ -4,6 +4,7 @@ import time
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Iterable, Sequence, Set
+from functools import partial
 from typing import Any, Union, cast
 
 from pytensor.configdefaults import config
@@ -148,6 +149,7 @@ class FunctionGraph(AbstractFunctionGraph):
             features = []
 
         self._features: list[Feature] = []
+        self._feature_methods: dict[str, Feature] = {}
         # All apply nodes in the subgraph defined by inputs and
         # outputs are cached in this field
         self.apply_nodes: set[Apply] = set()
@@ -682,8 +684,9 @@ class FunctionGraph(AbstractFunctionGraph):
         #    raise TypeError("Expected Feature instance, got "+\
         #            str(type(feature)))
 
-        # Add the feature
         self._features.append(feature)
+        for name in getattr(feature, "provides", ()):
+            self._feature_methods[name] = feature
 
     def remove_feature(self, feature: Feature) -> None:
         """Remove a feature from the graph.
@@ -693,13 +696,28 @@ class FunctionGraph(AbstractFunctionGraph):
 
         """
         try:
-            # Why do we catch the exception anyway?
             self._features.remove(feature)
         except ValueError:
             return
+        for name in list(self._feature_methods):
+            if self._feature_methods[name] is feature:
+                del self._feature_methods[name]
         detach = getattr(feature, "on_detach", None)
         if detach is not None:
             detach(self)
+
+    def __getattr__(self, name: str):
+        if name.startswith("_"):
+            raise AttributeError(name)
+        try:
+            feature_methods = self.__dict__["_feature_methods"]
+        except KeyError:
+            raise AttributeError(name)
+        try:
+            feature = feature_methods[name]
+        except KeyError:
+            raise AttributeError(name)
+        return partial(getattr(feature, name), self)
 
     def execute_callbacks(self, name: str, *args, **kwargs) -> None:
         """Execute callbacks.

--- a/pytensor/graph/fg.py
+++ b/pytensor/graph/fg.py
@@ -143,7 +143,6 @@ class FunctionGraph(AbstractFunctionGraph):
             inputs = [cast(Variable, _memo[i]) for i in inputs]
 
         self.execute_callbacks_time: float = 0.0
-        self.execute_callbacks_times: dict[Feature, float] = defaultdict(float)
 
         if features is None:
             features = []
@@ -903,29 +902,27 @@ class FunctionGraph(AbstractFunctionGraph):
                 e.attach_feature(feature.clone())
         return e, equiv
 
+    @property
+    def execute_callbacks_times(self) -> dict[Feature, float]:
+        """Per-feature accumulator of callback execution time.
+
+        Lazily initialized and stored under a private key so it stays out of
+        ``__dict__`` until first read. ``__getstate__`` drops it on pickle
+        (callback-time entries may close over optimizer references that
+        aren't picklable); the property re-creates it transparently.
+        """
+        d = self.__dict__
+        try:
+            return d["_execute_callbacks_times_dict"]
+        except KeyError:
+            cbt: dict[Feature, float] = defaultdict(float)
+            d["_execute_callbacks_times_dict"] = cbt
+            return cbt
+
     def __getstate__(self):
-        # This is needed as some features introduce instance methods
-        # This is not picklable
         d = self.__dict__.copy()
-        for feature in self._features:
-            for attr in getattr(feature, "pickle_rm_attr", []):
-                del d[attr]
-
-        # XXX: The `Feature` `DispatchingFeature` takes functions as parameter
-        # and they can be lambda functions, making them unpicklable.
-
-        # execute_callbacks_times have reference to optimizer, and they can't
-        # be pickled as the decorators with parameters aren't pickable.
-        if "execute_callbacks_times" in d:
-            del d["execute_callbacks_times"]
-
+        d.pop("_execute_callbacks_times_dict", None)
         return d
-
-    def __setstate__(self, dct):
-        self.__dict__.update(dct)
-        for feature in self._features:
-            if hasattr(feature, "unpickle"):
-                feature.unpickle(self)
 
     def __contains__(self, item: Variable | Apply) -> bool:
         if isinstance(item, Variable):

--- a/pytensor/graph/rewriting/basic.py
+++ b/pytensor/graph/rewriting/basic.py
@@ -1965,7 +1965,7 @@ class NodeProcessingGraphRewriter(GraphRewriter):
         if len(repl_pairs) == 0:
             return False
         try:
-            fgraph.replace_all_validate_remove(  # type: ignore
+            fgraph.replace_all_validate_remove(
                 repl_pairs, reason=node_rewriter, remove=remove
             )
             return True

--- a/pytensor/graph/rewriting/basic.py
+++ b/pytensor/graph/rewriting/basic.py
@@ -3,6 +3,7 @@
 import abc
 import copy
 import functools
+import importlib
 import inspect
 import logging
 import sys
@@ -181,6 +182,18 @@ class NodeRewriter(Rewriter):
         print(f"{' ' * level}{self.__class__.__name__} id={id(self)}", file=stream)
 
 
+def _restore_decorated_rewriter(module_name, qualname):
+    """Re-import a decorator-applied rewriter wrapper by ``module.qualname``.
+
+    The ``@graph_rewriter`` / ``@node_rewriter`` decorators bind the wrapper
+    instance at the same attribute as the raw function, so the wrapper is
+    name-resolvable. ``__reduce__`` uses this on ``FromFunctionGraphRewriter``
+    and ``FromFunctionNodeRewriter`` to pickle by lookup, since ``self.fn``
+    no longer matches the module attr after decoration.
+    """
+    return getattr(importlib.import_module(module_name), qualname)
+
+
 class FromFunctionGraphRewriter(GraphRewriter):
     """A `GraphRewriter` constructed from a given function."""
 
@@ -203,6 +216,9 @@ class FromFunctionGraphRewriter(GraphRewriter):
 
     def __str__(self):
         return self.__name__
+
+    def __reduce__(self):
+        return _restore_decorated_rewriter, (self.fn.__module__, self.fn.__qualname__)
 
 
 def graph_rewriter(f):
@@ -1007,6 +1023,9 @@ class FromFunctionNodeRewriter(NodeRewriter):
 
     def print_summary(self, stream=sys.stdout, level=0, depth=-1):
         print(f"{' ' * level}{self.transform} id={id(self)}", file=stream)
+
+    def __reduce__(self):
+        return _restore_decorated_rewriter, (self.fn.__module__, self.fn.__qualname__)
 
 
 def node_rewriter(

--- a/pytensor/graph/rewriting/basic.py
+++ b/pytensor/graph/rewriting/basic.py
@@ -3,7 +3,6 @@
 import abc
 import copy
 import functools
-import importlib
 import inspect
 import logging
 import sys
@@ -182,18 +181,6 @@ class NodeRewriter(Rewriter):
         print(f"{' ' * level}{self.__class__.__name__} id={id(self)}", file=stream)
 
 
-def _restore_decorated_rewriter(module_name, qualname):
-    """Re-import a decorator-applied rewriter wrapper by ``module.qualname``.
-
-    The ``@graph_rewriter`` / ``@node_rewriter`` decorators bind the wrapper
-    instance at the same attribute as the raw function, so the wrapper is
-    name-resolvable. ``__reduce__`` uses this on ``FromFunctionGraphRewriter``
-    and ``FromFunctionNodeRewriter`` to pickle by lookup, since ``self.fn``
-    no longer matches the module attr after decoration.
-    """
-    return getattr(importlib.import_module(module_name), qualname)
-
-
 class FromFunctionGraphRewriter(GraphRewriter):
     """A `GraphRewriter` constructed from a given function."""
 
@@ -216,9 +203,6 @@ class FromFunctionGraphRewriter(GraphRewriter):
 
     def __str__(self):
         return self.__name__
-
-    def __reduce__(self):
-        return _restore_decorated_rewriter, (self.fn.__module__, self.fn.__qualname__)
 
 
 def graph_rewriter(f):
@@ -1023,9 +1007,6 @@ class FromFunctionNodeRewriter(NodeRewriter):
 
     def print_summary(self, stream=sys.stdout, level=0, depth=-1):
         print(f"{' ' * level}{self.transform} id={id(self)}", file=stream)
-
-    def __reduce__(self):
-        return _restore_decorated_rewriter, (self.fn.__module__, self.fn.__qualname__)
 
 
 def node_rewriter(

--- a/pytensor/scan/rewriting.py
+++ b/pytensor/scan/rewriting.py
@@ -921,7 +921,7 @@ def add_nitsot_outputs(
     # replacements = dict(zip(old_scan_node.outputs, new_node_old_outputs))
     # replacements["remove"] = [old_scan_node]
     # return new_scan_node, replacements
-    fgraph.replace_all_validate_remove(  # type: ignore
+    fgraph.replace_all_validate_remove(
         list(zip(old_scan_node.outputs, new_node_old_outputs, strict=True)),
         remove=[old_scan_node],
         reason="scan_pushout_add",
@@ -1142,7 +1142,7 @@ class ScanInplaceOptimizer(GraphRewriter):
         new_node: Apply = new_op.make_node(*inputs)
 
         try:
-            fgraph.replace_all_validate_remove(  # type: ignore
+            fgraph.replace_all_validate_remove(
                 list(zip(node.outputs, new_node.outputs, strict=True)),
                 remove=[node],
                 reason="scan_make_inplace",

--- a/pytensor/tensor/utils.py
+++ b/pytensor/tensor/utils.py
@@ -80,7 +80,7 @@ def shape_of_variables(
 
         fgraph.attach_feature(ShapeFeature())
 
-    shape_feature = fgraph.shape_feature  # type: ignore[attr-defined]
+    shape_feature = fgraph.shape_feature
 
     input_dims = [
         dimension for inp in fgraph.inputs for dimension in shape_feature.shape_of[inp]

--- a/scripts/mypy-failing.txt
+++ b/scripts/mypy-failing.txt
@@ -1,4 +1,3 @@
-pytensor/compile/aliasing.py
 pytensor/compile/builders.py
 pytensor/compile/debug/debugmode.py
 pytensor/compile/executor.py

--- a/tests/graph/test_features.py
+++ b/tests/graph/test_features.py
@@ -13,6 +13,7 @@ from pytensor.graph.features import (
     register_feature_callback,
 )
 from pytensor.graph.fg import FunctionGraph
+from pytensor.graph.rewriting.basic import node_rewriter
 from tests.graph.utils import MyVariable, op1
 
 
@@ -123,6 +124,36 @@ class TestPickleRoundTrip:
         assert fg2.destroyers(fg2.inputs[0]) == []
         assert fg2.has_destroyers([fg2.inputs[0]]) is False
         assert isinstance(fg2.destroy_handler, DestroyHandler)
+
+    def test_history_reason_is_stringified_on_pickle(self):
+        """Decorated rewriters captured as History `reason` must not block pickling.
+
+        ``replace_all_validate(reason=node_rewriter)`` (e.g. basic.py:process_node)
+        stores the rewriter on every ``HistoryEntry``. Decorated rewriters
+        aren't picklable — the decorator rebinds the name to the wrapper, so
+        pickle's qualname lookup can't roundtrip ``self.fn``. A function-local
+        rewriter is unpicklable for an even simpler reason (``<locals>`` in
+        qualname), so this test would fail outright without the stringify.
+        """
+
+        @node_rewriter(None)
+        def local_rewriter(fgraph, node):
+            return None
+
+        x = pt.vector("x")
+        fg = FunctionGraph([x], [x * 2 + 1])
+        out = fg.outputs[0]
+        fg.replace_all_validate([(out, out + 0)], reason=local_rewriter)
+
+        fg2 = self._round_trip(fg)
+
+        replace_validate = next(
+            f for f in fg2._features if isinstance(f, ReplaceValidate)
+        )
+        entries = replace_validate.history[fg2]
+        assert entries, "expected at least one HistoryEntry post-replace"
+        assert all(isinstance(e.reason, str) for e in entries)
+        assert any(e.reason == "local_rewriter" for e in entries)
 
 
 def test_provides_callback_collision_rejected_at_class_time():

--- a/tests/graph/test_features.py
+++ b/tests/graph/test_features.py
@@ -29,7 +29,7 @@ class TestReplaceValidate:
         )
 
         class TestFeature(Feature):
-            def validate(self, *args):
+            def on_validate(self, *args):
                 raise Exception()
 
         fg.attach_feature(TestFeature())

--- a/tests/graph/test_features.py
+++ b/tests/graph/test_features.py
@@ -1,9 +1,17 @@
+import pickle
+
 import pytest
 
 import pytensor.tensor as pt
 from pytensor.graph import rewrite_graph
 from pytensor.graph.basic import equal_computations
-from pytensor.graph.features import Feature, FullHistory, ReplaceValidate
+from pytensor.graph.destroyhandler import DestroyHandler
+from pytensor.graph.features import (
+    Feature,
+    FullHistory,
+    ReplaceValidate,
+    register_feature_callback,
+)
 from pytensor.graph.fg import FunctionGraph
 from tests.graph.utils import MyVariable, op1
 
@@ -71,3 +79,80 @@ def test_full_history():
         history.next()
 
     assert equal_computations(fg.outputs, [pt.special.log_softmax(x)])
+
+
+class TestPickleRoundTrip:
+    """A pickled FunctionGraph must support the same Feature operations as a fresh one.
+
+    Regression: ``ReplaceValidate``'s history dict, the checkpoint counter,
+    and the ``execute_callbacks_times`` accumulator all used to be silently
+    dropped on pickle without being re-initialized on unpickle, so the next
+    rewrite would crash with ``'ReplaceValidate' object has no attribute 'history'``
+    or similar.
+    """
+
+    def _round_trip(self, fg):
+        return pickle.loads(pickle.dumps(fg))
+
+    def test_checkpoint_after_pickle(self):
+        x = pt.vector("x")
+        fg = FunctionGraph([x], [x * 2 + 1])
+        fg2 = self._round_trip(fg)
+        chk = fg2.checkpoint()
+        fg2.revert(chk)
+
+    def test_replace_all_validate_after_pickle(self):
+        x = pt.vector("x")
+        fg = FunctionGraph([x], [x * 2 + 1])
+        fg2 = self._round_trip(fg)
+        out = fg2.outputs[0]
+        fg2.replace_all_validate([(out, out + 0)], reason="test")
+
+    def test_execute_callbacks_after_pickle(self):
+        x = pt.vector("x")
+        fg = FunctionGraph([x], [x * 2 + 1])
+        fg2 = self._round_trip(fg)
+        fg2.execute_callbacks("on_import", next(iter(fg2.apply_nodes)), "test")
+        assert fg2.execute_callbacks_times
+
+    def test_destroy_handler_after_pickle(self):
+        x = pt.vector("x")
+        fg = FunctionGraph([x], [x * 2 + 1])
+        fg.attach_feature(DestroyHandler())
+        fg2 = self._round_trip(fg)
+        assert fg2.destroyers(fg2.inputs[0]) == []
+        assert fg2.has_destroyers([fg2.inputs[0]]) is False
+        assert isinstance(fg2.destroy_handler, DestroyHandler)
+
+
+def test_provides_callback_collision_rejected_at_class_time():
+    """A name cannot appear in both ``provides`` and the callback registry."""
+    with pytest.raises(TypeError, match="appear in both `provides` and as callbacks"):
+
+        class Bad(Feature):
+            provides = ("on_validate",)
+
+            @register_feature_callback
+            def on_validate(self, fgraph):
+                pass
+
+
+@pytest.mark.parametrize(
+    "feature_factory",
+    [ReplaceValidate, DestroyHandler],
+    ids=["ReplaceValidate", "DestroyHandler"],
+)
+def test_feature_provides_dispatch_contract(feature_factory):
+    """Names listed in ``Feature.provides`` are reachable as ``fgraph.<name>``
+    via ``__getattr__`` dispatch, both fresh and after a pickle round-trip."""
+    x = pt.vector("x")
+    fg = FunctionGraph([x], [x * 2 + 1])
+    feature = feature_factory()
+    fg.attach_feature(feature)
+
+    for name in feature.provides:
+        assert callable(getattr(fg, name)), name
+
+    fg2 = pickle.loads(pickle.dumps(fg))
+    for name in feature.provides:
+        assert callable(getattr(fg2, name)), name


### PR DESCRIPTION
I have been periodically hitting rewrite failures in PyMC, it turns out due to pickle roundtripping of `fgraph` that have been partially rewritten. Here is the specific error:

```
ERROR (pytensor.graph.rewriting.basic): SequentialGraphRewriter apply <pytensor.tensor.rewriting.elemwise.InplaceElemwiseOptimizer object at 0x331d13380>
ERROR (pytensor.graph.rewriting.basic): Traceback:
ERROR (pytensor.graph.rewriting.basic): Traceback (most recent call last):
  File "/Users/jesse.grabowski/Python/systematic-credit/.pixi/envs/default/lib/python3.12/site-packages/pytensor/graph/rewriting/basic.py", line 289, in apply
    sub_prof = rewriter.apply(fgraph)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jesse.grabowski/Python/systematic-credit/.pixi/envs/default/lib/python3.12/site-packages/pytensor/tensor/rewriting/elemwise.py", line 205, in apply
    fgraph.replace_all_validate(replacements, reason=reason)
  File "/Users/jesse.grabowski/Python/systematic-credit/.pixi/envs/default/lib/python3.12/site-packages/pytensor/graph/features.py", line 731, in replace_all_validate
    chk = fgraph.checkpoint()
          ^^^^^^^^^^^^^^^^^^^
  File "/Users/jesse.grabowski/Python/systematic-credit/.pixi/envs/default/lib/python3.12/site-packages/pytensor/graph/features.py", line 358, in __call__
    self.h.history[self.fgraph] = []
    ^^^^^^^^^^^^^^
AttributeError: 'ReplaceValidate' object has no attribute 'history'
```

*How we got here*
  
History originally monkey-patched fgraph.checkpoint with a lambda, but lambdas aren't pickleable. Commit 2dc512950 added pickle_rm_attr to strip those lambdas off fgraph.__dict__ on pickle. The history dict itself was also full of lambdas, so a `__getstate__` on `ReplaceValidate` dropped it too. Commit ddb24d793 then replaced the closures with pickleable classes (`GetCheckpoint`, `LambdaExtract`), making history pickleable in principle — but never undid the strip, and never added restoration code on the unpickle side.

So unpickle reinstalls fgraph.checkpoint but doesn't recreate self.history. The next `replace_all_validate` calls `fgraph.checkpoint()` and crashes. Latent for 11 years because nothing pickled a fgraph and then re-rewrote it. I think I hit it because we're doing `rewrite_pregrad`on pymc models, then pickle the graph and finish compiling on workers, but only in certain multiprocessing harnesses (`pm.sample_smc`, `pmx.fit_pathfinder`).

*Why a refactor instead of a patch*

I started with a one-line restoration of history, but the underlying Feature API has two hand-maintained matched pairs that know nothing about each other: `pickle_rm_attr <-> unpickle`, and `__getstate__ <->
  __setstate__`. They have to stay in sync or pickle bugs of this exact shape sneak in. The same bug existed unfound for execute_callbacks_times, which my initial patch immediately surfaced.

*What this PR does*

  Feature methods now belong to one of two groups, declared explicitly:                                    
   
  - Callbacks are decorated with @register_feature_callback. FunctionGraph.execute_callbacks only          
  dispatches registered callbacks.
  - provides is a tuple of method names listed on the Feature class. Anything listed there is callable as  
  `fgraph.<name>(...)` and resolves via `__getattr__` to `feature.<name>(fgraph, ...)`.   
  
Two advantages:                                                                                          
                  
  1. *VERY* small perf boost on provides dispatch — `FunctionGraph` checks a whitelist of names instead of looping  
  through _features with try/except on every callback.
  2. The pickle hacks are gone. No more pickle_rm_attr, no more unpickle. The pickle protocol is just      
  `__getstate__` and `__setstate__`, and everything works.                                                     
   
  The only remaining hack: `execute_callbacks_times` is now a lazy property, so it never lands in `__dict__`  
  and doesn't need special handling on pickle. I don't love it, but it works.
