### PR TITLE
Don't double-copy in numba linalg dispatches

### DIFF
--- a/pytensor/link/numba/dispatch/linalg/decomposition/dispatch.py
+++ b/pytensor/link/numba/dispatch/linalg/decomposition/dispatch.py
@@ -526,6 +526,8 @@ def numba_funcify_Schur(op, node, **kwargs):
 
     if integer_input and config.compiler_verbose:
         print("Schur requires casting discrete input to float")  # noqa: T201
+    if needs_complex_cast and config.compiler_verbose:
+        print("Schur requires casting real input to complex")  # noqa: T201
 
     # Complex input always produces complex output, and output == "complex" forces complex output
     if complex_input or output == "complex":
@@ -585,6 +587,8 @@ def numba_funcify_QZ(op, node, **kwargs):
 
     if (integer_input_a or integer_input_b) and config.compiler_verbose:
         print("QZ requires casting discrete input to float")  # noqa: T201
+    if needs_complex_cast and config.compiler_verbose:
+        print("QZ requires casting real input to complex")  # noqa: T201
 
     alpha_dtype = node.outputs[2].type.numpy_dtype if return_eigenvalues else out_dtype
 

--- a/pytensor/link/numba/dispatch/linalg/decomposition/dispatch.py
+++ b/pytensor/link/numba/dispatch/linalg/decomposition/dispatch.py
@@ -142,9 +142,10 @@ def numba_funcify_Eigh(op, node, **kwargs):
     discrete_inp = inp_dtype.kind in "ibu"
     out_dtype = node.outputs[0].type.numpy_dtype
 
-    # Casting discrete input to float allocates a new buffer, so in-place is moot.
-    effective_overwrite_a = op.overwrite_a and not discrete_inp
-    effective_overwrite_b = op.overwrite_b and not discrete_inp
+    # When discrete_inp, we astype() to a fresh buffer we own, so the kernel
+    # may safely mutate it regardless of the user's overwrite_a/b setting.
+    effective_overwrite_a = op.overwrite_a or discrete_inp
+    effective_overwrite_b = op.overwrite_b or discrete_inp
 
     if generalized:
 
@@ -200,9 +201,10 @@ def numba_funcify_Eigvalsh(op, node, **kwargs):
     discrete_inp = inp_dtype.kind in "ibu"
     out_dtype = node.outputs[0].type.numpy_dtype
 
-    # Casting discrete input to float allocates a new buffer, so in-place is moot.
-    effective_overwrite_a = overwrite_a and not discrete_inp
-    effective_overwrite_b = overwrite_b and not discrete_inp
+    # When discrete_inp, we astype() to a fresh buffer we own, so the kernel
+    # may safely mutate it regardless of the user's overwrite_a/b setting.
+    effective_overwrite_a = overwrite_a or discrete_inp
+    effective_overwrite_b = overwrite_b or discrete_inp
 
     if generalized:
 
