### PR TITLE
Add MLX GEMV dispatch

### DIFF
--- a/environment-osx-arm64.yml
+++ b/environment-osx-arm64.yml
@@ -20,6 +20,7 @@ dependencies:
   # Apple BLAS
   - libblas=*=*accelerate
   - numba>=0.57
+  - mlx
   # For testing
   - coveralls
   - diff-cover

--- a/environment-osx-arm64.yml
+++ b/environment-osx-arm64.yml
@@ -20,7 +20,6 @@ dependencies:
   # Apple BLAS
   - libblas=*=*accelerate
   - numba>=0.57
-  - mlx
   # For testing
   - coveralls
   - diff-cover

--- a/pytensor/link/mlx/dispatch/blas.py
+++ b/pytensor/link/mlx/dispatch/blas.py
@@ -21,10 +21,12 @@ def mlx_funcify_Gemv(op, node=None, **kwargs):
     static_beta = _as_float_constant(node.inputs[4]) if node is not None else None
 
     if static_alpha is not None and static_beta is not None:
+
         def gemv(y, alpha, A, x, beta):
             return mx.addmm(y, A, x, alpha=static_alpha, beta=static_beta)
 
     else:
+
         def gemv(y, alpha, A, x, beta):
             return beta * y + alpha * mx.matmul(A, x)
 

--- a/pytensor/link/mlx/dispatch/blas.py
+++ b/pytensor/link/mlx/dispatch/blas.py
@@ -1,7 +1,8 @@
 import mlx.core as mx
 
+from pytensor.graph.basic import Constant
 from pytensor.link.mlx.dispatch import mlx_funcify
-from pytensor.tensor.blas import BatchedDot
+from pytensor.tensor.blas import BatchedDot, Gemv
 
 
 @mlx_funcify.register(BatchedDot)
@@ -12,3 +13,28 @@ def mlx_funcify_BatchedDot(op, **kwargs):
         return mx.matmul(a, b)
 
     return batched_dot
+
+
+@mlx_funcify.register(Gemv)
+def mlx_funcify_Gemv(op, node=None, **kwargs):
+    static_alpha = _as_float_constant(node.inputs[1]) if node is not None else None
+    static_beta = _as_float_constant(node.inputs[4]) if node is not None else None
+
+    if static_alpha is not None and static_beta is not None:
+        def gemv(y, alpha, A, x, beta):
+            return mx.addmm(y, A, x, alpha=static_alpha, beta=static_beta)
+
+    else:
+        def gemv(y, alpha, A, x, beta):
+            return beta * y + alpha * mx.matmul(A, x)
+
+    return gemv
+
+
+def _as_float_constant(var):
+    if not isinstance(var, Constant):
+        return None
+    try:
+        return float(var.data)
+    except (TypeError, ValueError):
+        return None

--- a/tests/link/mlx/test_blas.py
+++ b/tests/link/mlx/test_blas.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from pytensor import tensor as pt
 from pytensor.compile.mode import Mode
 from pytensor.configdefaults import config
 from pytensor.graph.rewriting.db import RewriteDatabaseQuery
@@ -8,6 +9,57 @@ from pytensor.link.mlx import MLXLinker
 from pytensor.tensor import blas as pt_blas
 from pytensor.tensor.type import tensor3
 from tests.link.mlx.test_basic import compare_mlx_and_py
+
+
+mx = pytest.importorskip("mlx.core")
+
+
+def test_mlx_Gemv_static_scales():
+    y = pt.vector("y", dtype=config.floatX)
+    A = pt.matrix("A", dtype=config.floatX)
+    x = pt.vector("x", dtype=config.floatX)
+
+    out = pt_blas.gemv_no_inplace(
+        y,
+        np.asarray(0.5, dtype=config.floatX),
+        A,
+        x,
+        np.asarray(2.0, dtype=config.floatX),
+    )
+
+    rng = np.random.default_rng(sum(map(ord, "test_mlx_Gemv_static_scales")))
+    y_test = rng.normal(size=(3,)).astype(config.floatX)
+    A_test = rng.normal(size=(3, 2)).astype(config.floatX)
+    x_test = rng.normal(size=(2,)).astype(config.floatX)
+
+    compare_mlx_and_py(
+        [y, A, x],
+        [out],
+        [y_test, A_test, x_test],
+    )
+
+
+def test_mlx_Gemv_symbolic_scales():
+    y = pt.vector("y", dtype=config.floatX)
+    A = pt.matrix("A", dtype=config.floatX)
+    x = pt.vector("x", dtype=config.floatX)
+    alpha = pt.scalar("alpha", dtype=config.floatX)
+    beta = pt.scalar("beta", dtype=config.floatX)
+
+    out = pt_blas.gemv_no_inplace(y, alpha, A, x, beta)
+
+    rng = np.random.default_rng(sum(map(ord, "test_mlx_Gemv_symbolic_scales")))
+    y_test = rng.normal(size=(3,)).astype(config.floatX)
+    A_test = rng.normal(size=(3, 2)).astype(config.floatX)
+    x_test = rng.normal(size=(2,)).astype(config.floatX)
+    alpha_test = np.asarray(0.5, dtype=config.floatX)
+    beta_test = np.asarray(2.0, dtype=config.floatX)
+
+    compare_mlx_and_py(
+        [y, alpha, A, x, beta],
+        [out],
+        [y_test, alpha_test, A_test, x_test, beta_test],
+    )
 
 
 def test_mlx_BatchedDot():


