### PR TITLE
More robust diagonal constant check

### DIFF
--- a/pytensor/assumptions/diagonal.py
+++ b/pytensor/assumptions/diagonal.py
@@ -50,7 +50,9 @@ def _diagonal_from_constant(var: TensorConstant) -> FactState:
             result = FactState.FALSE
         else:
             eye_mask = np.eye(n, dtype=bool)
-            result = FactState.FALSE if np.any(data[..., ~eye_mask]) else FactState.TRUE
+            result = (
+                FactState.FALSE if np.any(data, where=~eye_mask) else FactState.TRUE
+            )
 
     var.tag.is_diagonal = result
     return result

--- a/pytensor/assumptions/diagonal.py
+++ b/pytensor/assumptions/diagonal.py
@@ -50,7 +50,7 @@ def _diagonal_from_constant(var: TensorConstant) -> FactState:
             result = FactState.FALSE
         else:
             eye_mask = np.eye(n, dtype=bool)
-            result = FactState.FALSE if np.any(data * ~eye_mask) else FactState.TRUE
+            result = FactState.FALSE if np.any(data[..., ~eye_mask]) else FactState.TRUE
 
     var.tag.is_diagonal = result
     return result

--- a/pytensor/assumptions/diagonal.py
+++ b/pytensor/assumptions/diagonal.py
@@ -49,10 +49,13 @@ def _diagonal_from_constant(var: TensorConstant) -> FactState:
         if m != n:
             result = FactState.FALSE
         else:
-            eye_mask = np.eye(n, dtype=bool)
-            result = (
-                FactState.FALSE if np.any(data, where=~eye_mask) else FactState.TRUE
-            )
+            # Off-diagonal has a nonzero iff there are more nonzeros in ``data``
+            # than on its diagonal.
+            diag = np.diagonal(data, axis1=-2, axis2=-1)
+            if np.count_nonzero(data) == np.count_nonzero(diag):
+                result = FactState.TRUE
+            else:
+                result = FactState.FALSE
 
     var.tag.is_diagonal = result
     return result

--- a/pytensor/assumptions/permutation.py
+++ b/pytensor/assumptions/permutation.py
@@ -37,19 +37,18 @@ def _permutation_from_constant(var: TensorConstant) -> FactState:
     data = np.asarray(var.data)
     if data.ndim < 2 or data.shape[-1] != data.shape[-2]:
         result = FactState.FALSE
-    elif not bool(np.all(data.sum(axis=-2) == 1)):
-        result = FactState.FALSE
-    elif not bool(np.all(data.sum(axis=-1) == 1)):
-        result = FactState.FALSE
     else:
