### PR TITLE
Numba: Cache cython-special functions

### DIFF
--- a/pytensor/link/numba/dispatch/cython_support.py
+++ b/pytensor/link/numba/dispatch/cython_support.py
@@ -6,7 +6,6 @@ from typing import Any, cast
 
 import numba
 import numpy as np
-from numba.extending import get_cython_function_address
 from numpy.typing import DTypeLike
 from scipy import LowLevelCallable
 
@@ -146,28 +145,20 @@ def _available_impls(func: Callable) -> list[tuple[Signature, Any, str]]:
     return impls
 
 
-def get_cython_special_ptr(module_name: str, capi_name: str) -> int:
-    """Return the address of a cython ``__pyx_capi__`` function as an integer.
-
-    Resolving the pointer by name at call time — rather than capturing it when the kernel is
-    built — lets Numba cache kernels that call into ``scipy.special.cython_special``, since the
-    process-specific address is no longer baked into the compiled object.
-    """
-    return get_cython_function_address(module_name, capi_name)
-
-
 class _CythonFunctionSpec:
     """The cython implementation selected for a requested ``(restype, arg_types)`` signature.
 
     Holds the resolved C signature together with the module and ``__pyx_capi__`` name needed to
-    resolve the function's address at call time via ``get_cython_special_ptr``. The address itself
-    is deliberately not captured here, so kernels calling the function stay disk-cacheable.
+    resolve the function's address at call time via ``get_cython_function_address``. The address
+    itself is deliberately not captured here, so kernels calling the function stay disk-cacheable.
     """
 
     def __init__(self, signature, capi_name, module_name):
         self._signature = signature
         self.capi_name = capi_name
         self.module_name = module_name
+        self.input_dtypes = signature.arg_dtypes
+        self.output_dtype = signature.res_dtype
 
     def signature(self):
         return numba.from_dtype(self._signature.res_dtype)(
@@ -182,12 +173,6 @@ class _CythonFunctionSpec:
         ):
             raise ValueError("skip_dispatch parameter must be last")
         return self._signature.arg_names[-1] == "__pyx_skip_dispatch"
-
-    def numpy_arg_dtypes(self):
-        return self._signature.arg_dtypes
-
-    def numpy_output_dtype(self):
-        return self._signature.res_dtype
 
 
 def wrap_cython_function(func, restype, arg_types):

--- a/pytensor/link/numba/dispatch/cython_support.py
+++ b/pytensor/link/numba/dispatch/cython_support.py
@@ -1,4 +1,3 @@
-import ctypes
 import importlib
 import re
 from collections.abc import Callable, Mapping
@@ -7,6 +6,7 @@ from typing import Any, cast
 
 import numba
 import numpy as np
+from numba.extending import get_cython_function_address
 from numpy.typing import DTypeLike
 from scipy import LowLevelCallable
 
@@ -116,8 +116,13 @@ class Signature:
         return Signature(res_dtype, res_c_type, arg_dtypes, arg_c_types, arg_names)
 
 
-def _available_impls(func: Callable) -> list[tuple[Signature, Any]]:
-    """Find all available implementations for a fused cython function."""
+def _available_impls(func: Callable) -> list[tuple[Signature, Any, str]]:
+    """Find all available implementations for a fused cython function.
+
+    Each entry is ``(signature, capsule, capi_name)``, where ``capi_name`` is the key under
+    which the implementation is exported in the module's ``__pyx_capi__`` table. That name is a
+    stable, picklable handle for the C function, used to re-resolve its address at runtime.
+    """
     impls = []
     mod = importlib.import_module(func.__module__)
 
@@ -137,44 +142,37 @@ def _available_impls(func: Callable) -> list[tuple[Signature, Any]]:
             signature = Signature.from_c_types(llc.signature.encode())
         except KeyError:
             continue
-        impls.append((signature, capsule))
+        impls.append((signature, capsule, name))
     return impls
 
 
