### PR TITLE
Fix local_log_div float64 precision loss for integer-literal operands

### DIFF
--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -712,7 +712,8 @@ def local_log_div(fgraph, node):
         if (isinstance(num, Constant) and _is_provably_positive(num, strict=True)) or (
             isinstance(den, Constant) and _is_provably_positive(den, strict=True)
         ):
-            return [log(num) - log(den)]
+            out_dtype = node.outputs[0].dtype
+            return [log(num.astype(out_dtype)) - log(den.astype(out_dtype))]
 
 
 @register_canonicalize

--- a/tests/tensor/rewriting/test_math.py
+++ b/tests/tensor/rewriting/test_math.py
@@ -5140,8 +5140,8 @@ def test_sign_reciprocal():
 @pytest.mark.parametrize(
     "build, expected_fn",
     [
-        (lambda x: pt.log(3.0 / x), lambda x: pt.log(3.0) - pt.log(x)),
-        (lambda x: pt.log(x / 3.0), lambda x: pt.log(x) - pt.log(3.0)),
+        (lambda x: pt.log(3.0 / x), lambda x: pt.log(np.float64(3.0)) - pt.log(x)),
+        (lambda x: pt.log(x / 3.0), lambda x: pt.log(x) - pt.log(np.float64(3.0))),
         (lambda x: pt.log(1.0 / x), lambda x: -pt.log(x)),
     ],
     ids=["pos_const_num", "pos_const_den", "one_over_x"],
@@ -5167,6 +5167,12 @@ def test_log_div_non_constant_not_rewritten():
     assert any(
         isinstance(getattr(node.op, "scalar_op", None), ps.TrueDiv) for node in nodes
     )
+
+
+def test_log_div_constant_keeps_precision():
+    # log(k / 2) must keep full precision, not fold log(2) at float32 (#2244).
+    k = pt.dscalar("k")
+    np.testing.assert_array_equal(function([k], pt.log(k / 2))(np.array(2.0)), 0.0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #2244.

## Problem

`local_log_div` rewrites `log(a / b) → log(a) - log(b)` when one operand is a positive constant. A Python integer literal (e.g. the `2` in `x / 2`) is stored as `int8`, and `log` upgrades int8/int16 inputs to **float32** (`upgrade_to_float`). On a float64 graph the split folds `log(2)` at float32 precision, so the result is wrong:

```python
import pytensor, pytensor.tensor as pt, numpy as np
k = pt.scalar("k", dtype="float64")
print(pytensor.function([k], pt.log(k / 2))(np.array(2.0)))  # -1.9047e-09, expected log(1) = 0.0
```

This is a regression in 3.0.5 — `local_log_div` was introduced by #2102 (commit `4a4268e`); 2.8.10–3.0.4 are unaffected (the int literal was never fed to `log` before).

## Fix

Cast both operands to the node's output dtype before `log`:

```python
out_dtype = node.outputs[0].dtype
return [log(num.astype(out_dtype)) - log(den.astype(out_dtype))]
```

Casting to the node's *existing* output dtype is dtype-neutral (float32 graphs stay float32, float64 stay float64), and the constant side still constant-folds, so no runtime cast is added. The rewrite becomes numerically transparent — it no longer changes the precision of `log(a / b)` relative to the un-rewritten graph.

## Tests

Adds a focused regression test that `log(k / 2)` keeps full float64 precision. Casting both sides also makes the rewrite transparent for **float-literal** constants, so the two float-literal cases in the existing `test_log_div_positive_constant` now expect a `float64` `log(3.0)` (they previously pinned the float32 constant). Full `test_math.py`: 202 passed, 9 skipped; ruff clean.

## Scope

- Fixes the precision loss `local_log_div` introduced for constant operands (integer **and** float literals); the rewrite no longer alters the numerical result of `log(a / b)`.
- **Does not** address #1073 (the broader "aggressive downcast of literals" root cause): Python literals are still autocast at construction — e.g. a non-representable float like `0.1` becomes `float32` before any rewrite runs. This PR only ensures `local_log_div` itself does not narrow precision further.
- An audit of the other rewrites in `pytensor/tensor/rewriting/` found no sibling rewrites with this failure mode, so this is the complete rewrite-side fix.

Closes #2244.
