### PR TITLE
Faster convolve numba

### DIFF
--- a/pytensor/link/numba/dispatch/random.py
+++ b/pytensor/link/numba/dispatch/random.py
@@ -212,7 +212,6 @@ def core_MvNormalRV(op, node):
         out += mean
         return out
 
-    random_fn.handles_out = True
     return random_fn
 
 

--- a/pytensor/link/numba/dispatch/signal/conv.py
+++ b/pytensor/link/numba/dispatch/signal/conv.py
@@ -17,27 +17,25 @@ def numba_funcify_Convolve1d(op, node, **kwargs):
 
     a_static_len = node.inputs[0].type.shape[-1]
     b_static_len = node.inputs[1].type.shape[-1]
-    a_known = isinstance(a_static_len, int)
-    b_known = isinstance(b_static_len, int)
-
-    kernel_len = None
-    kernel_is_b = True
-    if a_known and b_known:
-        if b_static_len <= a_static_len:
+    match a_static_len, b_static_len:
+        case int(), int():
+            if b_static_len <= a_static_len:
+                kernel_len, kernel_is_b = b_static_len, True
+            else:
+                kernel_len, kernel_is_b = a_static_len, False
+        case None, int():
             kernel_len, kernel_is_b = b_static_len, True
-        else:
+        case int(), None:
             kernel_len, kernel_is_b = a_static_len, False
-    elif b_known:
-        kernel_len, kernel_is_b = b_static_len, True
-    elif a_known:
-        kernel_len, kernel_is_b = a_static_len, False
+        case None, None:
+            kernel_len, kernel_is_b = None, True
 
     use_static = kernel_len is not None
 
     if use_static:
 
         @numba_basic.numba_njit(boundscheck=False)
-        def valid_convolve1d(x, y):
+        def valid_convolve1d(x, y, out=None):
             if kernel_is_b:
                 signal, kernel = x, y
             else:
@@ -45,83 +43,83 @@ def numba_funcify_Convolve1d(op, node, **kwargs):
             ns = signal.shape[0]
             if ns >= kernel_len:
                 length = ns - kernel_len + 1
-                ret = np.empty(length, out_dtype)
+                if out is None:
+                    out = np.empty(length, out_dtype)
                 for i in range(length):
                     acc = 0.0
                     for k in range(kernel_len):
                         acc += signal[i + k] * kernel[kernel_len - 1 - k]
-                    ret[i] = acc
+                    out[i] = acc
             else:
                 signal, kernel = kernel, signal
                 nk = ns
                 ns = signal.shape[0]
                 length = ns - nk + 1
-                ret = np.empty(length, out_dtype)
+                if out is None:
+                    out = np.empty(length, out_dtype)
                 for i in range(length):
                     acc = 0.0
                     for k in range(nk):
                         acc += signal[i + k] * kernel[nk - 1 - k]
-                    ret[i] = acc
-            return ret
+                    out[i] = acc
+            return out
 
     else:
 
         @numba_basic.numba_njit
-        def valid_convolve1d(x, y):
+        def valid_convolve1d(x, y, out=None):
             nx = len(x)
             ny = len(y)
             if nx < ny:
                 x, y = y, x
                 nx, ny = ny, nx
-            y_flipped = y[::-1]
-
             length = nx - ny + 1
-            ret = np.empty(length, out_dtype)
-
+            if out is None:
+                out = np.empty(length, out_dtype)
+            y_flipped = y[::-1]
             for i in range(length):
-                ret[i] = innerprod(x[i : i + ny], y_flipped)
-
-            return ret
+                out[i] = innerprod(x[i : i + ny], y_flipped)
+            return out
 
     @numba_basic.numba_njit
-    def full_convolve1d(x, y):
+    def full_convolve1d(x, y, out=None):
         nx = len(x)
         ny = len(y)
         if nx < ny:
             x, y = y, x
             nx, ny = ny, nx
+
+        if out is None:
+            length = nx + ny - 1
+            out = np.empty(length, out_dtype)
+
         y_flipped = y[::-1]
-
-        length = nx + ny - 1
-        ret = np.empty(length, out_dtype)
         idx = 0
-
         for i in range(ny - 1):
             k = i + 1
-            ret[idx] = innerprod(x[:k], y_flipped[-k:])
+            out[idx] = innerprod(x[:k], y_flipped[-k:])
             idx = idx + 1