-class _CythonWrapper(numba.types.WrapperAddressProtocol):
-    def __init__(self, pyfunc, signature, capsule):
-        self._keep_alive = capsule
-        get_name = ctypes.pythonapi.PyCapsule_GetName
-        get_name.restype = ctypes.c_char_p
-        get_name.argtypes = (ctypes.py_object,)
+def get_cython_special_ptr(module_name: str, capi_name: str) -> int:
+    """Return the address of a cython ``__pyx_capi__`` function as an integer.
 
-        raw_signature = get_name(capsule)
+    Resolving the pointer by name at call time — rather than capturing it when the kernel is
+    built — lets Numba cache kernels that call into ``scipy.special.cython_special``, since the
+    process-specific address is no longer baked into the compiled object.
+    """
+    return get_cython_function_address(module_name, capi_name)
 
-        get_pointer = ctypes.pythonapi.PyCapsule_GetPointer
-        get_pointer.restype = ctypes.c_void_p
-        get_pointer.argtypes = (ctypes.py_object, ctypes.c_char_p)
-        self._func_ptr = get_pointer(capsule, raw_signature)
 
+class _CythonFunctionSpec:
+    """The cython implementation selected for a requested ``(restype, arg_types)`` signature.
+
+    Holds the resolved C signature together with the module and ``__pyx_capi__`` name needed to
+    resolve the function's address at call time via ``get_cython_special_ptr``. The address itself
+    is deliberately not captured here, so kernels calling the function stay disk-cacheable.
+    """
+
+    def __init__(self, signature, capi_name, module_name):
         self._signature = signature
-        self._pyfunc = pyfunc
+        self.capi_name = capi_name
+        self.module_name = module_name
 
     def signature(self):
         return numba.from_dtype(self._signature.res_dtype)(
             *self._signature.arg_numba_types
         )
-
-    def __wrapper_address__(self):
-        return self._func_ptr
-
-    def __call__(self, *args, **kwargs):
-        # no strict argument because of the JIT
-        # TODO: check
-        args = [dtype(arg) for arg, dtype in zip(args, self._signature.arg_dtypes)]
-        if self.has_pyx_skip_dispatch():
-            output = self._pyfunc(*args[:-1], **kwargs)
-        else:
-            output = self._pyfunc(*args, **kwargs)
-        return self._signature.res_dtype(output)
 
     def has_pyx_skip_dispatch(self):
         if not self._signature.arg_names:
@@ -195,9 +193,9 @@ class _CythonWrapper(numba.types.WrapperAddressProtocol):
 def wrap_cython_function(func, restype, arg_types):
     impls = _available_impls(func)
     compatible = []
-    for sig, capsule in impls:
+    for sig, _capsule, capi_name in impls:
         if sig.provides(restype, arg_types):
-            compatible.append((sig, capsule))
+            compatible.append((sig, capi_name))
 
     def sort_key(args):
         sig, _ = args
@@ -213,5 +211,5 @@ def wrap_cython_function(func, restype, arg_types):
 
     if not compatible:
         raise NotImplementedError(f"Could not find a compatible impl of {func}")
-    sig, capsule = compatible[0]
-    return _CythonWrapper(func, sig, capsule)
+    sig, capi_name = compatible[0]
+    return _CythonFunctionSpec(sig, capi_name, func.__module__)

--- a/pytensor/link/numba/dispatch/scalar.py
+++ b/pytensor/link/numba/dispatch/scalar.py
@@ -4,6 +4,7 @@ from hashlib import sha256
 import numba
 import numpy as np
 from numba.core import types
+from numba.core.extending import get_cython_function_address
 
 from pytensor.graph.basic import Variable
 from pytensor.link.numba.cache import _call_cached_ptr, compile_numba_function_src
@@ -13,10 +14,7 @@ from pytensor.link.numba.dispatch.basic import (
     numba_funcify_and_cache_key,
     register_funcify_and_cache_key,
 )
-from pytensor.link.numba.dispatch.cython_support import (
-    get_cython_special_ptr,
-    wrap_cython_function,
-)
+from pytensor.link.numba.dispatch.cython_support import wrap_cython_function
 from pytensor.link.utils import (
     get_name_for_object,
 )
