### PR TITLE
Remove setuptools from runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ keywords = [
     "differentiation",
 ]
 dependencies = [
-    "setuptools>=59.0.0",
     "scipy>=1,<2",
     "numpy>=2.0,<3",
     "numba>=0.58,<=0.65.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=59.0.0",
     "cython",
-    "numpy>=2.0",
+    "numpy>=2.0,<3.0",
     "versioneer[toml]==0.29",
 ]
 build-backend = "setuptools.build_meta"
@@ -49,13 +49,13 @@ keywords = [
 dependencies = [
     "setuptools>=59.0.0",
     "scipy>=1,<2",
-    "numpy>=2.0",
+    "numpy>=2.0,<3",
     "numba>=0.58,<=0.65.1",
-    "filelock>=3.15",
-    "etuples",
-    "logical-unification",
-    "miniKanren",
-    "cons",
+    "filelock>=3.15,<4",
+    "etuples<1",
+    "logical-unification<1",
+    "miniKanren>=1,<2",
+    "cons<1",
 ]
 
 [project.urls]

--- a/pytensor/link/c/cmodule.py
+++ b/pytensor/link/c/cmodule.py
@@ -260,11 +260,9 @@ class DynamicModule:
 
 def _get_ext_suffix():
     """Get the suffix for compiled extensions"""
-    from setuptools._distutils.sysconfig import get_config_var
-
-    dist_suffix = get_config_var("EXT_SUFFIX")
+    dist_suffix = sysconfig.get_config_var("EXT_SUFFIX")
     if dist_suffix is None:
-        dist_suffix = get_config_var("SO")
+        dist_suffix = sysconfig.get_config_var("SO")
     return dist_suffix
 
 
@@ -1693,11 +1691,9 @@ def get_gcc_shared_library_arg():
 
 
 def std_include_dirs():
-    from setuptools._distutils.sysconfig import get_python_inc
-
     numpy_inc_dirs = [np.get_include()]
-    py_inc = get_python_inc()
-    py_plat_spec_inc = get_python_inc(plat_specific=True)
+    py_inc = sysconfig.get_path("include")
+    py_plat_spec_inc = sysconfig.get_path("platinclude")
     python_inc_dirs = (
         [py_inc] if py_inc == py_plat_spec_inc else [py_inc, py_plat_spec_inc]
     )
@@ -1707,17 +1703,11 @@ def std_include_dirs():
 
 @is_StdLibDirsAndLibsType
 def std_lib_dirs_and_libs() -> tuple[list[str], ...] | None:
-    from setuptools._distutils.sysconfig import (
-        get_config_var,
-        get_python_inc,
-        get_python_lib,
-    )
-
     # We cache the results as on Windows, this trigger file access and
     # this method is called many times.
     if std_lib_dirs_and_libs.data is not None:
         return std_lib_dirs_and_libs.data
-    python_inc = get_python_inc()
+    python_inc = sysconfig.get_path("include")
     if sys.platform == "win32":
         # Obtain the library name from the Python version instead of the
         # installation directory, in case the user defined a custom
@@ -1780,7 +1770,7 @@ def std_lib_dirs_and_libs() -> tuple[list[str], ...] | None:
 
         # get the name of the python library (shared object)
 
-        libname = str(get_config_var("LDLIBRARY"))
+        libname = str(sysconfig.get_config_var("LDLIBRARY"))
 
         if libname.startswith("lib"):
             libname = libname[3:]
@@ -1791,18 +1781,15 @@ def std_lib_dirs_and_libs() -> tuple[list[str], ...] | None:
         elif libname.endswith(".a"):
             libname = libname[:-2]
 
-        libdir = str(get_config_var("LIBDIR"))
+        libdir = str(sysconfig.get_config_var("LIBDIR"))
 
         std_lib_dirs_and_libs.data = [libname], [libdir]
 
     # sometimes, the linker cannot find -lpython so we need to tell it
-    # explicitly where it is located this returns
-    # somepath/lib/python2.x
-
-    python_lib = str(get_python_lib(plat_specific=True, standard_lib=True))
-    python_lib = os.path.dirname(python_lib)
-    if python_lib not in std_lib_dirs_and_libs.data[1]:
-        std_lib_dirs_and_libs.data[1].append(python_lib)
+    # explicitly where libpython lives.
+    libdir = sysconfig.get_config_var("LIBDIR")
+    if libdir and libdir not in std_lib_dirs_and_libs.data[1]:
+        std_lib_dirs_and_libs.data[1].append(libdir)
     return std_lib_dirs_and_libs.data
 
 
@@ -2567,11 +2554,9 @@ class GCC_compiler(Compiler):
                 cppfile.write("\n")
 
         if platform.python_implementation() == "PyPy":
-            from setuptools._distutils.sysconfig import get_config_var
-
             suffix = "." + get_lib_extension()
 
-            dist_suffix = get_config_var("SO")
+            dist_suffix = sysconfig.get_config_var("SO")
             if dist_suffix is not None and dist_suffix != "":
                 suffix = dist_suffix
 

--- a/pytensor/link/c/exceptions.py
+++ b/pytensor/link/c/exceptions.py
@@ -1,11 +1,8 @@
-from setuptools.errors import CompileError as BaseCompileError
-
-
 class MissingGXX(Exception):
     """This error is raised when we try to generate c code, but g++ is not available."""
 
 
-class CompileError(BaseCompileError):  # pyright: ignore
+class CompileError(Exception):
     """Custom `Exception` prints compilation errors with their original formatting."""
 
     def __str__(self):


### PR DESCRIPTION
Drops `setuptools` as a **runtime** dependency. It only entered the runtime deps because aesara-devs/aesara#1050 (2022) and pymc-devs/pytensor#277 (2023) reached for `setuptools._distutils.sysconfig` and `setuptools.errors.CompileError` to replace deprecated `distutils` — stdlib `sysconfig` had identical equivalents the whole time, and `_distutils` is a private namespace setuptools makes no stability promises about. The same concern was raised in pymc-devs/pytensor#2026 but closed without action. Lazy imports in pymc-devs/pytensor#1170 hid the cost; this PR removes it entirely.

Swaps the four `setuptools._distutils.sysconfig` calls in `link/c/cmodule.py` to stdlib `sysconfig`, replaces `setuptools.errors.CompileError` with a local `Exception` subclass, and drops `setuptools` from `[project.dependencies]` (kept in `[build-system].requires`). `pytest tests/link/c` passes; verified that `pytensor.function` end-to-end still works with `setuptools` blocked from import.

Related issues: pymc-devs/pytensor#2026, pymc-devs/pytensor#481
Prior PRs: pymc-devs/pytensor#277, pymc-devs/pytensor#483, pymc-devs/pytensor#812, pymc-devs/pytensor#1170, aesara-devs/aesara#1050