-
         for i in range(nx - ny + 1):
-            ret[idx] = innerprod(x[i : i + ny], y_flipped)
+            out[idx] = innerprod(x[i : i + ny], y_flipped)
             idx = idx + 1
-
         for i in range(ny - 1):
             k = ny - i - 1
-            ret[idx] = innerprod(x[-k:], y_flipped[:k])
+            out[idx] = innerprod(x[-k:], y_flipped[:k])
             idx = idx + 1
-
-        return ret
+        return out
 
     @numba_basic.numba_njit
-    def convolve_1d(x, y, mode):
+    def convolve_1d(x, y, mode, out=None):
         if mode:
-            return full_convolve1d(x, y)
+            return full_convolve1d(x, y, out=out)
         else:
-            return valid_convolve1d(x, y)
+            return valid_convolve1d(x, y, out=out)
+
+    convolve_1d.handles_out = True
 
     if use_static:
         extra_kwargs = dict(kernel_len=kernel_len, kernel_is_b=kernel_is_b)
     else:
         extra_kwargs = {}
-    cache_key = default_hash_key_from_props(op, **extra_kwargs, cache_version=1)
+    cache_key = default_hash_key_from_props(op, **extra_kwargs, cache_version=2)
     return convolve_1d, cache_key

--- a/pytensor/link/numba/dispatch/signal/conv.py
+++ b/pytensor/link/numba/dispatch/signal/conv.py
@@ -3,34 +3,85 @@ from numba.np.arraymath import _get_inner_prod
 
 from pytensor.link.numba.dispatch import basic as numba_basic
 from pytensor.link.numba.dispatch.basic import (
-    register_funcify_default_op_cache_key,
+    default_hash_key_from_props,
+    register_funcify_and_cache_key,
 )
 from pytensor.tensor.signal.conv import Convolve1d
 
 
-@register_funcify_default_op_cache_key(Convolve1d)
+@register_funcify_and_cache_key(Convolve1d)
 def numba_funcify_Convolve1d(op, node, **kwargs):
-    # This specialized version is faster than the overloaded numba np.convolve
     a_dtype, b_dtype = node.inputs[0].type.dtype, node.inputs[1].type.dtype
     out_dtype = node.outputs[0].type.dtype
     innerprod = _get_inner_prod(a_dtype, b_dtype)
 
-    @numba_basic.numba_njit
-    def valid_convolve1d(x, y):
-        nx = len(x)
-        ny = len(y)
-        if nx < ny:
-            x, y = y, x
-            nx, ny = ny, nx
-        y_flipped = y[::-1]
+    a_static_len = node.inputs[0].type.shape[-1]
+    b_static_len = node.inputs[1].type.shape[-1]
+    a_known = isinstance(a_static_len, int)
+    b_known = isinstance(b_static_len, int)
 
-        length = nx - ny + 1
-        ret = np.empty(length, out_dtype)
+    kernel_len = None
+    kernel_is_b = True
+    if a_known and b_known:
+        if b_static_len <= a_static_len:
+            kernel_len, kernel_is_b = b_static_len, True
+        else:
+            kernel_len, kernel_is_b = a_static_len, False
+    elif b_known:
+        kernel_len, kernel_is_b = b_static_len, True
+    elif a_known:
+        kernel_len, kernel_is_b = a_static_len, False
 
-        for i in range(length):
-            ret[i] = innerprod(x[i : i + ny], y_flipped)
+    use_static = kernel_len is not None
 
-        return ret
+    if use_static:
+
+        @numba_basic.numba_njit(boundscheck=False)
+        def valid_convolve1d(x, y):
+            if kernel_is_b:
+                signal, kernel = x, y
+            else:
+                signal, kernel = y, x
+            ns = signal.shape[0]
+            if ns >= kernel_len:
+                length = ns - kernel_len + 1
+                ret = np.empty(length, out_dtype)
+                for i in range(length):
+                    acc = 0.0
+                    for k in range(kernel_len):
+                        acc += signal[i + k] * kernel[kernel_len - 1 - k]
+                    ret[i] = acc
+            else:
+                signal, kernel = kernel, signal
+                nk = ns
+                ns = signal.shape[0]
+                length = ns - nk + 1
+                ret = np.empty(length, out_dtype)
+                for i in range(length):
+                    acc = 0.0
+                    for k in range(nk):
+                        acc += signal[i + k] * kernel[nk - 1 - k]
+                    ret[i] = acc
+            return ret
+
+    else:
+
+        @numba_basic.numba_njit
+        def valid_convolve1d(x, y):
+            nx = len(x)
+            ny = len(y)
+            if nx < ny:
+                x, y = y, x
+                nx, ny = ny, nx
+            y_flipped = y[::-1]
+
+            length = nx - ny + 1
+            ret = np.empty(length, out_dtype)
+
+            for i in range(length):
+                ret[i] = innerprod(x[i : i + ny], y_flipped)
+
+            return ret
 
     @numba_basic.numba_njit
     def full_convolve1d(x, y):
