### PR TITLE
Switch to augmented-matrix Frechet derivative for expm pullback

### DIFF
--- a/pytensor/tensor/linalg/products.py
+++ b/pytensor/tensor/linalg/products.py
@@ -66,7 +66,7 @@ class Expm(Op):
         (A,) = inputs
         (A_bar,) = output_grads
 
-        n = A.type.shape[-1]
+        n = A.shape[-1]
         zero = ptb.zeros_like(A)
         top = ptb.join(-1, A.mT, A_bar)
         bot = ptb.join(-1, zero, A.mT)

--- a/pytensor/tensor/linalg/products.py
+++ b/pytensor/tensor/linalg/products.py
@@ -1,4 +1,3 @@
-from pytensor import tensor as pt
 from pytensor.graph.basic import Apply
 from pytensor.graph.op import Op
 from pytensor.tensor import basic as ptb
@@ -46,37 +45,29 @@ class Expm(Op):
         return type(self)(**new_props)
 
     def pullback(self, inputs, outputs, output_grads):
-        from pytensor.tensor.linalg.solvers.general import solve
-
-        # Kalbfleisch and Lawless, J. Am. Stat. Assoc. 80 (1985) Equation 3.4
-        # Kind of... You need to do some algebra from there to arrive at
-        # this expression.
+        # Najfeld and Havel (1995) / Mathias (1996) augmented-matrix
+        # Fréchet derivative:
+        #
+        #     expm([[A, E], [0, A]]) = [[expm(A), L_A(E)], [0, expm(A)]]
+        #
+        # where L_A is the Fréchet derivative of expm at A. The pullback
+        # is the adjoint of this linear map under the Frobenius inner
+        # product, which equals L_{A.T}(A_bar). So building the augmented
+        # matrix with A.T on the diagonal and A_bar in the upper-right
+        # block yields dL/dA in the upper-right block of its expm.
         (A,) = inputs
-        (_,) = outputs  # Outputs not used; included for signature consistency only
+        (_,) = outputs
         (A_bar,) = output_grads
 
-        w, V = pt.linalg.eig(A)
+        # Prefer the static dim when available — JAX traces slice bounds at
+        # compile time and rejects symbolic ones.
+        n = A.type.shape[-1] if A.type.shape[-1] is not None else A.shape[-1]
+        zero = ptb.zeros_like(A)
+        top = ptb.join(-1, A.mT, A_bar)
+        bot = ptb.join(-1, zero, A.mT)
+        aug = ptb.join(-2, top, bot)
 
-        exp_w = pt.exp(w)
-        numer = pt.sub.outer(exp_w, exp_w)
-        denom = pt.sub.outer(w, w)
-
-        # When w_i ≈ w_j, we have a removable singularity in the expression for X, because
-        # lim b->a (e^a - e^b) / (a - b) = e^a (derivation left for the motivated reader)
-        X = pt.where(pt.abs(denom) < 1e-8, exp_w, numer / denom)
-
-        diag_idx = pt.arange(w.shape[0])
-        X = X[..., diag_idx, diag_idx].set(exp_w)
-
-        inner = solve(V, A_bar.T @ V).T
-        result = solve(V.T, inner * X) @ V.T
-
-        # At this point, result is always a complex dtype. If the input was real, the output should be
-        # real as well (and all the imaginary parts are numerical noise)
-        if A.dtype not in ("complex64", "complex128"):
-            return [result.real]
-
-        return [result]
+        return [expm(aug)[..., :n, n:]]
 
     def infer_shape(self, fgraph, node, shapes):
         return [shapes[0]]

--- a/pytensor/tensor/linalg/products.py
+++ b/pytensor/tensor/linalg/products.py
@@ -45,23 +45,28 @@ class Expm(Op):
         return type(self)(**new_props)
 
     def pullback(self, inputs, outputs, output_grads):
