### PR TITLE
Fix cycle error in FusionOptimizer

### DIFF
--- a/pytensor/tensor/rewriting/elemwise.py
+++ b/pytensor/tensor/rewriting/elemwise.py
@@ -721,6 +721,14 @@ class FusionOptimizer(GraphRewriter):
                         # Already part of the subgraph
                         continue
 
+                    if node_bitflag & all_subgraphs_bitset:
+                        # Already part of another subgraph
+                        if is_ancestor:
+                            unfuseable_ancestors_bitset |= node_ancestors_bitset
+                        else:
+                            unfuseable_clients_bitset |= node_bitflag
+                        continue
+
                     if is_ancestor:
                         if node_bitflag & unfuseable_ancestors_bitset:
                             # An unfuseable ancestor of the subgraph depends on this node, can't fuse
@@ -827,7 +835,8 @@ class FusionOptimizer(GraphRewriter):
                     ancestors_bitsets |= (
                         (node, node_ancestors_bitset | subgraph_and_ancestors)
                         for node, node_ancestors_bitset in ancestors_bitsets.items()
-                        if node_ancestors_bitset & subgraph_bitset
+                        if (node_ancestors_bitset & subgraph_bitset)
+                        and not (nodes_bitflags[node] & subgraph_bitset)
                     )
 
                 # Collect the subgraph

--- a/tests/tensor/rewriting/test_fusion_cycle.py
+++ b/tests/tensor/rewriting/test_fusion_cycle.py
@@ -1,0 +1,43 @@
+import pytensor.tensor as pt
+from pytensor.graph.fg import FunctionGraph
+from pytensor.tensor.rewriting.elemwise import FusionOptimizer
+
+
+def test_fusion_no_cycle_after_multi_output():
+    """Verify that multi-output fusions do not cause cycles in later discoveries.
+
+    A bug in the ancestors_bitsets update logic for multi-output subgraphs
+    incorrectly marked ancestors within the subgraph as depending on their
+    own descendants.
+    """
+    in_a = pt.vector("a")
+    a = pt.exp(in_a)
+    b = pt.exp(a)
+    c = pt.log(a)
+    d = pt.exp(b)
+    e = pt.exp(c)
+
+    fgraph = FunctionGraph([in_a], [d, e])
+    optimizer = FusionOptimizer()
+    # Should not raise ValueError: graph contains cycles
+    optimizer.apply(fgraph)
+
+
+def test_fusion_cycle_diamond():
+    """Test fusion in a diamond-like structure with mixed fuseability.
+
+    This structure can trigger cycles if subgraphs overlap or are non-convex.
+    """
+    x = pt.matrix("x")
+    a = pt.exp(x)
+    # Path 1: fuseable
+    b = pt.exp(a)
+    # Path 2: unfuseable in the middle
+    c = a[0]
+    d = pt.exp(c)
+    # Sink
+    out = b + d
+
+    fgraph = FunctionGraph([x], [out])
+    # Should not raise ValueError: graph contains cycles
+    FusionOptimizer().apply(fgraph)


### PR DESCRIPTION
Fix cycle error in FusionOptimizer by preventing overlapping subgraphs and bitset corruption

## Description
This PR addresses a structural regression in FusionOptimizer (introduced in recent ordering changes) where certain complex topologies or multi-output subgraphs could trigger a ValueError: graph contains cycles during the final topological sort of discovered subgraphs.

  The Problem:
   1. Overlapping Subgraphs: The discovery loop did not check if a node was already "claimed" by a previously discovered subgraph. This allowed nodes to be shared between subgraphs, creating circular dependencies in the meta-graph of subgraphs.
   2. Bitset Corruption: When a multi-output subgraph was discovered, the logic for updating successor dependencies incorrectly updated nodes within that same subgraph. This caused ancestors to appear as if they depended on their own descendants, corrupting the priority keys used for expansion and leading to non-convex subgraphs.

## Related Issue
- [ ] Closes #2170

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
- [x] Bug fix
