### PR TITLE
Support single string dims in XTensorType

### DIFF
--- a/pytensor/xtensor/type.py
+++ b/pytensor/xtensor/type.py
@@ -61,6 +61,8 @@ class XTensorType(Type, HasDataType, HasShape):
         else:
             self.dtype = np.dtype(dtype).name
 
+        if isinstance(dims, str):
+            dims = (dims,)
         self.dims = tuple(dims)
         if len(set(dims)) < len(dims):
             raise ValueError(f"Dimensions must be unique. Found duplicates in {dims}: ")
@@ -989,6 +991,8 @@ def _extract_data_and_dims(
     else:
         x_data = tensor_constant(x).data
         if dims is not None:
+            if isinstance(dims, str):
+                dims = (dims,)
             x_dims = tuple(dims)
         else:
             if x_data.ndim == 0:

--- a/tests/xtensor/test_type.py
+++ b/tests/xtensor/test_type.py
@@ -235,6 +235,20 @@ def test_isel_missing_dims():
     x.isel(c=0, missing_dims="ignore").dims == ("a", "b")
 
 
+def test_as_xtensor_string_dims():
+    x = as_xtensor(np.array([1, 2]), dims="repo")
+    assert x.type.dims == ("repo",)
+
+    z = xtensor(dims="features")
+    assert z.type.dims == ("features",)
+
+    w = xtensor_constant(np.array([1, 2, 3]), dims="samples")
+    assert w.type.dims == ("samples",)
+
+    v = xtensor_shared(np.array([1, 2]), dims="channel")
+    assert v.type.dims == ("channel",)
+
+
 def test_where():
     a = xtensor(dims=("a", "b"))
     a_test = DataArray(np.arange(6).reshape(2, 3), dims=a.dims)


### PR DESCRIPTION
## Summary

- `XTensorType.__init__` now normalizes a bare string `dims` to a single-element tuple, preventing unintended character iteration

Closes #1793