### PR TITLE
Replace several Ops by OpFromGraph

### DIFF
--- a/pytensor/compile/builders.py
+++ b/pytensor/compile/builders.py
@@ -11,6 +11,7 @@ from itertools import chain
 from typing import cast
 
 from pytensor.compile.maker import function
+from pytensor.compile.mode import get_mode
 from pytensor.compile.rebuild import rebuild_collect_shared
 from pytensor.compile.sharedvalue import SharedVariable
 from pytensor.gradient import DisconnectedType, disconnected_type, grad, pushforward
@@ -917,7 +918,9 @@ class OpFromGraph(Op, HasInnerGraph):
         if getattr(self, "_fn", None) is not None:
             return self._fn
 
-        self._fn = function(self.inner_inputs, self.inner_outputs, **self.kwargs)
+        kwargs = self.kwargs.copy()
+        mode = get_mode(kwargs.pop("mode", None)).excluding("symbolic_op_recognition")
+        self._fn = function(self.inner_inputs, self.inner_outputs, mode=mode, **kwargs)
         self._fn.trust_input = True
 
         return self._fn
@@ -940,3 +943,64 @@ class OpFromGraph(Op, HasInnerGraph):
         # zip strict not specified because we are in a hot loop
         for output, variable in zip(outputs, variables):
             output[0] = variable
+
+
+class SymbolicOp(OpFromGraph):
+    r"""OpFromGraph subclass that builds the inner graph from input types.
+
+    Subclasses define the forward graph via :meth:`build_inner_graph` and
+    optionally override :meth:`pullback` / :meth:`pushforward`.
+
+    Override :meth:`filter_inputs` to coerce raw arguments (e.g. Python
+    scalars) into typed Variables at call sites.
+
+    Set the class attribute ``inline`` to control whether the inner graph is
+    inlined during compilation (default ``False``).
+    """
+
+    inline: bool = False
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if "__props__" in cls.__dict__:
+            # MetaType installs props-only __hash__ and __eq__ which ignores the inner graph
+            # override with fgraph-aware version
+            cls.__hash__ = OpFromGraph.__hash__
+            cls.__eq__ = OpFromGraph.__eq__
+
+    @staticmethod
+    def filter_inputs(*inputs):
+        return inputs
+
+    def build_inner_graph(self, *inputs) -> list[Variable]:
+        raise NotImplementedError
+
+    def __init__(self, input_types=None, **kwargs):
+        """Construct op for the given input Types.
+
+        When input_types is None, construction is deferred until the first
+        __call__, which inspects the actual input types and builds the graph.
+        """
+        for prop in getattr(type(self), "__props__", ()):
+            if prop in kwargs:
+                setattr(self, prop, kwargs.pop(prop))
+        self._init_kwargs = kwargs
+        if input_types is not None:
+            kwargs.setdefault("inline", type(self).inline)
+            kwargs.setdefault("strict", True)
+            dummy_inputs = [t() for t in input_types]
+            outputs = self.build_inner_graph(*dummy_inputs)
+            super().__init__(dummy_inputs, outputs, **kwargs)
+
+    def __call__(self, *inputs, **kwargs):
+        inputs = self.filter_inputs(*inputs)
+        input_types = tuple(inp.type for inp in inputs)
+
+        if hasattr(self, "fgraph") and input_types == tuple(self.input_types):
+            return super().__call__(*inputs, **kwargs)
+
+        init_kwargs = dict(self._init_kwargs)
+        for prop in getattr(type(self), "__props__", ()):
+            init_kwargs[prop] = getattr(self, prop)
+        op = type(self)(input_types=list(input_types), **init_kwargs)
+        return super(SymbolicOp, op).__call__(*inputs, **kwargs)

--- a/pytensor/graph/features.py
+++ b/pytensor/graph/features.py
@@ -510,8 +510,8 @@ class FullHistory(Feature):
         from pytensor.graph.features import FullHistory
         from pytensor.graph.rewriting.utils import rewrite_graph
 
-        x = pt.scalar("x")
-        out = pt.log(pt.exp(x) / pt.sum(pt.exp(x)))
+        x = pt.vector("x")
+        out = pt.log(pt.exp(x) / pt.sum(pt.exp(x), keepdims=True))
 
         fg = FunctionGraph(outputs=[out])
         history = FullHistory()
@@ -528,22 +528,24 @@ class FullHistory(Feature):
                 pytensor.dprint(history.next())
 
     .. testoutput::
+        Log [id A] 5
+         └─ True_div [id B] 4
+            ├─ Exp [id C] 3
+            │  └─ x [id D]
+            └─ ExpandDims{axis=0} [id E] 2
+               └─ Sum{axes=None} [id F] 1
+                  └─ Exp [id G] 0
+                     └─ x [id D]
+        >> MergeOptimizer
         Log [id A] 4
          └─ True_div [id B] 3
-            ├─ Exp [id C] 2
-            │  └─ x [id D]
-            └─ Sum{axes=None} [id E] 1
-               └─ Exp [id F] 0
-                  └─ x [id D]
-        >> MergeOptimizer
-        Log [id A] 3
-         └─ True_div [id B] 2
             ├─ Exp [id C] 0
             │  └─ x [id D]
-            └─ Sum{axes=None} [id E] 1
-               └─ Exp [id C] 0
-                  └─ ···
-        >> local_mul_canonizer
+            └─ ExpandDims{axis=0} [id E] 2
+               └─ Sum{axes=None} [id F] 1
+                  └─ Exp [id C] 0
+                     └─ ···
+        >> local_softmax_stabilize
         Log [id A] 1
          └─ Softmax{axis=None} [id B] 0
             └─ x [id C]
@@ -564,22 +566,24 @@ class FullHistory(Feature):
         Log [id A] 1
          └─ Softmax{axis=None} [id B] 0
             └─ x [id C]
-        >> local_mul_canonizer
-        Log [id A] 3
-         └─ True_div [id B] 2
-            ├─ Exp [id C] 0
-            │  └─ x [id D]
-            └─ Sum{axes=None} [id E] 1
-               └─ Exp [id C] 0
-                  └─ ···
-        >> MergeOptimizer
+        >> local_softmax_stabilize
         Log [id A] 4
          └─ True_div [id B] 3
-            ├─ Exp [id C] 2
+            ├─ Exp [id C] 0
             │  └─ x [id D]
-            └─ Sum{axes=None} [id E] 1
-               └─ Exp [id F] 0
-                  └─ x [id D]
+            └─ ExpandDims{axis=0} [id E] 2
+               └─ Sum{axes=None} [id F] 1
+                  └─ Exp [id C] 0
+                     └─ ···
+        >> MergeOptimizer
+        Log [id A] 5
+         └─ True_div [id B] 4
+            ├─ Exp [id C] 3
+            │  └─ x [id D]
+            └─ ExpandDims{axis=0} [id E] 2
+               └─ Sum{axes=None} [id F] 1
+                  └─ Exp [id G] 0
+                     └─ x [id D]
 
 
     .. testcode::

--- a/pytensor/link/jax/dispatch/elemwise.py
+++ b/pytensor/link/jax/dispatch/elemwise.py
@@ -3,7 +3,7 @@ import jax.numpy as jnp
 
 from pytensor.link.jax.dispatch.basic import jax_funcify
 from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
-from pytensor.tensor.special import LogSoftmax, Softmax, SoftmaxGrad
+from pytensor.tensor.special import LogSoftmax, Softmax
 
 
 @jax_funcify.register(Elemwise)
@@ -92,17 +92,6 @@ def jax_funcify_Softmax(op, **kwargs):
         return jax.nn.softmax(x, axis=axis)
 
     return softmax
-
-
-@jax_funcify.register(SoftmaxGrad)
-def jax_funcify_SoftmaxGrad(op, **kwargs):
-    axis = op.axis
-
-    def softmax_grad(dy, sm):
-        dy_times_sm = dy * sm
-        return dy_times_sm - jnp.sum(dy_times_sm, axis=axis, keepdims=True) * sm
-
-    return softmax_grad
 
 
 @jax_funcify.register(LogSoftmax)

--- a/pytensor/link/mlx/dispatch/elemwise.py
+++ b/pytensor/link/mlx/dispatch/elemwise.py
@@ -14,7 +14,7 @@ from pytensor.scalar.basic import (
     Mul,
 )
 from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
-from pytensor.tensor.special import LogSoftmax, Softmax, SoftmaxGrad
+from pytensor.tensor.special import LogSoftmax, Softmax
 
 
 @mlx_funcify.register(DimShuffle)
@@ -103,17 +103,6 @@ def mlx_funcify_Softmax(op, **kwargs):
         return mx.softmax(x, axis=axis)
 
     return softmax
-
-
-@mlx_funcify.register(SoftmaxGrad)
-def mlx_funcify_SoftmaxGrad(op, **kwargs):
-    axis = op.axis
-
-    def softmax_grad(dy, sm):
-        dy_times_sm = dy * sm
-        return dy_times_sm - mx.sum(dy_times_sm, axis=axis, keepdims=True) * sm
-
-    return softmax_grad
 
 
 @mlx_funcify.register(LogSoftmax)

--- a/pytensor/link/numba/dispatch/compile_ops.py
+++ b/pytensor/link/numba/dispatch/compile_ops.py
@@ -50,7 +50,9 @@ def numba_deepcopy_tensor(x):
 
 
 @register_funcify_and_cache_key(OpFromGraph)
-def numba_funcify_OpFromGraph(op, node=None, **kwargs):
+def numba_funcify_OpFromGraph(
+    op, node=None, mode=NUMBA.excluding("symbolic_op_recognition"), **kwargs
+):
     _ = kwargs.pop("storage_map", None)
 
     # Apply inner rewrites
@@ -64,7 +66,7 @@ def numba_funcify_OpFromGraph(op, node=None, **kwargs):
         input_specs=input_specs,
         accept_inplace=True,
     )
