### PR TITLE
Fix local_subtensor_of_batch_dims when encountering stale broadcast types

### DIFF
--- a/pytensor/tensor/rewriting/basic.py
+++ b/pytensor/tensor/rewriting/basic.py
@@ -135,7 +135,7 @@ def get_simplified_shape(x: TensorVariable, *, fgraph) -> tuple:
     return tuple(x.shape)
 
 
-def get_simplified_broadcast_shape(first, *others, fgraph) -> list:
+def get_simplified_broadcast_shape(first, *others, fgraph, batch_ndim=None) -> list:
     """Per-axis fold of ``first`` with ``others``, prioritizing non-broadcastable lengths.
 
     The shape entry from ``first`` wins on every axis where ``first`` is not
@@ -145,23 +145,26 @@ def get_simplified_broadcast_shape(first, *others, fgraph) -> list:
     commutative, but the resulting symbolic shape is not — we want the
     simplest/most-static expression).
 
-    Assumes all inputs have the same ndim (the Elemwise contract).
+    With ``batch_ndim`` only the leading ``batch_ndim`` dimensions are folded and
+    returned, so inputs may differ on their trailing (core) dimensions, as with
+    ``Blockwise``. Otherwise all inputs must share ndim (the Elemwise contract).
     """
-    first_broadcastable = first.type.broadcastable
+    if batch_ndim is None:
+        batch_ndim = first.type.ndim
+
+    first_broadcastable = first.type.broadcastable[:batch_ndim]
     if not (any(first_broadcastable) and others):
-        return list(get_simplified_shape(first, fgraph=fgraph))
+        return list(get_simplified_shape(first, fgraph=fgraph))[:batch_ndim]
 
     broadcastable_dims = list(first_broadcastable)
-    broadcast_shape = list(get_simplified_shape(first, fgraph=fgraph))
+    broadcast_shape = list(get_simplified_shape(first, fgraph=fgraph))[:batch_ndim]
     for other in others:
         other_shape = get_simplified_shape(other, fgraph=fgraph)
-        for i, (other_broadcastable, other_dim_length) in enumerate(
-            zip(other.type.broadcastable, other_shape, strict=True)
-        ):
-            if other_broadcastable or not broadcastable_dims[i]:
+        for i in range(batch_ndim):
+            if other.type.broadcastable[i] or not broadcastable_dims[i]:
                 # Doesn't provide any new info
                 continue
-            broadcast_shape[i] = other_dim_length
+            broadcast_shape[i] = other_shape[i]
             broadcastable_dims[i] = False  # Don't override again
     return broadcast_shape
 

--- a/pytensor/tensor/rewriting/subtensor_lift.py
+++ b/pytensor/tensor/rewriting/subtensor_lift.py
@@ -320,8 +320,9 @@ def local_subtensor_of_batch_dims(fgraph, node):
 
     Bail on boolean masks and non-consecutive advanced indexing — numpy hoists
     those advanced groups to position 0, which would misalign the lifted