@@ -84,8 +82,8 @@ def numba_funcify_ScalarOp(op, node, **kwargs):
                 pass
             else:
                 has_pyx_skip_dispatch = scalar_func_numba.has_pyx_skip_dispatch()
-                input_inner_dtypes = scalar_func_numba.numpy_arg_dtypes()
-                output_inner_dtype = scalar_func_numba.numpy_output_dtype()
+                input_inner_dtypes = scalar_func_numba.input_dtypes
+                output_inner_dtype = scalar_func_numba.output_dtype
 
     if scalar_func_numba is None:
         return generate_fallback_impl(op, node, **kwargs), None
@@ -106,7 +104,7 @@ def numba_funcify_ScalarOp(op, node, **kwargs):
         @numba_basic.numba_njit
         def get_ptr_func():
             with numba.objmode(ptr=types.intp):
-                ptr = get_cython_special_ptr(module_name, capi_name)
+                ptr = get_cython_function_address(module_name, capi_name)
             return ptr
 
         global_env = {

--- a/pytensor/link/numba/dispatch/scalar.py
+++ b/pytensor/link/numba/dispatch/scalar.py
@@ -1,17 +1,22 @@
 import math
 from hashlib import sha256
 
+import numba
 import numpy as np
+from numba.core import types
 
 from pytensor.graph.basic import Variable
-from pytensor.link.numba.cache import compile_numba_function_src
+from pytensor.link.numba.cache import _call_cached_ptr, compile_numba_function_src
 from pytensor.link.numba.dispatch import basic as numba_basic
 from pytensor.link.numba.dispatch.basic import (
     generate_fallback_impl,
     numba_funcify_and_cache_key,
     register_funcify_and_cache_key,
 )
-from pytensor.link.numba.dispatch.cython_support import wrap_cython_function
+from pytensor.link.numba.dispatch.cython_support import (
+    get_cython_special_ptr,
+    wrap_cython_function,
+)
 from pytensor.link.utils import (
     get_name_for_object,
 )
@@ -89,18 +94,45 @@ def numba_funcify_ScalarOp(op, node, **kwargs):
     prefix = "x" if scalar_func_name != "x" else "y"
     input_names = [f"{prefix}{i}" for i in range(len(node.inputs))]
     input_signature = ", ".join(input_names)
-    global_env = {"scalar_func_numba": scalar_func_numba}
+
+    if cython_func is not None:
+        # Resolve the cython function pointer at call time, caching it in a module global keyed
+        # by `unique_func_name` to make ops backed by `scipy.special.cython_special` cacheable.
+        module_name = scalar_func_numba.module_name
+        capi_name = scalar_func_numba.capi_name
+        unique_func_name = f"{module_name}.{capi_name}"
+        func_type_ref = types.FunctionType(scalar_func_numba.signature())
+
+        @numba_basic.numba_njit
+        def get_ptr_func():
+            with numba.objmode(ptr=types.intp):
+                ptr = get_cython_special_ptr(module_name, capi_name)
+            return ptr
+
+        global_env = {
+            "_call_cached_ptr": _call_cached_ptr,
+            "get_ptr_func": get_ptr_func,
+            "func_type_ref": func_type_ref,
+            "unique_func_name": unique_func_name,
+        }
+        scalar_func_setup = (
+            "    scalar_func_numba = "
+            "_call_cached_ptr(get_ptr_func, func_type_ref, unique_func_name)\n"
+        )
+    else:
+        global_env = {"scalar_func_numba": scalar_func_numba}
+        scalar_func_setup = ""
 
     if input_inner_dtypes is None and output_inner_dtype is None:
         if not has_pyx_skip_dispatch:
             scalar_op_src = f"""
 def {scalar_op_fn_name}({input_signature}):
-    return scalar_func_numba({input_signature})
+{scalar_func_setup}    return scalar_func_numba({input_signature})
             """
         else:
             scalar_op_src = f"""
 def {scalar_op_fn_name}({input_signature}):
-    return scalar_func_numba({input_signature}, np.intc(1))
+{scalar_func_setup}    return scalar_func_numba({input_signature}, np.intc(1))
             """
 
     else:
@@ -120,12 +152,12 @@ def {scalar_op_fn_name}({input_signature}):
         if not has_pyx_skip_dispatch:
             scalar_op_src = f"""
 def {scalar_op_fn_name}({input_signature}):
-    return direct_cast(scalar_func_numba({converted_call_args}), output_dtype)
+{scalar_func_setup}    return direct_cast(scalar_func_numba({converted_call_args}), output_dtype)
             """
         else:
             scalar_op_src = f"""
 def {scalar_op_fn_name}({input_signature}):
-    return direct_cast(scalar_func_numba({converted_call_args}, np.intc(1)), output_dtype)
+{scalar_func_setup}    return direct_cast(scalar_func_numba({converted_call_args}, np.intc(1)), output_dtype)
             """
 
     scalar_op_fn = compile_numba_function_src(
@@ -134,8 +166,16 @@ def {scalar_op_fn_name}({input_signature}):
         globals() | global_env,
     )
 
-    # Functions that call a function pointer can't be cached
-    cache_key = None if cython_func else scalar_op_cache_key(op)
+    if cython_func is not None:
+        cache_key = scalar_op_cache_key(
+            op,
+            cython_capi=unique_func_name,
+            input_inner_dtypes=tuple(str(d) for d in input_inner_dtypes),
+            output_inner_dtype=str(output_inner_dtype),
+            has_pyx_skip_dispatch=has_pyx_skip_dispatch,
+        )
+    else:
+        cache_key = scalar_op_cache_key(op)
     return numba_basic.numba_njit(scalar_op_fn), cache_key
 
 

--- a/tests/link/numba/test_basic.py
+++ b/tests/link/numba/test_basic.py
@@ -8,7 +8,6 @@ from unittest import mock
 
 import numpy as np
 import pytest
-import scipy
 
 from pytensor.tensor import scalar_from_tensor
 
@@ -486,15 +485,6 @@ class TestNumbaWarnings:
     def setup_method(self, method):
         # Pytest messes up with the package filters, reenable here for testing
         _filter_numba_warnings()
-
-    @pytest.mark.filterwarnings("error")
-    def test_cache_pointer_func_warning_suppressed(self):
-        x = pt.vector("x", shape=(5,), dtype="float64")
-        out = pt.psi(x) * 2
-        fn = function([x], out, mode="NUMBA")
-
-        x_test = np.random.uniform(size=5)
-        np.testing.assert_allclose(fn(x_test), scipy.special.psi(x_test) * 2)
 
     @pytest.mark.filterwarnings("error")
     def test_cache_large_global_array_warning_suppressed(self):

--- a/tests/link/numba/test_elemwise.py
+++ b/tests/link/numba/test_elemwise.py
@@ -58,11 +58,6 @@ add_inplace = Elemwise(scalar_add, {0: 0})
             lambda x: pt.erfc(x),
         ),
         (
-            [pt.vector()],
-            [rng.standard_normal(100).astype(config.floatX)],
-            lambda x: pt.erfcx(x),
-        ),
-        (
             [pt.vector() for i in range(4)],
             [rng.standard_normal(100).astype(config.floatX) for i in range(4)],
             lambda x, y, x1, y1: (x + y) * (x1 + y1) * y,
@@ -103,7 +98,6 @@ add_inplace = Elemwise(scalar_add, {0: 0})
         "log1mexp",
         "erf",
         "erfc",
-        "erfcx",
         "complex_arithmetic",
         "switch",
         "add_inplace_scalar",
@@ -631,6 +625,8 @@ def test_gammainc_wrt_k_grad():
             np.array([0.0, 29.0, 31.0], dtype="float64"),
             np.array([1.0, 13.0, 11.0], dtype="float64"),
         ],