-    NUMBA.optimizer(fgraph)
+    mode.optimizer(fgraph)
     output_specs = [Out(o, borrow=False) for o in fgraph.outputs]
     insert_deepcopy(fgraph, wrapped_inputs=input_specs, wrapped_outputs=output_specs)
     fgraph_fn, fgraph_cache_key = numba_funcify_and_cache_key(

--- a/pytensor/link/numba/dispatch/elemwise.py
+++ b/pytensor/link/numba/dispatch/elemwise.py
@@ -36,13 +36,10 @@ from pytensor.scalar.basic import (
     Sub,
     TrueDiv,
     get_scalar_type,
-    maximum,
 )
-from pytensor.scalar.basic import add as add_as
 from pytensor.tensor.blas import BatchedDot
 from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
 from pytensor.tensor.math import Argmax, Dot, MulWithoutZeros, Sum
-from pytensor.tensor.special import LogSoftmax, Softmax, SoftmaxGrad
 
 
 @singledispatch
@@ -503,122 +500,6 @@ def numba_funcify_DimShuffle(op: DimShuffle, node, **kwargs):
 
     cache_version = 2
     return dimshuffle, cache_version
-
-
-@register_funcify_default_op_cache_key(Softmax)
-def numba_funcify_Softmax(op, node, **kwargs):
-    ndim = node.inputs[0].type.ndim
-    inp_dtype = node.inputs[0].type.numpy_dtype
-    axis = op.axis
-
-    if ndim > 1 and axis is not None:
-        reduce_max_py = create_multiaxis_reducer(
-            maximum,
-            identity=-np.inf,
-            axes=(axis,),
-            ndim=ndim,
-            out_dtype=inp_dtype,
-            keepdims=True,
-        )
-        reduce_sum_py = create_multiaxis_reducer(
-            add_as,
-            identity=0.0,
-            axes=(axis,),
-            ndim=ndim,
-            out_dtype=inp_dtype,
-            keepdims=True,
-        )
-
-        jit_fn = numba_basic.numba_njit(boundscheck=False)
-        reduce_max = jit_fn(reduce_max_py)
-        reduce_sum = jit_fn(reduce_sum_py)
-    else:
-        reduce_max = np.max
-        reduce_sum = np.sum
-
-    @numba_basic.numba_njit(boundscheck=False)
-    def softmax(x):
-        z = reduce_max(x)
-        e_x = np.exp(x - z)
-        w = reduce_sum(e_x)
-        sm = e_x / w
-        return sm
-
-    cache_version = 1
-    return softmax, cache_version
-
-
-@register_funcify_default_op_cache_key(SoftmaxGrad)
-def numba_funcify_SoftmaxGrad(op, node, **kwargs):
-    ndim = node.inputs[0].type.ndim
-    inp_dtype = node.inputs[0].type.numpy_dtype
-
-    axis = op.axis
-    if ndim > 1 and axis is not None:
-        reduce_sum_py = create_multiaxis_reducer(
-            add_as,
-            identity=0.0,
-            axes=(axis,),
-            ndim=ndim,
-            out_dtype=inp_dtype,
-            keepdims=True,
-        )
-
-        jit_fn = numba_basic.numba_njit(boundscheck=False)
-        reduce_sum = jit_fn(reduce_sum_py)
-    else:
-        reduce_sum = np.sum
-
-    @numba_basic.numba_njit(boundscheck=False)
-    def softmax_grad(dy, sm):
-        dy_times_sm = dy * sm
-        sum_dy_times_sm = reduce_sum(dy_times_sm)
-        dx = dy_times_sm - sum_dy_times_sm * sm
-        return dx
-
-    cache_version = 1
-    return softmax_grad, cache_version
-
-
-@register_funcify_default_op_cache_key(LogSoftmax)
-def numba_funcify_LogSoftmax(op, node, **kwargs):
-    ndim = node.inputs[0].type.ndim
-    inp_dtype = node.inputs[0].type.numpy_dtype
-    axis = op.axis
-
-    if ndim > 1 and axis is not None:
-        reduce_max_py = create_multiaxis_reducer(
-            maximum,
-            identity=-np.inf,
-            axes=(axis,),
-            ndim=ndim,
-            out_dtype=inp_dtype,
-            keepdims=True,
-        )
-        reduce_sum_py = create_multiaxis_reducer(
-            add_as,
-            identity=0.0,
-            axes=(axis,),
-            ndim=ndim,
-            out_dtype=inp_dtype,
-            keepdims=True,
-        )
-
-        jit_fn = numba_basic.numba_njit(boundscheck=False)
-        reduce_max = jit_fn(reduce_max_py)
-        reduce_sum = jit_fn(reduce_sum_py)
-    else:
-        reduce_max = np.max
-        reduce_sum = np.sum
-
-    @numba_basic.numba_njit(boundscheck=False)
-    def log_softmax(x):
-        xdev = x - reduce_max(x)
-        lsm = xdev - np.log(reduce_sum(np.exp(xdev)))
-        return lsm
-
-    cache_version = 1
-    return log_softmax, cache_version
 
 
 @register_funcify_default_op_cache_key(Argmax)

--- a/pytensor/link/pytorch/dispatch/elemwise.py
+++ b/pytensor/link/pytorch/dispatch/elemwise.py
@@ -6,7 +6,7 @@ from pytensor.link.pytorch.dispatch.basic import pytorch_funcify
 from pytensor.scalar import ScalarLoop
 from pytensor.tensor.elemwise import DimShuffle, Elemwise
 from pytensor.tensor.math import All, Any, Max, Min, Prod, Sum
-from pytensor.tensor.special import LogSoftmax, Softmax, SoftmaxGrad
+from pytensor.tensor.special import LogSoftmax, Softmax
 
 
 @pytorch_funcify.register(Elemwise)
@@ -129,9 +129,34 @@ def pytorch_funcify_min(op, **kwargs):
     return torch_min
 
 
+def _pytorch_softmax_dispatch(torch_fn, axis):
+    if axis is None:
+
+        def fn(x):
+            return torch_fn(x.ravel(), dim=0).reshape(x.shape)
+
+    elif len(axis) == 1:
+
+        def fn(x):
+            return torch_fn(x, dim=axis[0])
+
+    else:
+
+        def fn(x):
+            orig_shape = x.shape
+            x = torch.movedim(x, axis, tuple(range(-len(axis), 0)))
+            unflatten_shape = x.shape[: -len(axis)]
+            x = x.reshape(*unflatten_shape, -1)
+            x = torch_fn(x, dim=-1)
+            x = x.reshape(*unflatten_shape, *[orig_shape[a] for a in axis])
+            x = torch.movedim(x, tuple(range(-len(axis), 0)), axis)
+            return x
+
+    return fn
+
+
 @pytorch_funcify.register(Softmax)
 def pytorch_funcify_Softmax(op, **kwargs):
-    axis = op.axis
     dtype = kwargs["node"].inputs[0].dtype
 
     if not dtype.startswith("float"):
@@ -139,18 +164,11 @@ def pytorch_funcify_Softmax(op, **kwargs):
             "Pytorch Softmax is not currently implemented for non-float types."
         )
 
-    def softmax(x):
-        if axis is not None:
-            return torch.softmax(x, dim=axis)
-        else:
-            return torch.softmax(x.ravel(), dim=0).reshape(x.shape)
-
-    return softmax
+    return _pytorch_softmax_dispatch(torch.softmax, op.axis)
 
 
 @pytorch_funcify.register(LogSoftmax)
 def pytorch_funcify_LogSoftmax(op, **kwargs):
-    axis = op.axis
     dtype = kwargs["node"].inputs[0].dtype
 
     if not dtype.startswith("float"):
@@ -158,24 +176,7 @@ def pytorch_funcify_LogSoftmax(op, **kwargs):
             "Pytorch LogSoftmax is not currently implemented for non-float types."
         )
 
-    def log_softmax(x):
-        if axis is not None:
-            return torch.log_softmax(x, dim=axis)
-        else:
-            return torch.log_softmax(x.ravel(), dim=0).reshape(x.shape)
-
-    return log_softmax
-
-
-@pytorch_funcify.register(SoftmaxGrad)
-def jax_funcify_SoftmaxGrad(op, **kwargs):
-    axis = op.axis
-
-    def softmax_grad(dy, sm):
-        dy_times_sm = dy * sm
-        return dy_times_sm - torch.sum(dy_times_sm, dim=axis, keepdim=True) * sm
-
-    return softmax_grad
+    return _pytorch_softmax_dispatch(torch.log_softmax, op.axis)
 
 
 def elemwise_ravel_fn(base_fn, op, node, **kwargs):

--- a/pytensor/printing.py
+++ b/pytensor/printing.py
@@ -540,6 +540,7 @@ def debugprint(
     print_destroy_map: bool = False,
     print_view_map: bool = False,
     print_memory_map: bool = False,
+    print_inner_graphs: bool | Literal["auto"] = "auto",
     print_fgraph_inputs: bool = False,
 ) -> "str | TextIO | Any":  # rich.tree.Tree when file="rich"
     r"""Print a graph as text.
@@ -600,6 +601,8 @@ def debugprint(
         Whether to print the `view_map`\s of printed objects
     print_memory_map
         Whether to set both `print_destroy_map` and `print_view_map` to ``True``.
+    print_inner_graphs: bool or "auto", optional.
+        Whether to print inner graphs. Default "auto" leaves it to PyTensor discretion, or a per Op basis.
     print_fgraph_inputs
         Print the inputs of `FunctionGraph`\s.
 
@@ -631,6 +634,20 @@ def debugprint(
     if print_memory_map:
         print_destroy_map = True
         print_view_map = True
+
+    if print_inner_graphs == "auto":
+        from pytensor.compile.builders import SymbolicOp
+
+        def _show_inner_graph(op):
+            return isinstance(op, HasInnerGraph) and not isinstance(op, SymbolicOp)
+    elif print_inner_graphs:
+
+        def _show_inner_graph(op):
+            return isinstance(op, HasInnerGraph)
+    else:
+
+        def _show_inner_graph(op):
+            return False
 
     inputs_to_print = []
     outputs_to_print = []
@@ -784,6 +801,17 @@ N.B.:
             print_destroy_map=print_destroy_map,
             print_view_map=print_view_map,
         )
+
+    # Look at inner Op of Elemwise | Blockwise, as those don't document themselves as HasInnerGraph Ops
+    inner_graph_vars = [
+        v
+        for v in inner_graph_vars
+        if _show_inner_graph(v.owner.op)
+        or (
+            hasattr(v.owner.op, "scalar_op") and _show_inner_graph(v.owner.op.scalar_op)
+        )
+        or (hasattr(v.owner.op, "core_op") and _show_inner_graph(v.owner.op.core_op))
+    ]
 
     if len(inner_graph_vars) > 0:
         print("", file=_file)

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -21,7 +21,7 @@ import pytensor
 import pytensor.scalar.sharedvar
 from pytensor import config, printing
 from pytensor import scalar as ps
-from pytensor.compile.builders import OpFromGraph
+from pytensor.compile.builders import SymbolicOp
 from pytensor.gradient import DisconnectedType, disconnected_type, grad_undefined
 from pytensor.graph import RewriteDatabaseQuery
 from pytensor.graph.basic import Apply, Constant, Variable, equal_computations
@@ -3962,37 +3962,48 @@ def trace(a, offset=0, axis1=0, axis2=1):
     return diagonal(a, offset=offset, axis1=axis1, axis2=axis2).sum(-1)
 
 
-class AllocDiag(OpFromGraph):
-    """
-    Wrapper Op for alloc_diag graphs
-    """
+class AllocDiag(SymbolicOp):
+    """Allocate a diagonal matrix from a vector."""
 
-    def __init__(self, *args, axis1, axis2, offset, **kwargs):
+    __props__ = ("axis1", "axis2", "offset")
+
+    @staticmethod
+    def filter_inputs(*inputs):
+        return tuple(as_tensor_variable(inp) for inp in inputs)
+
+    def __init__(self, *, axis1, axis2, offset, **kwargs):
         self.axis1 = axis1
         self.axis2 = axis2
+        assert axis2 > axis1
         self.offset = offset
+        super().__init__(**kwargs)
 
-        super().__init__(*args, **kwargs, strict=True)
+    def build_inner_graph(self, diag):
+        result_shape = tuple(diag.shape)[:-1] + (diag.shape[-1] + abs(self.offset),) * 2
+        result = zeros(result_shape, dtype=diag.dtype)
+
+        idxs = arange(diag.shape[-1])
+        diagonal_slice = (slice(None),) * (len(result_shape) - 2) + (
+            idxs + np.maximum(0, -self.offset),
+            idxs + np.maximum(0, self.offset),
+        )
+
+        result = result[diagonal_slice].set(diag)
+
+        if diag.type.ndim > 1:
+            axes = list(range(diag.type.ndim - 1))
+            last_idx = axes[-1]
+            axes = [*axes[: self.axis1], last_idx + 1, *axes[self.axis1 :]]
+            axes = [*axes[: self.axis2], last_idx + 2, *axes[self.axis2 :]]
+            result = result.transpose(axes)
+
+        return [result]
 
     def __str__(self):
         return f"AllocDiag{{{self.axis1=}, {self.axis2=}, {self.offset=}}}"
 
     @staticmethod
     def is_offset_zero(node) -> bool:
-        """
-        Test if an AllocDiag Op has a diagonal offset of zero
-
-        Parameters
-        ----------
-        node
-            AllocDiag node to test
-
-        Returns
-        -------
-        is_offset_zero: bool
-            True if the offset is zero (``k = 0``).
-        """
-
         return node.op.offset == 0
 
 
@@ -4001,39 +4012,11 @@ def alloc_diag(diag, offset=0, axis1=0, axis2=1):
 
     diagonal(alloc_diag(x)) == x
     """
-    from pytensor.tensor import set_subtensor
-
     diag = as_tensor_variable(diag)
