### PR TITLE
Fix MLX variadic Elemwise crash on broadcast-shaped inputs

### DIFF
--- a/pytensor/link/mlx/dispatch/scalar.py
+++ b/pytensor/link/mlx/dispatch/scalar.py
@@ -1,3 +1,5 @@
+from functools import reduce
+
 import mlx.core as mx
 
 from pytensor.link.mlx.dispatch.basic import convert_dtype_to_mlx, mlx_funcify
@@ -45,19 +47,11 @@ def mlx_funcify_ScalarOp(op, node=None, **kwargs):
             f"No MLX conversion for scalar op {op} (mx.{func_name} not found)"
         )
 
-    # Variadic Add/Mul (3+ inputs) fold the binary op left-to-right, matching the
-    # C and Numba backends (which lower as ``a + b + c``). We avoid
-    # mx.stack(args) + mx.sum/prod: stacking requires identical input shapes and so
-    # breaks elementwise broadcasting (e.g. a (1, H) bias added to (B, H)), and
-    # reducing a stacked array changes dtype (bool/int -> int). The native binary
-    # mx.add/mx.multiply broadcast and preserve dtype, and fuse under mx.compile.
+    # Handle variadic ops (e.g. Add with 3+ inputs) by folding the binary op
     if node is not None and len(node.inputs) > nfunc_spec[1]:
 
         def variadic_fold(*args):
-            result = args[0]
-            for arg in args[1:]:
-                result = mlx_func(result, arg)
-            return result
+            return reduce(mlx_func, args)
 
         return variadic_fold
 

--- a/pytensor/link/mlx/dispatch/scalar.py
+++ b/pytensor/link/mlx/dispatch/scalar.py
@@ -45,26 +45,21 @@ def mlx_funcify_ScalarOp(op, node=None, **kwargs):
             f"No MLX conversion for scalar op {op} (mx.{func_name} not found)"
         )
 
-    # Handle variadic ops (e.g. Add with 3+ inputs)
+    # Variadic Add/Mul (3+ inputs) fold the binary op left-to-right, matching the
+    # C and Numba backends (which lower as ``a + b + c``). We avoid
+    # mx.stack(args) + mx.sum/prod: stacking requires identical input shapes and so
+    # breaks elementwise broadcasting (e.g. a (1, H) bias added to (B, H)), and
+    # reducing a stacked array changes dtype (bool/int -> int). The native binary
+    # mx.add/mx.multiply broadcast and preserve dtype, and fuse under mx.compile.
     if node is not None and len(node.inputs) > nfunc_spec[1]:
-        variadic_name = getattr(op, "nfunc_variadic", None)
-        if variadic_name:
-            mlx_variadic_func = getattr(mx, variadic_name, None)
-            if mlx_variadic_func:
 
-                def variadic_fn(*args):
-                    return mlx_variadic_func(mx.stack(list(args), axis=0), axis=0)
-
-                return variadic_fn
-
-        # Fallback: fold binary op
-        def fold_fn(*args):
+        def variadic_fold(*args):
             result = args[0]
             for arg in args[1:]:
                 result = mlx_func(result, arg)
             return result
 
-        return fold_fn
+        return variadic_fold
 
     return mlx_func
 

--- a/tests/link/mlx/test_elemwise.py
+++ b/tests/link/mlx/test_elemwise.py
@@ -33,7 +33,7 @@ from pytensor.tensor.math import max as pt_max
 from pytensor.tensor.math import min as pt_min
 from pytensor.tensor.math import sum as pt_sum
 from pytensor.tensor.special import log_softmax, softmax
-from pytensor.tensor.type import matrix, vector, vectors
+from pytensor.tensor.type import matrix, tensor, vector, vectors
 from tests.link.mlx.test_basic import compare_mlx_and_py
 
 
@@ -278,3 +278,40 @@ def test_softplus_extreme_values() -> None:
     relaxed_assert = partial(np.testing.assert_allclose, rtol=1e-4, atol=1e-8)
 
     compare_mlx_and_py([x], out, [x_test], assert_fn=relaxed_assert)
+
+
+@pytest.mark.parametrize("op", [add, mul], ids=["add", "mul"])
+def test_variadic_broadcast(op):
+    # Regression #2086: a 3-input Elemwise with broadcasting operands used to crash
+    # because the variadic path stacked the operands, which requires equal shapes.
+    x = tensor("x", shape=(3, 4))
+    y = tensor("y", shape=(1, 4))
+    z = tensor("z", shape=(3, 1))
+    out = op(x, y, z)
+    assert len(out.owner.inputs) == 3  # single 3-input Elemwise, no fusion needed
+
+    x_test = np.arange(12, dtype=config.floatX).reshape(3, 4) + 1
+    y_test = np.arange(4, dtype=config.floatX).reshape(1, 4) + 1
+    z_test = np.arange(3, dtype=config.floatX).reshape(3, 1) + 1
+    compare_mlx_and_py([x, y, z], [out], [x_test, y_test, z_test])
+
+
+@pytest.mark.parametrize("dtype", ["bool", "int8"], ids=["bool", "int8"])
+def test_variadic_add_dtype(dtype):
+    # Regression #2086: the variadic add upcast bool/int operands (e.g. int8 ->
+    # int32) and broke bool OR-semantics. Folding the binary op preserves dtype.
+    x = tensor("x", shape=(3,), dtype=dtype)
+    y = tensor("y", shape=(3,), dtype=dtype)
+    z = tensor("z", shape=(3,), dtype=dtype)
+    out = add(x, y, z)
+
+    def assert_fn(mlx_res, py_res):
+        np.testing.assert_allclose(mlx_res, py_res)
+        assert np.asarray(mlx_res).dtype == np.asarray(py_res).dtype
+
+    vals = (
+        np.array([True, False, True])
+        if dtype == "bool"
+        else np.array([1, 2, 3], dtype=dtype)
+    )
+    compare_mlx_and_py([x, y, z], [out], [vals, vals, vals], assert_fn=assert_fn)


