### PR TITLE
Fix typo'd out_dtype keys in elemwise fusion tests

### DIFF
--- a/tests/tensor/rewriting/test_elemwise.py
+++ b/tests/tensor/rewriting/test_elemwise.py
@@ -681,7 +681,7 @@ class TestFusion:
                 fxv - ((ixv * 100) // (iyv * 1000)),
                 {
                     "custom": "float64",
-                    "numpy + floatX": config.floatX,
+                    "numpy+floatX": config.floatX,
                     "numpy": "float64",
                 },
             ),  # 40
@@ -831,7 +831,7 @@ class TestFusion:
                 fxv - (iyv | izv),
                 {
                     "custom": "float64",
-                    "numpy + floatX": config.floatX,
+                    "numpy+floatX": config.floatX,
                     "numpy": "float64",
                 },
             ),
@@ -843,7 +843,7 @@ class TestFusion:
                 fxv - (iyv ^ izv),
                 {
                     "custom": "float64",
-                    "numpy + floatX": config.floatX,
+                    "numpy+floatX": config.floatX,
                     "numpy": "float64",
                 },
             ),  # 60
@@ -855,7 +855,7 @@ class TestFusion:
                 fxv - (iyv & izv),
                 {
                     "custom": "float64",
-                    "numpy + floatX": config.floatX,
+                    "numpy+floatX": config.floatX,
                     "numpy": "float64",
                 },
             ),
@@ -867,7 +867,7 @@ class TestFusion:
                 fxv - (~iyv),
                 {
                     "custom": "float64",
-                    "numpy + floatX": config.floatX,
+                    "numpy+floatX": config.floatX,
                     "numpy": "float64",
                 },
             ),


### PR DESCRIPTION
The per-`cast_policy` `out_dtype` dicts in `test_elemwise_fusion` key on `"numpy + floatX"` (with spaces), which never matches `config.cast_policy == "numpy+floatX"`, so those branches are unreachable. Fix the keys. No behavior change under the default policy.