-
     axis1, axis2 = normalize_axis_tuple((axis1, axis2), ndim=diag.type.ndim + 1)
     if axis1 > axis2:
         axis1, axis2 = axis2, axis1
-
-    # Create array with one extra dimension for resulting matrix
-    result_shape = tuple(diag.shape)[:-1] + (diag.shape[-1] + abs(offset),) * 2
-    result = zeros(result_shape, dtype=diag.dtype)
-
-    # Create slice for diagonal in final 2 axes
-    idxs = arange(diag.shape[-1])
-    diagonal_slice = (slice(None),) * (len(result_shape) - 2) + (
-        idxs + np.maximum(0, -offset),
-        idxs + np.maximum(0, offset),
-    )
-
-    # Fill in final 2 axes with diag
-    result = set_subtensor(result[diagonal_slice], diag)
-
-    if diag.type.ndim > 1:
-        # Re-order axes so they correspond to diagonals at axis1, axis2
-        axes = list(range(diag.type.ndim - 1))
-        last_idx = axes[-1]
-        axes = [*axes[:axis1], last_idx + 1, *axes[axis1:]]
-        axes = [*axes[:axis2], last_idx + 2, *axes[axis2:]]
-        result = result.transpose(axes)
-
-    return AllocDiag(
-        inputs=[diag], outputs=[result], axis1=axis1, axis2=axis2, offset=offset
-    )(diag)
+    return AllocDiag(axis1=axis1, axis2=axis2, offset=offset)(diag)
 
 
 def diag(v, k=0):

--- a/pytensor/tensor/linalg/products.py
+++ b/pytensor/tensor/linalg/products.py
@@ -1,13 +1,13 @@
 import scipy.linalg as scipy_linalg
 
 from pytensor import tensor as pt
-from pytensor.compile.builders import OpFromGraph
 from pytensor.graph.basic import Apply
 from pytensor.graph.op import Op
 from pytensor.tensor import basic as ptb
 from pytensor.tensor import math as ptm
 from pytensor.tensor.basic import as_tensor_variable
 from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.symbolic import TensorSymbolicOp
 from pytensor.tensor.type import matrix
 
 
@@ -72,50 +72,45 @@ class Expm(Op):
 expm = Blockwise(Expm())
 
 
-class KroneckerProduct(OpFromGraph):
-    """
-    Wrapper Op for Kronecker graphs
-    """
+class KroneckerProduct(TensorSymbolicOp):
+    """Kronecker product Op."""
+
+    def build_inner_graph(self, a, b):
+        if a.ndim + b.ndim <= 2:
+            raise TypeError(
+                "kron: inputs dimensions must sum to 3 or more. "
+                f"You passed {int(a.ndim)} and {int(b.ndim)}."
+            )
+        if a.ndim < b.ndim:
+            a = ptb.expand_dims(a, tuple(range(b.ndim - a.ndim)))
+        elif b.ndim < a.ndim:
+            b = ptb.expand_dims(b, tuple(range(a.ndim - b.ndim)))
+        a_reshaped = ptb.expand_dims(a, tuple(range(1, 2 * a.ndim, 2)))
+        b_reshaped = ptb.expand_dims(b, tuple(range(0, 2 * b.ndim, 2)))
+        out_shape = tuple(a.shape[i] * b.shape[i] for i in range(a.ndim))
+        output = (a_reshaped * b_reshaped).reshape(out_shape)
+        return [output]
+
+
+_kron = KroneckerProduct()
 
 
 def kron(a, b):
     """Kronecker product.
 
-    Same as np.kron(a, b)
+    Same as ``np.kron(a, b)``.
 
     Parameters
     ----------
-    a: array_like
-    b: array_like
+    a : array_like
+    b : array_like
 
     Returns
     -------
     array_like with a.ndim + b.ndim - 2 dimensions
+
     """
-    a = as_tensor_variable(a)
-    b = as_tensor_variable(b)
-
-    if a is b:
-        # In case a is the same as b, we need a different variable to build the OFG
-        b = a.copy()
-
-    if a.ndim + b.ndim <= 2:
-        raise TypeError(
-            "kron: inputs dimensions must sum to 3 or more. "
-            f"You passed {int(a.ndim)} and {int(b.ndim)}."
-        )
-
-    if a.ndim < b.ndim:
-        a = ptb.expand_dims(a, tuple(range(b.ndim - a.ndim)))
-    elif b.ndim < a.ndim:
-        b = ptb.expand_dims(b, tuple(range(a.ndim - b.ndim)))
-    a_reshaped = ptb.expand_dims(a, tuple(range(1, 2 * a.ndim, 2)))
-    b_reshaped = ptb.expand_dims(b, tuple(range(0, 2 * b.ndim, 2)))
-    out_shape = tuple(a.shape[i] * b.shape[i] for i in range(a.ndim))
-    output_out_of_shape = a_reshaped * b_reshaped
-    output_reshaped = output_out_of_shape.reshape(out_shape)
-
-    return KroneckerProduct(inputs=[a, b], outputs=[output_reshaped])(a, b)
+    return _kron(a, b)
 
 
 def matrix_dot(*args):

--- a/pytensor/tensor/rewriting/special.py
+++ b/pytensor/tensor/rewriting/special.py
@@ -1,20 +1,15 @@
 from pytensor.graph.rewriting.basic import copy_stack_trace, node_rewriter
-from pytensor.tensor.elemwise import DimShuffle
-from pytensor.tensor.math import Sum, exp, log, true_div
-from pytensor.tensor.math import sum as pt_sum
+from pytensor.scalar.basic import Exp
+from pytensor.tensor.elemwise import DimShuffle, Elemwise
+from pytensor.tensor.math import Sum, log, true_div
 from pytensor.tensor.rewriting.basic import register_stabilize
-from pytensor.tensor.rewriting.math import local_mul_canonizer
-from pytensor.tensor.special import Softmax, SoftmaxGrad, log_softmax
+from pytensor.tensor.special import Softmax, log_softmax
 from pytensor.tensor.subtensor import (
-    AdvancedIncSubtensor,
     AdvancedSubtensor,
     AdvancedSubtensor1,
     Subtensor,
 )
