### PR TITLE
Fix assumption bug with (1,1) eye

### DIFF
--- a/pytensor/assumptions/alloc.py
+++ b/pytensor/assumptions/alloc.py
@@ -50,19 +50,57 @@ def alloc_is_symmetric(key, op, feature, fgraph, node, input_states) -> list[Fac
     return true_if(node.inputs[0].type.ndim == 0)
 
 
+def _eye_is_square(n, m) -> FactState:
+    """Static squareness of an :class:`Eye` from its row/column size inputs:
+    TRUE when the two sizes are provably equal, FALSE when provably unequal,
+    UNKNOWN while either remains symbolic."""
+    if n is m:
+        return FactState.TRUE
+    if isinstance(n, TensorConstant) and isinstance(m, TensorConstant):
+        return FactState.TRUE if n.data.item() == m.data.item() else FactState.FALSE
+    return FactState.UNKNOWN
+
+
 def eye_identity_rule(key, op, feature, fgraph, node, input_states) -> list[FactState]:
-    """Rule body: TRUE when an :class:`Eye` node produces the identity matrix (square, k == 0)."""
+    """Rule for ORTHOGONAL / PERMUTATION / POSITIVE_DEFINITE: TRUE only when an
+    :class:`Eye` is the identity matrix (square, ``k == 0``). Every other Eye --
+    rectangular, off-main, or the all-zero matrix of an off-shape band -- lacks
+    all three properties, so it is FALSE once the shape is known and UNKNOWN
+    while it is still symbolic.
+    """
     n, m, k = node.inputs
     if not isinstance(k, TensorConstant):
         return [FactState.UNKNOWN]
     if k.data.item() != 0:
-        # Ones sit on an off-main diagonal, so this is not the identity.
+        # Identity requires the main diagonal; any off-main band rules it out.
         return [FactState.FALSE]
-    if n is m:
-        return [FactState.TRUE]
-    if isinstance(n, TensorConstant) and isinstance(m, TensorConstant):
-        return true_if(n.data.item() == m.data.item(), else_false=True)
-    return [FactState.UNKNOWN]
+    return [_eye_is_square(n, m)]
+
+
+def eye_zero_or_identity_rule(
+    key, op, feature, fgraph, node, input_states
+) -> list[FactState]:
+    """Rule for SYMMETRIC / DIAGONAL: a square :class:`Eye` has both properties
+    when it is the identity (``k == 0``) *or* when the requested off-main band
+    ``k`` falls entirely outside the shape, leaving an all-zero matrix. A
+    non-square Eye, or a square one whose off-main band intersects the shape, is
+    neither symmetric nor diagonal.
+    """
+    n, m, k = node.inputs
+    if not isinstance(k, TensorConstant):
+        return [FactState.UNKNOWN]
+    square = _eye_is_square(n, m)
+    if square is FactState.FALSE:
+        return [FactState.FALSE]
+    if k.data.item() == 0:
+        return [square]
+    # Off-main band: symmetric/diagonal only if the band misses the shape
+    # entirely, which needs the static sizes to decide.
+    if not (isinstance(n, TensorConstant) and isinstance(m, TensorConstant)):
+        return [FactState.UNKNOWN]
+    kval, nval, mval = k.data.item(), n.data.item(), m.data.item()
+    band_is_empty = kval <= -nval or kval >= mval
+    return true_if(band_is_empty, else_false=True)
 
 
 def alloc_diag_at_offset_zero(

--- a/pytensor/assumptions/diagonal.py
+++ b/pytensor/assumptions/diagonal.py
@@ -3,7 +3,7 @@ import numpy as np
 from pytensor.assumptions.alloc import (
     alloc_diag_at_offset_zero,
     alloc_of_zero,
-    eye_identity_rule,
+    eye_zero_or_identity_rule,
 )
 from pytensor.assumptions.core import (
     DIAGONAL,
@@ -81,7 +81,7 @@ def indexes_diagonal(node) -> bool:
     return all(first is op_indices[p] for p in idx_list[1:])
 
 
-register_assumption(DIAGONAL, Eye)(eye_identity_rule)
+register_assumption(DIAGONAL, Eye)(eye_zero_or_identity_rule)
 register_assumption(DIAGONAL, AllocDiag)(alloc_diag_at_offset_zero)
 register_assumption(DIAGONAL, Alloc)(alloc_of_zero)
 register_assumption(DIAGONAL, Cholesky)(propagate_first)

--- a/pytensor/assumptions/symmetric.py
+++ b/pytensor/assumptions/symmetric.py
@@ -1,7 +1,7 @@
 from pytensor.assumptions.alloc import (
     alloc_diag_at_offset_zero,
     alloc_is_symmetric,
-    eye_identity_rule,
+    eye_zero_or_identity_rule,
 )
 from pytensor.assumptions.core import (
     SYMMETRIC,
@@ -45,7 +45,7 @@ def _preserves_symmetry_under_broadcast(inp, feature) -> bool:
     return bool(feature.check(inp, SYMMETRIC))
 
 
-register_assumption(SYMMETRIC, Eye)(eye_identity_rule)
+register_assumption(SYMMETRIC, Eye)(eye_zero_or_identity_rule)
 register_assumption(SYMMETRIC, AllocDiag)(alloc_diag_at_offset_zero)
 register_assumption(SYMMETRIC, Alloc)(alloc_is_symmetric)
 register_assumption(SYMMETRIC, BlockDiagonal)(all_inputs_have_key)

--- a/tests/assumptions/test_alloc.py
+++ b/tests/assumptions/test_alloc.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 import pytensor.tensor as pt
@@ -5,6 +6,8 @@ from pytensor.assumptions import (
     ALL_KEYS,
     DIAGONAL,
     LOWER_TRIANGULAR,
+    ORTHOGONAL,
+    PERMUTATION,
     POSITIVE_DEFINITE,
     SYMMETRIC,
     UPPER_TRIANGULAR,
@@ -32,6 +35,37 @@ def test_eye_non_identity_is_false(eye_args):
     e = pt.eye(**eye_args)
     _, af = make_fgraph(e)
     assert af.get(e, DIAGONAL) == FactState.FALSE
+
+
+@pytest.mark.parametrize(
+    "key, expected",
+    [
+        (SYMMETRIC, FactState.TRUE),
+        (DIAGONAL, FactState.TRUE),
+        (POSITIVE_DEFINITE, FactState.FALSE),
+        (PERMUTATION, FactState.FALSE),
+        (ORTHOGONAL, FactState.FALSE),
+    ],
+)
+def test_square_eye_with_empty_band_is_zero_matrix(key, expected):
+    """``eye(1, 1, k=1)`` has an empty band, so it is the all-zero matrix ``[[0.]]``."""
+    e = pt.eye(1, 1, 1)
+    _, af = make_fgraph(e)
+    assert af.get(e, key) == expected
+
+
+def test_empty_band_eye_merges_with_zero_constant_without_conflict():
+    """An all-zero ``Eye``, constant-folded and merged onto an equal zero
+    ``Constant``, must not produce conflicting SYMMETRIC evidence."""
+    e = pt.eye(1, 1, 1)
+    z = pt.constant(np.zeros((1, 1)))
+    out = pt.add(e, z)
+    fg, af = make_fgraph(out)
+    af.get(e, SYMMETRIC)
+    af.get(z, SYMMETRIC)
+    fg.replace(e, z, reason="constant_fold+merge")
+    # A conflict would raise ConflictingAssumptionsError here.
+    assert af.get(z, SYMMETRIC) == FactState.TRUE
 
 
 def test_eye_symbolic_same_shape_is_identity():


### PR DESCRIPTION
When Eye is known static shape (1,1) and k != 0 we currently mark SYMMETRIC = False. This is wrong, it *is* symmetric. We have to check that k is actually inside that the shape of eye. In the (1, 1, 1) case, we zero((1, 1)) , which is trivially symmetric.