### PR TITLE
Don't inline xlogy and xlog1py early

### DIFF
--- a/pytensor/tensor/rewriting/ofg.py
+++ b/pytensor/tensor/rewriting/ofg.py
@@ -6,6 +6,7 @@ from pytensor.graph import Apply, Variable, clone_replace, node_rewriter
 from pytensor.graph.rewriting.basic import copy_stack_trace, dfs_rewriter
 from pytensor.tensor.basic import AllocDiag
 from pytensor.tensor.rewriting.basic import register_specialize
+from pytensor.tensor.special import XLog1PY, XLogY
 
 
 def inline_ofg_node(node: Apply) -> list[Variable]:
@@ -44,7 +45,7 @@ optdb.register(
 
 
 @register_specialize("inline_ofg")
-@node_rewriter([AllocDiag])
+@node_rewriter([AllocDiag, XLogY, XLog1PY])
 def late_inline_OpFromGraph(fgraph, node):
     """
     Inline `OpFromGraph` nodes.

--- a/pytensor/tensor/special.py
+++ b/pytensor/tensor/special.py
@@ -153,7 +153,12 @@ class XLogY(TensorSymbolicOp):
     matching the mathematically correct result (``-inf`` when y=0).
     """
 
-    inline = True
+    # Inlined late (at specialize) by `late_inline_xlogy_xlog1py` so the inner
+    # `x * log(y)` is hidden from canonicalize/stabilize rewrites that are
+    # unsafe at infinity (e.g. `local_greedy_distributor` turns
+    # `(a-1)*log(y)` into `a*log(y) - log(y)`, which yields nan when log(y) is
+    # -inf at the boundary). After stabilize the body is exposed for fusion.
+    inline = False
 
     def build_inner_graph(self, x, y):
         return [switch(eq(x, 0), 0, mul(x, log(y)))]
@@ -188,7 +193,8 @@ class XLog1PY(TensorSymbolicOp):
     matching the mathematically correct result.
     """
 
-    inline = True
+    # See note on `XLogY.inline`. Same hazard at y = -1 where log1p(y) = -inf.
+    inline = False
 
     def build_inner_graph(self, x, y):
         return [switch(eq(x, 0), 0, mul(x, log1p(y)))]

--- a/pytensor/tensor/special.py
+++ b/pytensor/tensor/special.py
@@ -153,7 +153,7 @@ class XLogY(TensorSymbolicOp):
     matching the mathematically correct result (``-inf`` when y=0).
     """
 
-    # Inlined late (at specialize) by `late_inline_xlogy_xlog1py` so the inner
+    # Inlined late (at specialize) by `late_inline_OpFromGraph` so the inner
     # `x * log(y)` is hidden from canonicalize/stabilize rewrites that are
     # unsafe at infinity (e.g. `local_greedy_distributor` turns
     # `(a-1)*log(y)` into `a*log(y) - log(y)`, which yields nan when log(y) is

--- a/tests/tensor/test_special.py
+++ b/tests/tensor/test_special.py
@@ -283,3 +283,35 @@ def test_xlog1py():
 
     rng = np.random.default_rng(286)
     utt.verify_grad(xlog1py, [rng.random((3, 4)), rng.random((3, 4))])
+
+
+def test_xlogy_no_distribute_at_boundary():
+    """Regression test: ``xlogy((a - 1), y)`` must not be algebraically
+    distributed into ``a*log(y) - log(y)`` when canonicalize/stabilize run.
+
+    The distribution is mathematically valid for finite values but breaks at
+    the boundary where ``log(y) = -inf``: ``a*(-inf) - (-inf) = nan``.
+
+    This pattern shows up in the chi-squared log-pdf
+    ``xlogy(nu/2 - 1, x)`` at ``x = 0`` with ``nu > 2``, where the answer
+    must be ``-inf`` (so the pdf at 0 is 0).
+
+    Achieved by keeping ``XLogY.inline = False``, which hides the inner
+    ``x * log(y)`` from `local_greedy_distributor`.
+    """
+    nu = tensor("nu", shape=(), dtype="int64")
+    x = vector("x")
+    f = function([nu, x], xlogy(nu / 2 - 1, x))
+    out = f(np.int64(3), np.array([0.0, 1.0, 2.0]))
+    np.testing.assert_array_equal(out, np.array([-np.inf, 0.0, 0.5 * np.log(2.0)]))
+
+
+def test_xlog1py_no_distribute_at_boundary():
+    """See ``test_xlogy_no_distribute_at_boundary``. Same hazard for
+    ``xlog1py`` at ``y = -1`` where ``log1p(y) = -inf``.
+    """
+    a = tensor("a", shape=(), dtype="int64")
+    y = vector("y")
+    f = function([a, y], xlog1py(a / 2 - 1, y))
+    out = f(np.int64(3), np.array([-1.0, 0.0, 1.0]))
+    np.testing.assert_array_equal(out, np.array([-np.inf, 0.0, 0.5 * np.log(2.0)]))


### PR DESCRIPTION
Follow up to #2110 This caused some preliz tests, because the algebraic canonizer distributed the terms eagerly, which is not safe when you have -infs in the graph. The thing is even registered in "stabilize"... 

We keep it inline until later