-    indices. On a broadcast (length-1) axis of an input, replace the advanced
-    index with length-1 zeros so the lifted input still broadcasts correctly.
+    indices. On a broadcast (length-1) axis of an input the index is dropped
+    (only zero is in bounds there), and an Alloc restores the full output shape
+    when a dropped index was what determined it.
     """
     elem, *idx = node.inputs
 
@@ -733,37 +734,27 @@ def lift_subtensor_through_alloc(fgraph, node):
     if _non_consecutive_adv_indexing(indices):
         return None
 
-    val_indexer: list = []
-    dangerous_index_reaches_val = False
-    for axis, idx in enumerate(indices):
-        if axis < n_added_dims:
-            # Axis was added by Alloc; index doesn't reach val.
-            continue
-        val_static_dim = val.type.shape[axis - n_added_dims]
-        if val_static_dim == 1:
-            # Broadcast val dim: slices stay (Alloc broadcasts on top);
-            # advanced indices become length-1 zeros for squeeze.
-            if isinstance(idx, slice):
-                val_indexer.append(slice(None))
-            else:
-                val_indexer.append(np.zeros((1,) * idx.type.ndim, dtype=np.int64))
-            continue
-        val_indexer.append(idx)
-        if not _index_provably_smaller(idx, val_static_dim):
-            # Per-axis check; doesn't account for net effect across all axes.
-            dangerous_index_reaches_val = True
+    # Indices on Alloc-added dims don't reach val; the rest line up with val's dims.
+    val_indexer = indices[n_added_dims:]
+    dangerous_index_reaches_val = any(
+        not val.type.broadcastable[axis]
+        # Per-axis check; doesn't account for net effect across all axes.
+        and not _index_provably_smaller(idx, val.type.shape[axis])
+        for axis, idx in enumerate(val_indexer)
+    )
 
-    nw_val = _canonical_indexing(val, val_indexer)
-    new_shape = indexed_result_shape(alloc_dims, indices)
-    drops_alloc = nw_val.type.broadcastable == node.outputs[0].type.broadcastable
+    # On broadcast val dims the index is neutralized (advanced indices dropped,
+    # shrinking slices made full); the trailing Alloc broadcasts val back up.
+    nw_val = _canonical_indexing(val, val_indexer, drop_broadcasted_index=True)
+    needs_alloc = broadcasted_by(nw_val, node.outputs[0])
 
-    if dangerous_index_reaches_val and not drops_alloc:
+    if dangerous_index_reaches_val and needs_alloc:
         return None
 
-    if drops_alloc:
-        result = nw_val
+    if needs_alloc:
+        result = alloc(nw_val, *indexed_result_shape(alloc_dims, indices))
     else:
-        result = alloc(nw_val, *new_shape)
+        result = nw_val
 
     copy_stack_trace(node.outputs[0], result)
     return [result]

--- a/pytensor/tensor/rewriting/subtensor_lift.py
+++ b/pytensor/tensor/rewriting/subtensor_lift.py
@@ -40,6 +40,8 @@ from pytensor.tensor.exceptions import NotScalarConstantError
 from pytensor.tensor.extra_ops import squeeze
 from pytensor.tensor.math import Dot, dot, minimum
 from pytensor.tensor.rewriting.basic import (
+    broadcasted_by,
+    get_simplified_broadcast_shape,
     register_canonicalize,
     register_specialize,
     register_stabilize,
@@ -77,13 +79,19 @@ from pytensor.tensor.type import TensorType
 from pytensor.tensor.variable import TensorConstant, TensorVariable
 
 
-def _canonical_indexing(var, indices):
+def _canonical_indexing(var, indices, drop_broadcasted_index=False):
     """Index ``var``, squeezing indexed broadcast dims whose index has size 1.
 
     On a length-1 dim only zero is a valid index, so the index is
     redundant — squeezing is equivalent and simpler.  If squeezed
     indices contributed unique output dimensions, those are reinserted
     via ``expand_dims`` after indexing.
