### PR TITLE
Selection and permutation assumptions

### DIFF
--- a/pytensor/assumptions/__init__.py
+++ b/pytensor/assumptions/__init__.py
@@ -8,6 +8,7 @@ import pytensor.assumptions.dimshuffle
 import pytensor.assumptions.orthogonal
 import pytensor.assumptions.positive_definite
 import pytensor.assumptions.reshape
+import pytensor.assumptions.selection
 import pytensor.assumptions.shape
 import pytensor.assumptions.subtensor
 import pytensor.assumptions.symmetric
@@ -19,6 +20,7 @@ from pytensor.assumptions.core import (
     LOWER_TRIANGULAR,
     ORTHOGONAL,
     POSITIVE_DEFINITE,
+    SELECTION,
     SYMMETRIC,
     UPPER_TRIANGULAR,
     AssumptionFeature,

--- a/pytensor/assumptions/__init__.py
+++ b/pytensor/assumptions/__init__.py
@@ -6,6 +6,7 @@ import pytensor.assumptions.blockwise
 import pytensor.assumptions.diagonal
 import pytensor.assumptions.dimshuffle
 import pytensor.assumptions.orthogonal
+import pytensor.assumptions.permutation
 import pytensor.assumptions.positive_definite
 import pytensor.assumptions.reshape
 import pytensor.assumptions.selection
@@ -19,6 +20,7 @@ from pytensor.assumptions.core import (
     IMPLIES,
     LOWER_TRIANGULAR,
     ORTHOGONAL,
+    PERMUTATION,
     POSITIVE_DEFINITE,
     SELECTION,
     SYMMETRIC,

--- a/pytensor/assumptions/core.py
+++ b/pytensor/assumptions/core.py
@@ -102,6 +102,7 @@ SYMMETRIC = AssumptionKey("symmetric", short_name="sym")
 POSITIVE_DEFINITE = AssumptionKey("positive_definite", short_name="pd")
 ORTHOGONAL = AssumptionKey("orthogonal", short_name="orth")
 SELECTION = AssumptionKey("selection", short_name="sel")
+PERMUTATION = AssumptionKey("permutation", short_name="perm")
 
 ALL_KEYS = (
     DIAGONAL,
@@ -111,11 +112,13 @@ ALL_KEYS = (
     POSITIVE_DEFINITE,
     ORTHOGONAL,
     SELECTION,
+    PERMUTATION,
 )
 
 # Implications about structural properties derivably from other structural properties
 register_implies(DIAGONAL, LOWER_TRIANGULAR, UPPER_TRIANGULAR, SYMMETRIC)
 register_implies(POSITIVE_DEFINITE, SYMMETRIC)
+register_implies(PERMUTATION, SELECTION, ORTHOGONAL)
 
 
 def register_assumption(

--- a/pytensor/assumptions/core.py
+++ b/pytensor/assumptions/core.py
@@ -101,6 +101,7 @@ UPPER_TRIANGULAR = AssumptionKey("upper_triangular", short_name="triu")
 SYMMETRIC = AssumptionKey("symmetric", short_name="sym")
 POSITIVE_DEFINITE = AssumptionKey("positive_definite", short_name="pd")
 ORTHOGONAL = AssumptionKey("orthogonal", short_name="orth")
+SELECTION = AssumptionKey("selection", short_name="sel")
 
 ALL_KEYS = (
     DIAGONAL,
@@ -109,6 +110,7 @@ ALL_KEYS = (
     SYMMETRIC,
     POSITIVE_DEFINITE,
     ORTHOGONAL,
+    SELECTION,
 )
 
 # Implications about structural properties derivably from other structural properties

--- a/pytensor/assumptions/core.py
+++ b/pytensor/assumptions/core.py
@@ -211,6 +211,9 @@ class AssumptionFeature(Feature):
             else:
                 self.cache[(new_var, key)] = FactState.join(old_state, new_state)
             self._var_to_keys.setdefault(new_var, set()).add(key)
+            # new_var gained a fact whose implications were cached UNKNOWN before it was
+            # known; flag it so the next get() sweep re-derives those stale entries.
+            self._stale_vars.add(new_var)
 
         self._stale_vars.update(node.outputs)
 

--- a/pytensor/assumptions/permutation.py
+++ b/pytensor/assumptions/permutation.py
@@ -1,0 +1,75 @@
+import numpy as np
+
+from pytensor.assumptions.alloc import eye_identity_rule
+from pytensor.assumptions.core import (
+    PERMUTATION,
+    FactState,
+    all_inputs_have_key,
+    propagate_first,
+    register_assumption,
+    register_constant_inference,
+)
+from pytensor.assumptions.dimshuffle import left_expand_dims_propagates_matrix_property
+from pytensor.assumptions.subtensor import subtensor_propagates_matrix_property
+from pytensor.tensor.basic import Eye
+from pytensor.tensor.elemwise import DimShuffle
+from pytensor.tensor.linalg.constructors import BlockDiagonal
+from pytensor.tensor.linalg.inverse import MatrixInverse, MatrixPinv
+from pytensor.tensor.linalg.products import KroneckerProduct
+from pytensor.tensor.math import Dot
+from pytensor.tensor.subtensor import Subtensor
+from pytensor.tensor.variable import TensorConstant
+
+
+# A PERMUTATION matrix is a square 0/1 matrix with exactly one 1 in every row and every
+# column -- a reordering of the identity's columns. It is a square SELECTION and is
+# ORTHOGONAL; unlike a general selection it is closed under transpose and inverse
+# (P.T = P^{-1} is again a permutation).
+
+
+def _permutation_from_constant(var: TensorConstant) -> FactState:
+    """Recognize a constant PERMUTATION matrix from its data, caching the scan on
+    ``var.tag.is_permutation``."""
+    cached: FactState | None = getattr(var.tag, "is_permutation", None)
+    if cached is not None:
+        return cached
+
+    data = np.asarray(var.data)
+    if data.ndim < 2 or data.shape[-1] != data.shape[-2]:
+        result = FactState.FALSE
+    else:
+        # The row/column-sum reductions are cheaper and short-circuit the full-size binary
+        # scan; a doubly-stochastic matrix shows the binary check is still required.
+        is_permutation = (
+            bool(np.all(data.sum(axis=-2) == 1))
+            and bool(np.all(data.sum(axis=-1) == 1))
+            and bool(np.all((data == 0) | (data == 1)))
+        )
+        result = FactState.TRUE if is_permutation else FactState.FALSE
+
+    var.tag.is_permutation = result
+    return result
+
+
+register_constant_inference(PERMUTATION, _permutation_from_constant)
+
+# eye(n, m, k) is a permutation iff it is the square identity -- the same condition that
+# makes it orthogonal.
+register_assumption(PERMUTATION, Eye)(eye_identity_rule)
+# The symmetric group is closed under matmul and inversion.
+register_assumption(PERMUTATION, Dot)(all_inputs_have_key)
+register_assumption(PERMUTATION, MatrixInverse)(propagate_first)
+register_assumption(PERMUTATION, MatrixPinv)(propagate_first)
+register_assumption(PERMUTATION, BlockDiagonal)(all_inputs_have_key)
+register_assumption(PERMUTATION, KroneckerProduct)(all_inputs_have_key)
+register_assumption(PERMUTATION, Subtensor)(subtensor_propagates_matrix_property)
+
+
+@register_assumption(PERMUTATION, DimShuffle)
+def _dimshuffle(key, op, feature, fgraph, node, input_states):
+    """Permutation survives matrix transpose (P.T = P^{-1}) and batch left-expand-dims."""
+    if input_states[0] is not FactState.TRUE:
+        return [FactState.UNKNOWN]
+    if op.is_matrix_transpose or left_expand_dims_propagates_matrix_property(op):
+        return [FactState.TRUE]
+    return [FactState.UNKNOWN]

--- a/pytensor/assumptions/selection.py
+++ b/pytensor/assumptions/selection.py
@@ -1,0 +1,127 @@
+import numpy as np
+
+from pytensor.assumptions.core import (
+    SELECTION,
+    FactState,
+    all_inputs_have_key,
+    register_assumption,
+    register_constant_inference,
+    true_if,
+)
+from pytensor.assumptions.subtensor import subtensor_propagates_matrix_property
+from pytensor.graph.basic import Variable
+from pytensor.tensor.basic import Eye
+from pytensor.tensor.linalg.constructors import BlockDiagonal
+from pytensor.tensor.linalg.products import KroneckerProduct
+from pytensor.tensor.subtensor import AdvancedSubtensor, Subtensor
+from pytensor.tensor.variable import TensorConstant
+
+
+def _selection_from_constant(var: TensorConstant) -> FactState:
+    """Recognize a constant SELECTION matrix from its data, caching the O(n*k) scan on
+    ``var.tag.is_selection``."""
+    cached: FactState | None = getattr(var.tag, "is_selection", None)
+    if cached is not None:
+        return cached
+
+    data = np.asarray(var.data)
+    if data.ndim < 2:
+        result = FactState.FALSE
+    else:
+        if not (data.sum(axis=-2) == 1).all():
+            is_selection = False
+        elif data.dtype.kind in "uib":
+            is_selection = data.max(initial=1) <= 1 and data.min(initial=0) >= 0
+        else:
+            is_selection = bool(((data == 0) | (data == 1)).all())
+        result = FactState.TRUE if is_selection else FactState.FALSE
+
+    var.tag.is_selection = result
+    return result
+
+
+register_constant_inference(SELECTION, _selection_from_constant)
+
+
+def column_selection_index(op, node) -> Variable | None:
+    """Return the 1-D integer index of an ``x[..., idx]`` advanced subtensor, or ``None``.
+
+    Matches every axis but the last a full slice, the last an integer vector. Selecting
+    columns preserves selection for any ``idx``; selecting rows does not, so only this
+    pattern is recognized.
+    """
+    x = node.inputs[0]
+    ndim = x.type.ndim
+    idx_list = op.idx_list
+    if ndim < 2 or len(idx_list) != ndim:
+        return None
+
+    full = slice(None, None, None)
+    if any(entry != full for entry in idx_list[:-1]):
+        return None
+
+    last = idx_list[-1]
+    if not isinstance(last, int) or isinstance(last, bool):
+        return None
+
+    index_var: Variable = node.inputs[1:][last]
+    if index_var.type.ndim != 1 or not index_var.type.dtype.startswith(("int", "uint")):
+        return None
+    return index_var
+
+
+@register_assumption(SELECTION, Eye)
+def _eye(key, op, feature, fgraph, node, input_states):
+    """``eye(n, m, k)`` is a selection iff ``k == 0`` (main diagonal) and ``n >= m``
+    (no trailing zero columns)."""
+    n, m, k = node.inputs
+    if not isinstance(k, TensorConstant):
+        return [FactState.UNKNOWN]
+    if k.data.item() != 0:
+        return [FactState.FALSE]
+    if n is m:
+        return [FactState.TRUE]
+    if isinstance(n, TensorConstant) and isinstance(m, TensorConstant):
+        return true_if(n.data.item() >= m.data.item(), else_false=True)
+    rows, cols = node.outputs[0].type.shape[-2:]
+    if rows is not None and cols is not None:
+        return true_if(rows >= cols, else_false=True)
+    return [FactState.UNKNOWN]
+
+
+register_assumption(SELECTION, BlockDiagonal)(all_inputs_have_key)
+register_assumption(SELECTION, KroneckerProduct)(all_inputs_have_key)
+
+
+@register_assumption(SELECTION, AdvancedSubtensor)
+def _advanced_subtensor(key, op, feature, fgraph, node, input_states):
+    if (
+        input_states[0] is FactState.TRUE
+        and column_selection_index(op, node) is not None
+    ):
+        return [FactState.TRUE]
+    return [FactState.UNKNOWN]
+
+
+@register_assumption(SELECTION, Subtensor)
+def _subtensor(key, op, feature, fgraph, node, input_states):
+    # Batch-axis indexing (trailing two axes untouched) keeps every per-matrix property.
+    states = subtensor_propagates_matrix_property(
+        key, op, feature, fgraph, node, input_states
+    )
+    if states[0] is FactState.TRUE:
+        return states
+
+    # A column slice keeps a subset of the one-hot columns -- still a selection.
+    if input_states[0] is FactState.TRUE:
+        x = node.inputs[0]
+        idx_list = op.idx_list
+        full = slice(None, None, None)
+        if (
+            2 <= x.type.ndim == len(idx_list)
+            and all(entry == full for entry in idx_list[:-1])
+            and isinstance(idx_list[-1], slice)
+        ):
+            return [FactState.TRUE]
+
+    return [FactState.UNKNOWN]

--- a/pytensor/assumptions/specify.py
+++ b/pytensor/assumptions/specify.py
@@ -68,6 +68,7 @@ def assume(
     positive_definite: bool | None = None,
     orthogonal: bool | None = None,
     selection: bool | None = None,
+    permutation: bool | None = None,
 ):
     """Attach structural assumptions to a symbolic tensor.
 
@@ -92,8 +93,9 @@ def assume(
     orthogonal : bool, optional
         Assert that *x* is (or is not) orthogonal.
     selection : bool, optional
-        Assert that *x* is (or is not) a selection matrix -- one whose every column is a
-        column of the identity (a one-hot unit vector), i.e. :math:`x = I_n[:, idx]`.
+        Assert that *x* is (or is not) a selection matrix
+    permutation : bool, optional
+        Assert that *x* is (or is not) a permutation matrix
 
     Returns
     -------
@@ -118,6 +120,7 @@ def assume(
         "positive_definite": positive_definite,
         "orthogonal": orthogonal,
         "selection": selection,
+        "permutation": permutation,
     }
     assumptions = {
         name: FactState.TRUE if value else FactState.FALSE

--- a/pytensor/assumptions/specify.py
+++ b/pytensor/assumptions/specify.py
@@ -67,6 +67,7 @@ def assume(
     symmetric: bool | None = None,
     positive_definite: bool | None = None,
     orthogonal: bool | None = None,
+    selection: bool | None = None,
 ):
     """Attach structural assumptions to a symbolic tensor.
 
@@ -90,6 +91,9 @@ def assume(
         Assert that *x* is (or is not) positive-definite.
     orthogonal : bool, optional
         Assert that *x* is (or is not) orthogonal.
+    selection : bool, optional
+        Assert that *x* is (or is not) a selection matrix -- one whose every column is a
+        column of the identity (a one-hot unit vector), i.e. :math:`x = I_n[:, idx]`.
 
     Returns
     -------
@@ -113,6 +117,7 @@ def assume(
         "symmetric": symmetric,
         "positive_definite": positive_definite,
         "orthogonal": orthogonal,
+        "selection": selection,
     }
     assumptions = {
         name: FactState.TRUE if value else FactState.FALSE

--- a/pytensor/assumptions/subtensor.py
+++ b/pytensor/assumptions/subtensor.py
@@ -1,6 +1,10 @@
 from pytensor.assumptions.core import (
     ALL_KEYS,
-    ORTHOGONAL,
+    DIAGONAL,
+    LOWER_TRIANGULAR,
+    POSITIVE_DEFINITE,
+    SYMMETRIC,
+    UPPER_TRIANGULAR,
     FactState,
     register_assumption,
     true_if,
@@ -46,7 +50,7 @@ def incsubtensor_propagates_matrix_property(
     - ``set`` over a partial batch region: every output slice comes from ``base``
       or ``value``, so both must carry the property.
     - ``inc``: the written region becomes ``base + value``; the property must be
-      closed under addition -- true for every key except ``orthogonal``.
+      closed under addition (diagonal, triangular, symmetric, positive-definite).
 
     An index that reaches into the core axes is left to the per-key rules (e.g.
     the diagonal-position write handled by ``indexes_diagonal``).
@@ -66,7 +70,14 @@ def incsubtensor_propagates_matrix_property(
             return [value_state]
         return true_if(base_state is FactState.TRUE and value_state is FactState.TRUE)
 
-    if key is ORTHOGONAL:
+    # Closed under addition
+    if key not in (
+        DIAGONAL,
+        LOWER_TRIANGULAR,
+        UPPER_TRIANGULAR,
+        SYMMETRIC,
+        POSITIVE_DEFINITE,
+    ):
         return [FactState.UNKNOWN]
     return true_if(base_state is FactState.TRUE and value_state is FactState.TRUE)
 

--- a/pytensor/tensor/rewriting/assumptions.py
+++ b/pytensor/tensor/rewriting/assumptions.py
@@ -37,8 +37,8 @@ class DrainSpecifyAssumptions(GraphRewriter):
         replacements = {}
         for node in nodes:
             [out] = node.outputs
+            # Resolve the asserted facts into the cache.
             for name, _ in node.op.assumptions:
-                # Register the assumption by calling .get()
                 assumption_feature.get(out, _KEY_BY_NAME[name])
             # Drain the marker: redirect its consumers to the raw input,
             # peeling nested SpecifyAssumptions so a single replace_all

--- a/pytensor/tensor/rewriting/linalg/products.py
+++ b/pytensor/tensor/rewriting/linalg/products.py
@@ -1,10 +1,13 @@
+import numpy as np
+
 from pytensor import tensor as pt
-from pytensor.assumptions import DIAGONAL, ORTHOGONAL, check_assumption
+from pytensor.assumptions import DIAGONAL, ORTHOGONAL, SELECTION, check_assumption
+from pytensor.assumptions.selection import column_selection_index
 from pytensor.graph.rewriting.basic import (
     copy_stack_trace,
     node_rewriter,
 )
-from pytensor.tensor.basic import ExtractDiag, alloc_diag, concatenate, diag
+from pytensor.tensor.basic import ExtractDiag, Eye, alloc_diag, concatenate, diag
 from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.elemwise import DimShuffle
 from pytensor.tensor.linalg.constructors import BlockDiagonal
@@ -16,6 +19,8 @@ from pytensor.tensor.rewriting.basic import (
     register_stabilize,
 )
 from pytensor.tensor.rewriting.blockwise import blockwise_of
+from pytensor.tensor.subtensor import AdvancedSubtensor
+from pytensor.tensor.variable import TensorConstant
 
 
 @register_canonicalize
@@ -224,3 +229,104 @@ def orthogonal_dot_transpose_to_eye(fgraph, node):
                 result = pt.broadcast_to(result, (*b.shape[:-2], *result.shape[-2:]))
             copy_stack_trace(node.outputs[0], result)
             return [result]
+
+
+def _selection_operand(fgraph, var):
+    """Return ``(idx, transposed, n_rows)`` for a selection matmul operand, or ``None``.
+
+    Non-``None`` when ``var`` is a selection ``S = eye(n)[:, idx]`` or its transpose
+    (``transposed`` True). ``idx`` is read off the graph when free (an ``Eye`` column-selection
+    or a literal constant); for an opaque assumed selection it is recovered with
+    ``argmax(S, axis=-2)``.
+    """
+
+    def recover_index(S):
+        if (owner := S.owner) is not None and isinstance(owner.op, AdvancedSubtensor):
+            match owner.inputs[0].owner_op_and_inputs:
+                case (Eye(), _, _, k) if (
+                    isinstance(k, TensorConstant) and k.data.item() == 0
+                ):
+                    return column_selection_index(owner.op, owner)
+        if isinstance(S, TensorConstant):
+            return pt.constant(np.argmax(S.data, axis=-2))
+        return pt.argmax(S, axis=-2)
+
+    # A batched matmul left-expands a 2-D selection to batch rank with a single
+    # broadcast DimShuffle; peel it to reach the underlying matrix.
+    match var.owner_op_and_inputs:
+        case (DimShuffle(is_left_expand_dims=True), inner):
+            core = inner
+        case _:
+            core = var
+
+    if core.type.ndim != 2:
+        return None
+
+    if check_assumption(fgraph, core, SELECTION):
+        return recover_index(core), False, core.shape[0]
+
+    match core.owner_op_and_inputs:
+        case (DimShuffle(is_matrix_transpose=True), s) if (
+            s.type.ndim == 2 and check_assumption(fgraph, s, SELECTION)
+        ):
+            return recover_index(s), True, s.shape[0]
+
+    return None
+
+
+@register_canonicalize
+@register_stabilize
+@node_rewriter([Dot, blockwise_of(Dot)])
+def selection_dot_to_indexing(fgraph, node):
+    """Replace a matmul by a selection matrix ``S = eye(n)[:, idx]`` with indexing.
+
+    Gathers (turn an ``O(n k m)`` matmul into an ``O(k m)`` take):
+
+    - ``x @ S``   -> ``x[..., idx]``      (gather columns)
+    - ``S.T @ x`` -> ``x[..., idx, :]``   (gather rows)
+
+    Scatters (turn it into a zero-fill plus an accumulate):
+
+    - ``S @ y``   -> rows of ``y`` accumulated into a zero matrix at positions ``idx``
+    - ``x @ S.T`` -> columns of ``x`` accumulated into a zero matrix at positions ``idx``
+    """
+    a, b = node.inputs
+    out_dtype = node.outputs[0].type.dtype
+
+    a_sel = _selection_operand(fgraph, a)
+    b_sel = _selection_operand(fgraph, b)
+
+    # Gathers first -- they index without allocating. A gather keeps the operand's dtype,
+    # so cast up to the matmul's output dtype when a mixed-dtype product would have upcast.
+    if b_sel is not None and not b_sel[1]:  # x @ S
+        out = a[..., b_sel[0]]
+        if a.type.dtype != out_dtype:
+            out = out.astype(out_dtype)
+        copy_stack_trace(node.outputs[0], out)
+        return [out]
+
+    if a_sel is not None and a_sel[1]:  # S.T @ x
+        out = b[..., a_sel[0], :]
+        if b.type.dtype != out_dtype:
+            out = out.astype(out_dtype)
+        copy_stack_trace(node.outputs[0], out)
+        return [out]
+
+    # Scatters: fill zeros, then accumulate the operand at the selected positions.
+    if a_sel is not None and not a_sel[1]:  # S @ y
+        idx, _, n = a_sel
+        batch = [b.shape[i] for i in range(b.type.ndim - 2)]
+        z = pt.zeros((*batch, n, b.shape[-1]), dtype=out_dtype)
+        out = pt.inc_subtensor(z[..., idx, :], b)
+        copy_stack_trace(node.outputs[0], out)
+        return [out]
+
+    if b_sel is not None and b_sel[1]:  # x @ S.T
+        idx, _, n = b_sel
+        batch = [a.shape[i] for i in range(a.type.ndim - 2)]
+        z = pt.zeros((*batch, a.shape[-2], n), dtype=out_dtype)
+        out = pt.inc_subtensor(z[..., idx], a)
+        copy_stack_trace(node.outputs[0], out)
+        return [out]
+
+    return None

--- a/pytensor/tensor/rewriting/linalg/products.py
+++ b/pytensor/tensor/rewriting/linalg/products.py
@@ -1,7 +1,13 @@
 import numpy as np
 
 from pytensor import tensor as pt
-from pytensor.assumptions import DIAGONAL, ORTHOGONAL, SELECTION, check_assumption
+from pytensor.assumptions import (
+    DIAGONAL,
+    ORTHOGONAL,
+    PERMUTATION,
+    SELECTION,
+    check_assumption,
+)
 from pytensor.assumptions.selection import column_selection_index
 from pytensor.graph.rewriting.basic import (
     copy_stack_trace,
@@ -241,12 +247,11 @@ def _selection_operand(fgraph, var):
     """
 
     def recover_index(S):
-        if (owner := S.owner) is not None and isinstance(owner.op, AdvancedSubtensor):
-            match owner.inputs[0].owner_op_and_inputs:
-                case (Eye(), _, _, k) if (
-                    isinstance(k, TensorConstant) and k.data.item() == 0
-                ):
-                    return column_selection_index(owner.op, owner)
+        match S.owner_op_and_inputs:
+            case (AdvancedSubtensor() as op, base, *_):
+                match base.owner_op_and_inputs:
+                    case (Eye(), _, _, TensorConstant(0)):
+                        return column_selection_index(op, S.owner)
         if isinstance(S, TensorConstant):
             return pt.constant(np.argmax(S.data, axis=-2))
         return pt.argmax(S, axis=-2)
@@ -330,3 +335,27 @@ def selection_dot_to_indexing(fgraph, node):
         return [out]
 
     return None
+
+
+@register_canonicalize
+@register_stabilize
+@node_rewriter([det])
+def det_of_permutation(fgraph, node):
+    """Replace ``det(P)`` by the sign of the permutation for a permutation matrix ``P``.
+
+    The determinant of a permutation is its sign: :math:`(-1)^k` where :math:`k` counts the
+    out-of-order pairs (``i < j`` with ``idx[i] > idx[j]``) of the index that orders its
+    columns, ``P = eye(n)[:, idx]``.
+    """
+    [x] = node.inputs
+    if x.type.ndim != 2 or not check_assumption(fgraph, x, PERMUTATION):
+        return None
+    operand = _selection_operand(fgraph, x)
+    if operand is None:
+        return None
+
+    idx = operand[0]
+    inversions = pt.triu((idx[:, None] > idx[None, :]).astype("int64"), k=1).sum()
+    sign = (1 - 2 * (inversions % 2)).astype(node.outputs[0].type.dtype)
+    copy_stack_trace(node.outputs[0], sign)
+    return [sign]

--- a/tests/assumptions/test_core.py
+++ b/tests/assumptions/test_core.py
@@ -18,6 +18,7 @@ from pytensor.graph.basic import Apply
 from pytensor.graph.fg import FunctionGraph
 from pytensor.graph.op import Op
 from pytensor.tensor.basic import Eye
+from pytensor.tensor.rewriting.assumptions import DrainSpecifyAssumptions
 from pytensor.tensor.type import TensorType
 from tests.assumptions.conftest import make_fgraph
 
@@ -155,6 +156,13 @@ def test_replace_propagates_true_fact_to_new_var():
     fg.replace(d_old, d_new, reason="replace")
     assert af.get(d_new, DIAGONAL) is FactState.TRUE
     assert af.get(y, DIAGONAL) is FactState.TRUE
+
+
+def test_drain_preserves_implied_facts():
+    x = pt.matrix("x", shape=(4, 4))
+    fg, af = make_fgraph(assume(x, diagonal=True) + 1, inputs=[x])
+    DrainSpecifyAssumptions().apply(fg)
+    assert af.check(x, SYMMETRIC)
 
 
 def test_replace_reprobes_downstream_unknown():

--- a/tests/assumptions/test_permutation.py
+++ b/tests/assumptions/test_permutation.py
@@ -1,0 +1,134 @@
+import numpy as np
+import pytest
+
+import pytensor.tensor as pt
+from pytensor.assumptions import ORTHOGONAL, PERMUTATION, SELECTION, FactState
+from pytensor.assumptions.specify import assume
+from tests.assumptions.conftest import make_fgraph
+
+
+@pytest.mark.parametrize(
+    "n, m, expected",
+    [
+        (5, 5, FactState.TRUE),
+        (5, 3, FactState.FALSE),
+        (3, 5, FactState.FALSE),
+    ],
+    ids=["square", "tall", "wide"],
+)
+def test_eye_is_permutation_only_when_square(n, m, expected):
+    e = pt.eye(n, m)
+    _, af = make_fgraph(e)
+    assert af.get(e, PERMUTATION) == expected
+
+
+def test_offset_eye_is_not_permutation():
+    e = pt.eye(5, 5, 1)
+    _, af = make_fgraph(e)
+    assert af.get(e, PERMUTATION) == FactState.FALSE
+
+
+def test_constant_permutation():
+    c = pt.constant(np.eye(4)[:, [2, 0, 3, 1]])
+    _, af = make_fgraph(c)
+    assert af.check(c, PERMUTATION)
+
+
+def test_constant_batched_permutation():
+    data = np.broadcast_to(np.eye(4)[:, [1, 0, 3, 2]], (3, 4, 4)).copy()
+    c = pt.constant(data)
+    _, af = make_fgraph(c)
+    assert af.check(c, PERMUTATION)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        np.eye(3)[:, [0, 2]],  # non-square
+        np.array([[2.0, 0.0], [0.0, 1.0]]),  # entry not in {0, 1}
+        np.arange(4),  # not a matrix
+    ],
+    ids=["nonsquare", "non_binary", "vector"],
+)
+def test_non_permutation_constants_are_false(data):
+    c = pt.constant(data)
+    _, af = make_fgraph(c)
+    assert af.get(c, PERMUTATION) == FactState.FALSE
+
+
+def test_selection_with_duplicate_column_is_not_permutation():
+    # Every column one-hot (a selection) but a repeated column leaves a row with two 1s
+    # and a row with none, so it is not a permutation.
+    c = pt.constant(np.array([[1.0, 1.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]))
+    _, af = make_fgraph(c)
+    assert af.check(c, SELECTION)
+    assert af.get(c, PERMUTATION) == FactState.FALSE
+
+
+def test_transpose_is_permutation():
+    # Unlike a general selection, a permutation is closed under transpose.
+    p = assume(pt.matrix("x", shape=(4, 4)), permutation=True)
+    _, af = make_fgraph(p.T)
+    assert af.check(p.T, PERMUTATION)
+
+
+@pytest.mark.parametrize(
+    "new_order, expected",
+    [
+        (("x", 0, 1), FactState.TRUE),  # left: trailing two axes stay the matrix
+        ((0, 1, "x"), FactState.UNKNOWN),  # right: matrix shifts off the trailing axes
+    ],
+    ids=["left", "right"],
+)
+def test_expand_dims_permutation(new_order, expected):
+    p = assume(pt.matrix("p", shape=(4, 4)), permutation=True)
+    expanded = p.dimshuffle(*new_order)
+    _, af = make_fgraph(expanded)
+    assert af.get(expanded, PERMUTATION) == expected
+
+
+def test_product_of_permutations_is_permutation():
+    a = assume(pt.matrix("a", shape=(4, 4)), permutation=True)
+    b = assume(pt.matrix("b", shape=(4, 4)), permutation=True)
+    _, af = make_fgraph(a @ b)
+    assert af.check(a @ b, PERMUTATION)
+
+
+def test_inverse_of_permutation_is_permutation():
+    p = assume(pt.matrix("p", shape=(4, 4)), permutation=True)
+    inv = pt.linalg.inv(p)
+    _, af = make_fgraph(inv)
+    assert af.check(inv, PERMUTATION)
+
+
+def test_block_diag_of_permutations_is_permutation():
+    bd = pt.linalg.block_diag(pt.eye(3), pt.constant(np.eye(2)[:, [1, 0]]))
+    _, af = make_fgraph(bd)
+    assert af.check(bd, PERMUTATION)
+
+
+def test_kron_of_permutations_is_permutation():
+    k = pt.linalg.kron(pt.eye(2), pt.constant(np.eye(3)[:, [2, 0, 1]]))
+    _, af = make_fgraph(k)
+    assert af.check(k, PERMUTATION)
+
+
+def test_permutation_implies_selection_and_orthogonal():
+    p = assume(pt.matrix("p", shape=(4, 4)), permutation=True)
+    _, af = make_fgraph(p)
+    assert af.check(p, SELECTION)
+    assert af.check(p, ORTHOGONAL)
+
+
+def test_not_selection_implies_not_permutation():
+    # Contrapositive of PERMUTATION -> SELECTION.
+    x = assume(pt.matrix("x", shape=(4, 4)), selection=False)
+    _, af = make_fgraph(x)
+    assert af.get(x, PERMUTATION) == FactState.FALSE
+
+
+def test_batch_index_preserves_permutation():
+    x = pt.tensor("x", shape=(3, 4, 4))
+    xs = assume(x, permutation=True)
+    _, af = make_fgraph(xs[0])
+    assert af.check(xs[0], PERMUTATION)

--- a/tests/assumptions/test_selection.py
+++ b/tests/assumptions/test_selection.py
@@ -1,0 +1,178 @@
+import numpy as np
+import pytest
+
+import pytensor.tensor as pt
+from pytensor.assumptions import SELECTION, FactState
+from pytensor.assumptions.specify import assume
+from tests.assumptions.conftest import make_fgraph
+
+
+def test_identity_eye_is_selection():
+    e = pt.eye(5)
+    _, af = make_fgraph(e)
+    assert af.check(e, SELECTION)
+
+
+@pytest.mark.parametrize(
+    "n, m, expected",
+    [
+        (5, 3, FactState.TRUE),  # tall: columns are distinct unit vectors
+        (3, 5, FactState.FALSE),  # wide: trailing columns are all zero
+    ],
+    ids=["tall", "wide"],
+)
+def test_nonsquare_eye_selection(n, m, expected):
+    e = pt.eye(n, m)
+    _, af = make_fgraph(e)
+    assert af.get(e, SELECTION) == expected
+
+
+def test_offset_eye_is_not_selection():
+    e = pt.eye(5, 5, 1)
+    _, af = make_fgraph(e)
+    assert af.get(e, SELECTION) == FactState.FALSE
+
+
+def test_eye_column_index_is_selection():
+    idx = pt.lvector("idx")
+    S = pt.eye(5)[:, idx]
+    _, af = make_fgraph(S)
+    assert af.check(S, SELECTION)
+
+
+def test_eye_column_constant_index_is_selection():
+    S = pt.eye(5)[:, np.array([0, 2, 4])]
+    _, af = make_fgraph(S)
+    assert af.check(S, SELECTION)
+
+
+def test_eye_column_slice_is_selection():
+    S = pt.eye(5)[:, 1:4]
+    _, af = make_fgraph(S)
+    assert af.check(S, SELECTION)
+
+
+def test_eye_row_index_is_not_claimed_selection():
+    # Selecting rows of the identity leaves all-zero columns, so it is not a
+    # selection matrix; the inference declines to claim it (UNKNOWN, not FALSE).
+    idx = pt.lvector("idx")
+    S = pt.eye(5)[idx]
+    _, af = make_fgraph(S)
+    assert af.get(S, SELECTION) == FactState.UNKNOWN
+
+
+def test_constant_selection_matrix():
+    c = pt.constant(np.eye(6)[:, [0, 2, 5, 1]])
+    _, af = make_fgraph(c)
+    assert af.check(c, SELECTION)
+
+
+def test_constant_batched_selection_matrix():
+    data = np.broadcast_to(np.eye(4)[:, [0, 2, 3]], (3, 4, 3)).copy()
+    c = pt.constant(data)
+    _, af = make_fgraph(c)
+    assert af.check(c, SELECTION)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        np.full((3, 3), 1.0),  # not one-hot per column
+        np.array([[1.0, 0.0], [1.0, 0.0]]),  # a zero column
+        np.array([[2.0, 0.0], [0.0, 1.0]]),  # entry not in {0, 1}
+        np.array([[0.5, 0.0], [0.5, 1.0]]),  # columns sum to 1 but are not binary
+        np.arange(5),  # not a matrix
+    ],
+    ids=["all_ones", "zero_column", "non_binary", "fractional_column", "vector"],
+)
+def test_non_selection_constants_are_false(data):
+    c = pt.constant(data)
+    _, af = make_fgraph(c)
+    assert af.get(c, SELECTION) == FactState.FALSE
+
+
+def test_block_diag_of_selections_is_selection():
+    bd = pt.linalg.block_diag(pt.eye(3), pt.eye(2)[:, [0]])
+    _, af = make_fgraph(bd)
+    assert af.check(bd, SELECTION)
+
+
+def test_block_diag_with_generic_block_is_unknown():
+    x = pt.matrix("x", shape=(3, 3))
+    bd = pt.linalg.block_diag(pt.eye(3), x)
+    _, af = make_fgraph(bd)
+    assert af.get(bd, SELECTION) == FactState.UNKNOWN
+
+
+def test_kron_of_selections_is_selection():
+    k = pt.linalg.kron(pt.eye(3), pt.eye(2))
+    _, af = make_fgraph(k)
+    assert af.check(k, SELECTION)
+
+
+def test_diagonal_is_not_claimed_selection():
+    # A general diagonal matrix (e.g. diag([2, 3])) is not a selection matrix.
+    d = pt.diag(pt.as_tensor([2.0, 3.0]))
+    _, af = make_fgraph(d)
+    assert not af.check(d, SELECTION)
+
+
+def test_assume_selection():
+    x = pt.matrix("x", shape=(5, 3))
+    xs = assume(x, selection=True)
+    _, af = make_fgraph(xs)
+    assert af.check(xs, SELECTION)
+
+
+def test_transpose_is_not_propagated():
+    # S.T is not a selection matrix in general (its columns may be all-zero), so
+    # transposition does not carry the property.
+    idx = pt.lvector("idx")
+    S = pt.eye(5)[:, idx]
+    _, af = make_fgraph(S.T)
+    assert af.get(S.T, SELECTION) == FactState.UNKNOWN
+
+
+@pytest.mark.parametrize(
+    "new_order, expected",
+    [
+        (("x", 0, 1), FactState.TRUE),  # left: trailing two axes stay the matrix
+        (
+            (0, 1, "x"),
+            FactState.UNKNOWN,
+        ),  # right: matrix shifts to (k, 1), not a selection
+    ],
+    ids=["left", "right"],
+)
+def test_expand_dims_selection(new_order, expected):
+    idx = pt.lvector("idx")
+    expanded = (pt.eye(5)[:, idx]).dimshuffle(*new_order)
+    _, af = make_fgraph(expanded)
+    assert af.get(expanded, SELECTION) == expected
+
+
+class TestSubtensorPropagation:
+    def test_batch_index_preserves_selection(self):
+        x = pt.tensor("x", shape=(3, 5, 2))
+        xs = assume(x, selection=True)
+        _, af = make_fgraph(xs[0])
+        assert af.check(xs[0], SELECTION)
+
+    def test_set_batch_slice_preserves_selection(self):
+        x = pt.tensor("x", shape=(3, 5, 2))
+        xs = assume(x, selection=True)
+        v = pt.tensor("v", shape=(5, 2))
+        vs = assume(v, selection=True)
+        y = pt.set_subtensor(xs[0], vs)
+        _, af = make_fgraph(y)
+        assert af.check(y, SELECTION)
+
+    def test_inc_is_not_selection(self):
+        # Selection is not closed under addition, so an inc write breaks it.
+        x = pt.tensor("x", shape=(3, 5, 2))
+        xs = assume(x, selection=True)
+        v = pt.tensor("v", shape=(5, 2))
+        vs = assume(v, selection=True)
+        y = pt.inc_subtensor(xs[0], vs)
+        _, af = make_fgraph(y)
+        assert af.get(y, SELECTION) == FactState.UNKNOWN

--- a/tests/tensor/rewriting/linalg/test_products.py
+++ b/tests/tensor/rewriting/linalg/test_products.py
@@ -10,8 +10,10 @@ from pytensor.configdefaults import config
 from pytensor.graph import FunctionGraph, ancestors
 from pytensor.graph.rewriting.utils import rewrite_graph
 from pytensor.tensor.basic import alloc_diag
+from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.linalg.constructors import BlockDiagonal
 from pytensor.tensor.linalg.products import KroneckerProduct
+from pytensor.tensor.math import Dot
 from tests.unittest_tools import assert_equal_computations
 
 
@@ -328,3 +330,103 @@ def test_orthogonal_dot_transpose_to_eye():
     expected_batch = pt.alloc(np.eye(n, dtype=config.floatX), b64, n64, n64)
 
     assert_equal_computations([rewritten_batch], [expected_batch])
+
+
+class TestSelectionDotToIndexing:
+    n = 6
+    idx_val = np.array([0, 2, 5, 1])
+
+    PATTERNS = [
+        ("col_gather", lambda S, d: d @ S, lambda n, k: (3, n)),
+        ("row_gather", lambda S, d: S.T @ d, lambda n, k: (n, 4)),
+        ("row_scatter", lambda S, d: S @ d, lambda n, k: (k, 4)),
+        ("col_scatter", lambda S, d: d @ S.T, lambda n, k: (3, k)),
+    ]
+    SETUPS = [
+        ("symbolic", False),
+        ("symbolic", True),
+        ("constant", False),
+        ("opaque", False),
+    ]
+
+    @pytest.mark.parametrize(
+        "source, batched", SETUPS, ids=["sym", "sym_batched", "const", "opaque"]
+    )
+    @pytest.mark.parametrize(
+        "build, core_shape",
+        [(b, c) for _, b, c in PATTERNS],
+        ids=[name for name, *_ in PATTERNS],
+    )
+    def test_rewrites_to_indexing(self, build, core_shape, source, batched):
+        n, idx = self.n, self.idx_val
+        k = len(idx)
+        S_np = np.eye(n)[:, idx]
+
+        if source == "constant":
+            S, extra_in, extra_val = pt.eye(n)[:, idx], [], []
+        elif source == "opaque":
+            s = pt.matrix("s", shape=(n, k))
+            S, extra_in, extra_val = assume(s, selection=True), [s], [S_np]
+        else:
+            iv = pt.lvector("idx")
+            S, extra_in, extra_val = pt.eye(n)[:, iv], [iv], [idx]
+
+        shape = (2, *core_shape(n, k)) if batched else core_shape(n, k)
+        d = pt.tensor("d", shape=shape)
+
+        f = function([d, *extra_in], build(S, d), mode="FAST_RUN")
+        assert not any(
+            isinstance(node.op, Dot)
+            or (isinstance(node.op, Blockwise) and isinstance(node.op.core_op, Dot))
+            for node in f.maker.fgraph.apply_nodes
+        )
+
+        dv = np.random.default_rng(0).normal(size=shape)
+        assert_allclose(f(dv, *extra_val), build(S_np, dv))
+
+    @pytest.mark.parametrize(
+        "idx", [idx_val, np.array([1, 1, 3])], ids=["distinct", "duplicate"]
+    )
+    @pytest.mark.parametrize("middle", ["diag_q", "general_a"])
+    def test_congruence(self, middle, idx):
+        # R @ M @ R.T collapses to a pure scatter. The duplicate-index case guards
+        # that inc_subtensor's accumulate reproduces the matmul for repeated columns.
+        n, k = self.n, len(idx)
+        iv = pt.lvector("idx")
+        R = pt.eye(n)[:, iv]
+        rng = np.random.default_rng(0)
+        if middle == "diag_q":
+            m = pt.vector("m")
+            mv = rng.normal(size=k) ** 2
+            M, M_np = pt.diag(m), np.diag(mv)
+        else:
+            m = pt.matrix("m")
+            mv = rng.normal(size=(k, k))
+            M, M_np = m, mv
+
+        f = function([m, iv], R @ M @ R.T, mode="FAST_RUN")
+        assert not any(
+            isinstance(node.op, Dot)
+            or (isinstance(node.op, Blockwise) and isinstance(node.op.core_op, Dot))
+            for node in f.maker.fgraph.apply_nodes
+        )
+        R_np = np.eye(n)[:, idx]
+        assert_allclose(f(mv, idx), R_np @ M_np @ R_np.T)
+
+
+def test_gather_matches_upcast_matmul_dtype():
+    x = pt.matrix("x", dtype="float32")
+    idx = pt.lvector("idx")
+    out = x @ pt.eye(5)[:, idx]
+    assert out.type.dtype == "float64"
+
+    f = function([x, idx], out, mode="FAST_RUN")
+    assert not any(
+        isinstance(node.op, Dot)
+        or (isinstance(node.op, Blockwise) and isinstance(node.op.core_op, Dot))
+        for node in f.maker.fgraph.apply_nodes
+    )
+    assert f.maker.fgraph.outputs[0].type.dtype == "float64"
+    xv = np.random.default_rng(0).normal(size=(3, 5)).astype("float32")
+    iv = np.array([0, 2, 4, 1])
+    assert_allclose(f(xv, iv), xv @ np.eye(5)[:, iv])

--- a/tests/tensor/rewriting/linalg/test_products.py
+++ b/tests/tensor/rewriting/linalg/test_products.py
@@ -430,3 +430,55 @@ def test_gather_matches_upcast_matmul_dtype():
     xv = np.random.default_rng(0).normal(size=(3, 5)).astype("float32")
     iv = np.array([0, 2, 4, 1])
     assert_allclose(f(xv, iv), xv @ np.eye(5)[:, iv])
+
+
+def test_permutation_rides_selection_rewrite():
+    n = 5
+    pv = np.eye(n)[:, [2, 0, 4, 1, 3]]
+    rng = np.random.default_rng(0)
+    p = pt.matrix("p", shape=(n, n))
+    P = assume(p, permutation=True)
+    x = pt.matrix("x")
+
+    def has_matmul(f):
+        return any(
+            isinstance(node.op, Dot)
+            or (isinstance(node.op, Blockwise) and isinstance(node.op.core_op, Dot))
+            for node in f.maker.fgraph.apply_nodes
+        )
+
+    f_left = function([p, x], P @ x, mode="FAST_RUN")
+    assert not has_matmul(f_left)
+    xv = rng.normal(size=(n, 3))
+    assert_allclose(f_left(pv, xv), pv @ xv)
+
+    f_right = function([p, x], x @ P, mode="FAST_RUN")
+    assert not has_matmul(f_right)
+    yv = rng.normal(size=(3, n))
+    assert_allclose(f_right(pv, yv), yv @ pv)
+
+
+@pytest.mark.parametrize(
+    "perm", [[0, 1, 2, 3], [1, 0, 2, 3], [1, 2, 3, 0], [2, 3, 0, 1]], ids=str
+)
+def test_det_of_permutation(perm):
+    from pytensor.tensor.linalg.summary import Det
+
+    pv = np.eye(4)[:, perm]
+    p = pt.matrix("p", shape=(4, 4))
+    P = assume(p, permutation=True)
+    f = function([p], pt.linalg.det(P), mode="FAST_RUN")
+    assert not any(isinstance(node.op, Det) for node in f.maker.fgraph.apply_nodes)
+    got = f(pv)
+    assert abs(got) == 1.0  # exact, not a floating-point approximation
+    assert_allclose(got, np.linalg.det(pv))
+
+
+def test_det_of_non_permutation_selection_is_not_rewritten():
+    from pytensor.tensor.linalg.summary import Det
+
+    idx = pt.lvector("idx")
+    S = pt.eye(4)[:, idx]
+    f = function([idx], pt.linalg.det(S), mode="FAST_RUN")
+    assert any(isinstance(node.op, Det) for node in f.maker.fgraph.apply_nodes)
+    assert_allclose(f(np.array([0, 1, 1, 3])), 0.0)  # duplicate column -> singular


### PR DESCRIPTION
New assumption for a selection matrix, a matrix where all values are 0/1 each column has exactly one non-zero value, `S = eye(n)[:, idx]`. 

Also adds a permutation matrix, which is a special case of selection matrix when every column *and row* has exactly one non-zero value. Selection can double-up on rows (but not columns), while permutation cannot. 

These show up in statespace matrics, when a matmul is used to project from one space to another (shocks -> states or states -> observations). Also in seasonal models, you get big cyclical matrices of the type:

```
[ 0 0 0 1 ]
[ 1 0 0 0 ]
[ 0 1 0 0 ]
[ 0 0 1 0 ]
```

For big seasonality (like annual daily = 365), we can switch this from a huge matmul to a cheap indexing.

Tagging these matrices unlocks advanced indexing rewrites:

- `x @ S -> x[..., idx]`
- `S.T @ x -> x[..., idx, :`
- `S @ y -> IncSubtensor(zeros[..., idx, :], y)`
- `x @ S.T -> IncSubtensor(zeros[..., idx], x)`

