### PR TITLE
Fix fusion replacement ordering

### DIFF
--- a/pytensor/tensor/rewriting/elemwise.py
+++ b/pytensor/tensor/rewriting/elemwise.py
@@ -27,7 +27,7 @@ from pytensor.graph.rewriting.basic import (
 )
 from pytensor.graph.rewriting.db import SequenceDB
 from pytensor.graph.rewriting.unify import OpPattern
-from pytensor.graph.traversal import toposort
+from pytensor.graph.traversal import toposort, walk_toposort
 from pytensor.graph.utils import InconsistencyError, MethodNotDefined
 from pytensor.scalar import (
     Add,
@@ -667,11 +667,9 @@ class FusionOptimizer(GraphRewriter):
                 if isinstance(client.op, Output)
             )
 
-            # Start main loop to find collection of fuseable subgraphs
-            # We store the collection in `sorted_subgraphs`, in reverse topological order
-            sorted_subgraphs: list[
-                tuple[int, tuple[tuple[Variable], tuple[Variable]]]
-            ] = []
+            # Start main loop to find collection of fuseable subgraphs. We collect them in
+            # discovery order; the final yield order is topologically sorted at the end.
+            discovered_subgraphs: list[tuple[tuple[Variable], tuple[Variable]]] = []
             # Keep a bitset of nodes that have been claimed by subgraphs
             all_subgraphs_bitset = 0
             # Start exploring in reverse topological order from candidate sink nodes
@@ -833,44 +831,38 @@ class FusionOptimizer(GraphRewriter):
                         if node_ancestors_bitset & subgraph_bitset
                     )
 
-                # Add new subgraph to sorted_subgraphs
-                # Because we start from sink nodes in reverse topological order, most times new subgraphs
-                # don't depend on previous subgraphs, so we can just append them at the end.
-                if not (unfuseable_ancestors_bitset & all_subgraphs_bitset):
-                    # That's the case here
-                    # None of the unfuseable_ancestors (i.e, the ancestors) are present in the previous collected subgraphs
-                    sorted_subgraphs.append(
-                        (subgraph_bitset, (subgraph_inputs, subgraph_outputs))
-                    )
-                else:
-                    # But not here, so we need to find the right position for insertion.
-                    # We iterate through the previous subgraphs in topological order (reverse of the stored order).
-                    # We cumulatively exclude each subgraph_bitset and perform the same dependency check again, until it passes.
-                    remaining_subgraphs_bitset = all_subgraphs_bitset
-                    for index, (other_subgraph_bitset, _) in enumerate(
-                        reversed(sorted_subgraphs)
-                    ):
-                        # Exclude subgraph bitset
-                        remaining_subgraphs_bitset &= ~other_subgraph_bitset
-                        if not (
-                            unfuseable_ancestors_bitset & remaining_subgraphs_bitset
-                        ):
-                            break  # bingo
-                    else:  # no-break
-                        raise RuntimeError(
-                            "Failed to find insertion point for fused subgraph"
-                        )
-                    sorted_subgraphs.insert(
-                        -(index + 1),
-                        (subgraph_bitset, (subgraph_inputs, subgraph_outputs)),
-                    )
-
-                # Add subgraph to all_subgraphs_bitset
+                # Collect the subgraph
+                discovered_subgraphs.append((subgraph_inputs, subgraph_outputs))
                 all_subgraphs_bitset |= subgraph_bitset
 