+
+    When ``drop_broadcasted_index`` is set, the index is neutralized on *every*
+    broadcast dim: a size>1 advanced index that would otherwise expand the dim is
+    dropped, and a slice that would otherwise shrink it (e.g. ``[1:]`` -> size 0)
+    is replaced by a full slice. This keeps ``var`` small at the cost of an
+    under-broadcast result; the caller must broadcast it back to the full shape.
     """
     squeeze_axes = []
     kept_indices = []
@@ -94,7 +102,12 @@ def _canonical_indexing(var, indices):
         zip(var.type.broadcastable, indices, strict=False)
     ):
         if isinstance(idx, slice):
-            kept_indices.append(idx)
+            if bcast and drop_broadcasted_index:
+                # Slicing a length-1 dim can shrink it (e.g. [1:] -> size 0);
+                # leave it untouched and let the caller broadcast it back.
+                kept_indices.append(slice(None))
+            else:
+                kept_indices.append(idx)
         else:
             if first_adv_axis is None:
                 first_adv_axis = axis
@@ -102,19 +115,22 @@ def _canonical_indexing(var, indices):
             # np.ndim works for all supported cases: int, numpy arrays, pytensor variables
             idx_ndim = np.ndim(idx)
             if bcast:
-                match idx:
-                    case Variable():
-                        idx_size1 = all(idx.type.broadcastable)
-                    case np.ndarray():
-                        idx_size1 = idx.size == 1
-                    case int() | np.integer():
-                        idx_size1 = True
-                    case _:
-                        raise AssertionError
+                if drop_broadcasted_index:
+                    drop_idx = True
+                else:
+                    match idx:
+                        case Variable():
+                            drop_idx = all(idx.type.broadcastable)
+                        case np.ndarray():
+                            drop_idx = idx.size == 1
+                        case int() | np.integer():
+                            drop_idx = True
+                        case _:
+                            raise AssertionError
 
                 # idx only contributes dummy dimensions (if any), not actual shape
                 # It doesn't really matter what the index was, only valid values are zeros.
-                if idx_size1:
+                if drop_idx:
                     max_drop_ndim = max(max_drop_ndim, idx_ndim)
                     squeeze_axes.append(axis)
                     continue
@@ -370,58 +386,13 @@ def local_subtensor_of_batch_dims(fgraph, node):
 
     elem_inputs = elem.owner.inputs
 
-    # Per-input copy of idx_tuple we may adjust on dims where some input is
-    # broadcast (length 1).
-    new_idxs = [list(idx_tuple) for _ in elem_inputs]
-    needs_per_input_adjustment = False
-
-    for dim, (dim_idx, *dim_bcast_inputs) in enumerate(
-        zip(
-            idx_tuple,
-            *(inp.type.broadcastable[:batch_ndim] for inp in elem_inputs),
-            # Indices can be shorter than input ndims
-            strict=False,
-        )
-    ):
-        if isinstance(dim_idx, slice) and dim_idx == slice(None):
-            # Full slice can be safely applied to all inputs.
-            continue
-
-        if not any(dim_bcast_inputs):
-            # No input is length 1 on this dim, original index applies to all.
-            continue
-
-        # An advanced (non-scalar) index can wastefully expand a size 1 dim.
-        # Basic indices (slices, ints, scalar variables) cannot.
-        is_advanced_idx = (
-            isinstance(dim_idx, TensorVariable) and dim_idx.type.ndim > 0
-        ) or (isinstance(dim_idx, np.ndarray) and dim_idx.ndim > 0)
-
-        if all(dim_bcast_inputs) and not is_advanced_idx:
-            # Every input is length 1 and the index is basic — it can't
-            # expand a size 1 dim, so apply as-is.
-            continue
-
-        # At least one input is length 1 on this dim — don't apply an index
-        # that could expand size 1. Slices stay; advanced indices become
-        # length 1 zeros that _canonical_indexing will squeeze (and reinsert
-        # as needed).
-        if isinstance(dim_idx, slice):
-            safe_bcast_dim_idx = slice(None)
-        else:
-            safe_bcast_dim_idx = np.zeros((1,) * dim_idx.type.ndim, dtype="int64")
-        for inp_idx, dim_bcast_inp in zip(new_idxs, dim_bcast_inputs, strict=True):
-            if dim_bcast_inp:
-                inp_idx[dim] = safe_bcast_dim_idx
-                needs_per_input_adjustment = True
-
-    if needs_per_input_adjustment:
-        indexed_inputs = [
-            _canonical_indexing(inp, tuple(new_idx))
-            for inp, new_idx in zip(elem_inputs, new_idxs, strict=True)
-        ]
-    else:
-        indexed_inputs = [inp[idx_tuple] for inp in elem_inputs]
+    # Drop indices on broadcast input dims instead of applying them: an advanced
+    # index can't validly index a length-1 dim (only zero is in bounds) and would
+    # wastefully expand it. The Elemwise broadcasts the small inputs back together.
+    indexed_inputs = [
+        _canonical_indexing(inp, idx_tuple, drop_broadcasted_index=True)
+        for inp in elem_inputs
+    ]
 
     [old_out] = node.outputs
 
@@ -431,13 +402,15 @@ def local_subtensor_of_batch_dims(fgraph, node):
     # Define elemwise operation on indexed inputs
     new_out = elem.owner.op(*indexed_inputs)
 
-    # The lifted Elemwise may produce a more-broadcast type than the original
-    # subtensor output — either because we collapsed all-bcast advanced-index
-    # dims to length 1, or because elem.type was stale and claimed non-bcast
-    # on a dim whose inputs are all length 1. Broadcast back to old_out's
-    # shape so the replacement is type-compatible (and the result correct).
-    if new_out.type.broadcastable != old_out.type.broadcastable:
-        new_out = alloc(new_out, *old_out.shape)
+    # The indices dropped on broadcast dims may have been needed to determine the output shape
+    # We use an alloc to enforce the output shape.
+    if broadcasted_by(new_out, old_out):
+        batch_shape = get_simplified_broadcast_shape(
+            *elem_inputs, fgraph=fgraph, batch_ndim=batch_ndim
+        )
+        new_batch_shape = indexed_result_shape(batch_shape, idx_tuple)
+        core_shape = tuple(new_out.shape)[len(new_batch_shape) :]
+        new_out = alloc(new_out, *new_batch_shape, *core_shape)
 
     # Copy stack trace to new output
     copy_stack_trace([old_out, *node.inputs], new_out)

--- a/pytensor/tensor/rewriting/subtensor_lift.py
+++ b/pytensor/tensor/rewriting/subtensor_lift.py
@@ -369,53 +369,59 @@ def local_subtensor_of_batch_dims(fgraph, node):
         return [new_elem]
 
     elem_inputs = elem.owner.inputs
-    elem_bcast = elem.type.broadcastable[:batch_ndim]
-    if all(inp.type.broadcastable[:batch_ndim] == elem_bcast for inp in elem_inputs):
-        # No need to worry about implicit broadcasting.
-        indexed_inputs = [inp[idx_tuple] for inp in elem_inputs]
 
-    else:
-        # The original indices may not make sense on some of the broadcasted dimensions
-        new_idxs = [list(idx_tuple) for _ in elem_inputs]
-        for dim, (dim_idx, dim_bcast_out, *dim_bcast_inputs) in enumerate(
-            zip(
-                idx_tuple,
-                elem_bcast,
-                *(inp.type.broadcastable[:batch_ndim] for inp in elem_inputs),
-                # Indices can be shorter than input ndims
-                strict=False,
-            )
-        ):
-            if isinstance(dim_idx, slice) and dim_idx == slice(None):
-                # Full slice can be safely applied to all inputs
-                continue
+    # Per-input copy of idx_tuple we may adjust on dims where some input is
+    # broadcast (length 1).
+    new_idxs = [list(idx_tuple) for _ in elem_inputs]
+    needs_per_input_adjustment = False
 
-            if not dim_bcast_out and all(dim_bcast_inputs):
-                # No valid lift: every input is length-1 on this dim but
-                # the Elemwise output type is non-broadcast there.
-                return None
+    for dim, (dim_idx, *dim_bcast_inputs) in enumerate(
+        zip(
+            idx_tuple,
+            *(inp.type.broadcastable[:batch_ndim] for inp in elem_inputs),
+            # Indices can be shorter than input ndims
+            strict=False,
+        )
+    ):
+        if isinstance(dim_idx, slice) and dim_idx == slice(None):
+            # Full slice can be safely applied to all inputs.
+            continue
 
-            if all(
-                dim_bcast_inp == dim_bcast_out for dim_bcast_inp in dim_bcast_inputs
-            ):
-                # This dim matches the output bcast for every input, so
-                # the original index can be applied to all inputs.
-                continue
+        if not any(dim_bcast_inputs):
+            # No input is length 1 on this dim, original index applies to all.
+            continue
 
-            # Slices stay; advanced indices become length-1 zeros
-            # that _canonical_indexing will squeeze.
-            if isinstance(dim_idx, slice):
-                safe_bcast_dim_idx = slice(None)
-            else:
-                safe_bcast_dim_idx = np.zeros((1,) * dim_idx.type.ndim, dtype="int64")
-            for inp_idx, dim_bcast_inp in zip(new_idxs, dim_bcast_inputs, strict=True):
-                if dim_bcast_inp:
-                    inp_idx[dim] = safe_bcast_dim_idx
+        # An advanced (non-scalar) index can wastefully expand a size 1 dim.
+        # Basic indices (slices, ints, scalar variables) cannot.
+        is_advanced_idx = (
+            isinstance(dim_idx, TensorVariable) and dim_idx.type.ndim > 0
+        ) or (isinstance(dim_idx, np.ndarray) and dim_idx.ndim > 0)
 
+        if all(dim_bcast_inputs) and not is_advanced_idx:
+            # Every input is length 1 and the index is basic — it can't
+            # expand a size 1 dim, so apply as-is.
+            continue
+
+        # At least one input is length 1 on this dim — don't apply an index
+        # that could expand size 1. Slices stay; advanced indices become
+        # length 1 zeros that _canonical_indexing will squeeze (and reinsert
+        # as needed).
+        if isinstance(dim_idx, slice):
+            safe_bcast_dim_idx = slice(None)
+        else:
+            safe_bcast_dim_idx = np.zeros((1,) * dim_idx.type.ndim, dtype="int64")
+        for inp_idx, dim_bcast_inp in zip(new_idxs, dim_bcast_inputs, strict=True):
+            if dim_bcast_inp:
+                inp_idx[dim] = safe_bcast_dim_idx
+                needs_per_input_adjustment = True
+
+    if needs_per_input_adjustment:
         indexed_inputs = [
             _canonical_indexing(inp, tuple(new_idx))
             for inp, new_idx in zip(elem_inputs, new_idxs, strict=True)
         ]
+    else:
+        indexed_inputs = [inp[idx_tuple] for inp in elem_inputs]
 
     [old_out] = node.outputs
 
@@ -424,6 +430,14 @@ def local_subtensor_of_batch_dims(fgraph, node):
 
     # Define elemwise operation on indexed inputs
     new_out = elem.owner.op(*indexed_inputs)
+
+    # The lifted Elemwise may produce a more-broadcast type than the original
+    # subtensor output — either because we collapsed all-bcast advanced-index
+    # dims to length 1, or because elem.type was stale and claimed non-bcast
+    # on a dim whose inputs are all length 1. Broadcast back to old_out's
+    # shape so the replacement is type-compatible (and the result correct).
+    if new_out.type.broadcastable != old_out.type.broadcastable:
+        new_out = alloc(new_out, *old_out.shape)
 
     # Copy stack trace to new output
     copy_stack_trace([old_out, *node.inputs], new_out)

--- a/pytensor/tensor/rewriting/subtensor_lift.py
+++ b/pytensor/tensor/rewriting/subtensor_lift.py
@@ -390,8 +390,19 @@ def local_subtensor_of_batch_dims(fgraph, node):
                 # Full slice can be safely applied to all inputs
                 continue
 
-            if all(dim_bcast_inp == elem_bcast for dim_bcast_inp in dim_bcast_inputs):
-                # This dim is not broadcasted for any of the inputs, original index can be applied to all inputs
+            if not dim_bcast_out and all(dim_bcast_inputs):
+                # No valid lift: every input is length-1 on this dim but
+                # the Elemwise output type is non-broadcast there. The
+                # zeros-replacement below would collapse the lifted result
+                # to length 1, which fgraph's type check rejects against
+                # the original advanced-indexed shape.
+                return None
+
+            if all(
+                dim_bcast_inp == dim_bcast_out for dim_bcast_inp in dim_bcast_inputs
+            ):
+                # This dim matches the output bcast for every input, so
+                # the original index can be applied to all inputs.
                 continue
 
             # Slices stay; advanced indices become length-1 zeros

--- a/pytensor/tensor/rewriting/subtensor_lift.py
+++ b/pytensor/tensor/rewriting/subtensor_lift.py
@@ -392,10 +392,7 @@ def local_subtensor_of_batch_dims(fgraph, node):
 
             if not dim_bcast_out and all(dim_bcast_inputs):
                 # No valid lift: every input is length-1 on this dim but
-                # the Elemwise output type is non-broadcast there. The
-                # zeros-replacement below would collapse the lifted result
-                # to length 1, which fgraph's type check rejects against
-                # the original advanced-indexed shape.
+                # the Elemwise output type is non-broadcast there.
                 return None
 
             if all(

--- a/tests/tensor/rewriting/test_subtensor_lift.py
+++ b/tests/tensor/rewriting/test_subtensor_lift.py
@@ -251,8 +251,9 @@ class TestLocalSubtensorOfBatchDims:
     @pytest.mark.parametrize(
         "idx", [np.zeros(20, dtype="int64"), slice(0, 5)], ids=["advanced", "slice"]
     )
-    def test_bails_on_stale_elemwise_output_type(self, idx):
-        """Bail when every input is broadcast on an indexed dim but the output is not."""
+    def test_lifts_through_stale_elemwise_output_type(self, idx):
+        """When every input is length 1 on an indexed dim but elem's output type
+        stale-claims non-bcast, the lift should still succeed by wrapping with alloc."""
         x_input = pt.tensor("x_input", shape=(None, 3, 3), dtype="float64")
         x_new_input = pt.tensor("x_new", shape=(1, 3, 3), dtype="float64")
         x = pt.identity(x_input)
@@ -260,11 +261,54 @@ class TestLocalSubtensorOfBatchDims:
         indexed = out[idx]
         fgraph = FunctionGraph([x_input, x_new_input], [indexed], clone=False)
 
-        # Forge a stale state: inputs are broadcastable on dim 0, but output is NOT.
-        # This happens naturally when upstream rewrites call fgraph.replace(x, x_new_input)
+        # Forge a stale state: inputs are broadcastable on dim 0, but elem
+        # output type is NOT. This happens naturally when upstream rewrites
+        # call fgraph.replace(x, x_new_input).
         fgraph.replace(x, x_new_input)
 
-        assert local_subtensor_of_batch_dims.transform(fgraph, indexed.owner) is None
+        [new_out] = local_subtensor_of_batch_dims.transform(fgraph, indexed.owner)
+        # The lifted graph must be type-compatible with the (stale) original.
+        fgraph.replace(indexed, new_out)
+
+        rng = np.random.default_rng(0)
+        x_val = rng.standard_normal((1, 3, 3))
+        f = function(
+            [x_new_input], new_out, on_unused_input="ignore", mode=NO_OPTIMIZATION_MODE
+        )
+        expected = (x_val * x_val)[idx]
+        np.testing.assert_allclose(f(x_val), expected)
+
+    def test_advanced_index_on_all_bcast_dim_does_not_expand(self):
+        """When all inputs are length 1 on an advanced-indexed dim, the lifted
+        Elemwise should keep them length 1 (and alloc once) rather than
+        repeating the computation K times."""
+        x = pt.tensor("x", shape=(1, 3), dtype="float64")
+        y = pt.tensor("y", shape=(1, 3), dtype="float64")
+        idx = np.zeros(5, dtype="int64")
+        out = (x + y)[idx]
+
+        [new_out] = local_subtensor_of_batch_dims.transform(
+            FunctionGraph([x, y], [out], clone=False), out.owner
+        )
+
+        # Final shape matches the original.
+        assert new_out.type.shape == (5, 3)
+
+        # The lifted Elemwise must operate on length 1 inputs (no K-fold
+        # expansion), and the K-sized dim must come from an Alloc wrapper.
+        from pytensor.tensor.basic import Alloc
+
+        assert isinstance(new_out.owner.op, Alloc)
+        [inner_elem, *_] = new_out.owner.inputs
+        assert isinstance(inner_elem.owner.op, Elemwise)
+        for inner_inp in inner_elem.owner.inputs:
+            assert inner_inp.type.shape[0] == 1
+
+        rng = np.random.default_rng(1)
+        x_val = rng.standard_normal((1, 3))
+        y_val = rng.standard_normal((1, 3))
+        f = function([x, y], new_out, mode=NO_OPTIMIZATION_MODE)
+        np.testing.assert_allclose(f(x_val, y_val), (x_val + y_val)[idx])
 
 
 def test_local_subtensor_of_dot():

--- a/tests/tensor/rewriting/test_subtensor_lift.py
+++ b/tests/tensor/rewriting/test_subtensor_lift.py
@@ -253,16 +253,17 @@ class TestLocalSubtensorOfBatchDims:
     )
     def test_bails_on_stale_elemwise_output_type(self, idx):
         """Bail when every input is broadcast on an indexed dim but the output is not."""
-        a = pt.tensor("a", shape=(1, 3, 3), dtype="float64")
-        b = pt.tensor("b", shape=(1, 3, 3), dtype="float64")
-        out = a * b
+        x_input = pt.tensor("x_input", shape=(None, 3, 3), dtype="float64")
+        x_new_input = pt.tensor("x_new", shape=(1, 3, 3), dtype="float64")
+        x = pt.identity(x_input)
+        out = x * x
+        indexed = out[idx]
+        fgraph = FunctionGraph([x_input, x_new_input], [indexed], clone=False)
 
         # Forge a stale state: inputs are broadcastable on dim 0, but output is NOT.
-        stale_out_type = pt.TensorType(dtype="float64", shape=(20, 3, 3))
-        out.type = stale_out_type
+        # This happens naturally when upstream rewrites call fgraph.replace(x, x_new_input)
+        fgraph.replace(x, x_new_input)
 
-        indexed = out[idx]
-        fgraph = FunctionGraph([a, b], [indexed], clone=False)
         assert local_subtensor_of_batch_dims.transform(fgraph, indexed.owner) is None
 
 

--- a/tests/tensor/rewriting/test_subtensor_lift.py
+++ b/tests/tensor/rewriting/test_subtensor_lift.py
@@ -248,6 +248,23 @@ class TestLocalSubtensorOfBatchDims:
         expected_out_sliced = block_test_op(x[2:, 0], y[2:])[:, 4:]
         assert equal_computations([rewritten_out_sliced], [expected_out_sliced])
 
+    @pytest.mark.parametrize(
+        "idx", [np.zeros(20, dtype="int64"), slice(0, 5)], ids=["advanced", "slice"]
+    )
+    def test_bails_on_stale_elemwise_output_type(self, idx):
+        """Bail when every input is broadcast on an indexed dim but the output is not."""
+        a = pt.tensor("a", shape=(1, 3, 3), dtype="float64")
+        b = pt.tensor("b", shape=(1, 3, 3), dtype="float64")
+        out = a * b
+
+        # Forge a stale state: inputs are broadcastable on dim 0, but output is NOT.
+        stale_out_type = pt.TensorType(dtype="float64", shape=(20, 3, 3))
+        out.type = stale_out_type
+
+        indexed = out[idx]
+        fgraph = FunctionGraph([a, b], [indexed], clone=False)
+        assert local_subtensor_of_batch_dims.transform(fgraph, indexed.owner) is None
+
 
 def test_local_subtensor_of_dot():
     m1 = matrix()

--- a/tests/tensor/rewriting/test_subtensor_lift.py
+++ b/tests/tensor/rewriting/test_subtensor_lift.py
@@ -74,6 +74,12 @@ NO_OPTIMIZATION_MODE = Mode(linker="py", optimizer=None)
 
 
 class TestLocalSubtensorOfBatchDims:
+    rewrite_kw = dict(
+        include=("ShapeOpt", "canonicalize", "specialize"),
+        exclude=("local_replace_AdvancedSubtensor",),
+        clone=True,
+    )
+
     def test_unary_multiple_clients(self):
         # as test0, but we reuse the output of the elemwise
         # So we should not lift the subtensor
@@ -151,7 +157,7 @@ class TestLocalSubtensorOfBatchDims:
             # Slice indexing on broadcastable dimension
             (
                 lambda x, y: add(x[None], y[None])[1:],
-                lambda x, y: add(x[None][1:], y[None][1:]),
+                lambda x, y: pt.alloc(pt.add(x[None], y[None]), 0, *x.type.shape),
             ),
             (
                 lambda x, y: add(x[None, :], y[:, None])[1:],
@@ -169,9 +175,7 @@ class TestLocalSubtensorOfBatchDims:
         out = original_fn(x, y)
         expected_opt_out = expected_fn(x, y)
         opt_out = rewrite_graph(out)
-        assert equal_computations([opt_out], [expected_opt_out]), debugprint(
-            [expected_opt_out, opt_out], print_type=True
-        )
+        assert_equal_computations([opt_out], [expected_opt_out], strict_dtype=False)
         eval_kwargs = dict(mode=NO_OPTIMIZATION_MODE, on_unused_input="ignore")
         np.testing.assert_allclose(
             opt_out.eval({x: x_test, y: y_test}, **eval_kwargs),
@@ -251,9 +255,10 @@ class TestLocalSubtensorOfBatchDims:
     @pytest.mark.parametrize(
         "idx", [np.zeros(20, dtype="int64"), slice(0, 5)], ids=["advanced", "slice"]
     )
-    def test_lifts_through_stale_elemwise_output_type(self, idx):
+    def test_stale_elemwise_output_type(self, idx):
         """When every input is length 1 on an indexed dim but elem's output type
