### PR TITLE
Fix walk_toposort spurious cycle on int node ids > 256

### DIFF
--- a/pytensor/graph/traversal.py
+++ b/pytensor/graph/traversal.py
@@ -567,7 +567,7 @@ def walk_toposort(
                 for client in clients.get(node, []):
                     # Remove itself from the dependent (ancestor) list of each client
                     d = deps_cache[client] = [
-                        a for a in deps_cache[client] if a is not node
+                        a for a in deps_cache[client] if a != node
                     ]
                     if not d:
                         # If there are no dependencies left to visit for this node, add it to the stack

--- a/tests/graph/test_traversal.py
+++ b/tests/graph/test_traversal.py
@@ -15,6 +15,7 @@ from pytensor.graph.traversal import (
     variable_depends_on,
     vars_between,
     walk,
+    walk_toposort,
 )
 from tests.graph.test_basic import MyOp, MyVariable
 from tests.graph.utils import MyInnerGraphOp, op_multiple_outputs
@@ -165,6 +166,18 @@ def test_walk():
         (r1, None),
         (r2, None),
     ]
+
+
+# Regression test for #2170. CPython caches int singletons in [-5, 256], so
+# an `is` comparison on ints from distinct sources holds for max id 256 and
+# breaks at 257. 1026 guards against a future bump of the cache ceiling.
+@pytest.mark.parametrize("n", [10, 257, 258, 1026])
+def test_walk_toposort_acyclic_int_chain(n):
+    def deps(i):
+        return [i + 1] if i < n - 1 else []
+
+    out = tuple(walk_toposort(range(n), deps=deps))
+    assert len(out) == n
 
 
 def test_ancestors():


### PR DESCRIPTION
## Description

`walk_toposort` removed resolved dependencies from Kahn's algorithm via identity comparison (`a is not node`). CPython caches `int` singletons only in `[-5, 256]`; for larger ints, two int objects with the same value are equal but not identical.

`FusionOptimizer.apply` (after #2150) calls `walk_toposort` with `range(N)` as the node iterable and a deps callback that returns ints fetched from a separate mapping (`sg_idx_of_out`). When the fusion pass discovers more than ~256 subgraphs, the two int sources have non-matching identity, dependencies are never removed, Kahn's gets stuck, and an acyclic subgraph DAG is mis-reported as containing cycles.

Switches the comparison to value equality (`a != node`). This is consistent with the rest of `walk_toposort`, which already keys its `clients`/`deps_cache`/`rset` containers by value (`in`, set membership), not identity. `Apply`/`Variable` nodes do not override `__eq__`/`__hash__`, so equality reduces to identity there — no behavior change for the existing call sites that traverse the op graph.

## Related Issue

- Closes #2170
- Supersedes #2171 (closed; was the wrong fix)

## Regression test

`tests/graph/test_traversal.py::test_walk_toposort_acyclic_int_chain` exercises an acyclic linear chain of `n` nodes via `range(n)` and an arithmetic deps callback. The defect first manifests at `n=258` (max id 257, one above the small-int cache). Parametrized over `[10, 257, 258, 1026]` so the boundary is pinned on both sides and a future bump to the small-int cache ceiling would still be caught.

## Checklist
- [x] Pre-commit linting/style checks pass
- [x] Included a regression test
- [x] No documentation change needed (one-line fix to internal traversal helper)

## Type of change
- [x] Bug fix