### PR TITLE
fix: Handle scalar inputs in JoinDims.perform (closes #2197)

### DIFF
--- a/pytensor/tensor/reshape.py
+++ b/pytensor/tensor/reshape.py
@@ -73,13 +73,16 @@ class JoinDims(Op):
         (x,) = inputs
         (out,) = outputs
 
-        output_shape = (
-            *x.shape[: self.start_axis],
-            -1,
-            *x.shape[self.start_axis + self.n_axes :],
-        )
-
-        out[0] = x.reshape(output_shape)
+        if self.n_axes == 0:
+            # Insert a dimension of size 1
+            out[0] = np.expand_dims(x, axis=self.start_axis)
+        else:
+            output_shape = (
+                *x.shape[: self.start_axis],
+                -1,
+                *x.shape[self.start_axis + self.n_axes :],
+            )
+            out[0] = x.reshape(output_shape)
 
     def pullback(self, inputs, outputs, output_grads):
         (x,) = inputs


### PR DESCRIPTION
## What

The `JoinDims` operation with `n_axes=0` (inserting a new dimension of size 1) or when joining axes that result in a size-1 dimension from a scalar (shape `()`) input causes a `ValueError` in the numba backend's vectorize shape check. This occurs because the numpy `reshape` with `-1` on a scalar array produces a shape `(1,)` array, but the numba vectorize codegen in 3.0.4 strictly validates that the runtime shape matches the declared shape.

## Fix

Add a special case in `JoinDims.perform` when `n_axes=0`: use `np.expand_dims` instead of `reshape`. This correctly handles scalar inputs and produces an array of shape `(1,)` without triggering the strict vectorize shape validation. For cases where `n_axes>0`, the existing reshape logic works correctly because the input is guaranteed to have at least `start_axis + n_axes` dimensions (validated in `make_node`).

Closes #2197