### PR TITLE
Keep `_make_scalar_loop` updates dtype-stable

### DIFF
--- a/pytensor/scalar/math.py
+++ b/pytensor/scalar/math.py
@@ -744,6 +744,11 @@ def _make_scalar_loop(n_steps, init, constant, inner_loop_fn, name, loop_op=Scal
     init = [i for i in init if i is not None]
     init_ = [i for i in init_ if i is not None]
     update_ = [u for u in update_ if u is not None]
+    # Each update is fed back as the next init, so their dtypes must match. A
+    # literal in the inner function can promote an update (e.g. a counter's
+    # `+ 1` becomes int64 under cast_policy="numpy+floatX"); cast it back. No-op
+    # when dtypes already agree.
+    update_ = [u.astype(i.type.dtype) for i, u in zip(init_, update_)]
     op = loop_op(
         init=init_,
         constant=constant_,

--- a/tests/scalar/test_loop.py
+++ b/tests/scalar/test_loop.py
@@ -3,7 +3,7 @@ import re
 import numpy as np
 import pytest
 
-from pytensor import In, Mode, function
+from pytensor import In, Mode, config, function
 from pytensor.compile import get_default_mode
 from pytensor.scalar import (
     Composite,
@@ -18,6 +18,7 @@ from pytensor.scalar import (
     sin,
 )
 from pytensor.scalar.loop import ScalarLoop
+from pytensor.scalar.math import _make_scalar_loop
 from pytensor.tensor import exp as tensor_exp
 from pytensor.tensor import lvector
 from pytensor.tensor.elemwise import Elemwise
@@ -129,6 +130,24 @@ def test_init_update_type_error():
     assert x.type.dtype == "float64"
     with pytest.raises(TypeError, match="Init and update types must be the same"):
         ScalarLoop(init=[x0], constant=[const], update=[x])
+
+
+@pytest.mark.parametrize("cast_policy", ["custom", "numpy+floatX"])
+def test_make_scalar_loop_promoting_update(cast_policy):
+    # A counter's `+ 1` promotes to int64 under cast_policy="numpy+floatX". The
+    # update is fed back as the next init, so _make_scalar_loop must cast it back
+    # to the init dtype to keep the loop well-typed.
+    n_steps = int64("n_steps")
+
+    def inner(n):
+        return [n + 1], None
+
+    with config.change_flags(cast_policy=cast_policy):
+        out = _make_scalar_loop(
+            n_steps, [np.array(0, dtype="int32")], [], inner, name="count"
+        )
+    assert out.type.dtype == "int32"
+    assert function([n_steps], out)(n_steps=5) == 5
 
 
 def test_rebuild_dtype():


### PR DESCRIPTION
`ScalarLoop` feeds each update back as the next init, so their dtypes must match (`_validate_updates` enforces this). A literal in an inner loop can promote an update — e.g. a counter's `+ 1` becomes int64 under `cast_policy="numpy+floatX"` — so `_make_scalar_loop` raises, which breaks the `betainc` / `gammainc` / `gammaincc` / `hyp2f1` gradients under that policy:

```python
import pytensor, pytensor.tensor as pt
with pytensor.config.change_flags(cast_policy="numpy+floatX"):
    a, b, x = pt.scalars("a", "b", "x")
    pt.grad(pt.betainc(a, b, x), [a, b])
# TypeError: Init and update types must be the same: i9(int16) != add.0(int64)
```

Fix: cast each update back to its init dtype in `_make_scalar_loop` — a no-op when they already agree, so no change under the default `custom` policy. Adds a parametrized loop test.
