### PR TITLE
Exclude general fusion from JAX and MLX modes

### DIFF
--- a/pytensor/compile/mode.py
+++ b/pytensor/compile/mode.py
@@ -464,7 +464,9 @@ NUMBA = Mode(
 
 JAX = Mode(
     JAXLinker(),
-    RewriteDatabaseQuery(include=["fast_run", "jax"]),
+    # `fusion` is not incompatible with JAX (it can run `Composite`), just not desired:
+    # XLA does its own fusion, so building `Composite` only adds graph-translation overhead.
+    RewriteDatabaseQuery(include=["fast_run", "jax"], exclude=["fusion"]),
 )
 PYTORCH = Mode(
     PytorchLinker(),
@@ -473,7 +475,7 @@ PYTORCH = Mode(
 
 MLX = Mode(
     MLXLinker(),
-    RewriteDatabaseQuery(include=["fast_run", "mlx"]),
+    RewriteDatabaseQuery(include=["fast_run", "mlx"], exclude=["fusion"]),
 )
 
 FAST_COMPILE = Mode(


### PR DESCRIPTION
The general elementwise->Composite fusion is runnable by the JIT backends, it is just not desired (JAX/XLA, torch.compile and MLX do their own fusion, so building Composite only adds graph-translation
overhead). It is therefore a Mode-level exclude, not a linker incompatibility.

A prior refactor that moved the exclude lists into the linkers accidentally narrowed JAX's (and later MLX's) general 'fusion' exclude to only 'local_careduce_fusion', so Composite started leaking into those graphs.
