### PR TITLE
Add MLX GER dispatch

### DIFF
--- a/pytensor/link/mlx/dispatch/blas.py
+++ b/pytensor/link/mlx/dispatch/blas.py
@@ -2,7 +2,7 @@ import mlx.core as mx
 
 from pytensor.graph.basic import Constant
 from pytensor.link.mlx.dispatch import mlx_funcify
-from pytensor.tensor.blas import BatchedDot, Gemv
+from pytensor.tensor.blas import BatchedDot, Gemv, Ger
 
 
 @mlx_funcify.register(BatchedDot)
@@ -31,6 +31,27 @@ def mlx_funcify_Gemv(op, node=None, **kwargs):
             return beta * y + alpha * mx.matmul(A, x)
 
     return gemv
+
+
+@mlx_funcify.register(Ger)
+def mlx_funcify_Ger(op, node=None, **kwargs):
+    static_alpha = _as_float_constant(node.inputs[1]) if node is not None else None
+
+    if static_alpha is not None:
+
+        def ger(A, alpha, x, y):
+            # GER is the rank-1 update A + alpha * outer(x, y). Expressed as a
+            # matmul of (m, 1) @ (1, n), this maps directly onto mx.addmm with beta=1.
+            return mx.addmm(
+                A, x.reshape(-1, 1), y.reshape(1, -1), alpha=static_alpha, beta=1.0
+            )
+
+    else:
+
+        def ger(A, alpha, x, y):
+            return A + alpha * mx.outer(x, y)
+
+    return ger
 
 
 def _as_float_constant(var):

--- a/tests/link/mlx/test_blas.py
+++ b/tests/link/mlx/test_blas.py
@@ -62,6 +62,46 @@ def test_mlx_Gemv_symbolic_scales():
     )
 
 
+def test_mlx_Ger_static_scale():
+    A = pt.matrix("A", dtype=config.floatX)
+    x = pt.vector("x", dtype=config.floatX)
+    y = pt.vector("y", dtype=config.floatX)
+
+    out = pt_blas.ger(A, np.asarray(0.5, dtype=config.floatX), x, y)
+
+    rng = np.random.default_rng(sum(map(ord, "test_mlx_Ger_static_scale")))
+    A_test = rng.normal(size=(3, 2)).astype(config.floatX)
+    x_test = rng.normal(size=(3,)).astype(config.floatX)
+    y_test = rng.normal(size=(2,)).astype(config.floatX)
+
+    compare_mlx_and_py(
+        [A, x, y],
+        [out],
+        [A_test, x_test, y_test],
+    )
+
+
+def test_mlx_Ger_symbolic_scale():
+    A = pt.matrix("A", dtype=config.floatX)
+    x = pt.vector("x", dtype=config.floatX)
+    y = pt.vector("y", dtype=config.floatX)
+    alpha = pt.scalar("alpha", dtype=config.floatX)
+
+    out = pt_blas.ger(A, alpha, x, y)
+
+    rng = np.random.default_rng(sum(map(ord, "test_mlx_Ger_symbolic_scale")))
+    A_test = rng.normal(size=(3, 2)).astype(config.floatX)
+    x_test = rng.normal(size=(3,)).astype(config.floatX)
+    y_test = rng.normal(size=(2,)).astype(config.floatX)
+    alpha_test = np.asarray(0.5, dtype=config.floatX)
+
+    compare_mlx_and_py(
+        [A, alpha, x, y],
+        [out],
+        [A_test, alpha_test, x_test, y_test],
+    )
+
+
 def test_mlx_BatchedDot():
     # tensor3 . tensor3
     a = tensor3("a")


### PR DESCRIPTION
## Summary
- Add an MLX funcifier for `Ger`, dispatching static-scale rank-1 updates to `mx.addmm` (expressing the outer product `x ⊗ y` as an `(m, 1) @ (1, n)` matmul accumulated onto `A` with `beta=1`), and preserving symbolic-scale support with the equivalent explicit `A + alpha * mx.outer(x, y)` expression.
- Add MLX tests for static and symbolic GER scales.
- Keep this scoped to GER dispatch only; this does not enable the broader `BlasOpt` pipeline for MLX yet.

