### PR TITLE
Fix MLX IncSubtensor with slice index

### DIFF
--- a/pytensor/link/mlx/dispatch/subtensor.py
+++ b/pytensor/link/mlx/dispatch/subtensor.py
@@ -40,9 +40,8 @@ def mlx_funcify_AdvancedSubtensor(op, node, **kwargs):
 
 
 @mlx_funcify.register(IncSubtensor)
-@mlx_funcify.register(AdvancedIncSubtensor1)
 def mlx_funcify_IncSubtensor(op, node, **kwargs):
-    if getattr(op, "set_instead_of_inc", False):
+    if op.set_instead_of_inc:
 
         def mlx_fn(x, indices, y):
             if not op.inplace:
@@ -59,7 +58,9 @@ def mlx_funcify_IncSubtensor(op, node, **kwargs):
             return x
 
     def incsubtensor(x, y, *ilist, mlx_fn=mlx_fn, idx_list=op.idx_list):
-        indices = indices_from_subtensor(ilist, idx_list)
+        # Coerce integer index inputs to Python ints (e.g. slice bounds), as
+        # MLX slices reject array-typed bounds. Mirrors mlx_funcify_Subtensor.
+        indices = indices_from_subtensor([int(element) for element in ilist], idx_list)
         if len(indices) == 1:
             indices = indices[0]
 
@@ -69,8 +70,9 @@ def mlx_funcify_IncSubtensor(op, node, **kwargs):
 
 
 @mlx_funcify.register(AdvancedIncSubtensor)
+@mlx_funcify.register(AdvancedIncSubtensor1)
 def mlx_funcify_AdvancedIncSubtensor(op, node, **kwargs):
-    if getattr(op, "set_instead_of_inc", False):
+    if op.set_instead_of_inc:
 
         def mlx_fn(x, indices, y):
             if not op.inplace:

--- a/tests/link/mlx/test_subtensor.py
+++ b/tests/link/mlx/test_subtensor.py
@@ -239,9 +239,9 @@ def test_mlx_IncSubtensor_slice_grad():
 
 
 @pytest.mark.xfail(
-    reason="Upstream mx.compile bug: a negative-strided in-place scatter whose "
-    "update derives from a negative-strided view returns wrong values "
-    "(correct when eager / use_compile=False).",
+    reason="Upstream mx.compile bug (ml-explore/mlx#3716): assigning an "
+    "elementwise expression to a negative-strided slice returns wrong values "
+    "under mx.compile (correct when eager / use_compile=False).",
     strict=True,
 )
 def test_mlx_IncSubtensor_negative_step_slice_grad():

--- a/tests/link/mlx/test_subtensor.py
+++ b/tests/link/mlx/test_subtensor.py
@@ -211,7 +211,6 @@ def test_mlx_subtensor_edge_cases():
     compare_mlx_and_py([], [out_pt], [])
 
 
-@pytest.mark.xfail(reason="MLX indexing with tuples not yet supported")
 def test_mlx_subtensor_with_variables():
     """Test subtensor operations with PyTensor variables as inputs."""
     # Test with variable arrays (not constants)
@@ -224,3 +223,30 @@ def test_mlx_subtensor_with_variables():
     # Set operation with variables
     out_pt = pt_subtensor.set_subtensor(x_pt[0, :2], y_pt)
     compare_mlx_and_py([x_pt, y_pt], [out_pt], [x_np, y_np])
