### PR TITLE
Fix MLX Convolve1d crash when Blockwise broadcasts the kernel

### DIFF
--- a/pytensor/link/mlx/dispatch/signal/conv.py
+++ b/pytensor/link/mlx/dispatch/signal/conv.py
@@ -21,6 +21,13 @@ def mlx_funcify_Convolve1d(op, node, **kwargs):
         data = mlx_typify(raw_data, dtype=None)
         kernel = mlx_typify(raw_kernel, dtype=None)
 
+        # Inside a Blockwise, a kernel that is broadcast across the batch is
+        # promoted to a leading-1 dim (e.g. ``(1, K)``) instead of being
+        # vmapped away. ``mx.convolve`` needs 1-D inputs, so flatten the kernel
+        # back to its core ``(K,)`` shape.
+        if kernel.ndim > 1:
+            kernel = kernel.reshape(-1)
+
         if runtime_mode_static:
             runtime_mode = full_mode
         else:

--- a/tests/link/mlx/test_signal_conv.py
+++ b/tests/link/mlx/test_signal_conv.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pytest
+
+import pytensor.tensor as pt
+from pytensor.tensor.type import matrix, vector
+from tests.link.mlx.test_basic import compare_mlx_and_py
+
+
+pytest.importorskip("mlx.core")
+
+
+@pytest.mark.parametrize("mode", ["full", "valid"])
+def test_convolve1d_vector(mode):
+    x = vector("x", dtype="float32")
+    k = vector("k", dtype="float32")
+    out = pt.signal.conv.convolve1d(x, k, mode=mode)
+
+    rng = np.random.default_rng(0)
+    x_np = rng.standard_normal(32).astype("float32")
+    k_np = rng.standard_normal(5).astype("float32")
+
+    compare_mlx_and_py([x, k], [out], [x_np, k_np])
+
+
+@pytest.mark.parametrize("mode", ["full", "valid"])
+def test_convolve1d_batched_kernel_broadcast(mode):
+    """A vector kernel shared across a batch of signals is wrapped in a
+    Blockwise that broadcasts it to a leading-1 dim, so the MLX core thunk
+    must flatten it back to 1-D before calling ``mx.convolve``.
+
+    Regression test for #2092.
+    """
+    x = matrix("x", dtype="float32")
+    k = vector("k", dtype="float32")
+    out = pt.signal.conv.convolve1d(x, k, mode=mode)
+
+    rng = np.random.default_rng(0)
+    x_np = rng.standard_normal((4, 32)).astype("float32")
+    k_np = rng.standard_normal(5).astype("float32")
+
+    compare_mlx_and_py([x, k], [out], [x_np, k_np])


### PR DESCRIPTION
Fixes #2092.

### Problem

`mlx_funcify_Convolve1d`'s `conv1d` thunk calls `mx.convolve(data, kernel, ...)`, which requires both inputs to be 1-D. When `convolve1d` is batched through `Blockwise` with a single kernel shared across the batch, PyTensor broadcasts the kernel to a leading-1 dim. The MLX `Blockwise` dispatcher `vmap`s over the real batch dim of the data (so `data` arrives correctly as `(N,)`) but treats the kernel's leading-1 dim as a broadcast (`in_axes=None`), so the core thunk receives a `(1, K)` kernel and `mx.convolve` raises `ValueError: [convolve] Inputs must be 1D`.

Empirically, instrumenting the thunk for the reproducer shows `data.shape == (32,)` and `kernel.shape == (1, 5)` — only the kernel is malformed.

### Fix

Flatten the kernel back to its core `(K,)` shape inside `conv1d` when it arrives with extra leading dims. Under the op's core signature `(n0),(k0),()->(o0)` the kernel is conceptually 1-D per core call, so any leading dim is a broadcast artifact and `reshape(-1)` is safe.

### Test

Added `tests/link/mlx/test_signal_conv.py` with the batched-kernel-broadcast case (and a plain-vector case as a control), both parametrized over `full`/`valid` and checked against the Python linker via the existing `compare_mlx_and_py` helper. Verified RED→GREEN: without the source change the batched-kernel tests fail with `[convolve] Inputs must be 1D` while the vector tests pass; with it all pass. The full `tests/link/mlx/` suite is green (149 passed, 4 pre-existing xfailed).

---
Disclosure: I use AI assistance (under my direction) to help with my contributions; I review and verify every change before submitting.