-        if data.dtype.kind in "uib":
-            # Fast check, only valid for integer/bool
-            is_permutation = data.max(initial=1) <= 1 and data.min(initial=0) >= 0
-        else:
-            # Otherwise a matrix is permutation iff there is exactly 1 nonzero entry per row
-            # and column. That non-zero value can only be 1 due to previous checks.
-            n = data.shape[-1]
-            is_permutation = np.count_nonzero(data) == (data.size // n if n else 0)
+        with np.errstate(invalid="ignore"):
+            if not (data.sum(axis=-2) == 1).all():
+                is_permutation = False
+            elif not (data.sum(axis=-1) == 1).all():
+                is_permutation = False
+            elif data.dtype.kind in "ub":
+                is_permutation = True
+            elif data.dtype.kind == "i":
+                is_permutation = data.min(initial=0) >= 0
+            else:
+                is_permutation = bool(((data == 0) | (data == 1)).all())
         result = FactState.TRUE if is_permutation else FactState.FALSE
 
     var.tag.is_permutation = result

--- a/pytensor/assumptions/permutation.py
+++ b/pytensor/assumptions/permutation.py
@@ -37,14 +37,19 @@ def _permutation_from_constant(var: TensorConstant) -> FactState:
     data = np.asarray(var.data)
     if data.ndim < 2 or data.shape[-1] != data.shape[-2]:
         result = FactState.FALSE
+    elif not bool(np.all(data.sum(axis=-2) == 1)):
+        result = FactState.FALSE
+    elif not bool(np.all(data.sum(axis=-1) == 1)):
+        result = FactState.FALSE
     else:
-        # The row/column-sum reductions are cheaper and short-circuit the full-size binary
-        # scan; a doubly-stochastic matrix shows the binary check is still required.
-        is_permutation = (
-            bool(np.all(data.sum(axis=-2) == 1))
-            and bool(np.all(data.sum(axis=-1) == 1))
-            and bool(np.all((data == 0) | (data == 1)))
-        )
+        if data.dtype.kind in "uib":
+            # Fast check, only valid for integer/bool
+            is_permutation = data.max(initial=1) <= 1 and data.min(initial=0) >= 0
+        else:
+            # Otherwise a matrix is permutation iff there is exactly 1 nonzero entry per row
+            # and column. That non-zero value can only be 1 due to previous checks.
+            n = data.shape[-1]
+            is_permutation = np.count_nonzero(data) == (data.size // n if n else 0)
         result = FactState.TRUE if is_permutation else FactState.FALSE
 
     var.tag.is_permutation = result

--- a/pytensor/assumptions/permutation.py
+++ b/pytensor/assumptions/permutation.py
@@ -48,7 +48,8 @@ def _permutation_from_constant(var: TensorConstant) -> FactState:
             elif data.dtype.kind == "i":
                 is_permutation = data.min(initial=0) >= 0
             else:
-                is_permutation = bool(((data == 0) | (data == 1)).all())
+                n = data.shape[-1]
+                is_permutation = np.count_nonzero(data) == (data.size // n if n else 0)
         result = FactState.TRUE if is_permutation else FactState.FALSE
 
     var.tag.is_permutation = result

--- a/pytensor/assumptions/selection.py
+++ b/pytensor/assumptions/selection.py
@@ -33,7 +33,12 @@ def _selection_from_constant(var: TensorConstant) -> FactState:
         elif data.dtype.kind in "uib":
             is_selection = data.max(initial=1) <= 1 and data.min(initial=0) >= 0
         else:
-            is_selection = bool(((data == 0) | (data == 1)).all())
+            # Column sums all == 1 plus ``count_nonzero == k`` (per slice) force one
+            # nonzero per column equal to 1
+            n_rows = data.shape[-2]
+            is_selection = np.count_nonzero(data) == (
+                data.size // n_rows if n_rows else 0
+            )
         result = FactState.TRUE if is_selection else FactState.FALSE
 
     var.tag.is_selection = result

--- a/pytensor/assumptions/selection.py
+++ b/pytensor/assumptions/selection.py
@@ -28,17 +28,15 @@ def _selection_from_constant(var: TensorConstant) -> FactState:
     if data.ndim < 2:
         result = FactState.FALSE
     else:
-        if not (data.sum(axis=-2) == 1).all():
-            is_selection = False
-        elif data.dtype.kind in "uib":
-            is_selection = data.max(initial=1) <= 1 and data.min(initial=0) >= 0
-        else:
-            # Column sums all == 1 plus ``count_nonzero == k`` (per slice) force one
-            # nonzero per column equal to 1
-            n_rows = data.shape[-2]
-            is_selection = np.count_nonzero(data) == (
-                data.size // n_rows if n_rows else 0
-            )
+        with np.errstate(invalid="ignore"):
+            if not (data.sum(axis=-2) == 1).all():
+                is_selection = False
+            elif data.dtype.kind in "ub":
+                is_selection = True
+            elif data.dtype.kind == "i":
+                is_selection = data.min(initial=0) >= 0
+            else:
+                is_selection = bool(((data == 0) | (data == 1)).all())
         result = FactState.TRUE if is_selection else FactState.FALSE
 
     var.tag.is_selection = result

--- a/pytensor/assumptions/selection.py
+++ b/pytensor/assumptions/selection.py
@@ -36,7 +36,10 @@ def _selection_from_constant(var: TensorConstant) -> FactState:
             elif data.dtype.kind == "i":
                 is_selection = data.min(initial=0) >= 0
             else:
-                is_selection = bool(((data == 0) | (data == 1)).all())
+                n_rows = data.shape[-2]
+                is_selection = np.count_nonzero(data) == (
+                    data.size // n_rows if n_rows else 0
+                )
         result = FactState.TRUE if is_selection else FactState.FALSE
 
     var.tag.is_selection = result


### PR DESCRIPTION
pymc-extras surfaced a small bug in _diagonal_from_constant, which used multiplication by a masking matrix to check for non-zero off-diagonal values. This raises a warning when there are non-finite values (inf/nan) in the matrix being checked. Use indexing instead to avoid the warnings.