-            # Finished exploring the whole graph
-            # Yield from sorted_subgraphs, discarding the subgraph_bitset
-            yield from (io for _, io in sorted_subgraphs)
+            # Yield sorted subgraphs
+            # A client must be fused before its direct ancestors,
+            # otherwise it would reintroduce the old nodes back into the graph.
+            # Indirect ancestry through non-fused variables is order-independent.
+
+            # Map each subgraph output variable to the respective subgraph index
+            subgraph_indices = range(len(discovered_subgraphs))
+            sg_idx_of_out = {
+                out: idx
+                for idx, (_, sg_outputs) in zip(subgraph_indices, discovered_subgraphs)
+                for out in sg_outputs
+            }
+
+            def direct_ancestors(
+                i, sg_idx_of_out=sg_idx_of_out, sgs=discovered_subgraphs
+            ):
+                # Return edges: inputs of this subgraph that are outputs of another subgraph
+                sg_inputs, _ = sgs[i]
+                return [
+                    ancestor_sg_idx
+                    for inp in sg_inputs
+                    if (ancestor_sg_idx := sg_idx_of_out.get(inp)) is not None
+                ]
+
+            for i in reversed(
+                tuple(walk_toposort(subgraph_indices, deps=direct_ancestors))  # type: ignore[type-var]
+            ):
+                yield discovered_subgraphs[i]
 
         max_operands = elemwise_max_operands_fct(None)
         reason = self.__class__.__name__

--- a/tests/tensor/rewriting/test_elemwise.py
+++ b/tests/tensor/rewriting/test_elemwise.py
@@ -1,3 +1,4 @@
+import itertools
 import warnings
 
 import numpy as np
@@ -234,6 +235,13 @@ def test_local_useless_expand_dims_in_reshape():
 
 
 class TestFusion:
+    @pytest.fixture(autouse=True)
+    def _raise_on_opt_error(self):
+        # Surface any rewrite failure (including FusionOptimizer planner errors)
+        # instead of letting SequentialGraphRewriter silently log them.
+        with config.change_flags(on_opt_error="raise"):
+            yield
+
     rewrites = RewriteDatabaseQuery(
         include=[
             "canonicalize",
@@ -1401,6 +1409,38 @@ class TestFusion:
                         frozenset((ps.sub, ps.neg)),
                         frozenset((ps.add, ps.exp)),
                     }
+
+    def test_replacement_order_regression(self):
+        # Regression test for #2145, example breaks old naive linear topological sorting
+        x = pt.vector("x", shape=(5,))
+
+        # Different operation shapes, force separate fused subgraphs
+        neg_x = pt.neg(x)  # shape (5,)
+        sum_x = pt.sum(x)  # shape ()
+        neg_max_x = pt.neg(pt.max(x))  # shape ()
+        neg_sum_x = pt.neg(sum_x[None])  # shape (1,)
+
+        # SG-A: fuses {neg_max_x, first_term} — discovered first (highest sink)
+        first_term = sum_x + neg_max_x
+        first_term.name = "first_term"
+
+        # SG-C: fuses {neg_x, second_term} — discovered second
+        second_term = neg_sum_x + neg_x
+        second_term.name = "second_term"
+
+        # SG-B: fuses {neg_sum_x, third_term} — discovered last
+        # SG-B produces neg_sum_x which SG-C consumes, so SG-C must be
+        # replaced before SG-B. The old insertion heuristic got this wrong
+        # because SG-C was collected before SG-B existed.
+        third_term = neg_sum_x + neg_max_x
+        third_term.name = "third_term"
+
+        terms = [first_term, second_term, third_term]
+        for i, permuted_terms in enumerate(itertools.permutations(terms)):
+            fgraph = FunctionGraph([x], permuted_terms, clone=True)
+            _, nb_fused, nb_replaced, *_ = FusionOptimizer().apply(fgraph)
+            assert nb_fused == 3
+            assert nb_replaced == 6
 
 
 class TimesN(ps.basic.UnaryScalarOp):


### PR DESCRIPTION
Apparently sequential toposort is not as trivial as I hoped for (even knowing there is some specialized literature out there on it). Should have LEAN-proofed my algorithm hehe

On the positive side I learned that to correctly replace in topological order in PyTensor it's enough to sort directly connected nodes, no need to perform an absolute toposort of all replaced nodes, because indirect nodes will hold the right replacements due to how inplace replacement works.

Closes #2145 