-        stale-claims non-bcast, the lift should still succeed by wrapping with alloc."""
+        stale-claims non-bcast, the lift still succeeds: the broadcast-back shape
+        is derived from the inputs (which are never stale), not from elem.type."""
         x_input = pt.tensor("x_input", shape=(None, 3, 3), dtype="float64")
         x_new_input = pt.tensor("x_new", shape=(1, 3, 3), dtype="float64")
         x = pt.identity(x_input)
@@ -266,49 +271,48 @@ class TestLocalSubtensorOfBatchDims:
         # call fgraph.replace(x, x_new_input).
         fgraph.replace(x, x_new_input)
 
+        # Confirm the state is genuinely stale: the Elemwise output type still
+        # claims dim 0 is non-broadcastable, while its (replaced) inputs are now
+        # length 1 there.
+        elem = indexed.owner.inputs[0]
+        assert not elem.type.broadcastable[0]
+        assert all(inp.type.broadcastable[0] for inp in elem.owner.inputs)
+
         [new_out] = local_subtensor_of_batch_dims.transform(fgraph, indexed.owner)
         # The lifted graph must be type-compatible with the (stale) original.
         fgraph.replace(indexed, new_out)
 
-        rng = np.random.default_rng(0)
-        x_val = rng.standard_normal((1, 3, 3))
-        f = function(
-            [x_new_input], new_out, on_unused_input="ignore", mode=NO_OPTIMIZATION_MODE
-        )
-        expected = (x_val * x_val)[idx]
-        np.testing.assert_allclose(f(x_val), expected)
+        rewritten = rewrite_graph(new_out, **self.rewrite_kw)
+        if isinstance(idx, slice):
+            # slice(0, 5) on a length-1 dim stays length 1, so no Alloc is needed.
+            expected = pt.sqr(x_new_input)
+        else:
+            expected = pt.alloc(pt.sqr(x_new_input), idx.shape[0], 3, 3)
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
 