@@ -68,4 +119,9 @@ def numba_funcify_Convolve1d(op, node, **kwargs):
         else:
             return valid_convolve1d(x, y)
 
-    return convolve_1d
+    if use_static:
+        extra_kwargs = dict(kernel_len=kernel_len, kernel_is_b=kernel_is_b)
+    else:
+        extra_kwargs = {}
+    cache_key = default_hash_key_from_props(op, **extra_kwargs, cache_version=1)
+    return convolve_1d, cache_key

--- a/pytensor/link/numba/dispatch/vectorize_codegen.py
+++ b/pytensor/link/numba/dispatch/vectorize_codegen.py
@@ -26,6 +26,9 @@ def encode_literals(literals: Sequence) -> str:
 def store_core_outputs(core_op_fn: Callable, nin: int, nout: int) -> Callable:
     """Create a Numba function that wraps a core function and stores its vectorized outputs.
 
+    If ``core_op_fn`` has a ``handles_out=True`` attribute, it is assumed to
+    already accept ``(inputs..., outputs...) -> None`` and is returned as-is.
+
     @njit
     def store_core_outputs(i0, i1, ..., in, o0, o1, ..., on):
         to0, to1, ..., ton = core_op_fn(i0, i1, ..., in)
@@ -35,6 +38,9 @@ def store_core_outputs(core_op_fn: Callable, nin: int, nout: int) -> Callable:
         on[...] = ton
 
     """
+    if getattr(core_op_fn, "handles_out", False):
+        return core_op_fn
+
     inputs = [f"i{i}" for i in range(nin)]
     outputs = [f"o{i}" for i in range(nout)]
     inner_outputs = [f"t{output}" for output in outputs]

--- a/pytensor/tensor/random/rewriting/numba.py
+++ b/pytensor/tensor/random/rewriting/numba.py
@@ -3,6 +3,7 @@ from pytensor.graph import node_rewriter
 from pytensor.graph.rewriting.basic import copy_stack_trace, dfs_rewriter
 from pytensor.tensor import as_tensor, constant
 from pytensor.tensor.random.op import RandomVariable, RandomVariableWithCoreShape
+from pytensor.tensor.rewriting.numba import simplify_core_shape_graphs
 from pytensor.tensor.rewriting.shape import ShapeFeature
 
 
@@ -68,6 +69,8 @@ def introduce_explicit_core_shape_rv(fgraph, node):
         core_shape = constant([], dtype="int64")
     else:
         core_shape = as_tensor(core_shape)