Towards #2213. Stacked on #2214 (MLX GEMV dispatch); this PR targets that branch and will retarget to `main` once #2214 merges.

## Test plan
- `python -m pytest tests/link/mlx/test_blas.py -q` passed in the `pytensor-dev` conda environment with `mlx` installed locally.
- `pre-commit run --all-files` passed.

## Benchmark notes
Raw MLX primitive timing compares `mx.addmm(A, x[:, None], y[None, :], alpha=alpha, beta=1.0)` against the unfused expression `A + alpha * mx.outer(x, y)`. Results are median per-call microseconds with sample standard deviation over 21 repeats.

```text
shape,iters,addmm_median_us,addmm_std_us,unfused_median_us,unfused_std_us,speedup
16x16,10000,236.94,2.91,236.98,2.42,1.00x
64x64,5000,670.36,183.78,860.01,57.24,1.28x
256x256,1500,780.69,65.53,929.34,65.10,1.19x
1024x1024,400,865.35,125.76,1385.44,174.39,1.60x
4096x4096,80,1048.23,484.51,3550.24,453.60,3.39x
16384x1024,80,1184.21,386.92,3451.89,489.97,2.91x
1024x16384,80,1100.52,406.52,3546.05,562.53,3.22x
```

Benchmark script:

```python
import time

import mlx.core as mx
import numpy as np

rng = np.random.default_rng(20260611)
alpha = 0.5
repeats = 21

shapes = [
    (16, 16, 10000),
    (64, 64, 5000),
    (256, 256, 1500),
    (1024, 1024, 400),
    (4096, 4096, 80),
    (16384, 1024, 80),
    (1024, 16384, 80),
]


def bench(fn, iters):
    for _ in range(30):
        mx.eval(fn())
    mx.synchronize()
    samples = []
    for _ in range(repeats):
        t0 = time.perf_counter()
        for _ in range(iters):
            mx.eval(fn())
        mx.synchronize()
        samples.append((time.perf_counter() - t0) / iters * 1e6)
    return np.asarray(samples)


print("shape,iters,addmm_median_us,addmm_std_us,unfused_median_us,unfused_std_us,speedup")
for m, n, iters in shapes:
    A = mx.array(rng.normal(size=(m, n)).astype("float32"))
    x = mx.array(rng.normal(size=(m,)).astype("float32"))
    y = mx.array(rng.normal(size=(n,)).astype("float32"))
    mx.eval(A, x, y)
    mx.synchronize()

    addmm = bench(
        lambda: mx.addmm(A, x.reshape(-1, 1), y.reshape(1, -1), alpha=alpha, beta=1.0),
        iters,
    )
    unfused = bench(lambda: A + alpha * mx.outer(x, y), iters)
    print(
        f"{m}x{n},{iters},"
        f"{np.median(addmm):.2f},{np.std(addmm, ddof=1):.2f},"
        f"{np.median(unfused):.2f},{np.std(unfused, ddof=1):.2f},"
        f"{np.median(unfused) / np.median(addmm):.2f}x"
    )
```

Unlike the GEMV case, the fused `addmm` path shows a clear kernel-level win for GER at non-trivial sizes (up to ~3.4x), because the unfused path materialises a full `m × n` outer product and a separate add, whereas `mx.addmm` fuses the rank-1 update and accumulation into one kernel. As with #2214, this PR stays dispatch-only: it adds the missing, tested MLX lowering target for `Ger` and establishes the backend primitive mapping, scalar-scale behaviour, and test coverage independently from the more delicate question of which BLAS rewrites should be enabled for MLX once follow-up optimizer work can safely turn on the GER-producing parts of `BlasOpt`.

Made with [Cursor](https://cursor.com)