### PR TITLE
Optimize solve of block_diag

### DIFF
--- a/pytensor/tensor/rewriting/linalg/solvers.py
+++ b/pytensor/tensor/rewriting/linalg/solvers.py
@@ -12,9 +12,10 @@ from pytensor.graph.rewriting.basic import (
 from pytensor.graph.rewriting.unify import OpPattern
 from pytensor.scan.op import Scan
 from pytensor.scan.rewriting import scan_seqopt1
-from pytensor.tensor.basic import atleast_Nd
+from pytensor.tensor.basic import atleast_Nd, split
 from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.elemwise import DimShuffle
+from pytensor.tensor.linalg.constructors import BlockDiagonal
 from pytensor.tensor.linalg.decomposition.cholesky import Cholesky, cholesky
 from pytensor.tensor.linalg.decomposition.lu import lu_factor
 from pytensor.tensor.linalg.solvers.core import SolveBase
@@ -159,6 +160,58 @@ def scalar_solve_to_division(fgraph, node):
 
     copy_stack_trace(old_out, new_out)
 
+    return [new_out]
+
+
+@register_canonicalize
+@register_stabilize
+@node_rewriter([blockwise_of(SolveBase)])
+def block_diag_solve_to_block_diag_solves(fgraph, node):
+    """Push ``solve(block_diag(A_1, ..., A_n), b)`` into per-block solves.
+
+    Splits ``b`` along axis ``-2`` into per-block chunks, solves each block independently with the
+    *same* solve op (preserving ``assume_a``, ``lower``, ``unit_diagonal``, etc.), and concatenates
+    the results. Vector ``b`` is reshaped to a column, solved, then squeezed back.
+
+    Re-using the solve properties is valid because of a block diagonal matrix to be symmetric, diagonal,
+    psd, or triangular, each component matrix must also have these properties.
+
+    See also :func:`local_block_diag_dot_to_dot_block_diag`.
+    """
+    A, b = node.inputs
+    A_owner_op = getattr(A.owner, "op", None)
+    if not isinstance(A_owner_op, Blockwise) or not isinstance(
+        A_owner_op.core_op, BlockDiagonal
+    ):
+        return None
+
+    blocks = A.owner.inputs
+    block_sizes = [block.type.shape[-1] for block in blocks]
+
+    # Rewrite is conservative: we require all component matrices to be provably square.
+    # It is possible to have a square matrix block_diagonal matrix comprised of non-square
+    # components. In that case the original graph is valid, but it is not decomposable.
+    if any(
+        size is None or block.type.shape[-2] != size
+        for size, block in zip(block_sizes, blocks)
+    ):
+        return None
+
+    core_op = node.op.core_op
+    # For vector b (b_ndim=1) split along its only axis; for matrix b (b_ndim=2)
+    # split along the row axis. Either way the per-block solve preserves b_ndim.
+    split_axis = -1 if core_op.b_ndim == 1 else -2
+    chunks = split(b, splits_size=block_sizes, n_splits=len(blocks), axis=split_axis)
+    per_block_op = Blockwise(core_op)
+
+    per_block_solutions = []
+    for block, chunk in zip(blocks, chunks):
+        sol = per_block_op(block, chunk)
+        copy_stack_trace(node.outputs[0], sol)
+        per_block_solutions.append(sol)
+
+    new_out = pt.concatenate(per_block_solutions, axis=split_axis)
+    copy_stack_trace(node.outputs[0], new_out)
     return [new_out]
 
 

--- a/pytensor/tensor/rewriting/linalg/solvers.py
+++ b/pytensor/tensor/rewriting/linalg/solvers.py
@@ -185,13 +185,13 @@ def block_diag_solve_to_block_diag_solves(fgraph, node):
     See also :func:`local_block_diag_dot_to_dot_block_diag`.
     """
     A, b = node.inputs
-    A_owner_op = getattr(A.owner, "op", None)
-    if not isinstance(A_owner_op, Blockwise) or not isinstance(
-        A_owner_op.core_op, BlockDiagonal
-    ):
-        return None
 
-    blocks = A.owner.inputs
+    match A.owner_op_and_inputs:
+        case (Blockwise(BlockDiagonal()), *blocks):
+            pass
+        case _:
+            return None
+
     block_sizes = [block.type.shape[-1] for block in blocks]
 
     # Rewrite is conservative: we require all component matrices to be provably square.
@@ -209,31 +209,28 @@ def block_diag_solve_to_block_diag_solves(fgraph, node):
     # If b is also a block_diag with matching block sizes, solve per matching
     # pair and rebuild block_diag. Strictly better than the row-split path:
     # avoids solving against the zero off-diagonal columns of each row-chunk.
-    b_owner_op = getattr(b.owner, "op", None)
-    b_blocks_match = (
-        core_op.b_ndim == 2
-        and isinstance(b_owner_op, Blockwise)
-        and isinstance(b_owner_op.core_op, BlockDiagonal)
-        and len(b.owner.inputs) == len(blocks)
-        and all(
-            B_i.type.shape[-2] == size and B_i.type.shape[-1] == size
-            for B_i, size in zip(b.owner.inputs, block_sizes)
-        )
-    )
-    if b_blocks_match:
-        per_block_solutions = [
-            per_block_op(A_i, B_i) for A_i, B_i in zip(blocks, b.owner.inputs)
-        ]
-        for sol in per_block_solutions:
-            copy_stack_trace(node.outputs[0], sol)
-        new_out = pt.linalg.block_diag(*per_block_solutions)
-        copy_stack_trace(node.outputs[0], new_out)
-        return [new_out]
+    match b.owner_op_and_inputs:
+        case (Blockwise(BlockDiagonal()), *b_blocks) if (
+            core_op.b_ndim == 2
+            and len(b_blocks) == len(blocks)
+            and all(
+                B_i.type.shape[-2] == size and B_i.type.shape[-1] == size
+                for B_i, size in zip(b_blocks, block_sizes)
+            )
+        ):
+            per_block_solutions = [
+                per_block_op(A_i, B_i) for A_i, B_i in zip(blocks, b_blocks)
+            ]
+            for sol in per_block_solutions:
+                copy_stack_trace(node.outputs[0], sol)
+            new_out = pt.linalg.block_diag(*per_block_solutions)
+            copy_stack_trace(node.outputs[0], new_out)
+            return [new_out]
 
     # For vector b (b_ndim=1) split along its only axis; for matrix b (b_ndim=2)
     # split along the row axis. Either way the per-block solve preserves b_ndim.
     split_axis = -1 if core_op.b_ndim == 1 else -2
-    chunks = split(b, splits_size=block_sizes, n_splits=len(blocks), axis=split_axis)
+    chunks = split(b, splits_size=block_sizes, axis=split_axis)
 
     per_block_solutions = []
     for block, chunk in zip(blocks, chunks):

--- a/pytensor/tensor/rewriting/linalg/solvers.py
+++ b/pytensor/tensor/rewriting/linalg/solvers.py
@@ -169,12 +169,18 @@ def scalar_solve_to_division(fgraph, node):
 def block_diag_solve_to_block_diag_solves(fgraph, node):
     """Push ``solve(block_diag(A_1, ..., A_n), b)`` into per-block solves.
 
-    Splits ``b`` along axis ``-2`` into per-block chunks, solves each block independently with the
-    *same* solve op (preserving ``assume_a``, ``lower``, ``unit_diagonal``, etc.), and concatenates
-    the results. Vector ``b`` is reshaped to a column, solved, then squeezed back.
+    Two cases:
 
-    Re-using the solve properties is valid because of a block diagonal matrix to be symmetric, diagonal,
-    psd, or triangular, each component matrix must also have these properties.
+    - ``b`` is also ``block_diag(B_1, ..., B_n)`` with matching block sizes:
+      decompose into ``block_diag(solve(A_i, B_i))`` (each per-block solve is
+      ``(m_i, m_i)`` instead of ``(m_i, m_total)``).
+    - Otherwise: split ``b`` into per-block row chunks and solve each block
+      independently, then concatenate.
+
+    Both paths reuse the user's solve op (preserving ``assume_a``, ``lower``,
+    ``unit_diagonal``, etc.) — valid because for a block-diagonal matrix to be
+    symmetric / diagonal / psd / triangular, each block must individually
+    satisfy that property.
 
     See also :func:`local_block_diag_dot_to_dot_block_diag`.
     """
@@ -198,11 +204,36 @@ def block_diag_solve_to_block_diag_solves(fgraph, node):
         return None
 
     core_op = node.op.core_op
+    per_block_op = Blockwise(core_op)
+
+    # If b is also a block_diag with matching block sizes, solve per matching
+    # pair and rebuild block_diag. Strictly better than the row-split path:
+    # avoids solving against the zero off-diagonal columns of each row-chunk.
+    b_owner_op = getattr(b.owner, "op", None)
+    b_blocks_match = (
+        core_op.b_ndim == 2
+        and isinstance(b_owner_op, Blockwise)
+        and isinstance(b_owner_op.core_op, BlockDiagonal)
+        and len(b.owner.inputs) == len(blocks)
+        and all(
+            B_i.type.shape[-2] == size and B_i.type.shape[-1] == size
+            for B_i, size in zip(b.owner.inputs, block_sizes)
+        )
+    )
+    if b_blocks_match:
+        per_block_solutions = [
+            per_block_op(A_i, B_i) for A_i, B_i in zip(blocks, b.owner.inputs)
+        ]
+        for sol in per_block_solutions:
+            copy_stack_trace(node.outputs[0], sol)
+        new_out = pt.linalg.block_diag(*per_block_solutions)
+        copy_stack_trace(node.outputs[0], new_out)
+        return [new_out]
+
     # For vector b (b_ndim=1) split along its only axis; for matrix b (b_ndim=2)
     # split along the row axis. Either way the per-block solve preserves b_ndim.
     split_axis = -1 if core_op.b_ndim == 1 else -2
     chunks = split(b, splits_size=block_sizes, n_splits=len(blocks), axis=split_axis)
-    per_block_op = Blockwise(core_op)
 
     per_block_solutions = []
     for block, chunk in zip(blocks, chunks):

--- a/tests/tensor/rewriting/linalg/test_solvers.py
+++ b/tests/tensor/rewriting/linalg/test_solvers.py
@@ -443,41 +443,53 @@ def test_lu_decomposition_reused_scan(assume_a, counter, transposed):
     np.testing.assert_allclose(resx0, resx1, rtol=rtol)
 
 
-@pytest.mark.parametrize("b_ndim", [1, 2], ids=["vector_b", "matrix_b"])
-def test_block_diag_solve_pushdown(b_ndim):
-    A = pt.matrix("A", shape=(3, 3))
-    B = pt.matrix("B", shape=(2, 2))
-    b_shape = (5,) if b_ndim == 1 else (5, 4)
+@pytest.mark.parametrize(
+    "b_ndim, solve_fn, expected_op, batch",
+    [
+        (1, pt.linalg.solve, Solve, 0),
+        (2, pt.linalg.solve, Solve, 4),
+        (1, lambda T, b: solve_triangular(T, b, lower=True), SolveTriangular, 0),
+    ],
+    ids=["vector_b", "matrix_b_batched", "solve_triangular"],
+)
+def test_block_diag_solve_pushdown(b_ndim, solve_fn, expected_op, batch):
+    A_shape = (batch, 3, 3) if batch else (3, 3)
+    B_shape = (batch, 2, 2) if batch else (2, 2)
+    if b_ndim == 1:
+        b_shape = (batch, 5) if batch else (5,)
+    else:
+        b_shape = (batch, 5, 4) if batch else (5, 4)
+    A = pt.tensor("A", shape=A_shape)
+    B = pt.tensor("B", shape=B_shape)
     b_var = pt.tensor("b", shape=b_shape)
-    f = function([A, B, b_var], pt.linalg.solve(pt.linalg.block_diag(A, B), b_var))
+    f = function([A, B, b_var], solve_fn(pt.linalg.block_diag(A, B), b_var))
 
-    assert not [
-        n
-        for n in f.maker.fgraph.toposort()
-        if isinstance(getattr(n.op, "core_op", n.op), BlockDiagonal)
-    ]
+    ops = [getattr(n.op, "core_op", n.op) for n in f.maker.fgraph.toposort()]
+    assert not any(isinstance(op, BlockDiagonal) for op in ops)
+    assert any(isinstance(op, expected_op) for op in ops)
+    if expected_op is SolveTriangular:
+        assert not any(isinstance(op, Solve) for op in ops)
 
     rng = np.random.default_rng(0)
     A_v, B_v, b_v = (
-        rng.normal(size=(3, 3)),
-        rng.normal(size=(2, 2)),
+        rng.normal(size=A_shape),
+        rng.normal(size=B_shape),
         rng.normal(size=b_shape),
     )
-    expected = np.linalg.solve(scipy.linalg.block_diag(A_v, B_v), b_v)
+    if expected_op is SolveTriangular:
+        # Make A and B lower-triangular so the per-block solve_triangular is valid.
+        A_v = np.tril(A_v) if not batch else np.stack([np.tril(a) for a in A_v])
+        B_v = np.tril(B_v) if not batch else np.stack([np.tril(b) for b in B_v])
+    if batch:
+        expected = np.stack(
+            [
+                np.linalg.solve(scipy.linalg.block_diag(A_v[i], B_v[i]), b_v[i])
+                for i in range(batch)
+            ]
+        )
+    else:
+        expected = np.linalg.solve(scipy.linalg.block_diag(A_v, B_v), b_v)
     assert_allclose(f(A_v, B_v, b_v), expected, atol=1e-10)
-
-
-def test_block_diag_solve_pushdown_preserves_solve_op_type():
-    """``solve_triangular(block_diag(L1, L2), b)`` must keep SolveTriangular
-    per block, not silently downgrade to generic Solve."""
-    L1, L2 = pt.matrix("L1", shape=(3, 3)), pt.matrix("L2", shape=(2, 2))
-    y = pt.vector("y", shape=(5,))
-    f = function(
-        [L1, L2, y], solve_triangular(pt.linalg.block_diag(L1, L2), y, lower=True)
-    )
-    ops = [getattr(n.op, "core_op", n.op) for n in f.maker.fgraph.toposort()]
-    assert not any(isinstance(op, Solve) for op in ops)
-    assert any(isinstance(op, SolveTriangular) for op in ops)
 
 
 @pytest.mark.parametrize(
@@ -495,32 +507,31 @@ def test_block_diag_solve_pushdown_bails_when_blocks_not_provably_square(second_
     ]
 
 
-def test_block_diag_solve_pushdown_batched():
-    """Both Blockwise(BlockDiagonal) and Blockwise(Solve) handle batching,
-    so the rewrite should also fire on a batched A."""
-    batch = 4
-    A = pt.tensor("A", shape=(batch, 3, 3))
-    B = pt.tensor("B", shape=(batch, 2, 2))
-    b_var = pt.tensor("b", shape=(batch, 5))
-    f = function(
-        [A, B, b_var],
-        pt.linalg.solve(pt.linalg.block_diag(A, B), b_var, b_ndim=1),
-    )
+def test_block_diag_solve_pushdown_both_sides_block_diag():
+    A1, A2 = pt.matrix("A1", shape=(3, 3)), pt.matrix("A2", shape=(2, 2))
+    B1, B2 = pt.matrix("B1", shape=(3, 3)), pt.matrix("B2", shape=(2, 2))
+    A = pt.linalg.block_diag(A1, A2)
+    B = pt.linalg.block_diag(B1, B2)
+    f = function([A1, A2, B1, B2], pt.linalg.solve(A, B))
 
-    assert not [
+    # Each Solve must consume the original A_i and B_i directly (not a slice or
+    # the materialized A/B block_diag). The output BlockDiagonal that wraps the
+    # per-block solves back together is expected and fine.
+    block_names = {"A1", "A2", "B1", "B2"}
+    solves = [
         n
         for n in f.maker.fgraph.toposort()
-        if isinstance(getattr(n.op, "core_op", n.op), BlockDiagonal)
+        if isinstance(getattr(n.op, "core_op", n.op), Solve)
     ]
+    assert len(solves) == 2
+    for n in solves:
+        assert {n.inputs[0].name, n.inputs[1].name} <= block_names
 
     rng = np.random.default_rng(0)
-    A_v = rng.normal(size=(batch, 3, 3))
-    B_v = rng.normal(size=(batch, 2, 2))
-    b_v = rng.normal(size=(batch, 5))
-    expected = np.stack(
-        [
-            np.linalg.solve(scipy.linalg.block_diag(A_v[i], B_v[i]), b_v[i])
-            for i in range(batch)
-        ]
+    A1_v, A2_v = rng.normal(size=(3, 3)), rng.normal(size=(2, 2))
+    B1_v, B2_v = rng.normal(size=(3, 3)), rng.normal(size=(2, 2))
+    expected = np.linalg.solve(
+        scipy.linalg.block_diag(A1_v, A2_v),
+        scipy.linalg.block_diag(B1_v, B2_v),
     )
-    assert_allclose(f(A_v, B_v, b_v), expected, atol=1e-10)
+    assert_allclose(f(A1_v, A2_v, B1_v, B2_v), expected, atol=1e-10)

--- a/tests/tensor/rewriting/linalg/test_solvers.py
+++ b/tests/tensor/rewriting/linalg/test_solvers.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import scipy.linalg
 from numpy.testing import assert_allclose
 
 import pytensor
@@ -11,6 +12,7 @@ from pytensor.gradient import grad
 from pytensor.graph import ancestors
 from pytensor.scan.op import Scan
 from pytensor.tensor.blockwise import Blockwise, BlockwiseWithCoreShape
+from pytensor.tensor.linalg.constructors import BlockDiagonal
 from pytensor.tensor.linalg.decomposition.cholesky import Cholesky, cholesky
 from pytensor.tensor.linalg.decomposition.lu import LUFactor
 from pytensor.tensor.linalg.solvers.core import SolveBase
@@ -439,3 +441,86 @@ def test_lu_decomposition_reused_scan(assume_a, counter, transposed):
     resx1 = fn_opt(A_test, x0_test)
     rtol = 1e-7 if config.floatX == "float64" else 1e-4
     np.testing.assert_allclose(resx0, resx1, rtol=rtol)
+
+
+@pytest.mark.parametrize("b_ndim", [1, 2], ids=["vector_b", "matrix_b"])
+def test_block_diag_solve_pushdown(b_ndim):
+    A = pt.matrix("A", shape=(3, 3))
+    B = pt.matrix("B", shape=(2, 2))
+    b_shape = (5,) if b_ndim == 1 else (5, 4)
+    b_var = pt.tensor("b", shape=b_shape)
+    f = function([A, B, b_var], pt.linalg.solve(pt.linalg.block_diag(A, B), b_var))
+
+    assert not [
+        n
+        for n in f.maker.fgraph.toposort()
+        if isinstance(getattr(n.op, "core_op", n.op), BlockDiagonal)
+    ]
+
+    rng = np.random.default_rng(0)
+    A_v, B_v, b_v = (
+        rng.normal(size=(3, 3)),
+        rng.normal(size=(2, 2)),
+        rng.normal(size=b_shape),
+    )
+    expected = np.linalg.solve(scipy.linalg.block_diag(A_v, B_v), b_v)
+    assert_allclose(f(A_v, B_v, b_v), expected, atol=1e-10)
+
+
+def test_block_diag_solve_pushdown_preserves_solve_op_type():
+    """``solve_triangular(block_diag(L1, L2), b)`` must keep SolveTriangular
+    per block, not silently downgrade to generic Solve."""
+    L1, L2 = pt.matrix("L1", shape=(3, 3)), pt.matrix("L2", shape=(2, 2))
+    y = pt.vector("y", shape=(5,))
+    f = function(
+        [L1, L2, y], solve_triangular(pt.linalg.block_diag(L1, L2), y, lower=True)
+    )
+    ops = [getattr(n.op, "core_op", n.op) for n in f.maker.fgraph.toposort()]
+    assert not any(isinstance(op, Solve) for op in ops)
+    assert any(isinstance(op, SolveTriangular) for op in ops)
+
+
+@pytest.mark.parametrize(
+    "second_shape", [(2, 5), (None, None)], ids=["non_square", "unknown_shape"]
+)
+def test_block_diag_solve_pushdown_bails_when_blocks_not_provably_square(second_shape):
+    A = pt.matrix("A", shape=(3, 3))
+    second = pt.matrix("second", shape=second_shape)
+    y = pt.vector("y")
+    f = function([A, second, y], pt.linalg.solve(pt.linalg.block_diag(A, second), y))
+    assert [
+        n
+        for n in f.maker.fgraph.toposort()
+        if isinstance(getattr(n.op, "core_op", n.op), BlockDiagonal)
+    ]
+
+
+def test_block_diag_solve_pushdown_batched():
+    """Both Blockwise(BlockDiagonal) and Blockwise(Solve) handle batching,
+    so the rewrite should also fire on a batched A."""
+    batch = 4
+    A = pt.tensor("A", shape=(batch, 3, 3))
+    B = pt.tensor("B", shape=(batch, 2, 2))
+    b_var = pt.tensor("b", shape=(batch, 5))
+    f = function(
+        [A, B, b_var],
+        pt.linalg.solve(pt.linalg.block_diag(A, B), b_var, b_ndim=1),
+    )
+
+    assert not [
+        n
+        for n in f.maker.fgraph.toposort()
+        if isinstance(getattr(n.op, "core_op", n.op), BlockDiagonal)
+    ]
+
+    rng = np.random.default_rng(0)
+    A_v = rng.normal(size=(batch, 3, 3))
+    B_v = rng.normal(size=(batch, 2, 2))
+    b_v = rng.normal(size=(batch, 5))
+    expected = np.stack(
+        [
+            np.linalg.solve(scipy.linalg.block_diag(A_v[i], B_v[i]), b_v[i])
+            for i in range(batch)
+        ]
+    )
+    assert_allclose(f(A_v, B_v, b_v), expected, atol=1e-10)


### PR DESCRIPTION
Similar rewrite to https://github.com/pymc-devs/pytensor/pull/1493. Given `solve(block_diag(A, B), C)`, we can split up C and do two smaller solves, returning `concat(solve(A, C[:n]), solve(B, C[n:])`.

Plays nicely with further rewrites, especially after https://github.com/pymc-devs/pytensor/pull/2032. If A is dense and B is orthogonal for example, this can end up as `concat(solve(A, C[:n]), B.T @ C[n:])`, which is much cheaper. Same goes for diagonality, etc.

The properties of the larger solve can be preserved, because if a block diagonal matrix is triangular, diagonal, psd, or symmetric, it must be the case that all component matrices have those properties.