### PR TITLE
Revert "Drop support for Python 3.11"

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.12'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: pip install --upgrade setuptools numpy versioneer wheel
@@ -204,7 +204,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.12'
+          python-version: '3.11'
 
       - name: Check SDist
         run: |

--- a/.github/workflows/slow-tests-issue.yml
+++ b/.github/workflows/slow-tests-issue.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.12"
+          python-version: "3.11"
       - name: Trigger the script
         continue-on-error: true
         working-directory: scripts/slowest_tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
     if: ${{ needs.changes.outputs.changes == 'true' }}
     strategy:
       matrix:
-        python-version: ["3.12", "3.14"]
+        python-version: ["3.11", "3.14"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -78,7 +78,7 @@ jobs:
       matrix:
         # default-mode: "NUMBA" is actually a no-op, to make sure we're testing default config settings
         default-mode: ["CVM", "NUMBA", "FAST_COMPILE"]
-        python-version: ["3.12", "3.14"]
+        python-version: ["3.11", "3.14"]
         os: ["ubuntu-latest"]
         install-jax: [0]
         install-torch: [0]
@@ -94,7 +94,7 @@ jobs:
           - [ "tensor rewriting", "tests/tensor/rewriting" ]
           - [ "tensor linalg", "tests/tensor/linalg" ]
         exclude:
-          - python-version: "3.12"
+          - python-version: "3.11"
             default-mode: "FAST_COMPILE"
         include:
           - part: ["doctests", "--doctest-modules pytensor --ignore=pytensor/misc/check_duplicate_key.py --ignore=pytensor/link --ignore=pytensor/ipython.py"]
@@ -117,7 +117,7 @@ jobs:
           - part: ["pytorch link", "tests/link/pytorch"]
             install-torch: 1
             default-mode: "CVM"
-            python-version: "3.12"
+            python-version: "3.11"
             os: "ubuntu-latest"
           - part: ["xtensor", "tests/xtensor"]
             install-xarray: 1
@@ -127,7 +127,7 @@ jobs:
           - part: ["mlx link", "tests/link/mlx"]
             install-mlx: 1
             default-mode: "CVM"
-            python-version: "3.12"
+            python-version: "3.11"
             os: "macos-15"
           - part: ["macos smoke test", "tests/tensor/test_elemwise.py tests/tensor/test_math_scipy.py tests/tensor/test_blas.py"]
             default-mode: "CVM"
@@ -223,7 +223,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Set up Python 3.12
+      - name: Set up Python 3.11
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
           environment-name: pytensor-test
@@ -239,7 +239,7 @@ jobs:
           python -c 'import pytensor; print(pytensor.config.__str__(print_doc=False))'
           python -c 'import pytensor; assert pytensor.config.blas__ldflags != "", "Blas flags are empty"'
         env:
-          PYTHON_VERSION: 3.12
+          PYTHON_VERSION: 3.11
       - name: Download previous benchmark data
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.12
+  - python=3.11
   - gcc_linux-64
   - gxx_linux-64
   - numpy

--- a/environment-osx-arm64.yml
+++ b/environment-osx-arm64.yml
@@ -7,7 +7,7 @@ name: pytensor-dev
 channels:
   - conda-forge
 dependencies:
-  - python>=3.12
+  - python>=3.11
   - compilers
   - numpy>=2.0.0
   - scipy>=1,<2

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ name: pytensor-dev
 channels:
   - conda-forge
 dependencies:
-  - python>=3.12
+  - python>=3.11
   - compilers
   - numpy>=2.0.0
   - scipy>=1,<2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pytensor"
 dynamic = ['version']
-requires-python = ">=3.12,<3.15"
+requires-python = ">=3.11,<3.15"
 authors = [{ name = "pymc-devs", email = "pymc.devs@gmail.com" }]
 description = "Optimizing compiler for evaluating mathematical expressions on CPUs and GPUs."
 readme = "README.rst"
@@ -30,6 +30,7 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
@@ -168,7 +169,7 @@ lines-after-imports = 2
 
 
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.11"
 ignore_missing_imports = true
 strict_equality = true
 warn_redundant_casts = true

--- a/pytensor/gradient.py
+++ b/pytensor/gradient.py
@@ -48,7 +48,7 @@ grad_time: float = 0.0
 
 
 # TODO: Add `overload` variants
-def as_list_or_tuple[V: Variable | None](
+def as_list_or_tuple(
     use_list: bool, use_tuple: bool, outputs: V | Sequence[V]
 ) -> V | list[V] | tuple[V, ...]:
     """Return either a single object or a list/tuple of objects.

--- a/pytensor/graph/basic.py
+++ b/pytensor/graph/basic.py
@@ -108,7 +108,7 @@ class Node(MetaObject):
         return debugprint(self, **kwargs)
 
 
-class Apply(Node, Generic[OpType]):  # noqa: UP046
+class Apply(Node, Generic[OpType]):
     """A `Node` representing the application of an operation to inputs.
 
     Basically, an `Apply` instance is an object that represents the
@@ -345,7 +345,7 @@ class Apply(Node, Generic[OpType]):  # noqa: UP046
         return self.op.params_type
 
 
-class Variable(Node, Generic[_TypeType, OptionalApplyType]):  # noqa: UP046
+class Variable(Node, Generic[_TypeType, OptionalApplyType]):
     r"""
     A :term:`Variable` is a node in an expression graph that represents a
     variable.
@@ -677,7 +677,7 @@ class AtomicVariable(Variable[_TypeType, None]):
         return cp
 
 
-class NominalVariable(Generic[_TypeType, _IdType], AtomicVariable[_TypeType]):  # noqa: UP046
+class NominalVariable(Generic[_TypeType, _IdType], AtomicVariable[_TypeType]):
     """A variable that enables alpha-equivalent comparisons."""
 
     __instances__: dict[tuple["Type", Hashable], "NominalVariable"] = {}

--- a/pytensor/graph/rewriting/unify.py
+++ b/pytensor/graph/rewriting/unify.py
@@ -14,7 +14,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from numbers import Number
 from types import UnionType
-from typing import Any
+from typing import Any, TypeAlias
 
 import numpy as np
 from cons.core import ConsError, _car, _cdr
@@ -262,7 +262,7 @@ class LiteralString:
     value: str
 
 
-type OpPatternOpTypeType = type[Op] | tuple[type[Op], ...] | UnionType
+OpPatternOpTypeType: TypeAlias = type[Op] | tuple[type[Op], ...] | UnionType
 
 
 @dataclass(unsafe_hash=True)

--- a/pytensor/graph/traversal.py
+++ b/pytensor/graph/traversal.py
@@ -20,7 +20,7 @@ NodeAndChildren = tuple[T, Iterable[T] | None]
 
 
 @overload
-def walk[T: Node](
+def walk(
     nodes: Iterable[T],
     expand: Callable[[T], Iterable[T] | None],
     bfs: bool = True,
@@ -29,7 +29,7 @@ def walk[T: Node](
 
 
 @overload
-def walk[T: Node](
+def walk(
     nodes: Iterable[T],
     expand: Callable[[T], Iterable[T] | None],
     bfs: bool,
@@ -37,7 +37,7 @@ def walk[T: Node](
 ) -> Generator[NodeAndChildren, None, None]: ...
 
 
-def walk[T: Node](
+def walk(
     nodes: Iterable[T],
     expand: Callable[[T], Iterable[T] | None],
     bfs: bool = True,
@@ -511,7 +511,7 @@ def truncated_graph_inputs(
     return truncated_inputs
 
 
-def walk_toposort[T: Node](
+def walk_toposort(
     graphs: Iterable[T],
     deps: Callable[[T], Iterable[T] | None],
 ) -> Generator[T, None, None]:
@@ -581,7 +581,7 @@ def walk_toposort[T: Node](
         raise ValueError("graph contains cycles")
 
 
-def general_toposort[T: Node](
+def general_toposort(
     outputs: Iterable[T],
     deps: Callable[[T], Iterable[T] | None],
     compute_deps_cache: Callable[[T], Iterable[T] | None] | None = None,

--- a/pytensor/graph/type.py
+++ b/pytensor/graph/type.py
@@ -9,7 +9,7 @@ from pytensor.graph.utils import MetaObject
 D = TypeVar("D")
 
 
-class Type(MetaObject, Generic[D]):  # noqa: UP046
+class Type(MetaObject, Generic[D]):
     """
     Interface specification for variable type instances.
 
@@ -23,12 +23,12 @@ class Type(MetaObject, Generic[D]):  # noqa: UP046
 
     """
 
-    variable_type: TypeAlias = Variable  # noqa: UP040
+    variable_type: TypeAlias = Variable
     """
     The `Type` that will be created by a call to `Type.make_variable`.
     """
 
-    constant_type: TypeAlias = Constant  # noqa: UP040
+    constant_type: TypeAlias = Constant
     """
     The `Type` that will be created by a call to `Type.make_constant`.
     """

--- a/pytensor/graph/utils.py
+++ b/pytensor/graph/utils.py
@@ -73,7 +73,7 @@ def simple_extract_stack(
     return trace
 
 
-def add_tag_trace[T: "Apply" | "Variable"](thing: T, user_line: int | None = None) -> T:
+def add_tag_trace(thing: T, user_line: int | None = None) -> T:
     """Add tag.trace to a node or variable.
 
     The argument is returned after being affected (inplace).

--- a/pytensor/link/numba/dispatch/linalg/solvers/lu_solve.py
+++ b/pytensor/link/numba/dispatch/linalg/solvers/lu_solve.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Literal
+from typing import Literal, TypeAlias
 
 import numpy as np
 from numba.core.extending import overload
@@ -21,7 +21,7 @@ from pytensor.link.numba.dispatch.linalg.utils import (
 )
 
 
-type _Trans = Literal[0, 1, 2]
+_Trans: TypeAlias = Literal[0, 1, 2]
 
 
 def _getrs(

--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -15,7 +15,7 @@ import math
 from collections.abc import Callable
 from itertools import chain
 from textwrap import dedent
-from typing import Any
+from typing import Any, TypeAlias
 
 import numpy as np
 
@@ -790,7 +790,7 @@ float64: ScalarType = get_scalar_type("float64")
 complex64: ScalarType = get_scalar_type("complex64")
 complex128: ScalarType = get_scalar_type("complex128")
 
-type _ScalarTypes = tuple[ScalarType, ...]
+_ScalarTypes: TypeAlias = tuple[ScalarType, ...]
 int_types: _ScalarTypes = (int8, int16, int32, int64)
 uint_types: _ScalarTypes = (uint8, uint16, uint32, uint64)
 float_types: _ScalarTypes = (float16, float32, float64)

--- a/pytensor/tensor/random/variable.py
+++ b/pytensor/tensor/random/variable.py
@@ -1,6 +1,7 @@
 import copy
 import warnings
 from functools import wraps
+from typing import TypeAlias
 
 import numpy as np
 
@@ -11,7 +12,7 @@ from pytensor.tensor.random.type import RandomGeneratorType, random_generator_ty
 from pytensor.tensor.variable import TensorVariable
 
 
-type RNG_AND_DRAW = tuple["RandomGeneratorVariable", TensorVariable]
+RNG_AND_DRAW: TypeAlias = tuple["RandomGeneratorVariable", TensorVariable]
 
 
 def warn_reuse(func):

--- a/pytensor/tensor/reshape.py
+++ b/pytensor/tensor/reshape.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterable, Sequence
 from itertools import pairwise
+from typing import TypeAlias
 
 import numpy as np
 from numpy.lib._array_utils_impl import normalize_axis_index, normalize_axis_tuple
@@ -15,7 +16,9 @@ from pytensor.tensor.type import tensor
 from pytensor.tensor.variable import TensorVariable
 
 
-type ShapeValueType = int | np.integer | ScalarVariable | TensorVariable | np.ndarray
+ShapeValueType: TypeAlias = (
+    int | np.integer | ScalarVariable | TensorVariable | np.ndarray
+)
 
 
 class JoinDims(Op):

--- a/pytensor/tensor/subtensor.py
+++ b/pytensor/tensor/subtensor.py
@@ -832,7 +832,7 @@ def slice_static_length(slc, dim_length):
 
 
 class BaseSubtensor:
-    """Base class for Subtensor operations that handles idx_list."""
+    """Base class for Subtensor operations that handles idx_list and hash/equality."""
 
     def __init__(self, idx_list: Sequence[int | slice]):
         index_counter = -1
@@ -867,6 +867,26 @@ class BaseSubtensor:
         self.n_index_vars = index_counter + 1
         self.idx_list = tuple(idx_list)
 
+    def _hashable_idx_list(self):
+        """Return a hashable version of idx_list (slices converted to tuples).
+
+        Slices are not hashable in Python < 3.12, so we convert them to tuples.
+        """
+        return tuple(
+            (slice, entry.start, entry.stop, entry.step)
+            if isinstance(entry, slice)
+            else entry
+            for entry in self.idx_list
+        )
+
+    def __hash__(self):
+        # Temporary workaround: slices are hashable in Python 3.12+
+        props_values = tuple(
+            self._hashable_idx_list() if prop == "idx_list" else getattr(self, prop)
+            for prop in self.__props__
+        )
+        return hash((type(self), props_values))
+
 
 class Subtensor(BaseSubtensor, COp):
     """Basic NumPy indexing operator."""
@@ -875,6 +895,7 @@ class Subtensor(BaseSubtensor, COp):
     view_map = {0: [0]}
     _f16_ok = True
     __props__ = ("idx_list",)
+    __hash__ = BaseSubtensor.__hash__
 
     def make_node(self, x, *inputs):
         """
@@ -1466,6 +1487,7 @@ class IncSubtensor(BaseSubtensor, COp):
         "set_instead_of_inc",
         "destroyhandler_tolerate_aliased",
     )
+    __hash__ = BaseSubtensor.__hash__
 
     def __init__(
         self,
@@ -2353,6 +2375,7 @@ class AdvancedSubtensor(BaseSubtensor, COp):
     """Implements NumPy's advanced indexing."""
 
     __props__ = ("idx_list",)
+    __hash__ = BaseSubtensor.__hash__
 
     def c_code_cache_version(self):
         hv = Subtensor.helper_c_code_cache_version()
@@ -2638,6 +2661,7 @@ class AdvancedIncSubtensor(BaseSubtensor, Op):
         "set_instead_of_inc",
         "ignore_duplicates",
     )
+    __hash__ = BaseSubtensor.__hash__
 
     def __init__(
         self,

--- a/pytensor/tensor/subtensor.py
+++ b/pytensor/tensor/subtensor.py
@@ -71,7 +71,7 @@ _logger = logging.getLogger("pytensor.tensor.subtensor")
 T = TypeVar("T")
 
 
-def flatten_index_variables[T](
+def flatten_index_variables(
     idx_vars: Sequence[T | None | slice],
 ) -> tuple[list[int | slice], list[T]]:
     counter = 0
@@ -99,7 +99,7 @@ def flatten_index_variables[T](
     return idx_list, flat_vars
 
 
-def unflatten_index_variables[T](
+def unflatten_index_variables(
     flat_indices: Sequence[T],
     idx_list: Sequence[slice | int],
 ) -> tuple[slice | T, ...]:

--- a/pytensor/xtensor/random/variable.py
+++ b/pytensor/xtensor/random/variable.py
@@ -1,4 +1,5 @@
 import copy
+from typing import TypeAlias
 
 import numpy as np
 
@@ -16,7 +17,7 @@ from pytensor.xtensor.random.type import (
 from pytensor.xtensor.type import XTensorVariable
 
 
-type XRNG_AND_DRAW = tuple["XRandomGeneratorVariable", XTensorVariable]
+XRNG_AND_DRAW: TypeAlias = tuple["XRandomGeneratorVariable", XTensorVariable]
 
 __all__ = [
     "XRandomGeneratorSharedVariable",


### PR DESCRIPTION
We had some nasty bugs in 3.0.4, so reverting the only major change (#2158, and #2196 that depends on it) so we can release a patched 3.0.5, will re-revert immediately