@@ -244,7 +246,6 @@ def numba_funcify_Cholesky(op, node, **kwargs):
     In particular, the `inplace` argument is not supported, which is why we choose to implement our own version.
     """
     lower = op.lower
-    overwrite_a = op.overwrite_a
 
     inp_dtype = node.inputs[0].type.numpy_dtype
     discrete_inp = inp_dtype.kind in "ibu"
@@ -252,6 +253,9 @@ def numba_funcify_Cholesky(op, node, **kwargs):
         print("Cholesky requires casting discrete input to float")  # noqa: T201
 
     out_dtype = node.outputs[0].type.numpy_dtype
+    # When discrete_inp, we astype() to a fresh buffer we own, so the kernel
+    # may safely mutate it regardless of the user's overwrite_a setting.
+    effective_overwrite_a = op.overwrite_a or discrete_inp
 
     @numba_basic.numba_njit
     def cholesky(a):
@@ -261,7 +265,7 @@ def numba_funcify_Cholesky(op, node, **kwargs):
         if discrete_inp:
             a = a.astype(out_dtype)
 
-        return _cholesky(a, lower, overwrite_a)
+        return _cholesky(a, lower, effective_overwrite_a)
 
     cache_version = 2
     return cholesky, cache_version
@@ -294,7 +298,9 @@ def numba_funcify_LU(op, node, **kwargs):
     out_dtype = node.outputs[0].type.numpy_dtype
     permute_l = op.permute_l
     p_indices = op.p_indices
-    overwrite_a = op.overwrite_a
+    # When discrete_inp, we astype() to a fresh buffer we own, so the kernel
+    # may safely mutate it regardless of the user's overwrite_a setting.
+    effective_overwrite_a = op.overwrite_a or discrete_inp
     # For the (P, L, U) case, P is real even when input is complex
     p_dtype = (
         node.outputs[0].type.numpy_dtype if not (permute_l or p_indices) else inp_dtype
@@ -322,21 +328,21 @@ def numba_funcify_LU(op, node, **kwargs):
                 a,
                 permute_l=permute_l,
                 p_indices=p_indices,
-                overwrite_a=overwrite_a,
+                overwrite_a=effective_overwrite_a,
             )
         elif permute_l:
             res = _lu_2(
                 a,
                 permute_l=permute_l,
                 p_indices=p_indices,
-                overwrite_a=overwrite_a,
+                overwrite_a=effective_overwrite_a,
             )
         else:
             res = _lu_3(
                 a,
                 permute_l=permute_l,
                 p_indices=p_indices,
-                overwrite_a=overwrite_a,
+                overwrite_a=effective_overwrite_a,
             )
 
         return res
@@ -353,7 +359,9 @@ def numba_funcify_LUFactor(op, node, **kwargs):
         print("LUFactor requires casting discrete input to float")  # noqa: T201
 
     out_dtype = node.outputs[0].type.numpy_dtype
-    overwrite_a = op.overwrite_a
+    # When discrete_inp, we astype() to a fresh buffer we own, so the kernel
+    # may safely mutate it regardless of the user's overwrite_a setting.
+    effective_overwrite_a = op.overwrite_a or discrete_inp
 
     @numba_basic.numba_njit
     def lu_factor(a):
@@ -366,7 +374,7 @@ def numba_funcify_LUFactor(op, node, **kwargs):
         if discrete_inp:
             a = a.astype(out_dtype)
 
-        LU, piv = _lu_factor(a, overwrite_a)
+        LU, piv = _lu_factor(a, effective_overwrite_a)
 
         return LU, piv
 
@@ -378,7 +386,6 @@ def numba_funcify_LUFactor(op, node, **kwargs):
 def numba_funcify_QR(op, node, **kwargs):
     mode = op.mode
     pivoting = op.pivoting
-    overwrite_a = op.overwrite_a
 
     in_dtype = node.inputs[0].type.numpy_dtype
     integer_input = in_dtype.kind in "ibu"
@@ -386,6 +393,9 @@ def numba_funcify_QR(op, node, **kwargs):
         print("QR requires casting discrete input to float")  # noqa: T201
 
     out_dtype = node.outputs[0].type.numpy_dtype
+    # When integer_input, we astype() to a fresh buffer we own, so the kernel
+    # may safely mutate it regardless of the user's overwrite_a setting.
+    effective_overwrite_a = op.overwrite_a or integer_input
 
     @numba_basic.numba_njit
     def qr(a):
@@ -432,7 +442,7 @@ def numba_funcify_QR(op, node, **kwargs):
                 a,
                 mode=mode,
                 pivoting=pivoting,
-                overwrite_a=overwrite_a,
+                overwrite_a=effective_overwrite_a,
             )
             return Q, R, P
 
@@ -441,7 +451,7 @@ def numba_funcify_QR(op, node, **kwargs):
                 a,
                 mode=mode,
                 pivoting=pivoting,
-                overwrite_a=overwrite_a,
+                overwrite_a=effective_overwrite_a,
             )
             return Q, R
 
@@ -450,7 +460,7 @@ def numba_funcify_QR(op, node, **kwargs):
                 a,
                 mode=mode,
                 pivoting=pivoting,
-                overwrite_a=overwrite_a,
+                overwrite_a=effective_overwrite_a,
             )
             return R, P
 
@@ -459,7 +469,7 @@ def numba_funcify_QR(op, node, **kwargs):
                 a,
                 mode=mode,
                 pivoting=pivoting,
-                overwrite_a=overwrite_a,
+                overwrite_a=effective_overwrite_a,
             )
             return R
 
@@ -468,7 +478,7 @@ def numba_funcify_QR(op, node, **kwargs):
                 a,
                 mode=mode,
                 pivoting=pivoting,
-                overwrite_a=overwrite_a,
+                overwrite_a=effective_overwrite_a,
             )
             return H, tau, R, P
 
@@ -477,7 +487,7 @@ def numba_funcify_QR(op, node, **kwargs):
                 a,
                 mode=mode,
                 pivoting=pivoting,
-                overwrite_a=overwrite_a,
+                overwrite_a=effective_overwrite_a,
             )
             return H, tau, R
 
@@ -510,13 +520,9 @@ def numba_funcify_Schur(op, node, **kwargs):
     complex_input = in_dtype.kind in "cz"
     needs_complex_cast = in_dtype.kind in "fd" and output == "complex"
 
-    # Disable overwrite_a for dtype conversion (real->complex upcast)
-    if needs_complex_cast:
-        overwrite_a = False
-        if config.compiler_verbose:
-            print(  # noqa: T201
-                "Schur: disabling overwrite_a due to dtype conversion (casting prevents in-place operation)"
-            )
+    # When we astype() (integer or real->complex), we own a fresh buffer,
+    # so the kernel may safely mutate it regardless of overwrite_a.
+    effective_overwrite_a = overwrite_a or integer_input or needs_complex_cast
 
     if integer_input and config.compiler_verbose:
         print("Schur requires casting discrete input to float")  # noqa: T201
@@ -535,7 +541,7 @@ def numba_funcify_Schur(op, node, **kwargs):
                 a = a.astype(out_dtype)
             elif needs_complex_cast:
                 a = a.astype(out_dtype)
-            T, Z = schur_complex(a, lwork=None, overwrite_a=overwrite_a)
+            T, Z = schur_complex(a, lwork=None, overwrite_a=effective_overwrite_a)
             return T, Z
     else:
         # Real input with real output
@@ -548,7 +554,7 @@ def numba_funcify_Schur(op, node, **kwargs):
                 )
             if integer_input:
                 a = a.astype(out_dtype)
-            T, Z = schur_real(a, lwork=None, overwrite_a=overwrite_a)
+            T, Z = schur_real(a, lwork=None, overwrite_a=effective_overwrite_a)
             return T, Z
 
     cache_version = 1
@@ -560,8 +566,6 @@ def numba_funcify_QZ(op, node, **kwargs):
     complex_output = op.complex_output
     sort = op.sort
     return_eigenvalues = op.return_eigenvalues
-    overwrite_a = op.overwrite_a
-    overwrite_b = op.overwrite_b
 
     in_dtype_a = node.inputs[0].type.numpy_dtype
     in_dtype_b = node.inputs[1].type.numpy_dtype
@@ -574,14 +578,10 @@ def numba_funcify_QZ(op, node, **kwargs):
         in_dtype_a.kind in "fd" or in_dtype_b.kind in "fd"
     ) and complex_output
 
-    # Disable overwrite for dtype conversion (real->complex upcast)
-    if needs_complex_cast:
-        overwrite_a = False
-        overwrite_b = False
-        if config.compiler_verbose:
-            print(  # noqa: T201
-                "QZ: disabling overwrite_a/b due to dtype conversion (casting prevents in-place operation)"
-            )
+    # When we astype() (integer or real->complex), we own a fresh buffer,
+    # so the kernel may safely mutate it regardless of overwrite_a/b.
+    effective_overwrite_a = op.overwrite_a or integer_input_a or needs_complex_cast
+    effective_overwrite_b = op.overwrite_b or integer_input_b or needs_complex_cast
 
     if (integer_input_a or integer_input_b) and config.compiler_verbose:
         print("QZ requires casting discrete input to float")  # noqa: T201
@@ -643,7 +643,7 @@ def numba_funcify_QZ(op, node, **kwargs):
                 b = b.astype(out_dtype)
             elif needs_complex_cast:
                 b = b.astype(out_dtype)
-            return qz_fn(a, b, sort, overwrite_a, overwrite_b)
+            return qz_fn(a, b, sort, effective_overwrite_a, effective_overwrite_b)
     else:
 
         @numba_basic.numba_njit
@@ -673,7 +673,7 @@ def numba_funcify_QZ(op, node, **kwargs):
                 b = b.astype(out_dtype)
             elif needs_complex_cast:
                 b = b.astype(out_dtype)
-            return qz_fn(a, b, overwrite_a, overwrite_b)
+            return qz_fn(a, b, effective_overwrite_a, effective_overwrite_b)
 
     cache_version = 1
     return qz, cache_version

--- a/pytensor/link/numba/dispatch/linalg/solvers/dispatch.py
+++ b/pytensor/link/numba/dispatch/linalg/solvers/dispatch.py
@@ -35,10 +35,11 @@ def numba_funcify_Solve(op, node, **kwargs):
     if must_cast_B and config.compiler_verbose:
         print("Solve requires casting second input `b`")  # noqa: T201
 
-    overwrite_a = op.overwrite_a
     lower = op.lower
-    overwrite_a = op.overwrite_a
-    overwrite_b = op.overwrite_b
+    # When we cast, we astype() to a fresh buffer we own, so the kernel may
+    # safely mutate it regardless of the user's overwrite_a/b setting.
+    overwrite_a = op.overwrite_a or must_cast_A
+    overwrite_b = op.overwrite_b or must_cast_B
     is_complex = out_dtype.kind == "c"
     transposed = False  # TODO: Solve doesnt currently allow the transposed argument
 
@@ -81,7 +82,6 @@ def numba_funcify_Solve(op, node, **kwargs):
 def numba_funcify_SolveTriangular(op, node, **kwargs):
     lower = op.lower
     unit_diagonal = op.unit_diagonal
-    overwrite_b = op.overwrite_b
 
     A_dtype, b_dtype = (i.type.numpy_dtype for i in node.inputs)
     out_dtype = node.outputs[0].type.numpy_dtype
@@ -92,6 +92,9 @@ def numba_funcify_SolveTriangular(op, node, **kwargs):
     must_cast_B = b_dtype != out_dtype
     if must_cast_B and config.compiler_verbose:
         print("SolveTriangular requires casting second input `b`")  # noqa: T201
+
+    # When we cast b, we own a fresh buffer the kernel may safely mutate.
+    overwrite_b = op.overwrite_b or must_cast_B
 
     @numba_basic.numba_njit
     def solve_triangular(a, b):
@@ -118,7 +121,6 @@ def numba_funcify_SolveTriangular(op, node, **kwargs):
 @register_funcify_default_op_cache_key(CholeskySolve)
 def numba_funcify_CholeskySolve(op, node, **kwargs):
     lower = op.lower
-    overwrite_b = op.overwrite_b
 
     c_dtype, b_dtype = (i.type.numpy_dtype for i in node.inputs)
     out_dtype = node.outputs[0].type.numpy_dtype
@@ -129,6 +131,9 @@ def numba_funcify_CholeskySolve(op, node, **kwargs):
     must_cast_b = b_dtype != out_dtype
     if must_cast_b and config.compiler_verbose:
         print("CholeskySolve requires casting second input `b`")  # noqa: T201
+
+    # When we cast b, we own a fresh buffer the kernel may safely mutate.
+    overwrite_b = op.overwrite_b or must_cast_b
 
     @numba_basic.numba_njit
     def cho_solve(c, b):

--- a/pytensor/tensor/rewriting/ofg.py
+++ b/pytensor/tensor/rewriting/ofg.py
@@ -1,6 +1,7 @@
 from pytensor.compile import optdb
 from pytensor.compile.builders import OpFromGraph
 from pytensor.graph import Apply, Variable, node_rewriter
+from pytensor.graph.fg import FrozenFunctionGraph
 from pytensor.graph.rewriting.basic import copy_stack_trace, dfs_rewriter
 from pytensor.tensor.basic import AllocDiag
 from pytensor.tensor.rewriting.basic import register_specialize
@@ -8,7 +9,7 @@ from pytensor.tensor.special import XLog1PY, XLogY
 
 
 def inline_ofg_node(node: Apply) -> list[Variable]:
-    frozen_fg = node.op._frozen_fgraph
+    frozen_fg: FrozenFunctionGraph = node.op._frozen_fgraph
     replacements = dict(zip(frozen_fg.inputs, node.inputs))
     inlined_outs = frozen_fg.bind(replacements)
     copy_stack_trace(frozen_fg.outputs, inlined_outs)


### PR DESCRIPTION
When we own a buffer due to dtype casting (int -> float or float -> complex), we can set `overwrite_a` to True for free. There was previously a misconception in the code that this needed to be preserved.