### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues.
+
+If GitHub private vulnerability reporting is available, use the **Report a vulnerability** button on the repository's Security tab. Otherwise, contact the maintainers through the project's documented support channels before sharing details publicly.
+
+When reporting a vulnerability, include the affected version or commit, a concise impact summary, reproduction steps, and any relevant configuration needed to reproduce the issue.


### PR DESCRIPTION
## Summary
- add a SECURITY.md with guidance for reporting vulnerabilities privately

## Why
The repository is in scope for security research on huntr, but it did not have an obvious repository-level security policy file. This gives reporters a default private-reporting path and discourages disclosure through public issues.

## Testing
- git diff --check