### PR TITLE
Remove custom slice hashing workaround (post Python 3.11 drop)

### DIFF
--- a/pytensor/tensor/subtensor.py
+++ b/pytensor/tensor/subtensor.py
@@ -832,7 +832,7 @@ def slice_static_length(slc, dim_length):
 
 
 class BaseSubtensor:
-    """Base class for Subtensor operations that handles idx_list and hash/equality."""
+    """Base class for Subtensor operations that handles idx_list."""
 
     def __init__(self, idx_list: Sequence[int | slice]):
         index_counter = -1
@@ -867,26 +867,6 @@ class BaseSubtensor:
         self.n_index_vars = index_counter + 1
         self.idx_list = tuple(idx_list)
 
-    def _hashable_idx_list(self):
-        """Return a hashable version of idx_list (slices converted to tuples).
-
-        Slices are not hashable in Python < 3.12, so we convert them to tuples.
-        """
-        return tuple(
-            (slice, entry.start, entry.stop, entry.step)
-            if isinstance(entry, slice)
-            else entry
-            for entry in self.idx_list
-        )
-
-    def __hash__(self):
-        # Temporary workaround: slices are hashable in Python 3.12+
-        props_values = tuple(
-            self._hashable_idx_list() if prop == "idx_list" else getattr(self, prop)
-            for prop in self.__props__
-        )
-        return hash((type(self), props_values))
-
 
 class Subtensor(BaseSubtensor, COp):
     """Basic NumPy indexing operator."""
@@ -895,7 +875,6 @@ class Subtensor(BaseSubtensor, COp):
     view_map = {0: [0]}
     _f16_ok = True
     __props__ = ("idx_list",)
-    __hash__ = BaseSubtensor.__hash__
 
     def make_node(self, x, *inputs):
         """
@@ -1487,7 +1466,6 @@ class IncSubtensor(BaseSubtensor, COp):
         "set_instead_of_inc",
         "destroyhandler_tolerate_aliased",
     )
-    __hash__ = BaseSubtensor.__hash__
 
     def __init__(
         self,
@@ -2375,7 +2353,6 @@ class AdvancedSubtensor(BaseSubtensor, COp):
     """Implements NumPy's advanced indexing."""
 
     __props__ = ("idx_list",)
-    __hash__ = BaseSubtensor.__hash__
 
     def c_code_cache_version(self):
         hv = Subtensor.helper_c_code_cache_version()
@@ -2661,7 +2638,6 @@ class AdvancedIncSubtensor(BaseSubtensor, Op):
         "set_instead_of_inc",
         "ignore_duplicates",
     )
-    __hash__ = BaseSubtensor.__hash__
 
     def __init__(
         self,


### PR DESCRIPTION
## Description

Now that the minimum supported Python is 3.12 (slices became hashable in [3.12](https://docs.python.org/3/whatsnew/3.12.html)), the custom slice-hashing workaround in `subtensor.py` is no longer needed.

This removes:
- `BaseSubtensor._hashable_idx_list()` — converted slices to tuples for hashing
- `BaseSubtensor.__hash__` — the custom hash that used the above
- The four `__hash__ = BaseSubtensor.__hash__` assignments on `Subtensor`, `IncSubtensor`, `AdvancedSubtensor`, and `AdvancedIncSubtensor`

Hashing and equality are now auto-generated by `MetaType` from each class's `__props__`, exactly as before the workaround was needed.

The custom `__hash__` methods on `AdvancedSubtensor1` / `AdvancedIncSubtensor1` are unrelated to slice hashing and are intentionally left untouched.

Closes #1888

## Verification
- Hash/equality/set-dedup of all four ops with slice `idx_list`s confirmed
- Graph build + eval for basic, advanced, and inc indexing confirmed
- `tests/tensor/rewriting/test_subtensor.py`: 174 passed, 2 skipped
- `ruff check` / `ruff format --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)