+        # gammainc is backed by scipy.special.cython_special, whose funcified kernel is njit-only
+        eval_obj_mode=False,
     )
 
 

--- a/tests/link/numba/test_scalar.py
+++ b/tests/link/numba/test_scalar.py
@@ -243,6 +243,73 @@ def test_erf_complex():
     )
 
 
+CYTHON_SPECIAL_CASES = [
+    (pt.erfcx, [np.array([-1.0, 0.0, 1.0, 3.0])]),
+    (pt.erfinv, [np.array([-0.5, 0.0, 0.3, 0.9])]),
+    (pt.erfcinv, [np.array([0.2, 0.7, 1.0, 1.5])]),
+    (pt.psi, [np.array([0.5, 1.0, 3.7, 12.3])]),
+    (pt.gamma, [np.array([0.5, 1.0, 3.7, 5.2])]),
+    (pt.j0, [np.array([0.1, 1.0, 5.0, 9.0])]),
+    (pt.j1, [np.array([0.1, 1.0, 5.0, 9.0])]),
+    (pt.i0, [np.array([0.1, 1.0, 3.0, 5.0])]),
+    (pt.i1, [np.array([0.1, 1.0, 3.0, 5.0])]),
+    (pt.owens_t, [np.array([0.5, 1.0, 2.0]), np.array([0.3, 0.7, 1.2])]),
+    (pt.gammainc, [np.array([1.0, 2.0, 3.0]), np.array([0.5, 2.0, 4.0])]),
+    (pt.gammaincc, [np.array([1.0, 2.0, 3.0]), np.array([0.5, 2.0, 4.0])]),
+    (pt.gammaincinv, [np.array([1.0, 2.0, 3.0]), np.array([0.2, 0.5, 0.8])]),
+    (pt.gammainccinv, [np.array([1.0, 2.0, 3.0]), np.array([0.2, 0.5, 0.8])]),
+    (pt.jv, [np.array([0.0, 1.0, 2.0]), np.array([1.0, 3.0, 5.0])]),
+    (pt.ive, [np.array([0.0, 1.0, 2.0]), np.array([1.0, 3.0, 5.0])]),
+    (pt.kve, [np.array([0.0, 1.0, 2.0]), np.array([1.0, 3.0, 5.0])]),
+    (pt.betainc, [np.array([1.0, 2.0]), np.array([2.0, 3.0]), np.array([0.3, 0.6])]),
+    (pt.betaincinv, [np.array([1.0, 2.0]), np.array([2.0, 3.0]), np.array([0.3, 0.6])]),
+    (
+        pt.hyp2f1,
+        [
+            np.array([0.5, 1.0]),
+            np.array([0.5, 1.0]),
+            np.array([1.5, 2.0]),
+            np.array([0.2, 0.4]),
+        ],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "op_fn, test_values",
+    CYTHON_SPECIAL_CASES,
+    ids=[
+        "erfcx",
+        "erfinv",
+        "erfcinv",
+        "psi",
+        "gamma",
+        "j0",
+        "j1",
+        "i0",
+        "i1",
+        "owens_t",
+        "gammainc",
+        "gammaincc",
+        "gammaincinv",
+        "gammainccinv",
+        "jv",
+        "ive",
+        "kve",
+        "betainc",
+        "betaincinv",
+        "hyp2f1",
+    ],
+)
+def test_cython_special_funcs(op_fn, test_values):
+    """Scalar ops backed by ``scipy.special.cython_special`` resolve their C function pointer at
+    runtime (see ``numba_funcify_ScalarOp``), so the funcified kernel is njit-only. Skip the
+    object-mode eval path, as is done for the LAPACK wrappers."""
+    inputs = [pt.vector(f"x{i}", dtype="float64") for i in range(len(test_values))]
+    out = op_fn(*inputs)
+    compare_numba_and_py(inputs, [out], test_values, eval_obj_mode=False)
+
+
 class TestScalarLoop:
     def test_scalar_for_loop_single_out(self):
         n_steps = ps.int64("n_steps")


### PR DESCRIPTION
Closes https://github.com/pymc-devs/pytensor/issues/1821

This is essentially the same machinery we use to cache the linalg LAPACK functions, introduced in  #1807. 

I removed the test of the "cannot cache function pointers" warning suppression, because I believe there's nothing left that emits it.