### PR TITLE
Add custom jax jvp for solve_sylvester

### DIFF
--- a/pytensor/link/jax/dispatch/linalg/solvers.py
+++ b/pytensor/link/jax/dispatch/linalg/solvers.py
@@ -82,8 +82,22 @@ def jax_funcify_ChoSolve(op, **kwargs):
 
 
 @jax_funcify.register(SolveSylvester)
-def jax_funcify_SolveSylsterer(op, **kwargs):
+def jax_funcify_SolveSylvester(op, **kwargs):
+    @jax.custom_vjp
     def solve_sylvester(a, b, c):
         return jax.scipy.linalg.solve_sylvester(a, b, c)
+
+    def _fwd(a, b, c):
+        x = jax.scipy.linalg.solve_sylvester(a, b, c)
+        return x, (a, b, x)
+
+    def _bwd(res, dx):
+        a, b, x = res
+        dc = jax.scipy.linalg.solve_sylvester(a.conj().T, b.conj().T, dx)
+        da = -dc @ x.conj().T
+        db = -x.conj().T @ dc
+        return da, db, dc
+
+    solve_sylvester.defvjp(_fwd, _bwd)
 
     return solve_sylvester

--- a/tests/link/jax/linalg/test_solvers.py
+++ b/tests/link/jax/linalg/test_solvers.py
@@ -184,3 +184,7 @@ def test_jax_solve_sylvester():
     out = linear_control.solve_sylvester(A, B, C)
 
     compare_jax_and_py([A, B, C], [out], [A_val, B_val, C_val])
+
+    # We're manually overriding the jax jvp for this Op, so we test the gradients too
+    A_bar, B_bar, C_bar = pt.grad(out.sum(), [A, B, C])
+    compare_jax_and_py([A, B, C], [A_bar, B_bar, C_bar], [A_val, B_val, C_val])

--- a/tests/link/jax/linalg/test_solvers.py
+++ b/tests/link/jax/linalg/test_solvers.py
@@ -182,9 +182,13 @@ def test_jax_solve_sylvester():
     C_val = rng.normal(size=(3, 3)).astype(config.floatX)
 
     out = linear_control.solve_sylvester(A, B, C)
-
-    compare_jax_and_py([A, B, C], [out], [A_val, B_val, C_val])
+    out_grads = pt.grad(out.sum(), [A, B, C])
+    _, out_grad_vals = compare_jax_and_py([A, B, C], out_grads, [A_val, B_val, C_val])
 
     # We're manually overriding the jax jvp for this Op, so we test the gradients too
-    A_bar, B_bar, C_bar = pt.grad(out.sum(), [A, B, C])
-    compare_jax_and_py([A, B, C], [A_bar, B_bar, C_bar], [A_val, B_val, C_val])
+    jax_fn, _ = compare_jax_and_py([A, B, C], [out], [A_val, B_val, C_val])
+    jax_grads = jax.grad(
+        lambda *args: jax_fn.vm.jit_fn(*args)[0].sum(), argnums=[0, 1, 2]
+    )(A_val, B_val, C_val)
+    for g1, g2 in zip(out_grad_vals, jax_grads):
+        np.testing.assert_allclose(g1, g2)


### PR DESCRIPTION
Jax added support for `solve_sylvester` but they didn't add a VJP. There is a bunch of discussion about corner cases in [this thread](https://github.com/jax-ml/jax/issues/669). I don't think we care -- these are about schur/eigenproblems. This is implicated in the autograd graph of solve_sylvester, but we can directly use adjoints. This is already what we do in python/c/numba. Kind of niche, but it comes up in statespace models using nutpie with gradient_backend='jax'.