-        # Najfeld and Havel (1995) / Mathias (1996) augmented-matrix
-        # Fréchet derivative:
-        #
-        #     expm([[A, E], [0, A]]) = [[expm(A), L_A(E)], [0, expm(A)]]
-        #
-        # where L_A is the Fréchet derivative of expm at A. The pullback
-        # is the adjoint of this linear map under the Frobenius inner
-        # product, which equals L_{A.T}(A_bar). So building the augmented
-        # matrix with A.T on the diagonal and A_bar in the upper-right
-        # block yields dL/dA in the upper-right block of its expm.
+        r"""Reverse-mode gradient via the augmented-matrix Fréchet derivative.
+
+        The Fréchet derivative :math:`L_A(E)` of :math:`\exp(A)` is the
+        upper-right block of one :math:`2n \times 2n` exponential [1]_:
+
+            .. math:: \exp \begin{pmatrix} A & E \\ 0 & A \end{pmatrix}
+                      = \begin{pmatrix} \exp(A) & L_A(E) \\ 0 & \exp(A) \end{pmatrix}.
+
+        The Frobenius adjoint of :math:`E \mapsto L_A(E)` is
+        :math:`Y \mapsto L_{A^T}(Y)`, so the pullback is recovered by placing
+        :math:`A^T` on the diagonal and the cotangent :math:`\bar{A}` in place
+        of :math:`E`.
+
+        References
+        ----------
+        .. [1] Mathias, R. (1996). A chain rule for matrix functions and
+               applications. *SIAM J. Matrix Anal. Appl.* 17(3), 610-620.
+        """
         (A,) = inputs
-        (_,) = outputs
         (A_bar,) = output_grads
 
-        # Prefer the static dim when available — JAX traces slice bounds at
-        # compile time and rejects symbolic ones.
-        n = A.type.shape[-1] if A.type.shape[-1] is not None else A.shape[-1]
+        n = A.type.shape[-1]
         zero = ptb.zeros_like(A)
         top = ptb.join(-1, A.mT, A_bar)
         bot = ptb.join(-1, zero, A.mT)

--- a/tests/tensor/linalg/test_products.py
+++ b/tests/tensor/linalg/test_products.py
@@ -141,7 +141,7 @@ def test_expm():
 
 
 @pytest.mark.parametrize(
-    "mode", ["symmetric", "nonsymmetric_real_eig", "nonsymmetric_complex_eig"][-1:]
+    "mode", ["symmetric", "nonsymmetric_real_eig", "nonsymmetric_complex_eig"]
 )
 def test_expm_grad(mode):
     rng = np.random.default_rng([898, sum(map(ord, mode))])


### PR DESCRIPTION
Our expm pullback sucks because eig is super slow. This PR switches our pullback to the formula jax uses. In one fell swoop we get support for complex inputs (previously held back by missing Real dispatch) and much better performance. Microbench table:

```
  ┌─────┬──────────┬──────┬──────────┬─────────────┬────────────┐
  │  N  │ Backend  │ impl │ min (ms) │ median (ms) │ new vs old │
  ├─────┼──────────┼──────┼──────────┼─────────────┼────────────┤
  │  10 │ FAST_RUN │ old  │    0.215 │       0.222 │                         │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │  10 │ FAST_RUN │ new  │    0.012 │       0.012 │ 18× faster              │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │  10 │ NUMBA    │ old  │    0.216 │       0.247 │                         │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │  10 │ NUMBA    │ new  │    0.012 │       0.012 │ 18× faster              │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │  10 │ JAX      │ old  │        — │           — │ fails: Real Op dispatch │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │  10 │ JAX      │ new  │    0.042 │       0.101 │ works                   │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │  30 │ FAST_RUN │ old  │     3.08 │        10.4 │                         │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │  30 │ FAST_RUN │ new  │    0.063 │       0.303 │ 49× faster              │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │  30 │ NUMBA    │ old  │     2.38 │        4.05 │                         │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │  30 │ NUMBA    │ new  │    0.053 │       0.057 │ 45× faster              │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │  30 │ JAX      │ old  │        — │           — │ fails                   │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │  30 │ JAX      │ new  │    0.224 │       0.287 │ works                   │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │  50 │ FAST_RUN │ old  │     6.60 │        11.6 │                         │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │  50 │ FAST_RUN │ new  │    0.172 │       0.177 │ 38× faster              │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │  50 │ NUMBA    │ old  │     10.5 │        41.3 │                         │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │  50 │ NUMBA    │ new  │    0.174 │       0.190 │ 60× faster              │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │  50 │ JAX      │ old  │        — │           — │ fails                   │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │  50 │ JAX      │ new  │    0.833 │        1.25 │ works                   │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │ 100 │ FAST_RUN │ old  │     53.6 │         178 │                         │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │ 100 │ FAST_RUN │ new  │     1.18 │        1.59 │ 45× faster              │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │ 100 │ NUMBA    │ old  │     52.5 │        77.7 │                         │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │ 100 │ NUMBA    │ new  │     1.08 │        1.29 │ 49× faster              │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │ 100 │ JAX      │ old  │        — │           — │ fails                   │
  ├─────┼──────────┼──────┼──────────┼─────────────┼─────────────────────────┤
  │ 100 │ JAX      │ new  │     3.18 │        5.20 │ works                   │
  └─────┴──────────┴──────┴──────────┴─────────────┴─────────────────────────┘

```