-from pytensor.tensor.type import (
-    values_eq_approx_remove_inf,
-    values_eq_approx_remove_nan,
-)
+from pytensor.tensor.type import values_eq_approx_remove_inf
 
 
 subtensor_ops = (
@@ -71,105 +66,34 @@ def local_logsoftmax(fgraph, node):
     return [ret]
 
 
-@register_stabilize
-@node_rewriter([SoftmaxGrad])
-def local_logsoftmax_grad(fgraph, node):
-    """
-    Detect Log(Softmax(x))'s grad and replace it with LogSoftmax(x)'s grad
+@register_stabilize("symbolic_op_recognition")
+@node_rewriter([true_div])
+def local_softmax_stabilize(fgraph, node):
+    """Detect exp(x) / sum(exp(x), keepdims=True) and replace with Softmax(x)."""
+    numerator, denominator = node.inputs
 
-    Note: only grad is affected
-    """
-    if (
-        node.inputs[0].owner is not None
-        and node.inputs[0].owner.op == true_div
-        and len(node.inputs[0].owner.inputs) >= 2
-        and node.inputs[0].owner.inputs[1].owner is not None
-        and isinstance(node.inputs[0].owner.inputs[1].owner.op, Softmax)
-        and node.inputs[1] == node.inputs[0].owner.inputs[1]
-        and not (
-            # skip if it will be optimized by
-            # local_advanced_indexing_crossentropy_onehot_grad
-            node.inputs[0].owner.op == true_div
-            and node.inputs[0].owner.inputs[0].owner is not None
-            and isinstance(
-                node.inputs[0].owner.inputs[0].owner.op, AdvancedIncSubtensor
-            )
-            # the rewrite only applies to legacy SoftmaxGrad
-            and node.op == SoftmaxGrad(axis=-1)
-            and node.inputs[0].owner.inputs[1].ndim == 2
-        )
-    ):
-        # get parameters from unoptimized op
-        grads, sm = node.inputs[0].owner.inputs
-        ret = grads - pt_sum(grads, axis=sm.owner.op.axis, keepdims=True) * sm
-        ret.tag.values_eq_approx = values_eq_approx_remove_nan
-        copy_stack_trace(node.outputs[0], ret)
-        return [ret]
+    if not numerator.type.dtype.startswith("float"):
+        return
 
+    match numerator.owner_op_and_inputs:
+        case Elemwise(Exp()), x:
+            pass
+        case _:
+            return None
 
-def softmax_simplifier(numerators, denominators):
-    for numerator in list(numerators):
-        if not numerator.type.dtype.startswith("float"):
-            continue
+    # Denominator may be wrapped in a DimShuffle (from keepdims=True)
+    match denominator.owner_op_and_inputs:
+        case DimShuffle(), sum_var:
+            pass
+        case _:
+            sum_var = denominator
 
-        if not (numerator.owner and numerator.owner.op == exp):
-            continue
+    match sum_var.owner_op_and_inputs:
+        case (Sum(axis=axis), exp_x) if exp_x is numerator:
+            pass
+        case _:
+            return None
 
-        matching_denom = None
-
-        for denominator in denominators:
-            # Division with dimshuffle
-            if denominator.owner and isinstance(denominator.owner.op, DimShuffle):
-                ds_order = denominator.owner.op.new_order
-                # Check that at most only one dimension is being reintroduced by
-                # a dimshuffle. The cases where all dimensions are reintroduced
-                # after a complete sum reduction end up in the else branch
-                if ds_order.count("x") != 1:
-                    continue
-                # Check that dimshuffle does not change order of original dims
-                ds_order_without_x = tuple(dim for dim in ds_order if dim != "x")
-                if tuple(sorted(ds_order_without_x)) != ds_order_without_x:
-                    continue
-                new_dim = ds_order.index("x")
-                z = denominator.owner.inputs[0]
-                if z.owner and isinstance(z.owner.op, Sum):
-                    sum_axis = z.owner.op.axis
-                    # Check that reintroduced dim was the one reduced
-                    if (
-                        (sum_axis is not None)
-                        and (len(sum_axis) == 1)
-                        and (sum_axis[0] == new_dim)
-                    ):
-                        if z.owner.inputs[0] is numerator:
-                            (sum_axis,) = sum_axis
-                            matching_denom = denominator
-                            break
-
-            # Division without dimshuffle
-            else:
-                z = denominator
-                if z.owner and isinstance(z.owner.op, Sum):
-                    sum_axis = z.owner.op.axis
-                    # Filter out partial summations over more than one axis
-                    # The cases where all axis of summation are explicitly given
-                    # as in `sum(matrix, axis=(0, 1))` are eventually rewritten
-                    # to `sum(matrix)` and this branch is not a blocker
-                    if sum_axis is not None and len(sum_axis) != 1:
-                        continue
-                    if z.owner.inputs[0] is numerator:
-                        if sum_axis is not None:
-                            (sum_axis,) = sum_axis
-                        matching_denom = denominator
-                        break
-
-        if matching_denom is not None:
-            softmax = Softmax(axis=sum_axis)(numerator.owner.inputs[0])
-            copy_stack_trace(numerator, softmax)
-            numerators.remove(numerator)
-            denominators.remove(matching_denom)
-            numerators.append(softmax)
-
-    return numerators, denominators
-
-
-local_mul_canonizer.add_simplifier(softmax_simplifier, "softmax_simplifier")
+    ret = Softmax(axis=axis)(x)
+    copy_stack_trace(node.outputs, ret)
+    return [ret]

--- a/pytensor/tensor/rewriting/subtensor_lift.py
+++ b/pytensor/tensor/rewriting/subtensor_lift.py
@@ -365,10 +365,10 @@ def local_subtensor_of_softmax(fgraph, node):
         else:
             # All dimensions are mixed, we can't lift the subtensor
             return None
+    elif len(axis) == 1:
+        axis = normalize_axis_index(axis[0], sm.ndim)
     else:
-        # Softmax currently only allows None or a single integer axis
-        # Unlike CAReduce it does not normalize negative indices
-        axis = normalize_axis_index(axis, sm.ndim)
+        return None
 
     [old_out] = node.outputs
     idx_tuple = indices_from_subtensor(idx, node.op.idx_list)

--- a/pytensor/tensor/special.py
+++ b/pytensor/tensor/special.py
@@ -1,782 +1,109 @@
-from textwrap import dedent
-
-import numpy as np
-import scipy
+from numpy.lib.array_utils import normalize_axis_tuple
 
 from pytensor.gradient import DisconnectedType, disconnected_type
-from pytensor.graph.basic import Apply
 from pytensor.graph.replace import _vectorize_node
-from pytensor.link.c.op import COp
-from pytensor.tensor.basic import as_tensor_variable
 from pytensor.tensor.elemwise import get_normalized_batch_axes
 from pytensor.tensor.math import (
     eq,
+    exp,
     gamma,
     gammaln,
     log,
     log1p,
     mul,
-    neg,
     sum,
     switch,
 )
 from pytensor.tensor.symbolic import TensorSymbolicOp
 
 
-class SoftmaxGrad(COp):
-    """
-    Gradient wrt x of the Softmax Op.
+class Softmax(TensorSymbolicOp):
+    r"""Softmax activation function.
 
+    :math:`\sigma(\mathbf{x})_j = \frac{e^{x_j}}{\sum_k e^{x_k}}`
+
+    Includes the numerical stabilization trick (subtracting the maximum).
     """
 
-    nin = 2
-    nout = 1
     __props__ = ("axis",)
 
-    def __init__(self, axis):
-        if axis is not None and not isinstance(axis, int):
-            raise TypeError("axis must be an integer or `None`")
+    def __init__(self, *, axis, **kwargs):
+        if isinstance(axis, (list, tuple)):
+            axis = tuple(axis)
+        elif isinstance(axis, int):
+            axis = (axis,)
         self.axis = axis
+        super().__init__(**kwargs)
 
-    def make_node(self, dy, sm):
-        dy = as_tensor_variable(dy)
-        sm = as_tensor_variable(sm)
+    def build_inner_graph(self, x):
+        x_stable = x - x.max(axis=self.axis, keepdims=True)
+        e_x = exp(x_stable)
+        return [e_x / e_x.sum(axis=self.axis, keepdims=True)]
 
-        if self.axis is not None and (self.axis >= sm.ndim or self.axis < -sm.ndim):
-            raise ValueError(
-                f"SoftmaxGrad axis(={self.axis}) out of bounds for {sm.ndim}D array {sm}"
-            )
-
-        return Apply(self, [dy, sm], [sm.type()])
-
-    def perform(self, node, input_storage, output_storage):
-        dy, sm = input_storage
-
-        dy_times_sm = dy * sm
-        dx = dy_times_sm - np.sum(dy_times_sm, axis=self.axis, keepdims=True) * sm
-        output_storage[0][0] = dx
-
-    def pullback(self, inp, outputs, grads):
-        dy, sm = inp
-        (g,) = grads
-
-        tmp = g + neg(sum(g * sm, axis=self.axis, keepdims=True))
-        g_dy = tmp * sm
-
-        tmp2 = sum(dy * sm, axis=self.axis, keepdims=True)
-        g_sm = tmp * dy - g * tmp2
-
-        return g_dy, g_sm
-
-    def infer_shape(self, fgraph, node, shape):
-        return [shape[1]]
-
-    def c_code_cache_version(self):
-        return (6,)
-
-    def c_code(self, node, name, inp, out, sub):
-        dy, sm = inp
-        (dx,) = out
-        axis = self.axis if self.axis is not None else "NPY_RAVEL_AXIS"
-        fail = sub["fail"]
-
-        return dedent(
-            f"""
-            PyArrayObject* op[3];
-            npy_uint32 op_flags[3];
-            npy_uint32 iter_flags;
-            NpyIter* iter;
-            NpyIter_IterNextFunc* get_next;
-            char** data_ptr;
-
-            int sm_ndim = PyArray_NDIM({sm});
-            int axis = {axis};
-            int iterate_axis = !(axis == NPY_RAVEL_AXIS || sm_ndim == 1);
-
-            // Validate inputs
-            if ((PyArray_TYPE({dy}) != NPY_DOUBLE) &&
-                (PyArray_TYPE({dy}) != NPY_FLOAT))
-            {{
-                PyErr_SetString(PyExc_TypeError, "types should be float or float64");
-                {fail};
-            }}
-            if ((PyArray_TYPE({sm}) != NPY_DOUBLE) &&
-                (PyArray_TYPE({sm}) != NPY_FLOAT))
-            {{
-                PyErr_SetString(PyExc_TypeError, "types should be float or float64");
-                {fail};
-            }}
-
-            if (iterate_axis)
-            {{
-                if (axis < 0) axis = sm_ndim + axis;
-                if ((axis < 0) || (iterate_axis && (axis > sm_ndim)))
-                {{
-                    PyErr_SetString(PyExc_ValueError, "invalid axis in SoftmaxGrad");
-                    {fail};
-                }}
-            }}
-            if (({dx} == NULL)
-                || !(PyArray_CompareLists(PyArray_DIMS({dx}), PyArray_DIMS({sm}), sm_ndim)))
-            {{
-                Py_XDECREF({dx});
-                {dx} = (PyArrayObject*)PyArray_SimpleNew(sm_ndim,
-                                                         PyArray_DIMS({sm}),
-                                                         PyArray_TYPE({sm}));
-                if (!{dx})
-                {{
-                    PyErr_SetString(PyExc_MemoryError, "failed to alloc SoftMaxGrad dx output");
-                    {fail};
-                }}
-            }}
-
-            // Create numpy iterator
-            op[0] = {dy};
-            op[1] = {sm};
-            op[2] = {dx};
-            op_flags[0] = NPY_ITER_READONLY;
-            op_flags[1] = NPY_ITER_READONLY;
-            op_flags[2] = NPY_ITER_READWRITE;
-            iter_flags = (iterate_axis)? NPY_ITER_MULTI_INDEX : 0;
-            iter = NpyIter_MultiNew(
-                3,
-                op,
-                iter_flags,
-                NPY_KEEPORDER,
-                NPY_NO_CASTING,
-                op_flags,
-                NULL
-            );
-
-            if (iter == NULL)
-            {{
-                PyErr_SetString(PyExc_MemoryError, "failed to create softmax iterator");
-                {fail};
-            }}
-
-            // SoftmaxGrad is applied across the entire array
-            if (!iterate_axis)
-            {{
-                get_next = NpyIter_GetIterNext(iter, NULL);
-                if (get_next == NULL)
-                {{
-                    NpyIter_Deallocate(iter);
-                    PyErr_SetString(PyExc_RuntimeError, "Failed to obtain SoftMaxGrad GetIterNext");
-                    {fail};
-                }}
-                data_ptr = NpyIter_GetDataPtrArray(iter);
-
-                // Compute and accumulate dy * sm
-                dtype_{dx} sum_dy_times_sm = 0.0;
-                do
-                {{
-                    dtype_{dy}* dy_ptr = (dtype_{dy}*)data_ptr[0];
-                    dtype_{sm}* sm_ptr = (dtype_{sm}*)data_ptr[1];
-                    dtype_{dx}* dx_ptr = (dtype_{dx}*)data_ptr[2];
-
-                    *dx_ptr = (dtype_{dx})((*dy_ptr) * (*sm_ptr));
-                    sum_dy_times_sm += *dx_ptr;
-                }} while(get_next(iter));
-
-                // Reset Iterator
-                if (NpyIter_GotoIterIndex(iter, 0) == NPY_FAIL)
-                {{
-                    PyErr_SetString(PyExc_RuntimeError, "Failed to reset softmax iterator");
-                    {fail};
-                }}
-
-                // Subtract sum(dy*sm) * sm
-                do
-                {{
-                    dtype_{sm}* sm_ptr = (dtype_{sm}*)data_ptr[1];
-                    dtype_{dx}* dx_ptr = (dtype_{dx}*)data_ptr[2];
-                    *dx_ptr -= sum_dy_times_sm * ((dtype_{dx})(*sm_ptr));
-                }} while(get_next(iter));
-            }}
-
-            // SoftmaxGrad is applied across a specific axis
-            else {{
-                // Collect axis strides and remove it from iteration
-                npy_intp axis_size = PyArray_DIM({sm}, axis);
-                npy_intp* axis_stride = NpyIter_GetAxisStrideArray(iter, axis);
-                if  (axis_stride == NULL)
-                {{
-                    PyErr_SetString(PyExc_RuntimeError, "Failed to obtain softmax axis strides");
-                    {fail};
-                }}
-                npy_intp dy_axis_stride = axis_stride[0] / sizeof(dtype_{dy});
-                npy_intp sm_axis_stride = axis_stride[1] / sizeof(dtype_{sm});
-                npy_intp dx_axis_stride = axis_stride[2] / sizeof(dtype_{dx});
-
-                if (NpyIter_RemoveAxis(iter, axis) == NPY_FAIL)
-                {{
-                    PyErr_SetString(PyExc_RuntimeError, "Failed to remove SoftmaxGrad axis from iterator");
-                    {fail};
-                }}
-
-                // Iterate over remaining axes
-                get_next = NpyIter_GetIterNext(iter, NULL);
-                if (get_next == NULL)
-                {{
-                    NpyIter_Deallocate(iter);
-                    PyErr_SetString(PyExc_RuntimeError, "Failed to obtain SoftamGrad GetIterNext");
-                    {fail};
-                }}
-
-                data_ptr = NpyIter_GetDataPtrArray(iter);
-                do
-                {{
-                    dtype_{dy}* dy_axis = (dtype_{dy}*)data_ptr[0];
-                    dtype_{sm}* sm_axis = (dtype_{sm}*)data_ptr[1];
-                    dtype_{dx}* dx_axis = (dtype_{dx}*)data_ptr[2];
-
-                    // Compute and accumulate dy * sm
-                    dtype_{dx} sum_dy_times_sm = 0.0;
-                    for (npy_intp i = 0; i < axis_size; i++)
-                    {{
-                        dx_axis[i * dx_axis_stride] = (dtype_{dx})(dy_axis[i * dy_axis_stride] * sm_axis[i * sm_axis_stride]);
-                        sum_dy_times_sm += dx_axis[i * dx_axis_stride];
-                    }}
-
-                    // Subtract sum(dy*sm) * sm
-                    for (npy_intp i = 0; i < axis_size; i++)
-                    {{
-                        dx_axis[i * dx_axis_stride] -= sum_dy_times_sm * (dtype_{dx})(sm_axis[i * sm_axis_stride]);
-                    }}
-
-                }} while(get_next(iter));
-            }}
-            NpyIter_Deallocate(iter);
-            """
-        )
-
-
-class Softmax(COp):
-    r"""
-    Softmax activation function
-    :math:`\\varphi(\\mathbf{x})_j =
-    \\frac{e^{\mathbf{x}_j}}{\sum_{k=1}^K e^{\mathbf{x}_k}}`
-    where :math:`K` is the total number of neurons in the layer. This
-    activation function gets applied row-wise.
-
-    """
-
-    nin = 1
-    nout = 1
-    __props__ = ("axis",)
-
-    def __init__(self, axis):
-        if axis is not None and not isinstance(axis, int):
-            raise TypeError("axis must be an integer or `None`")
-        self.axis = axis
-
-    def make_node(self, x):
-        x = as_tensor_variable(x)
-
-        if self.axis is not None and (self.axis >= x.ndim or self.axis < -x.ndim):
-            raise ValueError(
-                f"Softmax axis(={self.axis}) out of bounds for {x.ndim}D array {x}"
-            )
-
-        return Apply(self, [x], [x.type()])
-
-    def perform(self, node, input_storage, output_storage):
-        (x,) = input_storage
-        (z,) = output_storage
-        z[0] = scipy.special.softmax(x, axis=self.axis)
-
-    def pullback(self, inp, outputs, grads):
-        (_x,) = inp
-        (g_sm,) = grads
-        return [SoftmaxGrad(axis=self.axis)(g_sm, outputs[0])]
+    def pullback(self, inputs, outputs, output_grads):
+        (sm,) = outputs
+        (gz,) = output_grads
+        d = gz * sm
+        return [d - sm * sum(d, axis=self.axis, keepdims=True)]
 
     def pushforward(self, inputs, outputs, eval_points):
         if any(isinstance(t.type, DisconnectedType) for t in eval_points):
             return [disconnected_type()]
         return self.pullback(inputs, outputs, eval_points)
-
-    def infer_shape(self, fgraph, node, shape):
-        return shape
-
-    def c_headers(self, **kwargs):
-        return ["<cmath>"]
-
-    def c_code(self, node, name, inp, out, sub):
-        (x,) = inp
-        (sm,) = out
-        axis = self.axis if self.axis is not None else "NPY_RAVEL_AXIS"
-        fail = sub["fail"]
-        # dtype = node.inputs[0].type.dtype_specs()[1]
-        # TODO: put this into a templated function, in the support code
-        # TODO: declare the max of each row as an Op output
-        # TODO: use this to accept float32 and int32: node.inputs[0].type.dtype_specs()[1]
-        return dedent(
-            f"""
-            PyArrayObject* op[2];
-            npy_uint32 op_flags[2];
-            npy_uint32 iter_flags;
-            NpyIter* iter;
-            NpyIter_IterNextFunc* get_next;
-            char** data_ptr;
-
-            int x_ndim = PyArray_NDIM({x});
-            int axis = {axis};
-            int iterate_axis = !(axis == NPY_RAVEL_AXIS || x_ndim == 1);
-
-            // Validate inputs
-            if ((PyArray_TYPE({x}) != NPY_DOUBLE) &&
-                (PyArray_TYPE({x}) != NPY_FLOAT))
-            {{
-                PyErr_SetString(PyExc_TypeError, "not a float");
-                {fail}
-            }}
-
-            if (iterate_axis)
-            {{
-                if (axis < 0) axis = x_ndim + axis;
-                if ((axis < 0) || (iterate_axis && (axis > x_ndim)))
-                {{
-                    PyErr_SetString(PyExc_ValueError, "invalid axis in Softmax");
-                    {fail}
-                }}
-            }}
-
-            // Allocate Output Array
-            if (({sm}) == NULL || !(PyArray_CompareLists(PyArray_DIMS({sm}), PyArray_DIMS({x}), x_ndim)))
-            {{
-                Py_XDECREF({sm});
-                {sm} = (PyArrayObject*)PyArray_SimpleNew(x_ndim, PyArray_DIMS({x}), PyArray_TYPE({x}));
-                if(!{sm}) {{
-                    PyErr_SetString(PyExc_MemoryError, "failed to alloc Softmax output");
-                    {fail}
-                }}
-            }}
-
-            // Create numpy iterator
-            op[0] = {x};
-            op[1] = {sm};
-            op_flags[0] = NPY_ITER_READONLY;
-            op_flags[1] = NPY_ITER_READWRITE;
-            iter_flags = (iterate_axis)? NPY_ITER_MULTI_INDEX : 0;
-            iter = NpyIter_MultiNew(
-                2,
-                op,
-                iter_flags,
-                NPY_KEEPORDER,
-                NPY_NO_CASTING,
-                op_flags,
-                NULL
-            );
-
-            if (iter == NULL)
-            {{
-                PyErr_SetString(PyExc_MemoryError, "failed to create Softmax iterator");
-                {fail}
-            }}
-
-            // Softmax is applied across the entire array
-            if (!iterate_axis)
-            {{
-                get_next = NpyIter_GetIterNext(iter, NULL);
-                if (get_next == NULL)
-                {{
-                    NpyIter_Deallocate(iter);
-                    PyErr_SetString(PyExc_RuntimeError, "Failed to obtain Softmax GetIterNext");
-                    {fail}
-                }}
-                data_ptr = NpyIter_GetDataPtrArray(iter);
-
-                // Find axis max
-                dtype_{x}* x_ptr = (dtype_{x}*)data_ptr[0];
-                dtype_{x} max = *x_ptr;
-                if (get_next(iter))
-                {{
-                    do
-                    {{
-                        dtype_{x}* x_ptr = (dtype_{x}*)data_ptr[0];
-                        max = (*x_ptr > max)? *x_ptr : max;
-                    }} while(get_next(iter));
-                }}
-
-                // Reset Iterator
-                if (NpyIter_GotoIterIndex(iter, 0) == NPY_FAIL)
-                {{
-                    PyErr_SetString(PyExc_RuntimeError, "Failed to reset Softmax iterator");
-                    {fail}
-                }}
-
-                // Compute and accumulate exp(x-max(x)) exponent
-                double sum_exp_dev = 0.0;
-                do
-                {{
-                    dtype_{x}* x_ptr = (dtype_{x}*)data_ptr[0];
-                    dtype_{sm}* sm_ptr = (dtype_{sm}*)data_ptr[1];
-                    *sm_ptr = (dtype_{sm}) exp(*x_ptr - max);
-                    sum_exp_dev += *sm_ptr;
-                }} while(get_next(iter));
-
-                // Reset Iterator
-                if (NpyIter_GotoIterIndex(iter, 0) == NPY_FAIL)
-                {{
-                    PyErr_SetString(PyExc_RuntimeError, "Failed to reset Softmax iterator");
-                    {fail}
-                }}
-
-                // Divide by sum(exp(x-max(x)))
-                double inv_sum_exp_dev = 1.0 / sum_exp_dev;
-                do
-                {{
-                    dtype_{sm}* sm_ptr = (dtype_{sm}*)data_ptr[1];
-                    *sm_ptr *= inv_sum_exp_dev;
-                }} while(get_next(iter));
-            }}
-
-            // Softmax is applied across a specific axis
-            else {{
-                // Collect axis strides and remove it from iteration
-                npy_intp axis_size = PyArray_DIM({x}, axis);
-                npy_intp* axis_stride = NpyIter_GetAxisStrideArray(iter, axis);
-                if  (axis_stride == NULL)
-                {{
-                    PyErr_SetString(PyExc_RuntimeError, "Failed to obtain Softmax axis strides");
-                    {fail}
-                }}
-                npy_intp x_axis_stride = axis_stride[0] / sizeof(dtype_{x});
-                npy_intp sm_axis_stride = axis_stride[1] / sizeof(dtype_{sm});
-
-                if (NpyIter_RemoveAxis(iter, axis) == NPY_FAIL)
-                {{
-                    PyErr_SetString(PyExc_RuntimeError, "Failed to remove softmax axis from iterator");
-                    {fail}
-                }}
-
-                // Iterate over remaining axes
-                get_next = NpyIter_GetIterNext(iter, NULL);
-                if (get_next == NULL)
-                {{
-                    NpyIter_Deallocate(iter);
-                    PyErr_SetString(PyExc_RuntimeError, "Failed to obtain softmax GetIterNext");
-                    {fail}
-                }}
-
-                data_ptr = NpyIter_GetDataPtrArray(iter);
-                do
-                {{
-                    dtype_{x}* x_axis = (dtype_{x}*)data_ptr[0];
-                    dtype_{sm}* sm_axis = (dtype_{sm}*)data_ptr[1];
-
-                    // Find axis max
-                    dtype_{x} max = x_axis[0];
-                    for (npy_intp i = 1; i < axis_size; i++)
-                    {{
-                        dtype_{x} x_val = x_axis[i * x_axis_stride];
-                        max = (x_val > max)? x_val : max;
-                    }}
-
-                    // Compute and accumulate exp(x-max(x)) exponent
-                    dtype_{sm} sum_exp_dev = 0.0;
-                    for (npy_intp i = 0; i < axis_size; i++)
-                    {{
-                        sm_axis[i * sm_axis_stride] = (dtype_{sm}) exp(x_axis[i * x_axis_stride] - max);
-                        sum_exp_dev += sm_axis[i * sm_axis_stride];
-                    }}
-
-                    // Divide by sum(exp(x-max(x)))
-                    dtype_{sm} inv_sum_exp_dev = 1.0 / sum_exp_dev;
-                    for (npy_intp i = 0; i < axis_size; i++)
-                    {{
-                        sm_axis[i * sm_axis_stride] *= inv_sum_exp_dev;
-                    }}
-
-                }} while(get_next(iter));
-            }}
-            NpyIter_Deallocate(iter);
-            """
-        )
-
-    @staticmethod
-    def c_code_cache_version():
-        return (6,)
 
 
 def softmax(c, axis=None):
-    c = as_tensor_variable(c)
+    if axis is not None:
+        axis = normalize_axis_tuple(axis, c.type.ndim)
     return Softmax(axis=axis)(c)
 
 
-class LogSoftmax(COp):
-    r"""
-    LogSoftmax activation function
-    :math:`\\varphi(\\mathbf{x})_j =
-    \\e^{(\mathbf{x}_j - log{\sum_{k=1}^K e^{\mathbf{x}_k})}}
-    where :math:`K` is the total number of neurons in the layer. This
-    activation function gets applied row-wise.
+class LogSoftmax(TensorSymbolicOp):
+    r"""Log-softmax activation function.
 
+    :math:`\log \sigma(\mathbf{x})_j = x_j - \log \sum_k e^{x_k}`
+
+    Includes the numerical stabilization trick (subtracting the maximum).
     """
 
-    nin = 1
-    nout = 1
     __props__ = ("axis",)
 
-    def __init__(self, axis):
-        if axis is not None and not isinstance(axis, int):
-            raise TypeError("axis must be an integer or `None`")
+    def __init__(self, *, axis, **kwargs):
+        if isinstance(axis, (list, tuple)):
+            axis = tuple(axis)
+        elif isinstance(axis, int):
+            axis = (axis,)
         self.axis = axis
+        super().__init__(**kwargs)
 
-    def make_node(self, x):
-        x = as_tensor_variable(x)
+    def build_inner_graph(self, x):
+        x_stable = x - x.max(axis=self.axis, keepdims=True)
+        return [x_stable - log(exp(x_stable).sum(axis=self.axis, keepdims=True))]
 
-        if self.axis is not None and (self.axis >= x.ndim or self.axis < -x.ndim):
-            raise ValueError(
-                f"LogSoftmax axis(={self.axis}) out of bounds for {x.ndim}D array {x}"
-            )
-
-        return Apply(self, [x], [x.type()])
-
-    def perform(self, node, input_storage, output_storage):
-        (x,) = input_storage
-        (z,) = output_storage
-        z[0] = scipy.special.log_softmax(x, axis=self.axis)
-
-    def pullback(self, inp, outputs, grads):
-        (x,) = inp
-        sm = Softmax(axis=self.axis)(x)
-        return [grads[0] - sum(grads[0], axis=self.axis, keepdims=True) * sm]
-
-    def pushforward(self, inputs, outputs, eval_points):
-        if any(isinstance(t.type, DisconnectedType) for t in eval_points):
-            return [disconnected_type()]
-        return self.pullback(inputs, outputs, eval_points)
-
-    def infer_shape(self, fgraph, node, shape):
-        return shape
-
-    def c_headers(self, **kwargs):
-        return ["<cmath>"]
-
-    def c_code(self, node, name, inp, out, sub):
-        (x,) = inp
-        (sm,) = out
-        axis = self.axis if self.axis is not None else "NPY_RAVEL_AXIS"
-        fail = sub["fail"]
-
-        return dedent(
-            f"""
-            PyArrayObject* op[2];
-            npy_uint32 op_flags[2];
-            npy_uint32 iter_flags;
-            NpyIter* iter;
-            NpyIter_IterNextFunc* get_next;
-            char** data_ptr;
-
-            int x_ndim = PyArray_NDIM({x});
-            int axis = {axis};
-            int iterate_axis = !(axis == NPY_RAVEL_AXIS || x_ndim == 1);
-
-            // Validate inputs
-            if ((PyArray_TYPE({x}) != NPY_DOUBLE) &&
-                (PyArray_TYPE({x}) != NPY_FLOAT))
-            {{
-                PyErr_SetString(PyExc_TypeError, "not a float");
-                {fail}
-            }}
-
-            if (iterate_axis)
-            {{
-                if (axis < 0) axis = x_ndim + axis;
-                if ((axis < 0) || (iterate_axis && (axis > x_ndim)))
-                {{
-                    PyErr_SetString(PyExc_ValueError, "invalid axis in LogSoftmax");
-                    {fail}
-                }}
-            }}
-            // Allocate Output Array
-            if (({sm}) == NULL || !(PyArray_CompareLists(PyArray_DIMS({sm}), PyArray_DIMS({x}), x_ndim)))
-            {{
-                Py_XDECREF({sm});
-                {sm} = (PyArrayObject*)PyArray_SimpleNew(x_ndim, PyArray_DIMS({x}), PyArray_TYPE({x}));
-                if(!{sm}) {{
-                    PyErr_SetString(PyExc_MemoryError, "failed to alloc LogSoftmax output");
-                    {fail}
-                }}
-            }}
-
-            // Create numpy iterator
-            op[0] = {x};
-            op[1] = {sm};
-            op_flags[0] = NPY_ITER_READONLY;
-            op_flags[1] = NPY_ITER_READWRITE;
-            iter_flags = (iterate_axis)? NPY_ITER_MULTI_INDEX : 0;
-            iter = NpyIter_MultiNew(
-                2,
-                op,
-                iter_flags,
-                NPY_KEEPORDER,
-                NPY_NO_CASTING,
-                op_flags,
-                NULL
-            );
-
-            if (iter == NULL)
-            {{
-                PyErr_SetString(PyExc_MemoryError, "failed to create LogSoftmax iterator");
-                {fail}
-            }}
-
-            // LogSoftmax is applied across the entire array
-            if (!iterate_axis)
-            {{
-                get_next = NpyIter_GetIterNext(iter, NULL);
-                if (get_next == NULL)
-                {{
-                    NpyIter_Deallocate(iter);
-                    PyErr_SetString(PyExc_RuntimeError, "Failed to obtain LogSoftmax GetIterNext");
-                    {fail}
-                }}
-                data_ptr = NpyIter_GetDataPtrArray(iter);
-
-                // Find axis max
-                dtype_{x}* x_ptr = (dtype_{x}*)data_ptr[0];
-                dtype_{x} max = *x_ptr;
-                if (get_next(iter))
-                {{
-                    do
-                    {{
-                        dtype_{x}* x_ptr = (dtype_{x}*)data_ptr[0];
-                        max = (*x_ptr > max)? *x_ptr : max;
-                    }} while(get_next(iter));
-                }}
-
-                // Reset Iterator
-                if (NpyIter_GotoIterIndex(iter, 0) == NPY_FAIL)
-                {{
-                    PyErr_SetString(PyExc_RuntimeError, "Failed to reset LogSoftmax iterator");
-                    {fail}
-                }}
-
-                // Compute xdev and sum(exp(xdev))
-                dtype_{sm} sum_exp_xdev = 0.0;
-                do
-                {{
-                    dtype_{x}* x_ptr = (dtype_{x}*)data_ptr[0];
-                    dtype_{sm}* sm_ptr = (dtype_{sm}*)data_ptr[1];
-                    *sm_ptr = (dtype_{sm})((*x_ptr) - max);
-                    sum_exp_xdev += exp(*sm_ptr);
-                }} while(get_next(iter));
-
-                // Reset Iterator
-                if (NpyIter_GotoIterIndex(iter, 0) == NPY_FAIL)
-                {{
-                    PyErr_SetString(PyExc_RuntimeError, "Failed to reset LogSoftmax iterator");
-                    {fail}
-                }}
-
-                // Subtract log(sum(exp(xdev)))
-                dtype_{sm} log_sum_exp_xdev = log(sum_exp_xdev);
-                do
-                {{
-                    dtype_{sm}* sm_ptr = (dtype_{sm}*)data_ptr[1];
-                    *sm_ptr -= log_sum_exp_xdev;
-                }} while(get_next(iter));
-            }}
-
-            // LogSoftmax is applied across a specific axis
-            else {{
-                // Collect axis strides and remove it from iteration
-                npy_intp axis_size = PyArray_DIM({x}, axis);
-                npy_intp* axis_stride = NpyIter_GetAxisStrideArray(iter, axis);
-                if  (axis_stride == NULL)
-                {{
-                    PyErr_SetString(PyExc_RuntimeError, "Failed to obtain LogSoftmax axis strides");
-                    {fail}
-                }}
-                npy_intp x_axis_stride = axis_stride[0] / sizeof(dtype_{x});
-                npy_intp sm_axis_stride = axis_stride[1] / sizeof(dtype_{sm});
-
-                if (NpyIter_RemoveAxis(iter, axis) == NPY_FAIL)
-                {{
-                    PyErr_SetString(PyExc_RuntimeError, "Failed to remove LogSoftmax axis from iterator");
-                    {fail}
-                }}
-
-                // Iterate over remaining axes
-                get_next = NpyIter_GetIterNext(iter, NULL);
-                if (get_next == NULL)
-                {{
-                    NpyIter_Deallocate(iter);
-                    PyErr_SetString(PyExc_RuntimeError, "Failed to obtain LogSoftmax GetIterNext");
-                    {fail}
-                }}
-
-                data_ptr = NpyIter_GetDataPtrArray(iter);
-                do
-                {{
-                    dtype_{x}* x_axis = (dtype_{x}*)data_ptr[0];
-                    dtype_{sm}* sm_axis = (dtype_{sm}*)data_ptr[1];
-
-                    // Find axis max
-                    dtype_{x} max = x_axis[0];
-                    for (npy_intp i = 1; i < axis_size; i++)
-                    {{
-                        dtype_{x} x_val = x_axis[i * x_axis_stride];
-                        max = (x_val > max)? x_val : max;
-                    }}
-
-                    // Compute xdev and sum(exp(xdev))
-                    dtype_{sm} sum_exp_xdev = 0.0;
-                    for (npy_intp i = 0; i < axis_size; i++)
-                    {{
-                        sm_axis[i * sm_axis_stride] = (dtype_{x})(x_axis[i * x_axis_stride] - max);
-                        sum_exp_xdev += exp(sm_axis[i * sm_axis_stride]);
-                    }}
-
-                    // Subtract log(sum(exp(xdev))
-                    dtype_{sm} log_sum_exp_xdev = log(sum_exp_xdev);
-                    for (npy_intp i = 0; i < axis_size; i++)
-                    {{
-                        sm_axis[i * sm_axis_stride] -= log_sum_exp_xdev;
-                    }}
-
-                }} while(get_next(iter));
-            }}
-            NpyIter_Deallocate(iter);
-            """
-        )
-
-    @staticmethod
-    def c_code_cache_version():
-        return (3,)
+    def pullback(self, inputs, outputs, output_grads):
+        (x,) = inputs
+        (gz,) = output_grads
+        sm = softmax(x, axis=self.axis)
+        return [gz - sum(gz, axis=self.axis, keepdims=True) * sm]
 
 
 def log_softmax(c, axis=None):
-    c = as_tensor_variable(c)
+    if axis is not None:
+        axis = normalize_axis_tuple(axis, c.type.ndim)
     return LogSoftmax(axis=axis)(c)
 
 
 @_vectorize_node.register(Softmax)
 @_vectorize_node.register(LogSoftmax)
 def vectorize_softmax_node(op, node, batched_x):
-    """
-    Vectorize Softmax and LogSoftmax nodes.
-
-    """
     core_ndim = node.inputs[0].type.ndim
     batch_ndim = batched_x.type.ndim - core_ndim
 
     if not batch_ndim:
-        return op.make_node(batched_x)
+        return [op(batched_x)]
 
     batch_axes = get_normalized_batch_axes(op.axis, core_ndim, batch_ndim)
-
-    if len(batch_axes) > 1:
-        from pytensor.tensor.blockwise import vectorize_node_fallback
-
-        # The softmax Ops only allow a specific axis (integer) or all axis (None).
-        # If the vectorized operation requires more than one axis we have to default to a Blockwise
-        return vectorize_node_fallback(op, node, batched_x)
-
-    [batch_axis] = batch_axes
-    return type(op)(axis=batch_axis).make_node(batched_x)
+    return [type(op)(axis=batch_axes)(batched_x)]
 
 
 def poch(z, m):

--- a/pytensor/tensor/special.py
+++ b/pytensor/tensor/special.py
@@ -9,7 +9,18 @@ from pytensor.graph.replace import _vectorize_node
 from pytensor.link.c.op import COp
 from pytensor.tensor.basic import as_tensor_variable
 from pytensor.tensor.elemwise import get_normalized_batch_axes
-from pytensor.tensor.math import gamma, gammaln, log, neg, sum
+from pytensor.tensor.math import (
+    eq,
+    gamma,
+    gammaln,
+    log,
+    log1p,
+    mul,
+    neg,
+    sum,
+    switch,
+)
+from pytensor.tensor.symbolic import TensorSymbolicOp
 
 
 class SoftmaxGrad(COp):
@@ -808,6 +819,76 @@ def betaln(a, b):
     return gammaln(a) + gammaln(b) - gammaln(a + b)
 
 
+class XLogY(TensorSymbolicOp):
+    """Compute x * log(y), returning 0 when x = 0.
+
+    Matches :func:`scipy.special.xlogy`. The gradient is not masked at x=0,
+    matching the mathematically correct result (``-inf`` when y=0).
+    """
+
+    inline = True
+
+    def build_inner_graph(self, x, y):
+        return [switch(eq(x, 0), 0, mul(x, log(y)))]
+
+    def pullback(self, inputs, outputs, output_grads):
+        x, y = inputs
+        (gz,) = output_grads
+        return [gz * log(y), gz * x / y]
+
+
+_xlogy = XLogY()
+
+
+def xlogy(x, y):
+    """Compute x * log(y), returning 0 when x = 0.
+
+    Matches :func:`scipy.special.xlogy`.
+
+    Parameters
+    ----------
+    x : array_like
+    y : array_like
+
+    """
+    return _xlogy(x, y)
+
+
+class XLog1PY(TensorSymbolicOp):
+    """Compute x * log(1 + y), returning 0 when x = 0.
+
+    Matches :func:`scipy.special.xlog1py`. The gradient is not masked at x=0,
+    matching the mathematically correct result.
+    """
+
+    inline = True
+
+    def build_inner_graph(self, x, y):
+        return [switch(eq(x, 0), 0, mul(x, log1p(y)))]
+
+    def pullback(self, inputs, outputs, output_grads):
+        x, y = inputs
+        (gz,) = output_grads
+        return [gz * log1p(y), gz * x / (1 + y)]
+
+
+_xlog1py = XLog1PY()
+
+
+def xlog1py(x, y):
+    """Compute x * log(1 + y), returning 0 when x = 0.
+
+    Matches :func:`scipy.special.xlog1py`.
+
+    Parameters
+    ----------
+    x : array_like
+    y : array_like
+
+    """
+    return _xlog1py(x, y)
+
+
 __all__ = [
     "beta",
     "betaln",
@@ -816,4 +897,6 @@ __all__ = [
     "logit",
     "poch",
     "softmax",
+    "xlog1py",
+    "xlogy",
 ]

--- a/pytensor/tensor/symbolic.py
+++ b/pytensor/tensor/symbolic.py
@@ -1,0 +1,10 @@
+from pytensor.compile.builders import SymbolicOp
+from pytensor.tensor.basic import as_tensor_variable
+
+
+class TensorSymbolicOp(SymbolicOp):
+    """SymbolicOp that converts inputs via ``as_tensor_variable``."""
+
+    @staticmethod
+    def filter_inputs(*inputs):
+        return tuple(as_tensor_variable(inp) for inp in inputs)

--- a/pytensor/tensor/xlogx.py
+++ b/pytensor/tensor/xlogx.py
@@ -1,66 +1,37 @@
-import numpy as np
-
-from pytensor import scalar as ps
-from pytensor.tensor.elemwise import Elemwise
+import warnings
 
 
-class XlogX(ps.UnaryScalarOp):
-    """
-    Compute X * log(X), with special case 0 log(0) = 0.
+def xlogx(x):
+    """Compute x * log(x), returning 0 when x = 0.
 
-    """
-
-    def impl(self, x):
-        if x == 0.0:
-            return 0.0
-        return x * np.log(x)
-
-    def pullback(self, inputs, outputs, grads):
-        (x,) = inputs
-        (gz,) = grads
-        return [gz * (1 + ps.log(x))]
-
-    def c_code(self, node, name, inputs, outputs, sub):
-        (x,) = inputs
-        (z,) = outputs
-        if node.inputs[0].type in [ps.float32, ps.float64]:
-            return f"""{z} =
-                {x} == 0.0
-                ? 0.0
-                : {x} * log({x});"""
-        raise NotImplementedError("only floatingpoint is implemented")
-
-
-scalar_xlogx = XlogX(ps.upgrade_to_float)
-xlogx = Elemwise(scalar_xlogx, name="xlogx")
-
-
-class XlogY0(ps.BinaryScalarOp):
-    """
-    Compute X * log(Y), with special case 0 log(0) = 0.
+    .. deprecated::
+        Use ``pytensor.tensor.special.xlogy(x, x)`` instead.
 
     """
+    warnings.warn(
+        "pytensor.tensor.xlogx.xlogx is deprecated. "
+        "Use pytensor.tensor.special.xlogy(x, x) instead.",
+        FutureWarning,
+        stacklevel=2,
+    )
+    from pytensor.tensor.special import xlogy
 
-    def impl(self, x, y):
-        if x == 0.0:
-            return 0.0
-        return x * np.log(y)
-
-    def pullback(self, inputs, outputs, grads):
-        x, y = inputs
-        (gz,) = grads
-        return [gz * ps.log(y), gz * x / y]
-
-    def c_code(self, node, name, inputs, outputs, sub):
-        x, y = inputs
-        (z,) = outputs
-        if node.inputs[0].type in [ps.float32, ps.float64]:
-            return f"""{z} =
-                {x} == 0.0
-                ? 0.0
-                : {x} * log({y});"""
-        raise NotImplementedError("only floatingpoint is implemented")
+    return xlogy(x, x)
 
 
-scalar_xlogy0 = XlogY0(ps.upgrade_to_float)
-xlogy0 = Elemwise(scalar_xlogy0, name="xlogy0")
+def xlogy0(x, y):
+    """Compute x * log(y), returning 0 when x = 0.
+
+    .. deprecated::
+        Use ``pytensor.tensor.special.xlogy(x, y)`` instead.
+
+    """
+    warnings.warn(
+        "pytensor.tensor.xlogx.xlogy0 is deprecated. "
+        "Use pytensor.tensor.special.xlogy(x, y) instead.",
+        FutureWarning,
+        stacklevel=2,
+    )
+    from pytensor.tensor.special import xlogy
+
+    return xlogy(x, y)

--- a/tests/graph/test_features.py
+++ b/tests/graph/test_features.py
@@ -53,8 +53,8 @@ class TestReplaceValidate:
 
 
 def test_full_history():
-    x = pt.scalar("x")
-    out = pt.log(pt.exp(x) / pt.sum(pt.exp(x)))
+    x = pt.vector("x")
+    out = pt.log(pt.exp(x) / pt.sum(pt.exp(x), keepdims=True))
     fg = FunctionGraph(outputs=[out], clone=True, copy_inputs=False)
     history = FullHistory()
     fg.attach_feature(history)
@@ -64,22 +64,22 @@ def test_full_history():
     assert equal_computations(fg.outputs, [out])
 
     history.end()
-    assert equal_computations(fg.outputs, [pt.special.log_softmax(x)])
+    assert equal_computations(fg.outputs, [pt.special.log_softmax(x, axis=None)])
 
     history.prev()
-    assert equal_computations(fg.outputs, [pt.log(pt.special.softmax(x))])
+    assert equal_computations(fg.outputs, [pt.log(pt.special.softmax(x, axis=None))])
 
     for i in range(10):
         history.prev()
     assert equal_computations(fg.outputs, [out])
 
     history.goto(2)
-    assert equal_computations(fg.outputs, [pt.log(pt.special.softmax(x))])
+    assert equal_computations(fg.outputs, [pt.log(pt.special.softmax(x, axis=None))])
 
     for i in range(10):
         history.next()
 
-    assert equal_computations(fg.outputs, [pt.special.log_softmax(x)])
+    assert equal_computations(fg.outputs, [pt.special.log_softmax(x, axis=None)])
 
 
 class TestPickleRoundTrip:

--- a/tests/link/jax/test_elemwise.py
+++ b/tests/link/jax/test_elemwise.py
@@ -8,7 +8,7 @@ from pytensor.tensor import elemwise as pt_elemwise
 from pytensor.tensor.math import all as pt_all
 from pytensor.tensor.math import prod
 from pytensor.tensor.math import sum as pt_sum
-from pytensor.tensor.special import SoftmaxGrad, log_softmax, softmax
+from pytensor.tensor.special import log_softmax, softmax
 from pytensor.tensor.type import matrix, tensor, vector, vectors
 from tests.link.jax.test_basic import compare_jax_and_py
 from tests.tensor.test_elemwise import check_elemwise_runtime_broadcast
@@ -83,17 +83,6 @@ def test_logsoftmax(axis):
     out = log_softmax(x, axis=axis)
 
     compare_jax_and_py([x], [out], [x_test_value])
-
-
-@pytest.mark.parametrize("axis", [None, 0, 1])
-def test_softmax_grad(axis):
-    dy = matrix("dy")
-    dy_test_value = np.array([[1, 1, 1], [0, 0, 0]], dtype=config.floatX)
-    sm = matrix("sm")
-    sm_test_value = np.arange(6, dtype=config.floatX).reshape(2, 3)
-    out = SoftmaxGrad(axis=axis)(dy, sm)
-
-    compare_jax_and_py([dy, sm], [out], [dy_test_value, sm_test_value])
 
 
 def test_multiple_input_multiply():

--- a/tests/link/mlx/test_elemwise.py
+++ b/tests/link/mlx/test_elemwise.py
@@ -32,7 +32,7 @@ from pytensor.tensor.math import any as pt_any
 from pytensor.tensor.math import max as pt_max
 from pytensor.tensor.math import min as pt_min
 from pytensor.tensor.math import sum as pt_sum
-from pytensor.tensor.special import SoftmaxGrad, log_softmax, softmax
+from pytensor.tensor.special import log_softmax, softmax
 from pytensor.tensor.type import matrix, vector, vectors
 from tests.link.mlx.test_basic import compare_mlx_and_py
 
@@ -83,17 +83,6 @@ def test_softmax(axis):
     x_test_value = np.arange(6, dtype=config.floatX).reshape(2, 3)
     out = softmax(x, axis=axis)
     compare_mlx_and_py([x], [out], [x_test_value])
-
-
-@pytest.mark.parametrize("axis", [None, 0, 1])
-def test_softmax_grad(axis):
-    dy = matrix("dy")
-    dy_test_value = np.array([[1, 1, 1], [0, 0, 0]], dtype=config.floatX)
-    sm = matrix("sm")
-    sm_test_value = np.arange(6, dtype=config.floatX).reshape(2, 3)
-    out = SoftmaxGrad(axis=axis)(dy, sm)
-
-    compare_mlx_and_py([dy, sm], [out], [dy_test_value, sm_test_value])
 
 
 @pytest.mark.parametrize("axis", [None, 0, 1])

--- a/tests/link/numba/test_elemwise.py
+++ b/tests/link/numba/test_elemwise.py
@@ -15,7 +15,7 @@ from pytensor.scalar import add as scalar_add
 from pytensor.tensor import blas, matrix, tensor3
 from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
 from pytensor.tensor.math import All, Any, Max, Min, Prod, ProdWithoutZeros, Sum
-from pytensor.tensor.special import LogSoftmax, Softmax, SoftmaxGrad
+from pytensor.tensor.special import LogSoftmax, Softmax
 from tests.link.numba.test_basic import (
     compare_numba_and_py,
     numba_mode,
@@ -409,53 +409,6 @@ def test_scalar_Elemwise_Clip():
     c = pt.clip(z, 1, 3)
 
     compare_numba_and_py(inputs, [c], [1, 1])
-
-
-@pytest.mark.parametrize(
-    "dy, sm, axis, exc",
-    [
-        (
-            (pt.matrix(), np.array([[1, 1, 1], [0, 0, 0]], dtype=config.floatX)),
-            (pt.matrix(), rng.random(size=(2, 3)).astype(config.floatX)),
-            None,
-            None,
-        ),
-        (
-            (pt.matrix(), np.array([[1, 1, 1], [0, 0, 0]], dtype=config.floatX)),
-            (pt.matrix(), rng.random(size=(2, 3)).astype(config.floatX)),
-            0,
-            None,
-        ),
-        (
-            (pt.matrix(), np.array([[1, 1, 1], [0, 0, 0]], dtype=config.floatX)),
-            (pt.matrix(), rng.random(size=(2, 3)).astype(config.floatX)),
-            1,
-            None,
-        ),
-    ],
-)
-def test_SoftmaxGrad(dy, sm, axis, exc):
-    dy, dy_test_value = dy
-    sm, sm_test_value = sm
-    g = SoftmaxGrad(axis=axis)(dy, sm)
-
-    cm = contextlib.suppress() if exc is None else pytest.warns(exc)
-    with cm:
-        compare_numba_and_py(
-            [dy, sm],
-            [g],
-            [dy_test_value, sm_test_value],
-        )
-
-
-def test_SoftMaxGrad_constant_dy():
-    dy = pt.constant(np.zeros((3,), dtype=config.floatX))
-    sm = pt.vector(shape=(3,))
-    inputs = [sm]
-
-    g = SoftmaxGrad(axis=None)(dy, sm)
-
-    compare_numba_and_py(inputs, [g], [np.ones((3,), dtype=config.floatX)])
 
 
 @pytest.mark.parametrize(

--- a/tests/link/pytorch/test_elemwise.py
+++ b/tests/link/pytorch/test_elemwise.py
@@ -7,7 +7,7 @@ import pytensor.tensor.math as ptm
 from pytensor.configdefaults import config
 from pytensor.scalar.basic import ScalarOp, get_scalar_type
 from pytensor.tensor.elemwise import Elemwise
-from pytensor.tensor.special import SoftmaxGrad, log_softmax, softmax
+from pytensor.tensor.special import log_softmax, softmax
 from pytensor.tensor.type import matrix, tensor, tensor3, vector
 from tests.link.pytorch.test_basic import compare_pytorch_and_py
 
@@ -130,16 +130,6 @@ def test_logsoftmax(axis, dtype):
             compare_pytorch_and_py([x], [out], [test_input])
     else:
         compare_pytorch_and_py([x], [out], [test_input])
-
-
-@pytest.mark.parametrize("axis", [None, 0, 1])
-def test_softmax_grad(axis):
-    dy = matrix("dy")
-    dy_value = np.array([[1, 1, 1], [0, 0, 0]], dtype=config.floatX)
-    sm = matrix("sm")
-    sm_value = np.arange(6, dtype=config.floatX).reshape(2, 3)
-    out = SoftmaxGrad(axis=axis)(dy, sm)
-    compare_pytorch_and_py([dy, sm], [out], [dy_value, sm_value])
 
 
 def test_cast():

--- a/tests/tensor/rewriting/test_special.py
+++ b/tests/tensor/rewriting/test_special.py
@@ -10,8 +10,8 @@ from pytensor.configdefaults import config
 from pytensor.graph.fg import FunctionGraph
 from pytensor.graph.rewriting.basic import check_stack_trace
 from pytensor.graph.rewriting.db import RewriteDatabaseQuery
-from pytensor.tensor.math import add, exp, log, true_div
-from pytensor.tensor.special import LogSoftmax, Softmax, SoftmaxGrad, softmax
+from pytensor.tensor.math import exp, log
+from pytensor.tensor.special import LogSoftmax, Softmax, softmax
 from pytensor.tensor.type import matrix
 from tests import unittest_tools as utt
 
@@ -96,31 +96,6 @@ class TestLogSoftmaxRewrites:
         f = FunctionGraph([sa], [myfunc(sa)])
         _fast_run_rewrites(f)
         assert check_stack_trace(f, ops_to_check="all")
-
-    def test_logsoftmax_grad_true_div_elemwise(self):
-        """
-        Checks that the gradient of an expression similar to a ``log(softmax)`` but
-        with a different elemwise operation than true_div is not rewritten.
-        """
-
-        x = matrix("x")
-        y = log(softmax(x, axis=-1))
-        g = pytensor.tensor.grad(y.sum(), x)
-
-        softmax_grad_node = g.owner
-        assert softmax_grad_node.op == SoftmaxGrad(axis=-1)
-        true_div_node = softmax_grad_node.inputs[0].owner
-        assert true_div_node.op == true_div
-
-        # We replace thk elemwise true_div op by an elemwise add.
-        new_g = SoftmaxGrad(axis=-1)(
-            add(*true_div_node.inputs), softmax_grad_node.inputs[1]
-        )
-
-        fgraph = FunctionGraph([x], [new_g])
-        _fast_run_rewrites.rewrite(fgraph)
-
-        assert SoftmaxGrad(axis=-1) in [n.op for n in fgraph.toposort()]
 
 
 def test_softmax_graph():

--- a/tests/tensor/test_special.py
+++ b/tests/tensor/test_special.py
@@ -147,10 +147,7 @@ def test_vectorize_softmax(op, constructor, core_axis, batch_axis):
 
     new_out = vectorize_graph(out, {x: batch_x})
     assert isinstance(new_out.owner.op, op)
-    if len(batch_axis) == 1:
-        assert (new_out.owner.op.axis,) == batch_axis
-    else:
-        assert new_out.owner.op.axis == batch_axis
+    assert new_out.owner.op.axis == batch_axis
 
 
 def test_poch():

--- a/tests/tensor/test_special.py
+++ b/tests/tensor/test_special.py
@@ -6,15 +6,16 @@ from scipy.special import log_softmax as scipy_log_softmax
 from scipy.special import logit as scipy_logit
 from scipy.special import poch as scipy_poch
 from scipy.special import softmax as scipy_softmax
+from scipy.special import xlog1py as scipy_xlog1py
+from scipy.special import xlogy as scipy_xlogy
 
+from pytensor import grad
 from pytensor.compile.maker import function
 from pytensor.configdefaults import config
 from pytensor.graph.replace import vectorize_graph
-from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.special import (
     LogSoftmax,
     Softmax,
-    SoftmaxGrad,
     beta,
     betaln,
     factorial,
@@ -22,6 +23,8 @@ from pytensor.tensor.special import (
     logit,
     poch,
     softmax,
+    xlog1py,
+    xlogy,
 )
 from pytensor.tensor.type import matrix, tensor, tensor3, tensor4, vector, vectors
 from tests import unittest_tools as utt
@@ -74,15 +77,15 @@ class TestSoftmax(utt.InferShapeTester):
         with pytest.raises(TypeError):
             Softmax(1.5)
 
-        x = [tensor3()] * LogSoftmax.nin
-        Softmax(2)(*x)
-        Softmax(-3)(*x)
+        x = tensor3()
+        Softmax(axis=2)(x)
+        Softmax(axis=-3)(x)
 
         with pytest.raises(ValueError):
-            Softmax(3)(*x)
+            Softmax(axis=3)(x)
 
         with pytest.raises(ValueError):
-            Softmax(-4)(*x)
+            Softmax(axis=-4)(x)
 
 
 class TestLogSoftmax(utt.InferShapeTester):
@@ -114,44 +117,15 @@ class TestLogSoftmax(utt.InferShapeTester):
         with pytest.raises(TypeError):
             LogSoftmax(1.5)
 
-        x = [tensor3()] * LogSoftmax.nin
-        LogSoftmax(2)(*x)
-        LogSoftmax(-3)(*x)
+        x = tensor3()
+        LogSoftmax(axis=2)(x)
+        LogSoftmax(axis=-3)(x)
 
         with pytest.raises(ValueError):
-            LogSoftmax(3)(*x)
+            LogSoftmax(axis=3)(x)
 
         with pytest.raises(ValueError):
-            LogSoftmax(-4)(*x)
-
-
-class TestSoftmaxGrad(utt.InferShapeTester):
-    def test_infer_shape(self):
-        admat = matrix()
-        bdmat = matrix()
-        rng = np.random.default_rng(utt.fetch_seed())
-        admat_val = rng.random((3, 4)).astype(config.floatX)
-        bdmat_val = rng.random((3, 4)).astype(config.floatX)
-        self._compile_and_check(
-            [admat, bdmat],
-            [SoftmaxGrad(axis=-1)(admat, bdmat)],
-            [admat_val, bdmat_val],
-            SoftmaxGrad,
-        )
-
-    def test_valid_axis(self):
-        with pytest.raises(TypeError):
-            SoftmaxGrad(1.5)
-
-        x = [tensor3()] * SoftmaxGrad.nin
-        SoftmaxGrad(2)(*x)
-        SoftmaxGrad(-3)(*x)
-
-        with pytest.raises(ValueError):
-            SoftmaxGrad(3)(*x)
-
-        with pytest.raises(ValueError):
-            SoftmaxGrad(-4)(*x)
+            LogSoftmax(axis=-4)(x)
 
 
 @pytest.mark.parametrize(
@@ -172,14 +146,11 @@ def test_vectorize_softmax(op, constructor, core_axis, batch_axis):
     assert isinstance(out.owner.op, op)
 
     new_out = vectorize_graph(out, {x: batch_x})
+    assert isinstance(new_out.owner.op, op)
     if len(batch_axis) == 1:
-        assert isinstance(new_out.owner.op, op)
         assert (new_out.owner.op.axis,) == batch_axis
     else:
-        assert isinstance(new_out.owner.op, Blockwise) and isinstance(
-            new_out.owner.op.core_op, op
-        )
-        assert new_out.owner.op.core_op.axis == core_axis
+        assert new_out.owner.op.axis == batch_axis
 
 
 def test_poch():
@@ -244,3 +215,74 @@ def test_betaln():
     np.testing.assert_allclose(
         actual, expected, rtol=1e-7 if config.floatX == "float64" else 1e-5
     )
+
+
+def test_xlogy():
+    x, y = vectors("x", "y")
+    out = xlogy(x, y)
+
+    f = function([x, y], out)
+    x_test = np.array([0.0, 0.5, 1.0, 2.0])
+    y_test = np.array([0.0, 0.5, 1.0, 2.0])
+    np.testing.assert_allclose(f(x_test, y_test), scipy_xlogy(x_test, y_test))
+
+    # test grad edge cases
+    gx, gy = grad(out.sum(), [x, y])
+    gf = function([x, y], [gx, gy])
+    # x=0, y=0: grad_x = log(0) = -inf, grad_y = 0/0 = nan
+    [gxv], [gyv] = gf(np.array([0.0]), np.array([0.0]))
+    assert gxv == -np.inf
+    assert np.isnan(gyv)
+    # x=0, y=1: grad_x = log(1) = 0, grad_y = 0/1 = 0
+    [gxv], [gyv] = gf(np.array([0.0]), np.array([1.0]))
+    np.testing.assert_allclose(gxv, 0.0)
+    np.testing.assert_allclose(gyv, 0.0)
+
+    rng = np.random.default_rng(239)
+    utt.verify_grad(xlogy, [rng.random((3, 4)), rng.random((3, 4))])
+
+
+def test_xlogy_as_xlogx():
+    x = vector("x")
+    out = xlogy(x, x)
+
+    f = function([x], out)
+    x_test = np.array([0.0, 0.5, 1.0, 2.0])
+    np.testing.assert_allclose(f(x_test), scipy_xlogy(x_test, x_test))
+
+    # test grad edge cases
+    gx = grad(out.sum(), x)
+    gf = function([x], gx)
+    # x=0: 1+log(0) = -inf
+    np.testing.assert_equal(gf(np.array([0.0]))[0], -np.inf)
+    # x=1: 1+log(1) = 1
+    np.testing.assert_allclose(gf(np.array([1.0]))[0], 1.0)
+
+    rng = np.random.default_rng(260)
+    utt.verify_grad(lambda x: xlogy(x, x), [rng.random((3, 4))])
+
+
+def test_xlog1py():
+    x, y = vectors("x", "y")
+    out = xlog1py(x, y)
+
+    f = function([x, y], out)
+
+    x_test = np.array([0.0, 0.5, 1.0, 2.0])
+    y_test = np.array([-1.0, 0.0, 1.0, 2.0])
+    np.testing.assert_allclose(f(x_test, y_test), scipy_xlog1py(x_test, y_test))
+
+    # test grad edge cases
+    gx, gy = grad(out.sum(), [x, y])
+    gf = function([x, y], [gx, gy])
+    # x=0, y=-1: grad_x = log1p(-1) = -inf, grad_y = 0/(1+(-1)) = nan
+    [gxv], [gyv] = gf(np.array([0.0]), np.array([-1.0]))
+    assert gxv == -np.inf
+    assert np.isnan(gyv)
+    # x=0, y=0: grad_x = log1p(0) = 0, grad_y = 0/1 = 0
+    [gxv], [gyv] = gf(np.array([0.0]), np.array([0.0]))
+    np.testing.assert_allclose(gxv, 0.0)
+    np.testing.assert_allclose(gyv, 0.0)
+
+    rng = np.random.default_rng(286)
+    utt.verify_grad(xlog1py, [rng.random((3, 4)), rng.random((3, 4))])


### PR DESCRIPTION
- **Add print_inner_graphs parameter to debugprint** Closes #1285 
- **Add SymbolicOp: OpFromGraph subclass with deferred graph construction**
- **Convert AllocDiag and KroneckerProduct to SymbolicOp**
- **Implement xlogy and xlog1py as SymbolicOp, deprecate xlogx module**  Closes #2106 
- **Convert Softmax and LogSoftmax to TensorSymbolicOp**

Related to https://github.com/pymc-devs/pytensor/issues/1210

These Ops are needed to hide the inner graph for easier graph rewriting, or to control autodiff. There's no need to implement new primitives for this functionality. Removing primitive Ops makes maintaining multiple backends easier, and benefits from optimizations we do do the core primitives.

I had postponed softmax because it had a custom C kernel, but with the change from it being the default I think it's fine. Numba is doing the same thing it was doing before (but less code), and libraries that may prefer direct dispatch like JAX/PyTorch/MLX continue to do so.

 I adde a new SymbolicOp subclass, much in line with the prototype SymbolicRandomVariable in PyMC. It has a method to build the inner graph on demant from input types, and a simpler interface than OFG (OFG is a bit too much already, so I didn't want to extend it further, we can reconsider this).

Next we could tackle https://github.com/pymc-devs/pytensor/issues/1221, which would allow us to still work with them as objects (needed for dispatching in PyMC), but allows us to have less real Ops, and to also inline, which can be great for memory optimization / rewrites. (E.g., a MvNormal L -> covariance -> L across the RV boundary doesn't get optimized now), plus memory opt and all that. That's left for another PR though