-    def test_advanced_index_on_all_bcast_dim_does_not_expand(self):
-        """When all inputs are length 1 on an advanced-indexed dim, the lifted
-        Elemwise should keep them length 1 (and alloc once) rather than
-        repeating the computation K times."""
+    def test_advanced_index_on_broadcast_dim_does_not_expand_inputs(self):
+        """An advanced index on a dim that is length 1 in every input must not be
+        applied to those inputs (it would expand them 1->K and duplicate the
+        computation). They stay length 1 and the K-sized dim comes from one Alloc."""
         x = pt.tensor("x", shape=(1, 3), dtype="float64")
         y = pt.tensor("y", shape=(1, 3), dtype="float64")
-        idx = np.zeros(5, dtype="int64")
-        out = (x + y)[idx]
+        out = (x + y)[np.zeros(5, dtype="int64")]
 
-        [new_out] = local_subtensor_of_batch_dims.transform(
-            FunctionGraph([x, y], [out], clone=False), out.owner
-        )
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.alloc(x + y, 5, 3)
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
 
-        # Final shape matches the original.
-        assert new_out.type.shape == (5, 3)
+    def test_broadcast_dim_does_not_block_lift(self):
+        """An advanced index on a broadcast dim (which needs an Alloc back) must
+        not stop the lift: the shrinking index on the other, non-broadcast dim
+        still pushes the Elemwise inside. Here ``exp`` runs on a single row
+        instead of a million."""
+        x = pt.matrix("x", shape=(1_000_000, 1))
+        out = pt.exp(x)[0, np.array([0, 0, 0])]
 
