### PR TITLE
Add @ (matmul) operator to XTensorVariable

### DIFF
--- a/pytensor/xtensor/type.py
+++ b/pytensor/xtensor/type.py
@@ -931,6 +931,12 @@ class XTensorVariable(Variable[_XTensorTypeType, OptionalApplyType]):
         """Generalized dot product with another XTensorVariable."""
         return px.math.dot(self, other, dim=dim)
 
+    def __matmul__(self, other):
+        return px.math.dot(self, other)
+
+    def __rmatmul__(self, other):
+        return px.math.dot(other, self)
+
     def broadcast_like(self, other, exclude=None):
         """Broadcast against another XTensorVariable."""
         _, self_bcast = px.shape.broadcast(other, self, exclude=exclude)

--- a/tests/xtensor/test_math.py
+++ b/tests/xtensor/test_math.py
@@ -355,6 +355,42 @@ def test_xelemwise_vectorize():
     check_vectorization([ab, bc], [ab + bc])
 
 
+def test_matmul():
+    """Test basic @ operator."""
+    # Matrix-vector
+    x = xtensor("x", dims=("a", "b"), shape=(2, 3))
+    y = xtensor("y", dims=("b",), shape=(3,))
+    z = x @ y
+    assert z.type.dims == ("a",)
+
+    fn = xr_function([x, y], z)
+    x_test = DataArray(np.ones((2, 3)), dims=("a", "b"))
+    y_test = DataArray(np.ones(3), dims=("b",))
+    z_test = fn(x_test, y_test)
+    expected = x_test.dot(y_test)
+    xr_assert_allclose(z_test, expected)
+
+    # Matrix-matrix
+    x = xtensor("x", dims=("a", "b"), shape=(2, 3))
+    y = xtensor("y", dims=("b", "c"), shape=(3, 4))
+    z = x @ y
+    assert z.type.dims == ("a", "c")
+
+    fn = xr_function([x, y], z)
+    x_test = DataArray(np.add.outer(np.arange(2.0), np.arange(3.0)), dims=("a", "b"))
+    y_test = DataArray(np.add.outer(np.arange(3.0), np.arange(4.0)), dims=("b", "c"))
+    z_test = fn(x_test, y_test)
+    expected = x_test.dot(y_test)
+    xr_assert_allclose(z_test, expected)
+
+
+def test_matmul_vectorize():
+    x = xtensor("x", dims=("a", "b"), shape=(2, 3))
+    y = xtensor("y", dims=("b",), shape=(3,))
+
+    check_vectorization([x, y], [x @ y])
+
+
 def test_dot_vectorize():
     x = xtensor("x", dims=("a", "b"), shape=(2, 3))
     y = xtensor("y", dims=("b", "c"), shape=(3, 4))

--- a/tests/xtensor/test_math.py
+++ b/tests/xtensor/test_math.py
@@ -367,7 +367,7 @@ def test_matmul():
     x_test = DataArray(np.ones((2, 3)), dims=("a", "b"))
     y_test = DataArray(np.ones(3), dims=("b",))
     z_test = fn(x_test, y_test)
-    expected = x_test.dot(y_test)
+    expected = x_test @ y_test
     xr_assert_allclose(z_test, expected)
 
     # Matrix-matrix
@@ -380,15 +380,8 @@ def test_matmul():
     x_test = DataArray(np.add.outer(np.arange(2.0), np.arange(3.0)), dims=("a", "b"))
     y_test = DataArray(np.add.outer(np.arange(3.0), np.arange(4.0)), dims=("b", "c"))
     z_test = fn(x_test, y_test)
-    expected = x_test.dot(y_test)
+    expected = x_test @ y_test
     xr_assert_allclose(z_test, expected)
-
-
-def test_matmul_vectorize():
-    x = xtensor("x", dims=("a", "b"), shape=(2, 3))
-    y = xtensor("y", dims=("b",), shape=(3,))
-
-    check_vectorization([x, y], [x @ y])
 
 
 def test_dot_vectorize():


### PR DESCRIPTION
Add `__matmul__` and `__rmatmul__` to `XTensorVariable`, delegating to `dot` — matching how xarray's `DataArray` implements `@`.

`x @ y` contracts over shared named dims: `(a, b) @ (b, c)` → `(a, c)`.

Relates to #1501