### PR DESCRIPTION
Closes #2086.

## Problem

The MLX backend lowers a variadic elementwise `Add`/`Mul` (3+ inputs) by stacking the operands and reducing:

```python
# pytensor/link/mlx/dispatch/scalar.py
def variadic_fn(*args):
    return mlx_variadic_func(mx.stack(list(args), axis=0), axis=0)  # mx.sum / mx.prod
```

`mx.stack` requires **all** operands to have identical shapes. But `Elemwise` only *rank-aligns* its inputs (broadcastable dimensions stay length-1), so any variadic op with a broadcasting operand crashes with `ValueError: [stack] All arrays must have the same shape` — e.g. a `(1, H)` bias added to `(B, H)`, a scalar constant inside a fused `Composite`, or the LSTM step from #2086.

### Reproducer

```python
import numpy as np
import pytensor
import pytensor.tensor as pt

B, H = 64, 256
x = pt.matrix("x", dtype="float32")
h = pt.matrix("h", dtype="float32")
c = pt.matrix("c", dtype="float32")
Wx = pt.matrix("Wx", dtype="float32")
Wh = pt.matrix("Wh", dtype="float32")
bias = pt.vector("bias", dtype="float32")

z = x @ Wx + h @ Wh + bias                       # fuses a 3-input Add (Wx, Wh, bias)
i, f, g, o = pt.split(z, [H, H, H, H], n_splits=4, axis=-1)
c_new = pt.sigmoid(f) * c + pt.sigmoid(i) * pt.tanh(g)
h_new = pt.sigmoid(o) * pt.tanh(c_new)

f_mlx = pytensor.function([x, h, c, Wx, Wh, bias], [h_new, c_new], mode="MLX")
rng = np.random.default_rng(0)
f_mlx(
    rng.standard_normal((B, H)).astype("float32"),
    rng.standard_normal((B, H)).astype("float32"),
    rng.standard_normal((B, H)).astype("float32"),
    rng.standard_normal((H, 4 * H)).astype("float32"),
    rng.standard_normal((H, 4 * H)).astype("float32"),
    np.zeros(4 * H, dtype="float32"),
)
# ValueError: [stack] All arrays must have the same shape
```

A minimal trigger without fusion:

```python
pt.add(pt.tensor(shape=(3, 4)), pt.tensor(shape=(1, 4)), pt.tensor(shape=(3, 1))).eval(..., mode="MLX")
```

## Root cause & fix

The N-ary `Add`/`Mul` semantics is a **broadcasting binary reduction**, not a stack-over-a-new-axis. The reference C and Numba backends already lower it that way (`a + b + c`); the `mx.stack` + `mx.sum/prod` approach was an attempt to use a native n-ary reducer, but MLX has no list-accepting broadcasting reducer, so it imposed an equal-shape constraint the op never had. As a side effect, reducing a stacked array also **upcasts dtype** (a 3-input `bool` add returns `int32` instead of preserving `bool` OR-semantics; `int8` becomes `int32`) even when shapes already match.

This PR replaces the stack/reduce branch with a left-to-right fold of the native binary op:

```python
if node is not None and len(node.inputs) > nfunc_spec[1]:
    def variadic_fold(*args):
        result = args[0]
        for arg in args[1:]:
            result = mlx_func(result, arg)
        return result
    return variadic_fold
```

`mx.add`/`mx.multiply` broadcast natively and preserve dtype, and the binary chain fuses under `mx.compile` (which the MLX linker already uses). This aligns MLX with the C/Numba reference lowering. Only `Add`/`Mul` are reachable here (`Maximum`/`Minimum` are strictly binary, `nin=2`), so no other op changes behavior.

## Tests

Added to `tests/link/mlx/test_elemwise.py` (reusing `compare_mlx_and_py`):

- `test_variadic_broadcast[add|mul]` — 3-input op with broadcast shapes `(3,4)/(1,4)/(3,1)`; asserts a single 3-input `Elemwise` (so it exercises the variadic branch without relying on fusion).
- `test_variadic_add_dtype[bool|int8]` — locks dtype preservation / bool OR-semantics that the old stack+reduce path corrupted.

Verified RED→GREEN: the broadcast tests crash and the dtype tests fail the dtype assertion on `main`; all pass with the fix. The full `tests/link/mlx/` suite is green (149 passed, 4 pre-existing xfailed), ruff check + format clean.

## Follow-ups

There are two related improvements I deliberately kept **out of scope** to keep this a focused, low-risk fix. I'll add a comment describing them and open tracking issues only once a maintainer agrees they're worth filing.

---

Disclosure: I used AI assistance (under my direction) while preparing this change; I reviewed and verified every line, test, and result.

Made with [Cursor](https://cursor.com)