### PR TITLE
Fix `until` scan gradient step count with recurring outputs

### DIFF
--- a/pytensor/scan/op.py
+++ b/pytensor/scan/op.py
@@ -2473,7 +2473,12 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         else:
             grad_steps = inputs[0]
         if info.as_while:
-            n_steps = outs[0].shape[0]
+            # Number of steps the while-loop actually executed. grad_steps already
+            # accounts for the initial-state rows included in recurrent output
+            # buffers; outs[0].shape[0] would overcount by the initial state when
+            # the first output is a recurrent one, shifting every sequence
+            # gradient by one position.
+            n_steps = grad_steps
 
         # Restrict the number of grad steps according to self.truncate_gradient
         if self.truncate_gradient != -1:

--- a/tests/scan/test_basic.py
+++ b/tests/scan/test_basic.py
@@ -2496,6 +2496,36 @@ class TestGradUntil:
     def test_grad_until_and_truncate_sequence_taps(self):
         ScanCompatibilityTests.check_grad_until_and_truncate_sequence_taps(mode=None)
 
+    def test_grad_until_with_recurrent_state(self):
+        # With a sit-sot state, the first output buffer includes the initial state.
+        # Deriving the executed-step count from that buffer's length shifts every
+        # sequence gradient one position to the right. The nitsot-only cases above
+        # never see this because their first output has no initial-state row.
+        x0 = scalar(name="x0")
+        a = np.asarray(1.3, dtype=config.floatX)
+        xs = scan(
+            lambda y, x: (a * x + y, until(a * x + y > 5.0)),
+            sequences=self.x,
+            outputs_info=[x0],
+            return_updates=False,
+        )
+        g_seq, g_x0 = grad(xs.sum(), [self.x, x0])
+        f = function([self.x, x0], [xs, g_seq, g_x0])
+
+        seq_v = np.linspace(0.4, 0.9, 12).astype(config.floatX)
+        x0_v = np.asarray(0.2, dtype=config.floatX)
+        out, g_seq_v, g_x0_v = f(seq_v, x0_v)
+        k = out.shape[0]
+        assert 1 < k < seq_v.shape[0], "until must fire mid-sequence"
+
+        # x_t = a^(t+1) x0 + sum_{j<=t} a^(t-j) y_j for t < k, so for the loss
+        # sum_t x_t: d/dy_j = (a^(k-j) - 1) / (a - 1) for j < k, 0 after; and
+        # d/dx0 = a (a^k - 1) / (a - 1).
+        j = np.arange(seq_v.shape[0])
+        g_seq_ref = np.where(j < k, (a ** (k - j) - 1) / (a - 1), 0.0)
+        utt.assert_allclose(g_seq_v, g_seq_ref)
+        utt.assert_allclose(g_x0_v, a * (a**k - 1) / (a - 1))
+
 
 def test_mintap_onestep():
     seq = ivector("seq")


### PR DESCRIPTION
Gradients of `until` scan are wrong. When the scan has sit-sot/mit-sot inputs, using `n_steps = outs[0].shape[0]` overcounts, because it includes the initial state. This shifts all gradient position by 1.

Our tests never caught it because we use a test with only nit-sot. Came up while I was working on https://github.com/pymc-devs/pymc-extras/pull/676