+
+    [core_shape] = simplify_core_shape_graphs([core_shape])
 
     new_outs = (
         RandomVariableWithCoreShape(

--- a/pytensor/tensor/rewriting/numba.py
+++ b/pytensor/tensor/rewriting/numba.py
@@ -1,10 +1,38 @@
 from pytensor.compile import optdb
 from pytensor.graph import node_rewriter
 from pytensor.graph.rewriting.basic import dfs_rewriter
-from pytensor.graph.traversal import applys_between
+from pytensor.graph.rewriting.utils import rewrite_graph
+from pytensor.graph.traversal import ancestors, applys_between
 from pytensor.tensor.basic import as_tensor, constant
 from pytensor.tensor.blockwise import Blockwise, BlockwiseWithCoreShape
 from pytensor.tensor.rewriting.shape import ShapeFeature
+from pytensor.tensor.shape import Shape, Shape_i
+
+
+def simplify_core_shape_graphs(core_shapes):
+    """Simplify core shape expressions by canonicalizing shape arithmetic.
+
+    Temporarily detaches Shape/Shape_i outputs from their owners so that
+    rewrite_graph operates only on the arithmetic above them (e.g.
+    constant-folding static shapes, eliminating dead Switch branches).
+    """
+    shape_boundary = [
+        var
+        for var in ancestors(core_shapes)
+        if var.owner is not None and isinstance(var.owner.op, (Shape, Shape_i))
+    ]
+    saved_owners = [(v, v.owner, v.index) for v in shape_boundary]
+    for v, _, _ in saved_owners:
+        v.owner = None
+    try:
+        core_shapes = list(
+            rewrite_graph(core_shapes, include=("canonicalize",), clone=False)
+        )
+    finally:
+        for v, owner, idx in saved_owners:
+            v.owner = owner
+            v.index = idx
+    return core_shapes
 
 
 @node_rewriter([Blockwise])
@@ -92,6 +120,8 @@ def introduce_explicit_core_shape_blockwise(fgraph, node):
     ):
         # If Blockwise shows up in the shape graph we can't introduce the core shape
         return None
+
+    core_shapes = simplify_core_shape_graphs(core_shapes)
 
     return BlockwiseWithCoreShape(
         [*node.inputs, *core_shapes],

--- a/pytensor/tensor/rewriting/shape.py
+++ b/pytensor/tensor/rewriting/shape.py
@@ -18,7 +18,9 @@ from pytensor.graph.rewriting.basic import (
 from pytensor.graph.traversal import ancestors
 from pytensor.graph.utils import InconsistencyError, get_variable_trace_string
 from pytensor.tensor.basic import (
+    Alloc,
     MakeVector,
+    alloc,
     as_tensor_variable,
     cast,
     constant,
@@ -1249,6 +1251,36 @@ def local_lift_specify_shape_inc_subtensor(fgraph, node):
         new_out = inc_op(new_x, y, *idx_vars)
         copy_stack_trace(node.outputs[0], new_out)
         return [new_out]
+
+
+@register_canonicalize("shape_unsafe")
+@register_specialize("shape_unsafe")
+@node_rewriter([SpecifyShape])
+def local_specify_shape_alloc(fgraph, node):
+    """Replace specify_shape(alloc(x, *shape), *specified) -> alloc(x, *new_shape).
+
+    Each new_shape dim is the specified dim if given, otherwise the original alloc dim.
+    """
+    alloc_out, *specified = node.inputs
+    if not isinstance(alloc_out.owner_op, Alloc):
+        return None
+
+    value, *alloc_shape = alloc_out.owner.inputs
+
+    new_shape = list(alloc_shape)
+    changed = False
+    for i, s in enumerate(specified):
+        if isinstance(s.type, NoneTypeT):
+            continue
+        new_shape[i] = s
+        changed = True
+
+    if not changed:
+        return None
+
+    new_out = alloc(value, *new_shape)
+    copy_stack_trace(node.outputs[0], new_out)
+    return [new_out]
 
 
 @register_infer_shape

--- a/tests/tensor/rewriting/test_blockwise.py
+++ b/tests/tensor/rewriting/test_blockwise.py
@@ -9,11 +9,15 @@ from pytensor.graph.basic import equal_computations
 from pytensor.graph.traversal import apply_ancestors
 from pytensor.scalar import log as scalar_log
 from pytensor.tensor import add, alloc, iscalar, matrix, scalar, tensor, tensor3
+from pytensor.tensor.basic import MakeVector, constant
 from pytensor.tensor.blockwise import Blockwise, BlockwiseWithCoreShape
 from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.linalg.inverse import MatrixPinv
+from pytensor.tensor.math import add as tensor_add
+from pytensor.tensor.math import maximum, minimum
 from pytensor.tensor.rewriting.blockwise import local_useless_blockwise
-from pytensor.tensor.shape import Reshape
+from pytensor.tensor.shape import Reshape, Shape_i
+from pytensor.tensor.signal.conv import Convolve1d
 
 
 def test_useless_blockwise_of_elemwise():
@@ -186,3 +190,47 @@ def test_blockwise_reshape():
         new_y.eval({"x": test_x}, mode=no_rewrites),
         rewritten_y.eval({"x": test_x}, mode=no_rewrites),
     )
+
+
+@pytest.mark.parametrize(
+    "mode, x_shape, k_shape",
+    [
+        ("valid", (3, 10), (3, 4)),
+        ("full", (3, 10), (3, 4)),
+        ("valid", (None, None), (None, None)),
+        ("full", (None, None), (None, None)),
+    ],
+)
+def test_blockwise_core_shape_simplified(mode, x_shape, k_shape):
+    x = tensor("x", shape=x_shape)
+    k = tensor("k", shape=k_shape)
+    out = Blockwise(Convolve1d())(
+        x, k, constant(mode == "full", dtype="bool"), return_list=True
+    )
+    fn = function([x, k], out, mode="NUMBA")
+
+    [bwcs_node] = [
+        n
+        for n in fn.maker.fgraph.apply_nodes
+        if isinstance(n.op, BlockwiseWithCoreShape)
+    ]
+    core_shape = bwcs_node.inputs[-1]
+
+    static = all(s is not None for s in x_shape + k_shape)
+    if static:
+        n, kk = x_shape[1], k_shape[1]
+        expected_len = (n + kk - 1) if mode == "full" else (n - kk + 1)
+        expected = constant(np.array([expected_len]))
+        assert equal_computations([core_shape], [expected])
+    else:
+        n = Shape_i(1)(x)
+        kk = Shape_i(1)(k)
+        if mode == "full":
+            expected = MakeVector("int64")(
+                tensor_add(constant(-1, dtype="int64"), n, kk)
+            )
+        else:
+            expected = MakeVector("int64")(
+                constant(1, dtype="int64") + maximum(n, kk) - minimum(n, kk)
+            )
+        assert equal_computations([core_shape], [expected], in_xs=[x, k], in_ys=[x, k])

--- a/tests/tensor/rewriting/test_shape.py
+++ b/tests/tensor/rewriting/test_shape.py
@@ -689,6 +689,21 @@ def test_local_lift_specify_shape_inc_subtensor():
     )
 
 
+def test_local_specify_shape_alloc():
+    x = scalar("x")
+    s1 = iscalar("s1")
+    s2 = iscalar("s2")
+
+    out = pt.specify_shape(alloc(x, s1), s2)
+
+    new_out = rewrite_graph(out, clone=True)
+    utt.assert_equal_computations([new_out], [alloc(x, s2)])
+
+    # Rewrite is excluded when shape_unsafe is excluded
+    new_out = rewrite_graph(out, clone=True, exclude=("shape_unsafe",))
+    utt.assert_equal_computations([out], [new_out])
+
+
 def test_local_Shape_i_ground():
     x = tensor(dtype=np.float64, shape=(None, 2))
     s = Shape_i(1)(x)


### PR DESCRIPTION
LLVM really wins when it knows the static shape of the kernel, it can vectorize the inner loop.


| Benchmark | Main (μs) | Branch (μs) | Speedup | Specialization? |
|---|---:|---:|---:|---|
| **numba batch=False mode=valid** | 2.50 | 1.47 | **1.70x** | Yes — static shapes (183,), (6,) |
| **numba batch=True mode=valid** | 9.23 | 2.15 | **4.29x** | Yes — static shapes (7,183), (7,6) |
| numba batch=False mode=full | 2.49 | 2.47 | 1.01x | No effect — `full` path unchanged; specialization only rewrites `valid_convolve1d` |
| numba batch=True mode=full | 9.26 | 8.76 | 1.06x | No effect — `full` path unchanged |
| numba grad full | 82.28 | 81.00 | ~1.0x | No — inputs have `shape=(8, None)`, `use_static=False` |
| numba grad valid | 80.72 | 80.27 | ~1.0x | No — inputs have `shape=(8, None)`, `use_static=False` |

On the defaul/demo MMM model in pymc-marketing this translates to a ~1.2x speedup in the logp+dlogp function.

This PR also develops a mechanism to provide the out_argument for blockwise/non-scalar RV functions, which avoids the useless copy of the inner function buffer to the blockwise batched buffer. We should follow up and start using this in as many places as we can.

For now there's a hacky `.handles_out` argument that specifies the behavior, we can think of a better API, but I wouldn't hang too much on it.

The speed benefits are smaller (you can see 1-2 us in batched cases where the argument plays a role). It's more dramatic for blockwise of cheap inner graphs, and obviously reduces intermediate memory consumption. 