### PR TITLE
Combine depandabot updates in single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     labels:
       - "GitHub CI/CD"
       - "no releasenotes"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Some days we hog the whole CI for a while because each GA update gets its own PR, this should combine them in a single PR