+
+
+def test_mlx_IncSubtensor_slice_grad():
+    """Gradient of a basic slice lowers to an ``IncSubtensor`` with slice bounds
+    passed as (array) inputs; these must be coerced to Python ints for MLX."""
+    x_pt = pt.vector("x", dtype="float32")
+    x_np = np.arange(6, dtype=np.float32)
+
+    # Contiguous and strided (RoPE-style) slices both exercise the slice path.
+    for sl in (x_pt[0:3], x_pt[0::2]):
+        g = pt.grad((sl**2).sum(), x_pt)
+        assert isinstance(g.owner.op, pt_subtensor.IncSubtensor)
+        compare_mlx_and_py([x_pt], [g], [x_np])
+
+
+@pytest.mark.xfail(
+    reason="Upstream mx.compile bug: a negative-strided in-place scatter whose "
+    "update derives from a negative-strided view returns wrong values "
+    "(correct when eager / use_compile=False).",
+    strict=True,
+)
+def test_mlx_IncSubtensor_negative_step_slice_grad():
+    x_pt = pt.vector("x", dtype="float32")
+    x_np = np.arange(6, dtype=np.float32)
+    g = pt.grad((x_pt[::-1] ** 2).sum(), x_pt)
+    assert isinstance(g.owner.op, pt_subtensor.IncSubtensor)
+    compare_mlx_and_py([x_pt], [g], [x_np])


### PR DESCRIPTION
## Summary

`inc_subtensor`/`set_subtensor` with a **slice** index fails on the MLX backend:

```
ValueError: Slice indices must be integers or None.
```

This breaks the gradient of **any** basic slicing (`x[a:b]`, `x[::2]`, …), because the gradient of *"read a slice"* is *"increment that slice of a zero tensor"* — an `IncSubtensor` with a slice. The forward `Subtensor` works; only the gradient's `IncSubtensor` fails.

## Reproducer

```python
import numpy as np, pytensor, pytensor.tensor as pt
pytensor.config.floatX = "float32"

x = pt.vector("x")

# forward slice works on MLX:
f = pytensor.function([x], x[0:3], mode="MLX")
print(f(np.arange(6, dtype="float32")))            # OK -> [0. 1. 2.]

# gradient of a slice -> IncSubtensor(zeros[0:3], ...) -> FAILS on MLX (before this PR):
g = pt.grad((x[0:3] ** 2).sum(), x)
pytensor.function([x], g, mode="MLX")              # ValueError: Slice indices must be integers or None.

# same graph on the default backend is fine:
print(pytensor.function([x], g, mode=None)(np.arange(6, dtype="float32")))   # [0. 2. 4. 0. 0. 0.]
```

The interleaved / rotate-half RoPE pattern (`x[..., 0::2]`, `x[..., d//2:]`) is the common transformer case that hits this.

## Root cause

In `pytensor/link/mlx/dispatch/subtensor.py`, the forward `mlx_funcify_Subtensor` coerces its index inputs to Python ints:

```python
indices = indices_from_subtensor([int(element) for element in ilists], op.idx_list)
```

but `mlx_funcify_IncSubtensor` passed the index inputs through unchanged. For an `IncSubtensor` whose `idx_list` contains a slice, the slice bounds therefore arrive as `mx.array` scalars, and MLX's `x[slice] += y` rejects array-typed slice bounds.

## Fix

Coerce integer index inputs to Python ints in `mlx_funcify_IncSubtensor`, exactly as the forward `mlx_funcify_Subtensor` already does. This matches the canonical semantics defined by the C/Numba `impl` and mirrors JAX/PyTorch.

`AdvancedIncSubtensor1` (whose index is an integer **vector** that must *not* be `int()`-coerced) is moved off the shared `IncSubtensor` dispatcher onto `mlx_funcify_AdvancedIncSubtensor`, mirroring PyTorch's canonical basic-vs-advanced grouping. This is semantically equivalent (`idx_list` is always `(0,)`, so `x[(idx,)] == x[idx]`).

## Tests

- New `test_mlx_IncSubtensor_slice_grad` exercises the gradient of a contiguous slice (`x[0:3]`) and a strided RoPE-style slice (`x[0::2]`), asserting the node is an `IncSubtensor` and comparing against the Python backend. Confirmed RED on `main`, GREEN with this PR.
- The fix also un-`xfail`s `test_mlx_subtensor_with_variables` (`set_subtensor(x[0, :2], y)` with variable inputs) — same root cause, previously mis-attributed to "MLX indexing with tuples not yet supported".
- A separate, pre-existing limitation surfaced (negative-step slice gradient under `mx.compile`) is documented with a `strict` `xfail` and tracked upstream; details + a pure-MLX reproducer in a follow-up comment.