### PR TITLE
Fold variadic Add/Mul in JAX and PyTorch backends instead of stacking

### DIFF
--- a/pytensor/link/jax/dispatch/scalar.py
+++ b/pytensor/link/jax/dispatch/scalar.py
@@ -100,19 +100,13 @@ def jax_funcify_ScalarOp(op, node, **kwargs):
         jax_func = getattr(jnp, func_name)
 
     if len(node.inputs) > op.nfunc_spec[1]:
-        # Some Scalar Ops accept multiple number of inputs, behaving as a variadic function,
-        # even though the base Op from `func_name` is specified as a binary Op.
-        # This happens with `Add`, which can work as a `Sum` for multiple scalars.
-        jax_variadic_func = getattr(jnp, op.nfunc_variadic, None)
-        if not jax_variadic_func:
-            raise NotImplementedError(
-                f"Dispatch not implemented for Scalar Op {op} with {len(node.inputs)} inputs"
-            )
+        # Some Scalar Ops (e.g. Add/Mul) accept more inputs than the binary base Op,
+        # behaving as variadic. Fold the binary op, which broadcasts and preserves
+        # dtype; stacking + jnp.sum/prod would upcast bool/int.
+        binary_jax_func = jax_func
 
         def jax_func(*args):
-            return jax_variadic_func(
-                jnp.stack(jnp.broadcast_arrays(*args), axis=0), axis=0
-            )
+            return functools.reduce(binary_jax_func, args)
 
     return jax_func
 

--- a/pytensor/link/pytorch/dispatch/scalar.py
+++ b/pytensor/link/pytorch/dispatch/scalar.py
@@ -1,4 +1,5 @@
 import importlib
+from functools import reduce
 
 import torch
 
@@ -40,19 +41,13 @@ def pytorch_funcify_ScalarOp(op, node, **kwargs):
         pytorch_func = getattr(torch, func_name)
 
     if len(node.inputs) > op.nfunc_spec[1]:
-        # Some Scalar Ops accept multiple number of inputs, behaving as a variadic function,
-        # even though the base Op from `func_name` is specified as a binary Op.
-        # This happens with `Add`, which can work as a `Sum` for multiple scalars.
-        pytorch_variadic_func = getattr(torch, op.nfunc_variadic, None)
-        if not pytorch_variadic_func:
-            raise NotImplementedError(
-                f"Dispatch not implemented for Scalar Op {op} with {len(node.inputs)} inputs"
-            )
+        # Some Scalar Ops (e.g. Add/Mul) accept more inputs than the binary base Op,
+        # behaving as variadic. Fold the binary op, which broadcasts and preserves
+        # dtype; stacking + torch.sum/prod would upcast bool/int.
+        binary_pytorch_func = pytorch_func
 
         def pytorch_func(*args):
-            return pytorch_variadic_func(
-                torch.stack(torch.broadcast_tensors(*args), axis=0), axis=0
-            )
+            return reduce(binary_pytorch_func, args)
 
     return pytorch_func
 

--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -1801,7 +1801,6 @@ class Maximum(BinaryScalarOp):
     commutative = True
     associative = True
     nfunc_spec = ("maximum", 2, 1)
-    nfunc_variadic = "maximum"
     identity = -np.inf
 
     def impl(self, *inputs):
@@ -1848,7 +1847,6 @@ class Minimum(BinaryScalarOp):
     commutative = True
     associative = True
     nfunc_spec = ("minimum", 2, 1)
-    nfunc_variadic = "minimum"
     identity = np.inf
 
     def impl(self, *inputs):
@@ -1895,7 +1893,6 @@ class Add(ScalarOp):
     commutative = True
     associative = True
     nfunc_spec = ("add", 2, 1)
-    nfunc_variadic = "sum"
 
     def impl(self, *inputs):
         return sum(inputs)
@@ -1937,7 +1934,6 @@ class Mul(ScalarOp):
     commutative = True
     associative = True
     nfunc_spec = ("multiply", 2, 1)
-    nfunc_variadic = "prod"
 
     def impl(self, *inputs):
         return np.prod(inputs)

--- a/tests/link/jax/test_scalar.py
+++ b/tests/link/jax/test_scalar.py
@@ -324,3 +324,38 @@ def test_jax_logp():
             value_test_value,
         ],
     )
+
+
+@pytest.mark.parametrize("op", [pt.add, pt.mul], ids=["add", "mul"])
+def test_jax_variadic_broadcast(op):
+    x = pt.tensor("x", shape=(3, 4))
+    y = pt.tensor("y", shape=(1, 4))
+    z = pt.tensor("z", shape=(3, 1))
+    out = op(x, y, z)
+    assert len(out.owner.inputs) == 3
+
+    rng = np.random.default_rng(0)
+    test_inputs = [
+        rng.normal(size=s).astype(config.floatX) for s in [(3, 4), (1, 4), (3, 1)]
+    ]
+    compare_jax_and_py([x, y, z], [out], test_inputs)
+
+
+@pytest.mark.parametrize("dtype", ["bool", "int8"], ids=["bool", "int8"])
+def test_jax_variadic_add_dtype(dtype):
+    # Folding the binary op preserves dtype; stack + jnp.sum upcast bool/int.
+    x = pt.tensor("x", shape=(3,), dtype=dtype)
+    y = pt.tensor("y", shape=(3,), dtype=dtype)
+    z = pt.tensor("z", shape=(3,), dtype=dtype)
+    out = pt.add(x, y, z)
+
+    def assert_fn(jax_res, py_res):
+        np.testing.assert_allclose(jax_res, py_res)
+        assert np.asarray(jax_res).dtype == np.asarray(py_res).dtype
+
+    vals = (
+        np.array([True, False, True])
+        if dtype == "bool"
+        else np.array([1, 2, 3], dtype=dtype)
+    )
+    compare_jax_and_py([x, y, z], [out], [vals, vals, vals], assert_fn=assert_fn)

