### PR TITLE
Lazy scipy import

### DIFF
--- a/pytensor/__init__.py
+++ b/pytensor/__init__.py
@@ -1,3 +1,6 @@
+import sys
+
+
 __docformat__ = "restructuredtext en"
 
 
@@ -14,7 +17,6 @@ from pytensor.configdefaults import config
 
 # isort: off
 from pytensor import tensor
-from pytensor import sparse
 from pytensor.compile import (
     In,
     Mode,
@@ -32,7 +34,22 @@ from pytensor.scan.basic import scan
 from pytensor.scan.views import map
 from pytensor.compile.builders import OpFromGraph
 from pytensor.link.jax.ops import wrap_jax
+from pytensor import _sparse_lazy
 # isort: on
+
+
+def __getattr__(name):
+    if name == "sparse":
+        # During pytensor.sparse's own import, submodules may do
+        # `import pytensor.sparse.X as Y` which probes pytensor.sparse via
+        # getattr before the parent attribute has been set. Return the
+        # partially-loaded module from sys.modules to avoid re-entry.
+        if "pytensor.sparse" in sys.modules:
+            return sys.modules["pytensor.sparse"]
+        import pytensor.sparse as sparse
+
+        return sparse
+    raise AttributeError(f"module 'pytensor' has no attribute {name!r}")
 
 
 # Some config variables are registered by submodules. Only after all those

--- a/pytensor/_sparse_lazy.py
+++ b/pytensor/_sparse_lazy.py
@@ -1,0 +1,31 @@
+"""Lazy registration of scipy.sparse handlers on pytensor's dispatchers.
+
+Imported by `pytensor/__init__.py` so `pytensor.sparse` doesn't have to be
+loaded eagerly at startup. The fallbacks match `type(x).__module__` against
+`scipy.sparse` as a string, so this module itself doesn't import scipy.sparse;
+the real handlers (and their scipy.sparse dependency) are pulled in only when
+an actual scipy.sparse value is passed to `as_symbolic` / `shared`.
+"""
+
+from pytensor.basic import _as_symbolic
+from pytensor.compile.sharedvalue import shared_constructor
+
+
+def _lazy_as_symbolic_sparse(x):
+    if type(x).__module__.startswith("scipy.sparse"):
+        from pytensor.sparse.basic import as_symbolic_sparse
+
+        return as_symbolic_sparse
+    return None
+
+
+def _lazy_shared_sparse(x):
+    if type(x).__module__.startswith("scipy.sparse"):
+        from pytensor.sparse.sharedvar import sparse_constructor
+
+        return sparse_constructor
+    return None
+
+
+_as_symbolic.register_lazy(_lazy_as_symbolic_sparse)  # type: ignore[attr-defined]
+shared_constructor.register_lazy(_lazy_shared_sparse)  # type: ignore[attr-defined]

--- a/pytensor/basic.py
+++ b/pytensor/basic.py
@@ -2,6 +2,7 @@ from functools import singledispatch
 from typing import Any
 
 from pytensor.graph import Variable
+from pytensor.utils import add_lazy_dispatcher
 
 
 def as_symbolic(x: Any, name: str | None = None, **kwargs) -> Variable:
@@ -40,3 +41,6 @@ def _as_symbolic(x: Any, **kwargs) -> Variable:
     from pytensor.tensor import as_tensor_variable
 
     return as_tensor_variable(x, **kwargs)
+
+
+add_lazy_dispatcher(_as_symbolic)

--- a/pytensor/compile/sharedvalue.py
+++ b/pytensor/compile/sharedvalue.py
@@ -10,6 +10,7 @@ from pytensor.graph.basic import Variable
 from pytensor.graph.utils import add_tag_trace
 from pytensor.link.basic import Container
 from pytensor.link.c.type import generic
+from pytensor.utils import add_lazy_dispatcher
 
 
 if TYPE_CHECKING:
@@ -223,3 +224,6 @@ def shared_constructor(value, name=None, strict=False, allow_downcast=None, **kw
         allow_downcast=allow_downcast,
         name=name,
     )
+
+
+add_lazy_dispatcher(shared_constructor)

--- a/pytensor/scalar/math.py
+++ b/pytensor/scalar/math.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from textwrap import dedent
 
 import numpy as np
-from scipy import special
 
 from pytensor.configdefaults import config
 from pytensor.gradient import grad_not_implemented, grad_undefined
@@ -43,6 +42,11 @@ from pytensor.scalar.basic import (
 )
 from pytensor.scalar.basic import abs as scalar_abs
 from pytensor.scalar.loop import ScalarLoop
+from pytensor.utils import lazy_scipy_module
+
+
+# scipy.special is considerably slow to import; defer to first use
+special = lazy_scipy_module("special")
 
 
 C_CODE_PATH = Path(__file__).parent / "c_code"

--- a/pytensor/tensor/blas.py
+++ b/pytensor/tensor/blas.py
@@ -83,9 +83,9 @@ from pathlib import Path
 
 import numpy as np
 from numpy.lib.array_utils import normalize_axis_tuple
-from scipy.linalg import get_blas_funcs
 
 from pytensor.graph import Variable, vectorize_graph
+from pytensor.tensor.linalg._lazy import scipy_linalg
 
 
 try:
@@ -135,13 +135,11 @@ def view_roots(node: Variable) -> list[Variable]:
 
 def must_initialize_y_gemv():
     # Check whether Scipy GEMV could output nan if y in not initialized
-    from scipy.linalg.blas import get_blas_funcs
-
     if must_initialize_y_gemv._result is None:
         y = np.full((2,), np.nan)
         x = np.ones((2,))
         A = np.ones((2, 2))
-        gemv = get_blas_funcs("gemv", dtype=y.dtype)
+        gemv = scipy_linalg.get_blas_funcs("gemv", dtype=y.dtype)
         gemv(1.0, A.T, x, 0.0, y, overwrite_y=True, trans=True)
         must_initialize_y_gemv._result = np.isnan(y).any()
 
@@ -200,15 +198,13 @@ class Gemv(Op):
         return Apply(self, inputs, [y.type()])
 
     def perform(self, node, inputs, out_storage):
-        from scipy.linalg.blas import get_blas_funcs
-
         y, alpha, A, x, beta = inputs
         if (
             y.shape[0] != 0
             and x.shape[0] != 0
             and y.dtype in {"float32", "float64", "complex64", "complex128"}
         ):
-            gemv = get_blas_funcs("gemv", dtype=y.dtype)
+            gemv = scipy_linalg.get_blas_funcs("gemv", dtype=y.dtype)
 
             if A.shape[0] != y.shape[0] or A.shape[1] != x.shape[0]:
                 raise ValueError(
@@ -312,7 +308,7 @@ class Ger(Op):
         A, alpha, x, y = inputs
         if A.size:
             # GER doesn't handle zero-sized inputs
-            ger_func = get_blas_funcs("ger", dtype=A.dtype)
+            ger_func = scipy_linalg.get_blas_funcs("ger", dtype=A.dtype)
             if A.flags["C_CONTIGUOUS"]:
                 # Work on transposed system to avoid copying
                 A = ger_func(alpha, y, x, a=A.T, overwrite_a=self.destructive).T

--- a/pytensor/tensor/linalg/_lazy.py
+++ b/pytensor/tensor/linalg/_lazy.py
@@ -1,0 +1,12 @@
+"""Lazy scipy.linalg proxy.
+
+scipy.linalg is one of the slowest scipy submodules to import (~250ms) and is
+only needed at runtime in `Op.perform` methods, never at graph-construction
+time. This module exposes a proxy that defers the import until first attribute
+access.
+"""
+
+from pytensor.utils import lazy_scipy_module
+
+
+scipy_linalg = lazy_scipy_module("linalg")

--- a/pytensor/tensor/linalg/constructors.py
+++ b/pytensor/tensor/linalg/constructors.py
@@ -1,11 +1,10 @@
-import scipy.linalg as scipy_linalg
-
 import pytensor
 from pytensor import tensor as pt
 from pytensor.graph.basic import Apply
 from pytensor.graph.op import Op
 from pytensor.tensor import basic as ptb
 from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.linalg._lazy import scipy_linalg
 from pytensor.tensor.linalg.dtype_utils import _largest_common_dtype
 from pytensor.tensor.variable import TensorVariable
 from pytensor.utils import unzip

--- a/pytensor/tensor/linalg/decomposition/cholesky.py
+++ b/pytensor/tensor/linalg/decomposition/cholesky.py
@@ -2,7 +2,6 @@ import warnings
 from typing import Literal
 
 import numpy as np
-from scipy import linalg as scipy_linalg
 
 from pytensor.graph import Apply, Op
 from pytensor.raise_op import CheckAndRaise
@@ -11,6 +10,7 @@ from pytensor.tensor import basic as ptb
 from pytensor.tensor import math as ptm
 from pytensor.tensor.basic import as_tensor_variable
 from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.linalg._lazy import scipy_linalg
 from pytensor.tensor.linalg.dtype_utils import linalg_output_dtype
 from pytensor.tensor.type import tensor
 

--- a/pytensor/tensor/linalg/decomposition/eigen.py
+++ b/pytensor/tensor/linalg/decomposition/eigen.py
@@ -2,7 +2,6 @@ import warnings
 from typing import cast
 
 import numpy as np
-import scipy.linalg as scipy_linalg
 
 from pytensor.gradient import DisconnectedType
 from pytensor.graph.basic import Apply
@@ -10,6 +9,7 @@ from pytensor.graph.op import Op
 from pytensor.tensor import TensorLike
 from pytensor.tensor.basic import as_tensor_variable, diag, eye, tril, triu
 from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.linalg._lazy import scipy_linalg
 from pytensor.tensor.linalg.dtype_utils import linalg_real_output_dtype
 from pytensor.tensor.math import sub, switch
 from pytensor.tensor.type import Variable, tensor, vector

--- a/pytensor/tensor/linalg/decomposition/lu.py
+++ b/pytensor/tensor/linalg/decomposition/lu.py
@@ -2,8 +2,6 @@ from collections.abc import Sequence
 from typing import cast
 
 import numpy as np
-from scipy import linalg as scipy_linalg
-from scipy.linalg import get_lapack_funcs
 
 from pytensor import tensor as pt
 from pytensor.gradient import DisconnectedType
@@ -12,6 +10,7 @@ from pytensor.tensor import TensorLike
 from pytensor.tensor import basic as ptb
 from pytensor.tensor.basic import as_tensor_variable
 from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.linalg._lazy import scipy_linalg
 from pytensor.tensor.linalg.dtype_utils import (
     linalg_output_dtype,
     linalg_real_output_dtype,
@@ -280,7 +279,7 @@ class LUFactor(Op):
             outputs[1][0] = np.array([], dtype=np.int32)
             return
 
-        (getrf,) = get_lapack_funcs(("getrf",), (A,))
+        (getrf,) = scipy_linalg.get_lapack_funcs(("getrf",), (A,))
         LU, p, info = getrf(A, overwrite_a=self.overwrite_a)
         if info != 0:
             LU[...] = np.nan

--- a/pytensor/tensor/linalg/decomposition/qr.py
+++ b/pytensor/tensor/linalg/decomposition/qr.py
@@ -1,7 +1,6 @@
 from typing import Literal, cast
 
 import numpy as np
-from scipy.linalg import get_lapack_funcs
 
 from pytensor import ifelse
 from pytensor import tensor as pt
@@ -13,6 +12,7 @@ from pytensor.tensor import basic as ptb
 from pytensor.tensor import math as ptm
 from pytensor.tensor.basic import as_tensor_variable
 from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.linalg._lazy import scipy_linalg
 from pytensor.tensor.linalg.dtype_utils import linalg_output_dtype
 from pytensor.tensor.type import tensor
 
@@ -156,13 +156,13 @@ class QR(Op):
         M, N = x.shape
 
         if self.pivoting:
-            (geqp3,) = get_lapack_funcs(("geqp3",), (x,))
+            (geqp3,) = scipy_linalg.get_lapack_funcs(("geqp3",), (x,))
             qr, jpvt, tau, *_work_info = self._call_and_get_lwork(
                 geqp3, x, lwork=-1, overwrite_a=self.overwrite_a
             )
             jpvt -= 1  # geqp3 returns a 1-based index array, so subtract 1
         else:
-            (geqrf,) = get_lapack_funcs(("geqrf",), (x,))
+            (geqrf,) = scipy_linalg.get_lapack_funcs(("geqrf",), (x,))
             qr, tau, *_work_info = self._call_and_get_lwork(
                 geqrf, x, lwork=-1, overwrite_a=self.overwrite_a
             )
@@ -194,7 +194,7 @@ class QR(Op):
             outputs[2][0] = R
             return
 
-        (gor_un_gqr,) = get_lapack_funcs(("orgqr",), (qr,))
+        (gor_un_gqr,) = scipy_linalg.get_lapack_funcs(("orgqr",), (qr,))
 
         if M < N:
             Q, _work, _info = self._call_and_get_lwork(

--- a/pytensor/tensor/linalg/decomposition/schur.py
+++ b/pytensor/tensor/linalg/decomposition/schur.py
@@ -1,14 +1,13 @@
 from typing import Literal
 
 import numpy as np
-from scipy import linalg as scipy_linalg
-from scipy.linalg import get_lapack_funcs
 
 import pytensor
 from pytensor.graph import Apply, Op
 from pytensor.tensor import TensorLike
 from pytensor.tensor.basic import as_tensor_variable
 from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.linalg._lazy import scipy_linalg
 from pytensor.tensor.linalg.dtype_utils import linalg_output_dtype
 from pytensor.tensor.type import matrix, vector
 from pytensor.tensor.variable import TensorVariable
@@ -443,7 +442,7 @@ class QZ(Op):
             sort_function, _ = self.make_sort_function()
             select = sort_function(alpha, beta)
 
-            tgsen = get_lapack_funcs("tgsen", (AA, BB))
+            tgsen = scipy_linalg.get_lapack_funcs("tgsen", (AA, BB))
             lwork = 4 * AA.shape[0] + 16 if gges_type in "sd" else 1
             AA, BB, *ab, Q, Z, _, _, _, _, info = tgsen(
                 select,

--- a/pytensor/tensor/linalg/products.py
+++ b/pytensor/tensor/linalg/products.py
@@ -1,5 +1,3 @@
-import scipy.linalg as scipy_linalg
-
 from pytensor import tensor as pt
 from pytensor.graph.basic import Apply
 from pytensor.graph.op import Op
@@ -7,6 +5,7 @@ from pytensor.tensor import basic as ptb
 from pytensor.tensor import math as ptm
 from pytensor.tensor.basic import as_tensor_variable
 from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.linalg._lazy import scipy_linalg
 from pytensor.tensor.symbolic import TensorSymbolicOp
 from pytensor.tensor.type import matrix
 

--- a/pytensor/tensor/linalg/solvers/general.py
+++ b/pytensor/tensor/linalg/solvers/general.py
@@ -2,12 +2,12 @@ import warnings
 from functools import partial
 
 import numpy as np
-import scipy.linalg as scipy_linalg
 
 from pytensor import tensor as pt
 from pytensor.graph.op import Op
 from pytensor.tensor.basic import diagonal
 from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.linalg._lazy import scipy_linalg
 from pytensor.tensor.linalg.decomposition.lu import pivot_to_permutation
 from pytensor.tensor.linalg.solvers.core import SolveBase, _default_b_ndim
 from pytensor.tensor.linalg.solvers.triangular import solve_triangular

--- a/pytensor/tensor/linalg/solvers/linear_control.py
+++ b/pytensor/tensor/linalg/solvers/linear_control.py
@@ -1,7 +1,6 @@
 from typing import Literal, cast
 
 import numpy as np
-from scipy.linalg import get_lapack_funcs
 
 import pytensor
 import pytensor.tensor.basic as ptb
@@ -12,6 +11,7 @@ from pytensor.tensor import TensorLike
 from pytensor.tensor.basic import as_tensor_variable, zeros
 from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.functional import vectorize
+from pytensor.tensor.linalg._lazy import scipy_linalg
 from pytensor.tensor.linalg.decomposition.lu import lu
 from pytensor.tensor.linalg.decomposition.qr import qr
 from pytensor.tensor.linalg.decomposition.schur import qz, schur
@@ -69,7 +69,7 @@ class TRSYL(Op):
         X = outputs_storage[0]
 
         out_dtype = node.outputs[0].type.dtype
-        (trsyl,) = get_lapack_funcs(("trsyl",), (A, B, C))
+        (trsyl,) = scipy_linalg.get_lapack_funcs(("trsyl",), (A, B, C))
 
         if A.size == 0 or B.size == 0:
             return np.empty_like(C, dtype=out_dtype)

--- a/pytensor/tensor/linalg/solvers/psd.py
+++ b/pytensor/tensor/linalg/solvers/psd.py
@@ -1,11 +1,11 @@
 import numpy as np
-from scipy.linalg import get_lapack_funcs
 
 from pytensor.graph.basic import Apply
 from pytensor.graph.op import Op
 from pytensor.tensor import TensorLike
 from pytensor.tensor import basic as ptb
 from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.linalg._lazy import scipy_linalg
 from pytensor.tensor.linalg.dtype_utils import linalg_output_dtype
 from pytensor.tensor.linalg.solvers.core import SolveBase, _default_b_ndim
 from pytensor.tensor.type import tensor
@@ -35,7 +35,7 @@ class CholeskySolve(SolveBase):
     def perform(self, node, inputs, output_storage):
         c, b = inputs
 
-        (potrs,) = get_lapack_funcs(("potrs",), (c, b))
+        (potrs,) = scipy_linalg.get_lapack_funcs(("potrs",), (c, b))
 
         if c.shape[0] != c.shape[1]:
             raise ValueError("The factored matrix c is not square.")

--- a/pytensor/tensor/linalg/solvers/triangular.py
+++ b/pytensor/tensor/linalg/solvers/triangular.py
@@ -1,11 +1,11 @@
 from typing import cast
 
 import numpy as np
-from scipy.linalg import get_lapack_funcs
 
 from pytensor.graph.op import Op
 from pytensor.tensor import basic as ptb
 from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.linalg._lazy import scipy_linalg
 from pytensor.tensor.linalg.solvers.core import SolveBase, _default_b_ndim
 from pytensor.tensor.variable import TensorVariable
 
@@ -38,7 +38,7 @@ class SolveTriangular(SolveBase):
         if A.shape[0] != b.shape[0]:
             raise ValueError(f"shapes of a {A.shape} and b {b.shape} are incompatible")
 
-        (trtrs,) = get_lapack_funcs(("trtrs",), (A, b))
+        (trtrs,) = scipy_linalg.get_lapack_funcs(("trtrs",), (A, b))
 
         # Quick return for empty arrays
         if b.size == 0:

--- a/pytensor/tensor/linalg/solvers/tridiagonal.py
+++ b/pytensor/tensor/linalg/solvers/tridiagonal.py
@@ -2,11 +2,11 @@ import typing
 from typing import TYPE_CHECKING
 
 import numpy as np
-from scipy.linalg import get_lapack_funcs
 
 from pytensor.graph import Apply, Op
 from pytensor.tensor.basic import as_tensor, diagonal
 from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.linalg._lazy import scipy_linalg
 from pytensor.tensor.type import tensor, vector
 from pytensor.tensor.variable import TensorVariable
 
@@ -64,7 +64,7 @@ class LUFactorTridiagonal(Op):
                 n = None
 
         dummy_arrays = [np.zeros((), dtype=inp.type.dtype) for inp in (dl, d, du)]
-        out_dtype = get_lapack_funcs("gttrf", dummy_arrays).dtype
+        out_dtype = scipy_linalg.get_lapack_funcs("gttrf", dummy_arrays).dtype
         outputs = [
             vector(shape=(None if n is None else (n - 1),), dtype=out_dtype),
             vector(shape=(n,), dtype=out_dtype),
@@ -75,7 +75,7 @@ class LUFactorTridiagonal(Op):
         return Apply(self, [dl, d, du], outputs)
 
     def perform(self, node, inputs, output_storage):
-        gttrf = get_lapack_funcs("gttrf", dtype=node.outputs[0].type.dtype)
+        gttrf = scipy_linalg.get_lapack_funcs("gttrf", dtype=node.outputs[0].type.dtype)
         dl, d, du, du2, ipiv, _ = gttrf(
             *inputs,
             overwrite_dl=self.overwrite_dl,
@@ -148,7 +148,7 @@ class SolveLUFactorTridiagonal(Op):
         dummy_arrays = [
             np.zeros((), dtype=inp.type.dtype) for inp in (dl, d, du, du2, b)
         ]
-        out_dtype = get_lapack_funcs("gttrs", dummy_arrays).dtype
+        out_dtype = scipy_linalg.get_lapack_funcs("gttrs", dummy_arrays).dtype
         if self.b_ndim == 1:
             output_shape = (n,)
         else:
@@ -158,7 +158,7 @@ class SolveLUFactorTridiagonal(Op):
         return Apply(self, [dl, d, du, du2, ipiv, b], outputs)
 
     def perform(self, node, inputs, output_storage):
-        gttrs = get_lapack_funcs("gttrs", dtype=node.outputs[0].type.dtype)
+        gttrs = scipy_linalg.get_lapack_funcs("gttrs", dtype=node.outputs[0].type.dtype)
         x, _ = gttrs(
             *inputs,
             overwrite_b=self.overwrite_b,

--- a/pytensor/tensor/random/basic.py
+++ b/pytensor/tensor/random/basic.py
@@ -19,11 +19,11 @@ from pytensor.tensor.random.utils import (
     normalize_size_param,
 )
 from pytensor.tensor.utils import faster_broadcast_to, faster_ndindex
+from pytensor.utils import lazy_scipy_module
 
 
-# Scipy.stats is considerably slow to import
-# We import scipy.stats lazily inside `ScipyRandomVariable`
-stats = None
+# scipy.stats is considerably slow to import; defer to first use
+stats = lazy_scipy_module("stats")
 
 
 try:
@@ -62,9 +62,6 @@ class ScipyRandomVariable(RandomVariable):
 
     @classmethod
     def rng_fn(cls, *args, **kwargs):
-        global stats
-        if stats is None:
-            import scipy.stats as stats
         size = args[-1]
         res = cls.rng_fn_scipy(*args, **kwargs)
 

--- a/pytensor/tensor/signal/conv.py
+++ b/pytensor/tensor/signal/conv.py
@@ -3,7 +3,6 @@ from typing import cast as type_cast
 
 import numpy as np
 from numpy import convolve as numpy_convolve
-from scipy.signal import convolve as scipy_convolve
 
 from pytensor.gradient import disconnected_type
 from pytensor.graph import Apply, Constant
@@ -18,6 +17,11 @@ from pytensor.tensor.pad import pad
 from pytensor.tensor.subtensor import flip
 from pytensor.tensor.type import tensor
 from pytensor.tensor.variable import TensorVariable
+from pytensor.utils import lazy_scipy_module
+
+
+# scipy.signal is considerably slow to import; defer to first use
+scipy_signal = lazy_scipy_module("signal")
 
 
 if TYPE_CHECKING:
@@ -256,7 +260,7 @@ class Convolve2d(AbstractConvolveNd, Op):  # type: ignore[misc]
     def perform(self, node, inputs, outputs):
         in1, in2, full_mode = inputs
         mode = "full" if full_mode else "valid"
-        outputs[0][0] = scipy_convolve(in1, in2, mode=mode, method=self.method)
+        outputs[0][0] = scipy_signal.convolve(in1, in2, mode=mode, method=self.method)
 
 
 def convolve2d(

--- a/pytensor/utils.py
+++ b/pytensor/utils.py
@@ -19,6 +19,7 @@ __all__ = [
     "NPY_RAVEL_AXIS",
     "PYTHON_INT_BITWIDTH",
     "NoDuplicateOptWarningFilter",
+    "add_lazy_dispatcher",
     "call_subprocess_Popen",
     "get_unbound_function",
     "lazy_scipy_module",
@@ -55,6 +56,50 @@ def lazy_scipy_module(submodule):
     first attribute access; subsequent calls hit the cached module directly.
     """
     return _LazyScipyModule(f"scipy.{submodule}")
+
+
+def add_lazy_dispatcher(dispatcher):
+    """Extend a `functools.singledispatch` dispatcher with lazy fallback handlers.
+
+    The dispatcher gains a `register_lazy(fallback)` method. A fallback is
+    a callable `fallback(obj) -> handler | None`. When standard dispatch falls
+    through to the `object` default, registered fallbacks are tried in order;
+    the first to return a non-None handler has that handler registered for
+    `type(obj)` (so subsequent calls dispatch directly) and is then called.
+
+    This lets a package register a handler for a third-party type without
+    importing the third-party module at registration time -- the fallback can
+    detect the type by `type(obj).__module__` and trigger a lazy import only
+    when an instance actually shows up.
+
+    Calling this more than once on the same dispatcher is a no-op (returns
+    the already-extended dispatcher unchanged).
+    """
+    if hasattr(dispatcher, "register_lazy"):
+        return dispatcher
+
+    fallbacks: list = []
+    original_default = dispatcher.registry[object]
+
+    @dispatcher.register(object)
+    def _wrapped_default(arg, *args, **kwargs):
+        for fallback in fallbacks:
+            handler = fallback(arg)
+            # Guard against a fallback that hands back the wrapped default
+            # itself (e.g. when a lazy import didn't actually register a
+            # specific handler for type(arg)) -- registering it would cause
+            # infinite recursion on the next call.
+            if handler is not None and handler is not _wrapped_default:
+                dispatcher.register(type(arg))(handler)
+                return handler(arg, *args, **kwargs)
+        return original_default(arg, *args, **kwargs)
+
+    def register_lazy(fallback):
+        fallbacks.append(fallback)
+        return fallback
+
+    dispatcher.register_lazy = register_lazy
+    return dispatcher
 
 
 __excepthooks: list = []

--- a/pytensor/utils.py
+++ b/pytensor/utils.py
@@ -21,10 +21,40 @@ __all__ = [
     "NoDuplicateOptWarningFilter",
     "call_subprocess_Popen",
     "get_unbound_function",
+    "lazy_scipy_module",
     "maybe_add_to_os_environ_pathlist",
     "output_subprocess_Popen",
     "subprocess_Popen",
 ]
+
+
+class _LazyScipyModule:
+    """Proxy that defers `scipy.<sub>` import until first attribute access."""
+
+    __slots__ = ("_name", "_real")
+
+    def __init__(self, name):
+        self._name = name
+        self._real = None
+
+    def __getattr__(self, name):
+        # `_real` is in __slots__, so this lookup hits the slot, not __getattr__.
+        if self._real is None:
+            import importlib
+
+            self._real = importlib.import_module(self._name)
+        return getattr(self._real, name)
+
+
+def lazy_scipy_module(submodule):
+    """Return a lazy proxy for `scipy.<submodule>` that defers the import.
+
+    Use this for slow scipy submodules that are only needed at runtime in
+    `Op.perform` / `impl()` paths (e.g. `scipy.signal`, `scipy.special`,
+    `scipy.linalg`, `scipy.stats`). The proxy caches the real module on
+    first attribute access; subsequent calls hit the cached module directly.
+    """
+    return _LazyScipyModule(f"scipy.{submodule}")
 
 
 __excepthooks: list = []

--- a/tests/benchmarks/test_import_time.py
+++ b/tests/benchmarks/test_import_time.py
@@ -1,0 +1,13 @@
+import subprocess
+import sys
+
+
+def test_import_time_pytensor_tensor(benchmark):
+    def run():
+        subprocess.run(
+            [sys.executable, "-c", "import pytensor.tensor"],
+            check=True,
+            capture_output=True,
+        )
+
+    benchmark.pedantic(run, rounds=5, iterations=1)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,3 +1,6 @@
+import subprocess
+import sys
+
 import pytensor
 
 
@@ -32,3 +35,31 @@ def test_root_module_not_polluted():
         "wrap_jax",
         "wrap_py",
     ]
+
+
+def test_eager_import_scipy_submodules():
+    expensive_scipy_modules = (
+        "scipy.linalg",
+        "scipy.sparse",
+        "scipy.special",
+        "scipy.signal",
+        "scipy.stats",
+    )
+
+    code = (
+        "import sys\n"
+        "import pytensor.tensor  # noqa: F401\n"
+        f"loaded = [m for m in {expensive_scipy_modules!r} if m in sys.modules]\n"
+        "print(','.join(loaded))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    loaded = [m for m in result.stdout.strip().split(",") if m]
+    assert not loaded, (
+        f"`import pytensor.tensor` eagerly loaded scipy submodules: {loaded}. "
+        "These should be deferred to first use."
+    )


### PR DESCRIPTION
We have regressed a bit again, this time added a test. Import time x4 faster, and only 4x slower than numpy itself, which is quite the lower bound.

| Commit | Description | Median (ms) |
|--------|-------------|-------------|
| `main` | main (baseline) | 556.1 |
| `874dd4315` | Add import-time benchmark for pytensor.tensor | 554.9 |
| `48eada024` | Use lazy_scipy_module helper for scipy.stats | 553.7 |
| `deae42736` | Lazy import scipy.signal in tensor.signal.conv | 314.7 |
| `99634e273` | Lazy import scipy.special in scalar.math | 295.6 |
| `068e56fd1` | Lazy import scipy.linalg in tensor.linalg and tensor.blas | 238.4 |
| `1da508b6b` | Lazy import scipy.sparse via fallback dispatch | 188.7 |
| `ed3d26d08` | Test that import pytensor.tensor stays lazy for slow scipy submodules | 193.0 |

We rarely use scipy in the end, besides checking for sparse variables, our numba/jax backends don't really need scipy and don't trigger it in the hot path. So it's strictly cost for not much.

The one gotcha was the shared/as_symbolic constructors. This PR adds a lazy dispatcher so only users who actually use sparse variables pay the import cost. This should further help with https://github.com/pymc-devs/pymc/pull/7964

Once lazy imports land on our latest supported version (10 years?) we can switch to them :)