### PR DESCRIPTION
## Summary
- Add an MLX funcifier for `Gemv`, dispatching static-scale GEMV to `mx.addmm` and preserving symbolic-scale support with the equivalent explicit expression.
- Add MLX tests for static and symbolic GEMV scales.
- Keep this scoped to GEMV dispatch only; this does not enable the broader `BlasOpt` pipeline for MLX yet.

Towards #2213.

## Test plan
- `python -m pytest tests/link/mlx/test_blas.py -q` passed in the `pytensor-dev` conda environment with `mlx` installed locally.
- `pre-commit run --all-files` passed.

## Benchmark notes
Raw MLX primitive timing compares `mx.addmm(y, A, x, alpha=alpha, beta=beta)` against the unfused expression `beta * y + alpha * mx.matmul(A, x)`. Results are median per-call microseconds with sample standard deviation over 21 repeats.

```text
shape,iters,addmm_median_us,addmm_std_us,unfused_median_us,unfused_std_us,speedup
16x16,10000,220.67,3.93,245.76,5.62,1.11x
64x64,5000,232.46,3.94,250.19,6.32,1.08x
256x256,1500,231.84,3.51,248.69,10.25,1.07x
1024x1024,400,235.91,14.67,276.00,4.32,1.17x
4096x4096,80,506.47,60.03,686.60,57.48,1.36x
16384x1024,80,460.76,60.17,675.43,68.36,1.47x
1024x16384,80,467.81,58.57,583.62,86.46,1.25x
```

Benchmark script:

```python
import time

import mlx.core as mx
import numpy as np

rng = np.random.default_rng(20260611)
alpha = 0.5
beta = 2.0
repeats = 21

shapes = [
    (16, 16, 10000),
    (64, 64, 5000),
    (256, 256, 1500),
    (1024, 1024, 400),
    (4096, 4096, 80),
    (16384, 1024, 80),
    (1024, 16384, 80),
]


def bench(fn, iters):
    for _ in range(30):
        mx.eval(fn())
    mx.synchronize()
    samples = []
    for _ in range(repeats):
        t0 = time.perf_counter()
        for _ in range(iters):
            mx.eval(fn())
        mx.synchronize()
        samples.append((time.perf_counter() - t0) / iters * 1e6)
    return np.asarray(samples)


print("shape,iters,addmm_median_us,addmm_std_us,unfused_median_us,unfused_std_us,speedup")
for m, k, iters in shapes:
    A = mx.array(rng.normal(size=(m, k)).astype("float32"))
    x = mx.array(rng.normal(size=(k,)).astype("float32"))
    y = mx.array(rng.normal(size=(m,)).astype("float32"))
    mx.eval(A, x, y)
    mx.synchronize()

    addmm = bench(lambda: mx.addmm(y, A, x, alpha=alpha, beta=beta), iters)
    unfused = bench(lambda: beta * y + alpha * mx.matmul(A, x), iters)
    print(
        f"{m}x{k},{iters},"
        f"{np.median(addmm):.2f},{np.std(addmm, ddof=1):.2f},"
        f"{np.median(unfused):.2f},{np.std(unfused, ddof=1):.2f},"
        f"{np.median(unfused) / np.median(addmm):.2f}x"
    )
```

A PyTensor-level benchmark with `MLXLinker(use_compile=False)` showed that wrapper overhead masks most of this kernel-level difference for large arrays, so this PR should not be read as claiming a large end-to-end speedup by itself. It is still worth merging because it adds the missing, tested MLX lowering target for `Gemv`: once follow-up optimizer work can safely enable the GEMV-producing parts of `BlasOpt` for MLX, common matrix-vector patterns can lower directly to `mx.addmm` instead of being blocked by a missing dispatch. Keeping this PR dispatch-only also reduces review risk: it establishes the backend primitive mapping, scalar-scale behavior, and test coverage independently from the more delicate question of which BLAS rewrites should be enabled for MLX.

Made with [Cursor](https://cursor.com)