-        # The lifted Elemwise must operate on length 1 inputs (no K-fold
-        # expansion), and the K-sized dim must come from an Alloc wrapper.
-        from pytensor.tensor.basic import Alloc
-
-        assert isinstance(new_out.owner.op, Alloc)
-        [inner_elem, *_] = new_out.owner.inputs
-        assert isinstance(inner_elem.owner.op, Elemwise)
-        for inner_inp in inner_elem.owner.inputs:
-            assert inner_inp.type.shape[0] == 1
-
-        rng = np.random.default_rng(1)
-        x_val = rng.standard_normal((1, 3))
-        y_val = rng.standard_normal((1, 3))
-        f = function([x, y], new_out, mode=NO_OPTIMIZATION_MODE)
-        np.testing.assert_allclose(f(x_val, y_val), (x_val + y_val)[idx])
+        rewritten = rewrite_graph(out, **self.rewrite_kw)
+        expected = pt.alloc(pt.exp(x[0]), 3)
+        assert_equal_computations([rewritten], [expected], strict_dtype=False)
 
 
 def test_local_subtensor_of_dot():


### PR DESCRIPTION
## Description
The local_subtensor_of_batch_dims rewrite crashes with a TypeError when it attempts to lift a subtensor through an Elemwise node that is in a "stale" state.

A stale state occurs mid-optimization when upstream rewrites have made an Elemwise node's inputs broadcastable (length-1), but the node's output Type has not yet been updated to reflect this (remaining non-broadcastable).

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works

## Type of change
- [x] Bug fix

## Issues
- Closes #2169
