### PR TITLE
Normalize string dims across all xtensor paths

### DIFF
--- a/pytensor/xtensor/basic.py
+++ b/pytensor/xtensor/basic.py
@@ -73,6 +73,9 @@ class XTensorFromTensor(XTypeCastOp):
 
     def __init__(self, dims: Sequence[str]):
         super().__init__()
+
+        if isinstance(dims, str):
+            dims = (dims,)
         self.dims = tuple(dims)
 
     def make_node(self, x):

--- a/pytensor/xtensor/linalg.py
+++ b/pytensor/xtensor/linalg.py
@@ -26,6 +26,8 @@ def cholesky(
     dims : Sequence[str]
         The two core dimensions of the input variable, over which the Cholesky decomposition is computed.
     """
+    if isinstance(dims, str):
+        dims = (dims,)
     if len(dims) != 2:
         raise ValueError(f"Cholesky needs two dims, got {len(dims)}")
 
@@ -71,6 +73,8 @@ def solve(
         Unused by PyTensor. PyTensor will return nan if the operation fails.
     """
     a, b = as_xtensor(a), as_xtensor(b)
+    if isinstance(dims, str):
+        dims = (dims,)
     input_core_dims: tuple[tuple[str, str], tuple[str] | tuple[str, str]]
     output_core_dims: tuple[tuple[str] | tuple[str, str]]
     if len(dims) == 2:

--- a/tests/xtensor/test_linalg.py
+++ b/tests/xtensor/test_linalg.py
@@ -76,6 +76,18 @@ def test_solve_matrix_b():
     )
 
 
+def test_cholesky_string_dims():
+    x = xtensor("x", dims=("a", "batch", "b"), shape=(4, 3, 4))
+    with pytest.raises(ValueError, match="Cholesky needs two dims"):
+        cholesky(x, dims="ab")
+
+
+def test_solve_string_dims():
+    a = xtensor("a", dims=("city", "country"), shape=(None, 4))
+    with pytest.raises(ValueError, match="Solve dims must have length 2 or 3"):
+        solve(a, a, dims="abc")
+
+
 def test_linalg_vectorize():
     # Note: We only need to test a couple Ops, since the vectorization logic is not Op specific
     a = xtensor("b", dims=("a",), shape=(3,))

--- a/tests/xtensor/test_type.py
+++ b/tests/xtensor/test_type.py
@@ -239,6 +239,10 @@ def test_as_xtensor_string_dims():
     x = as_xtensor(np.array([1, 2]), dims="repo")
     assert x.type.dims == ("repo",)
 
+    t = tensor("t", shape=(2,))
+    x2 = as_xtensor(t, dims="repo")
+    assert x2.type.dims == ("repo",)
+
     z = xtensor(dims="features")
     assert z.type.dims == ("features",)
 


### PR DESCRIPTION
## Summary

Normalizes bare string `dims` to single-element tuples in all xtensor paths that iterate over dims, preventing unintended character iteration.

Previously only `XTensorType.__init__` and `_extract_data_and_dims` were fixed (PR #2129). This follows up on the spots that were missed:

- **`XTensorFromTensor.__init__`** — covers `as_xtensor(tensor_var, dims="repo")`
- **`cholesky`** — covers `cholesky(x, dims="ab")`
- **`solve`** — covers `solve(a, b, dims="abc")`

Closes #1793