--- a/tests/link/pytorch/test_elemwise.py
+++ b/tests/link/pytorch/test_elemwise.py
@@ -182,3 +182,38 @@ def test_vmap_elemwise():
     vals = torch.zeros(2, 3).normal_()
     np.testing.assert_allclose(f(vals), torch.relu(vals))
     assert op.call_shapes == [torch.Size([])], op.call_shapes
+
+
+@pytest.mark.parametrize("op", [pt.add, pt.mul], ids=["add", "mul"])
+def test_pytorch_variadic_broadcast(op):
+    x = tensor("x", shape=(3, 4))
+    y = tensor("y", shape=(1, 4))
+    z = tensor("z", shape=(3, 1))
+    out = op(x, y, z)
+    assert len(out.owner.inputs) == 3
+
+    rng = np.random.default_rng(0)
+    test_inputs = [
+        rng.normal(size=s).astype(config.floatX) for s in [(3, 4), (1, 4), (3, 1)]
+    ]
+    compare_pytorch_and_py([x, y, z], [out], test_inputs)
+
+
+@pytest.mark.parametrize("dtype", ["bool", "int8"], ids=["bool", "int8"])
+def test_pytorch_variadic_add_dtype(dtype):
+    # Folding the binary op preserves dtype; stack + torch.sum upcast bool/int.
+    x = tensor("x", shape=(3,), dtype=dtype)
+    y = tensor("y", shape=(3,), dtype=dtype)
+    z = tensor("z", shape=(3,), dtype=dtype)
+    out = pt.add(x, y, z)
+
+    def assert_fn(torch_res, py_res):
+        np.testing.assert_allclose(torch_res, py_res)
+        assert np.asarray(torch_res).dtype == np.asarray(py_res).dtype
+
+    vals = (
+        np.array([True, False, True])
+        if dtype == "bool"
+        else np.array([1, 2, 3], dtype=dtype)
+    )
+    compare_pytorch_and_py([x, y, z], [out], [vals, vals, vals], assert_fn=assert_fn)


### PR DESCRIPTION
Follow-up to #2235 (the MLX variadic fix). In that PR's discussion, @ricardoV94 noted the stacked `jnp.sum` strategy "is [not] what you would want (in either jax or mlx)". This applies the same fold to the JAX and PyTorch backends.

## Problem

Both backends lower a variadic elementwise `Add`/`Mul` (3+ inputs) by stacking the operands and reducing with the `nfunc_variadic` reducer (`sum`/`prod`):

```python
# jax/dispatch/scalar.py (pytorch is analogous)
def jax_func(*args):
    return jax_variadic_func(jnp.stack(jnp.broadcast_arrays(*args), axis=0), axis=0)
```

They broadcast first, so unlike MLX they don't crash — but reducing a stacked array **upcasts the dtype**, diverging from the declared output dtype and the Python/C reference:

| dtype | PyTensor reference (`py`) | current `stack`+`sum` | this PR (fold) |
|---|---|---|---|
| `bool` | `bool` `[T, T, T]` (OR) | `int32`/`int64` `[2, 2, 3]` | `bool` `[T, T, T]` |
| `int8` | `int8` | `int32`/`int64` | `int8` |
| `float32` | `float32` | `float32` | `float32` |

(Measured on jax 0.4.23 and torch 2.9.0.)

## Fix

Fold the binary op (`jnp.add`/`jnp.multiply`, `torch.add`/`torch.multiply`) left-to-right with `functools.reduce`. The binary op broadcasts and preserves dtype, so the result matches the reference exactly — including bool OR semantics. This also matches the C/Numba backends (which emit `a + b + c`) and the MLX fix in #2235, and removes the rank-raising `stack` allocation. The fold reuses the same already-tested binary op the 2-input case dispatches to, so it's behaviour-preserving for the common numeric case.

## Tests

Added to `tests/link/jax/test_scalar.py` and `tests/link/pytorch/test_elemwise.py` (reusing `compare_jax_and_py` / `compare_pytorch_and_py`):

- `test_*_variadic_broadcast[add|mul]` — 3-input op with broadcast shapes `(3,4)/(1,4)/(3,1)`.
- `test_*_variadic_add_dtype[bool|int8]` — locks dtype preservation with an explicit dtype-checking `assert_fn`.

Verified RED -> GREEN: the dtype tests fail on `main` (upcast) and pass with the fold; the broadcast tests pass both ways (these backends already broadcast). The jax-scalar and pytorch-elemwise suites are otherwise green (3 pre-existing `betaincinv`/`gammaincinv`/`gammainccinv` `NotImplementedError`s are unrelated to this change).

---

Disclosure: I used AI assistance (under my direction) while preparing this change; I reviewed and verified every line, test, and result.

Made with [Cursor](https://cursor.com)