### PR TITLE
Subtensor lift: reason about advanced indices jointly when gating

### DIFF
--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -9,6 +9,7 @@ from pytensor import compile
 from pytensor.assumptions.core import UNIQUE_INDICES, check_assumption
 from pytensor.compile import optdb
 from pytensor.graph.basic import Constant, Variable
+from pytensor.graph.fg import FunctionGraph
 from pytensor.graph.rewriting.basic import (
     WalkingGraphRewriter,
     copy_stack_trace,
@@ -23,6 +24,7 @@ from pytensor.tensor.basic import (
     Alloc,
     ARange,
     Join,
+    Nonzero,
     ScalarFromTensor,
     TensorFromScalar,
     alloc,
@@ -61,6 +63,7 @@ from pytensor.tensor.rewriting.basic import (
 )
 from pytensor.tensor.rewriting.blockwise import blockwise_of
 from pytensor.tensor.shape import (
+    Reshape,
     Shape,
     Shape_i,
     shape_padleft,
@@ -76,6 +79,7 @@ from pytensor.tensor.subtensor import (
     IncSubtensor,
     Subtensor,
     _is_provably_non_negative,
+    _is_provably_positive,
     _non_consecutive_adv_indexing,
     advanced_inc_subtensor1,
     advanced_subtensor1,
@@ -232,12 +236,167 @@ def _constant_has_unique_indices(idx) -> bool:
     return result
 
 
-def _has_unique_indices(fgraph, idx) -> bool:
-    """Whether ``idx``'s entries are provably duplicate-free: a constant with
-    unique entries, or a variable asserted ``unique_indices`` by the user."""
-    return _constant_has_unique_indices(idx) or check_assumption(
-        fgraph, idx, UNIQUE_INDICES
-    )
+def _arange_provably_unique(start, stop, step) -> bool:
+    """Whether ``arange(start, stop, step)`` selects each position at most once.
+
+    Its entries are always distinct values; they map to distinct positions as
+    long as they don't wrap around zero, i.e. they all share a sign (``arange(-2,
+    2)`` aliases on a size-2 axis, but ``arange(2, 6)`` and ``arange(-6, -2)`` do
+    not). This is proved from whichever bounds are statically known.
+    """
+    constants: list[int | None] = []
+    for v in (start, stop, step):
+        try:
+            constants.append(int(get_scalar_constant_value(v)))
+        except NotScalarConstantError:
+            constants.append(None)
+    start_c, stop_c, step_c = constants
+
+    # Both endpoints non-negative -> every entry lies between them -> all >= 0,
+    # whatever the step direction (covers symbolic ``arange(x.shape[0])``).
+    if _is_provably_non_negative(start) and _is_provably_non_negative(stop):
+        return True
+
+    # With a known direction only one endpoint binds each sign. Ascending entries
+    # span ``[start, stop)`` (min is ``start``, max ``< stop``); descending entries
+    # span ``(stop, start]`` (max is ``start``, min ``> stop``).
+    if _is_provably_positive(step):  # ascending
+        if _is_provably_non_negative(start):  # all >= 0
+            return True
+        if stop_c is not None and stop_c <= 0:  # all <= -1
+            return True
+    elif step_c is not None and step_c < 0:  # descending
+        if _is_provably_non_negative(stop):  # all >= 0  (e.g. arange(k, 5, -1))
+            return True
+        if start_c is not None and start_c < 0:  # all <= -1  (e.g. arange(-1, k, -1))
+            return True
+
+    # Fully constant: compute the exact entry range without materializing it. The
+    # checks above only bound the last entry as past ``stop``, so they need ``stop``
+    # on the right side of zero. This catches the rest -- ranges whose last entry
+    # overshoots ``stop`` across zero yet stays single-signed, e.g.
+    # ``arange(6, -2, -2)`` is ``[6, 4, 2, 0]`` and ``arange(-5, 1, 3)`` is ``[-5, -2]``.
+    if (
+        start_c is not None
+        and stop_c is not None
+        and step_c is not None
+        and step_c != 0
+    ):
+        n = max(0, -(-(stop_c - start_c) // step_c))  # length, via ceil division
+        if n <= 1:
+            return True
+        last_c = start_c + (n - 1) * step_c
+        return min(start_c, last_c) >= 0 or max(start_c, last_c) < 0
+    return False
+
+
+def _index_provably_unique(idx, fgraph: FunctionGraph | None) -> bool:
+    """Whether a single index selects each position on its own axis at most once.
+
+    This is the duplicate-free reasoning shared by accumulation gating (where
+    repeated positions would scatter-add) and by ``_index_provably_not_larger``
+    (a duplicate-free index can't enlarge its axis). It excludes only the
+    statically-smaller fallback, which bounds the size without ruling out
+    repeated positions.
+
+    ``fgraph`` is the handle to the ``AssumptionFeature``: it lets a user-declared
+    ``unique_indices`` assumption prove uniqueness when the static value, ``arange``
+    shape, or view structure can't. Pass ``None`` to skip that leg (no assumptions).
+    """
+    if isinstance(idx, slice) or idx.ndim == 0:
+        return True
+    if all(idx.type.broadcastable):
+        return True
+    if idx.type.dtype == "bool":
+        return True
+    if _constant_has_unique_indices(idx):
+        return True
+    if check_assumption(fgraph, idx, UNIQUE_INDICES):
+        return True
+    if isinstance(idx.owner_op, ARange):
+        return _arange_provably_unique(*idx.owner.inputs)
+    if isinstance(idx.owner_op, Reshape | DimShuffle):
+        # Views that only reorder or insert size-1 dims keep the value multiset.
+        return _index_provably_unique(idx.owner.inputs[0], fgraph)
+    return False
+
+
+def _constant_indices_jointly_unique(consts) -> bool:
+    """Whether stacked constant indices have no duplicate coordinate tuples.
+
+    The stacked ``np.unique`` can be expensive on large indices, so the result
+    is cached on the first constant's tag. Uniqueness is a property of the whole
+    group, and a constant may belong to several groups (constants are shared
+    across the graph), so the cache is keyed by the group's identities rather
+    than a single flag.
+    """
+    key = tuple(id(c) for c in consts)
+    cache = getattr(consts[0].tag, "jointly_unique_indices", None)
+    if cache is None:
+        cache = consts[0].tag.jointly_unique_indices = {}
+    if key not in cache:
+        datas = [np.asarray(c.data) for c in consts]
+        # A coordinate axis that mixes positive and negative values may alias
+        # (``0`` and ``-dim`` are the same position), so distinctness of the raw
+        # values no longer proves distinctness of the coordinates.
+        if any((data >= 0).any() and (data < 0).any() for data in datas):
+            cache[key] = False
+        else:
+            coords = np.broadcast_arrays(*datas)
+            stacked = np.stack([coord.ravel() for coord in coords])
+            cache[key] = bool(np.unique(stacked, axis=1).shape[1] == stacked.shape[1])
+    return bool(cache[key])
+
+
+def _indices_jointly_unique(idxs, fgraph: FunctionGraph | None) -> bool:
+    """Whether advanced indices produce no duplicate joint coordinate tuples.
+
+    For accumulation (``inc``), and for bounding a gather by the indexed axes'
+    size, what matters is that the broadcast coordinate tuples
+    ``(idx0[k], idx1[k], ...)`` are all distinct. Sufficient conditions, in
+    increasing generality:
+
+    - every index is duplicate-free on its own axis, so the tuples are distinct
+      regardless of the others (sound under broadcasting, and the path basic
+      slice/scalar indexing trivially takes);
+    - the indices are all the coordinates of a single ``Nonzero``, distinct by
+      construction (e.g. symbolic ``tril_indices``);
+    - the indices are all constants whose stacked coordinate tuples have no
+      duplicates (catches cases where no single axis is unique on its own).
+
+    ``fgraph`` is forwarded to ``_index_provably_unique`` so a user-declared
+    ``unique_indices`` assumption can satisfy the per-axis leg; pass ``None`` to
+    skip assumptions.
+    """
+    if all(_index_provably_unique(idx, fgraph) for idx in idxs):
+        return True
+    if len(idxs) > 1:
+        owners = {idx.owner for idx in idxs}
+        if (
+            len(owners) == 1
+            and (owner := next(iter(owners))) is not None
+            and isinstance(owner.op, Nonzero)
+            and set(idxs) == set(owner.outputs)
+        ):
+            return True
+        if all(isinstance(idx, Constant) for idx in idxs):
+            return _constant_indices_jointly_unique(idxs)
+    return False
+
+
+def _advanced_indices_jointly_unique(indices, fgraph: FunctionGraph | None) -> bool:
+    """Whether the advanced (``ndim > 0`` tensor) indices in a reconstructed index
+    tuple have distinct joint coordinate tuples.
+
+    Slice and scalar (basic) indices are ignored: basic indexing is trivially
+    duplicate-free, so only the advanced array indices are weighed. ``fgraph`` is
+    forwarded to ``_indices_jointly_unique`` for the ``unique_indices`` assumption
+    lookup (see there); pass ``None`` to skip assumptions.
+    """
+    adv_idxs = [
+        idx for idx in indices if isinstance(idx, TensorVariable) and idx.type.ndim > 0
+    ]
+    return _indices_jointly_unique(adv_idxs, fgraph)
 
 
 def _constant_is_arange(idx) -> tuple[int, int, int] | None:
@@ -1138,7 +1297,7 @@ def local_set_to_inc_subtensor(fgraph, node):
     # set->inc is only valid when ilist is duplicate-free: ``set(x[ilist] + other)``
     # is last-wins at repeated positions, while ``inc(other)`` would accumulate the
     # contributions of every occurrence and over-count them.
-    if not _has_unique_indices(fgraph, node.inputs[2]):
+    if not _index_provably_unique(node.inputs[2], fgraph):
         return
     ret = advanced_inc_subtensor1(node.inputs[0], other, node.inputs[2])
 
@@ -1191,15 +1350,11 @@ def local_add_of_sparse_write(fgraph, node):
         # -> x[idx].inc(v)`` holds for any indices. A dense set, by contrast, is
         # last-wins, so collapsing it to an inc would over-count repeated
         # positions. Basic (slice/scalar) IncSubtensor is always unique; advanced
-        # integer-array set indices must be checked, weighing only the advanced
-        # indices and not the flattened slice bounds.
+        # integer-array set indices must be jointly duplicate-free, weighing only
+        # the advanced indices and not the flattened slice bounds.
         if inner_op.set_instead_of_inc and not isinstance(inner_op, IncSubtensor):
-            adv_idxs = [
-                idx
-                for idx in indices_from_subtensor(idx_vars, inner_op.idx_list)
-                if isinstance(idx, TensorVariable) and idx.type.ndim > 0
-            ]
-            if not all(_has_unique_indices(fgraph, idx) for idx in adv_idxs):
+            indices = indices_from_subtensor(idx_vars, inner_op.idx_list)
+            if not _advanced_indices_jointly_unique(indices, fgraph):
                 continue
 
         others = [node.inputs[j] for j in range(len(node.inputs)) if j != i]
@@ -1987,9 +2142,8 @@ def local_read_of_write_same_indices(fgraph, node):
     Applies when the outer read and inner write share identical index
     variables (``is`` check) and the same ``idx_list``.  The inc case
     additionally requires duplicate-free indices: slices and scalar indices
-    are trivially unique, while integer-array indices must be constant with
-    no repeated entries (mixing positive and negative values counts as
-    potentially duplicated since they may alias).
+    are trivially unique, while advanced integer-array indices must be jointly
+    duplicate-free (see ``_indices_jointly_unique``).
 
     Companion rewrites:
 
@@ -2026,13 +2180,11 @@ def local_read_of_write_same_indices(fgraph, node):
         copy_stack_trace(out, r)
         return [r]
     else:
-        # Inc case: advanced integer-array indices must be duplicate-free;
+        # Inc case: advanced integer-array indices must be jointly duplicate-free;
         # slices and scalar indices are trivially unique.
         indices = indices_from_subtensor(outer_idx_vars, node.op.idx_list)
-        for idx in indices:
-            if isinstance(idx, TensorVariable) and idx.type.ndim > 0:
-                if not _has_unique_indices(fgraph, idx):
-                    return None
+        if not _advanced_indices_jointly_unique(indices, fgraph):
+            return None
 
         x_at_idx = x[tuple(indices)]
         copy_stack_trace(out, x_at_idx)
@@ -2387,19 +2539,12 @@ def local_write_of_write_same_indices(fgraph, node):
         new_val = b
         use_set = True
     elif inner_is_set:
-        # x[idx].set(a)[idx].inc(b) — needs unique indices.
-        # Basic indexing (slices/scalars) is always duplicate-free.
-        # For advanced indexing, per-axis uniqueness is conservative but
-        # sufficient: it guarantees no duplicates in the joint cross-product
-        # after broadcasting. Weigh only the advanced indices, not the flattened
-        # slice bounds.
+        # x[idx].set(a)[idx].inc(b) — needs unique indices. Basic indexing
+        # (slices/scalars) is always duplicate-free; advanced indices must have
+        # duplicate-free joint coordinate tuples.
         if not isinstance(node.op, IncSubtensor):
-            adv_idxs = [
-                idx
-                for idx in indices_from_subtensor(outer_idx_vars, node.op.idx_list)
-                if isinstance(idx, TensorVariable) and idx.type.ndim > 0
-            ]
-            if not all(_has_unique_indices(fgraph, idx) for idx in adv_idxs):
+            indices = indices_from_subtensor(outer_idx_vars, node.op.idx_list)
+            if not _advanced_indices_jointly_unique(indices, fgraph):
                 return
         new_val = a + b
         if (

--- a/pytensor/tensor/rewriting/subtensor_lift.py
+++ b/pytensor/tensor/rewriting/subtensor_lift.py
@@ -4,7 +4,6 @@ from typing import cast
 import numpy as np
 from numpy.lib.array_utils import normalize_axis_index, normalize_axis_tuple
 
-from pytensor.assumptions.core import UNIQUE_INDICES, check_assumption
 from pytensor.compile import optdb
 from pytensor.graph import (
     Constant,
@@ -22,7 +21,6 @@ from pytensor.graph.rewriting.basic import (
 from pytensor.tensor.basic import (
     Alloc,
     AllocDiag,
-    ARange,
     ExtractDiag,
     Eye,
     Join,
@@ -49,7 +47,8 @@ from pytensor.tensor.rewriting.basic import (
 )
 from pytensor.tensor.rewriting.elemwise import local_dimshuffle_lift
 from pytensor.tensor.rewriting.subtensor import (
-    _constant_has_unique_indices,
+    _index_provably_unique,
+    _indices_jointly_unique,
     local_adv_idx_to_diagonal,
     local_adv_idx_to_slice,
     local_advanced_read_of_write_constant_indices,
@@ -215,33 +214,69 @@ def _lift_subtensor_non_axis(
         return None
 
 
-def _index_provably_not_larger(idx, val_static_dim, fgraph=None) -> bool:
+def _static_size_not_larger(idx, val_static_dim) -> bool:
+    # A purely static bound: the index selects no more elements than the axis holds.
+    # Reshape/DimShuffle preserve the element count, so follow them to whichever
+    # view in the chain has a fully-known static shape.
+    if val_static_dim is not None:
+        idx_static_shape = idx.type.shape
+        if not any(d is None for d in idx_static_shape) and (
+            np.prod(idx_static_shape) <= val_static_dim
+        ):
+            return True
+    if isinstance(idx.owner_op, Reshape | DimShuffle):
+        return _static_size_not_larger(idx.owner.inputs[0], val_static_dim)
+    return False
+
+
+def _index_provably_not_larger(
+    idx, val_static_dim, fgraph: FunctionGraph | None
+) -> bool:
     # Per-axis check: an index that can't repeat a position can't enlarge that axis.
     # Does not account for cross-axis broadcast expansion from outer indexing.
-    if isinstance(idx, slice) or idx.ndim == 0:
+    # Try the cheap purely-static size bound first; only then the (potentially
+    # graph-walking) uniqueness reasoning. Both follow Reshape/DimShuffle views,
+    # which preserve the element count, so uniqueness is still checked just once.
+    # ``fgraph`` is forwarded to ``_index_provably_unique`` for the user-declared
+    # ``unique_indices`` assumption (None to skip it).
+    if _static_size_not_larger(idx, val_static_dim):
         return True
-    if all(idx.type.broadcastable):
-        return True
-    if idx.type.dtype == "bool":
-        return True
-    if _constant_has_unique_indices(idx):
-        return True
-    if check_assumption(fgraph, idx, UNIQUE_INDICES):
-        return True
-    if isinstance(idx.owner_op, ARange):
-        return True
-    if isinstance(idx.owner_op, Reshape | DimShuffle):
-        # Views that don't add dimensions
-        if _index_provably_not_larger(idx.owner.inputs[0], val_static_dim, fgraph):
-            return True
+    return _index_provably_unique(idx, fgraph)
 
-    # Fallback to static shape analysis
-    if val_static_dim is None:
-        return False
-    idx_static_shape = idx.type.shape
-    if any(d is None for d in idx_static_shape):
-        return False
-    return bool(np.prod(idx_static_shape) < val_static_dim)
+
+def _indices_provably_not_larger(idxs_and_dims, fgraph: FunctionGraph | None) -> bool:
+    """Whether advanced-indexing some consecutive axes selects no more elements
+    than those axes already hold, so lifting a Subtensor through the indexing
+    can't increase computation.
+
+    ``idxs_and_dims`` pairs each advanced index (``ndim > 0``) with the static
+    size of the axis it indexes. ``fgraph`` is forwarded to the uniqueness helpers
+    for the ``unique_indices`` assumption lookup (None to skip it).
+    """
+    if not idxs_and_dims:
+        return True
+
+    idxs = [idx for idx, _ in idxs_and_dims]
+    dims = [dim for _, dim in idxs_and_dims]
+    idx_shapes = [idx.type.shape for idx in idxs]
+
+    # With static shapes the result size is known exactly, so just compare it
+    # against the number of elements the indexed axes hold.
+    if all(d is not None for d in dims) and all(
+        None not in shape for shape in idx_shapes
+    ):
+        return bool(np.prod(np.broadcast_shapes(*idx_shapes)) <= np.prod(dims))
+
+    # Otherwise each index, on its own axis, may select no more than that axis
+    # holds (e.g. an arange or a statically-smaller index)...
+    if all(_index_provably_not_larger(idx, dim, fgraph) for idx, dim in idxs_and_dims):
+        return True
+    # ...or the indices are jointly duplicate-free, which on its own bounds the
+    # result by the axes' size even when the per-axis sizes are unknown. Only the
+    # joint-only conditions (single Nonzero, jointly-unique constants) can add
+    # anything here: the per-axis pass above already failed, so at least one index
+    # is not provably unique and the per-axis leg of the joint check is moot.
+    return _indices_jointly_unique(idxs, fgraph)
 
 
 @register_canonicalize
@@ -345,17 +380,20 @@ def local_subtensor_of_batch_dims(fgraph, node):
     if _non_consecutive_adv_indexing(idx_tuple):
         return None
 
-    # Skip when lifting would expand a gather past a non-broadcast input's size.
+    # Skip when indexing each input would select more elements than it holds,
+    # making the lifted Elemwise do more work. The advanced indices are weighed
+    # together, over the consecutive axes they jointly index.
     for inp in elem.owner.inputs:
-        for axis, idx in enumerate(idx_tuple):
-            if axis >= inp.type.ndim:
-                break
-            if not isinstance(idx, TensorVariable) or idx.type.ndim == 0:
-                continue
-            if inp.type.broadcastable[axis]:
-                continue
-            if not _index_provably_not_larger(idx, inp.type.shape[axis], fgraph):
-                return None
+        input_static_shape = inp.type.shape
+        adv_indices_and_dims = [
+            (adv_index, input_static_shape[axis])
+            for axis, adv_index in enumerate(idx_tuple[: inp.type.ndim])
+            if isinstance(adv_index, TensorVariable)
+            and adv_index.type.ndim > 0
+            and not inp.type.broadcastable[axis]
+        ]
+        if not _indices_provably_not_larger(adv_indices_and_dims, fgraph):
+            return None
 
     batch_ndim = (
         elem.owner.op.batch_ndim(elem.owner)
@@ -742,11 +780,16 @@ def lift_subtensor_through_alloc(fgraph, node):
 
     # Indices on Alloc-added dims don't reach val; the rest line up with val's dims.
     val_indexer = indices[n_added_dims:]
-    dangerous_index_reaches_val = any(
-        not val.type.broadcastable[axis]
-        # Per-axis check; doesn't account for net effect across all axes.
-        and not _index_provably_not_larger(idx, val.type.shape[axis], fgraph)
-        for axis, idx in enumerate(val_indexer)
+    val_static_shape = val.type.shape
+    val_adv_indices_and_dims = [
+        (adv_index, val_static_shape[axis])
+        for axis, adv_index in enumerate(val_indexer)
+        if isinstance(adv_index, TensorVariable)
+        and adv_index.type.ndim > 0
+        and not val.type.broadcastable[axis]
+    ]
+    dangerous_index_reaches_val = not _indices_provably_not_larger(
+        val_adv_indices_and_dims, fgraph
     )
 
     # On broadcast val dims the index is neutralized (advanced indices dropped,

--- a/tests/tensor/rewriting/test_subtensor.py
+++ b/tests/tensor/rewriting/test_subtensor.py
@@ -20,12 +20,15 @@ from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.math import Dot, dot, exp, sqr
 from pytensor.tensor.rewriting.subtensor import (
+    _index_provably_unique,
     _slice_to_arange,
     local_add_of_sparse_write,
     local_adv_idx_to_slice,
     local_blockwise_inc_subtensor,
+    local_read_of_write_same_indices,
     local_replace_AdvancedSubtensor,
     local_useless_slice,
+    local_write_of_write_same_indices,
 )
 from pytensor.tensor.shape import (
     SpecifyShape,
@@ -283,10 +286,30 @@ def test_local_add_of_sparse_write():
         [rewritten_basic], [x[s].inc(v[0])], strict_dtype=False
     )
 
+    # set-into-zeros with jointly-unique advanced indices (neither axis unique on
+    # its own) is rewritten via the joint-uniqueness check on the set path.
+    X = matrix("X")
+    rows = pt.constant(np.array([0, 1, 1], dtype="int32"))
+    cols = pt.constant(np.array([0, 0, 1], dtype="int32"))
+    out_joint = X + pt.zeros(X.shape)[rows, cols].set(v)
+    rewritten_joint = rewrite_graph(
+        out_joint, include=[], custom_rewrite=sparse_rewriter
+    )
+    utt.assert_equal_computations([rewritten_joint], [X[rows, cols].inc(v)])
+
+    # set-into-zeros with a jointly-duplicated advanced index is left alone (the
+    # (1, 1) coordinate repeats), since a dense set there is last-wins.
+    dup_rows = pt.constant(np.array([0, 1, 1], dtype="int32"))
+    dup_cols = pt.constant(np.array([0, 1, 1], dtype="int32"))
+    out_joint_dup = X + pt.zeros(X.shape)[dup_rows, dup_cols].set(v)
+    rewritten_joint_dup = rewrite_graph(
+        out_joint_dup, include=[], custom_rewrite=sparse_rewriter
+    )
+    utt.assert_equal_computations([rewritten_joint_dup], [out_joint_dup])
+
     # A bounded slice flattens its (symbolic) bounds into the index variables;
     # those must not be mistaken for advanced indices. With a leading slice and a
     # unique advanced index the sparse write still collapses.
-    X = matrix("X")
     w = matrix("w")
     u = pt.constant(np.array([0, 2], dtype="int32"))
     lo, hi = iscalar("lo"), iscalar("hi")
@@ -297,6 +320,54 @@ def test_local_add_of_sparse_write():
     utt.assert_equal_computations(
         [rewritten_slice], [X[lo:hi, u].inc(w)], strict_dtype=False
     )
+
+
+class TestIndexProvablyUniqueArange:
+    """An ``arange`` index is duplicate-free when its entries don't wrap around
+    zero, i.e. they all share a sign. ``_index_provably_unique`` proves this for
+    non-negative ascending ranges (symbolic-friendly) and, with constant bounds,
+    for any single-signed range regardless of step direction."""
+
+    def test_arange(self):
+        k = iscalar("k")
+        n = vector("v").shape[0]
+
+        def unique(arange):
+            return _index_provably_unique(arange, None)
+
+        # Non-negative, symbolic-friendly (proved without constant bounds).
+        assert unique(pt.arange(k)) is True
+        assert unique(pt.arange(n)) is True  # n = shape, provably >= 0
+        assert unique(pt.arange(2, k)) is True
+        assert unique(pt.arange(n, 0, -1)) is True  # reverse range, both bounds >= 0
+
+        # Descending into a non-negative stop: entries > stop >= 0, any start.
+        assert unique(pt.arange(k, 0, -1)) is True
+        assert unique(pt.arange(k, 5, -1)) is True
+
+        # Descending from a negative start: entries <= start < 0, any stop.
+        assert unique(pt.arange(-1, k, -1)) is True
+
+        # Constant single-signed ranges, either step direction.
+        assert unique(pt.arange(2, 6)) is True
+        assert unique(pt.arange(-6, -2)) is True  # all negative
+        assert unique(pt.arange(5, -1, -1)) is True  # descending, [5..0]
+        assert (
+            unique(pt.arange(6, -2, -2)) is True
+        )  # descending, [6,4,2,0], overshoots stop
+        assert (
+            unique(pt.arange(-5, 1, 3)) is True
+        )  # ascending, [-5,-2], overshoots stop
+        assert unique(pt.arange(-1, -6, -1)) is True  # descending, all negative
+
+        # Straddling zero -> may wrap -> not provably unique.
+        assert unique(pt.arange(-2, 2)) is False
+        assert unique(pt.arange(0, -5, -1)) is False  # 0 with negatives
+
+        # Sign not statically known.
+        assert unique(pt.arange(5, k, -1)) is False  # unknown stop sign
+        assert unique(pt.arange(k, 5)) is False  # unknown start sign
+        assert unique(pt.arange(k, -5, -1)) is False  # unknown start, neg stop
 
 
 class TestLocalUselessSubtensor:
@@ -1376,6 +1447,79 @@ class TestReadOfWriteSameIndices:
         )
         assert check_stack_trace(f, ops_to_check=(AdvancedSubtensor1, Elemwise))
 
+    def test_inc_jointly_unique_constant_idx(self):
+        """Multiple advanced indices that are jointly (not per-axis) duplicate-free
+        are recognized via the joint check, so inc read-of-write simplifies even
+        though neither ``rows`` nor ``cols`` is unique on its own."""
+        x = matrix(dtype="float64")
+        y = vector(dtype="float64")
+        rows = pt.constant(np.array([0, 1, 1], dtype="int32"))
+        cols = pt.constant(np.array([0, 0, 1], dtype="int32"))
+
+        o = inc_subtensor(x[rows, cols], y)[rows, cols]
+        result = utt.RewriteTester(
+            [x, y], [o], include=[], custom_rewrite=local_read_of_write_same_indices
+        )
+        result.assert_graph(x[rows, cols] + y)
+
+    def test_inc_tril_indices_nonzero(self):
+        """``tril_indices`` coordinates come from a single ``Nonzero``, distinct by
+        construction, so the inc read-of-write simplifies even though the indices
+        are symbolic and neither axis is unique on its own."""
+        n = iscalar("n")
+        x = matrix(dtype="float64")
+        y = vector(dtype="float64")
+        rows, cols = pt.tril_indices(n)
+
+        o = inc_subtensor(x[rows, cols], y)[rows, cols]
+        result = utt.RewriteTester(
+            [x, y, n], [o], include=[], custom_rewrite=local_read_of_write_same_indices
+        )
+        result.assert_graph(x[rows, cols] + y)
+
+    def test_inc_symbolic_bool_mask(self):
+        """A boolean mask selects each position at most once, so it is duplicate-free
+        even when symbolic; the inc read-of-write simplifies to ``x[mask] + v``."""
+        x = vector(dtype="float64")
+        v = vector(dtype="float64")
+        mask = vector("mask", dtype="bool")
+
+        o = inc_subtensor(x[mask], v)[mask]
+        result = utt.RewriteTester(
+            [x, v, mask],
+            [o],
+            include=[],
+            custom_rewrite=local_read_of_write_same_indices,
+        )
+        result.assert_graph(x[mask] + v)
+
+    def test_inc_symbolic_arange(self):
+        """An ``arange`` is strictly monotonic, so its entries are distinct even
+        when symbolic; the inc read-of-write simplifies to ``x[idx] + v``. A
+        negative-start arange may wrap around (``arange(-2, k)`` aliases positions
+        on a small axis), so it is not duplicate-free and inc must not be
+        rewritten."""
+        k = iscalar("k")
+        x = vector(dtype="float64")
+        v = vector(dtype="float64")
+
+        idx = pt.arange(k)
+        o = inc_subtensor(x[idx], v)[idx]
+        result = utt.RewriteTester(
+            [x, v, k], [o], include=[], custom_rewrite=local_read_of_write_same_indices
+        )
+        result.assert_graph(x[idx] + v)
+
+        mixed = pt.arange(-2, k)
+        o_mixed = inc_subtensor(x[mixed], v)[mixed]
+        result_mixed = utt.RewriteTester(
+            [x, v, k],
+            [o_mixed],
+            include=[],
+            custom_rewrite=local_read_of_write_same_indices,
+        )
+        result_mixed.assert_graph(o_mixed)
+
     @pytest.mark.parametrize(
         "cidx_values, n_rows",
         [
@@ -1775,6 +1919,43 @@ class TestWriteOfWriteSameIndices:
         out = inc_subtensor(set_subtensor(zeros[:stop], a)[:stop], b)
         rewritten = rewrite_graph(out, include=("canonicalize", "specialize"))
         utt.assert_equal_computations([rewritten], [inc_subtensor(zeros[:stop], a + b)])
+
+    def test_inc_of_set_advanced_jointly_unique(self):
+        """Inc-of-set fires when advanced indices are jointly duplicate-free, even
+        though neither axis is unique on its own: ``tril_indices`` coordinates come
+        from a single ``Nonzero`` and collapse to ``x[idx].set(a + b)``. A leading
+        slice flattens its (symbolic) bounds into the index variables; those must
+        not be mistaken for advanced indices that block the joint check, so the
+        collapse still fires with a leading slice."""
+        n = iscalar("n")
+        rows, cols = pt.tril_indices(n)
+
+        x = matrix("x", dtype="float64")
+        a = vector("a", dtype="float64")
+        b = vector("b", dtype="float64")
+        out = inc_subtensor(set_subtensor(x[rows, cols], a)[rows, cols], b)
+        result = utt.RewriteTester(
+            [x, a, b, n],
+            [out],
+            include=[],
+            custom_rewrite=local_write_of_write_same_indices,
+        )
+        result.assert_graph(set_subtensor(x[rows, cols], a + b))
+
+        xs = tensor3("x", dtype="float64")
+        a2 = matrix("a", dtype="float64")
+        b2 = matrix("b", dtype="float64")
+        lo, hi = iscalar("lo"), iscalar("hi")
+        out_slice = inc_subtensor(
+            set_subtensor(xs[lo:hi, rows, cols], a2)[lo:hi, rows, cols], b2
+        )
+        result_slice = utt.RewriteTester(
+            [xs, a2, b2, lo, hi, n],
+            [out_slice],
+            include=[],
+            custom_rewrite=local_write_of_write_same_indices,
+        )
+        result_slice.assert_graph(set_subtensor(xs[lo:hi, rows, cols], a2 + b2))
 
     def test_inc_of_set_advanced_with_slice_rewritten(self):
         """A bounded slice flattens its (symbolic) bounds into the index
@@ -2848,8 +3029,9 @@ def test_cholesky_unconstrain_grad(exp_before_materialize):
 
     packed = pt.vector("packed")
     if exp_before_materialize:
-        # We test the same optimized result regardless of whether
-        # the diagonals are updated before or after materialization
+        # Same ``L`` two ways: exponentiate the diagonal in the packed vector
+        # before scattering, or (else branch) scatter first and exponentiate the
+        # matrix diagonal. Equivalent, but optimize to different graphs under BlasOpt.
         packed_diag_indices = pt.arange(n + 1).cumsum()[1:] - 1
         log_diag = packed[packed_diag_indices]
         packed_update = packed[packed_diag_indices].set(pt.exp(log_diag))
@@ -2873,7 +3055,6 @@ def test_cholesky_unconstrain_grad(exp_before_materialize):
 
     mode = get_default_mode().excluding("fuse_indexed_into_elemwise")
     f = function([packed], [loss, grad], mode=mode)
-    f.dprint(print_shape=True)
 
     idx_types = (
         Subtensor,
@@ -2885,13 +3066,16 @@ def test_cholesky_unconstrain_grad(exp_before_materialize):
         ExtractDiag,
     )
     n_idx = sum(1 for n in f.maker.fgraph.toposort() if isinstance(n.op, idx_types))
-    # The ``BlasOpt`` rewrites lower ``L @ L.T`` to ``Gemm``; the gradient then
-    # fuses the diagonal-gradient term into a ``Gemm`` operand, materializing one
-    # extra set-subtensor. A linker that cannot use them lists ``BlasOpt`` in
-    # ``incompatible_rewrites`` (e.g. the numba linker), keeping the plain ``Dot``
-    # lowering with that term as a vector. Both lowerings are correct.
+    # Post-materialization, the log-det gradient is a diagonal matrix added to
+    # ``L@L.T`` at the matrix level; BlasOpt's GemmOptimizer fuses ``add(dot, C)``
+    # into one Gemm, materializing that diagonal as one extra set-subtensor (7 ops).
+    # Pre-materialization keeps the term in the packed vector's index space, so
+    # there's no matrix-level add to fuse (6 ops). Without Gemm (BlasOpt in the
+    # linker's incompatible_rewrites, e.g. numba) the term never reaches the matrix
+    # and both collapse to 6. All lowerings are correct.
     blas_rewrites_run = "BlasOpt" not in f.maker.mode.linker.incompatible_rewrites
-    assert n_idx == (7 if blas_rewrites_run else 6)
+    expected_n_idx = 7 if (blas_rewrites_run and not exp_before_materialize) else 6
+    assert n_idx == expected_n_idx
 
     x = np.array([1.0, 0.5, 2.0, 0.3, 0.1, 1.5])
     # Expected values were computed once by running ``f(x)``.

--- a/tests/tensor/rewriting/test_subtensor_lift.py
+++ b/tests/tensor/rewriting/test_subtensor_lift.py
@@ -235,6 +235,36 @@ class TestLocalSubtensorOfBatchDims:
         )
         result.assert_graph(x[idx] + y[idx])
 
+    def test_elemwise_jointly_unique_adv_indices_lift(self):
+        """A group of adv indices that each repeat but pair up to distinct
+        coordinates (tril_indices) can't select more elements than the indexed
+        axes hold, so it lifts."""
+        # Symbolic indices: the outputs of a single Nonzero.
+        n = pt.scalar("n", dtype="int64")
+        x = pt.matrix("x")
+        rows, cols = pt.tril_indices(n)
+        # ``local_add_canonizer`` simplifies the ``n - 0`` inside ``tril_indices``,
+        # which then lets the duplicate ``arange`` merge -- noise for this test.
+        result = RewriteTester(
+            [n, x], [pt.exp(x)[rows, cols]], exclude=("local_add_canonizer",)
+        )
+        result.assert_graph(pt.exp(x[rows, cols]))
+        result.assert_eval(3, np.arange(9.0).reshape(3, 3))
+
+        # Constant indices, static array shape: proved through the exact size.
+        x = pt.matrix("x", shape=(5, 5))
+        rows, cols = (pt.constant(i) for i in np.tril_indices(5))
+        result = RewriteTester([x], [pt.exp(x)[rows, cols]])
+        result.assert_graph(pt.exp(x[rows, cols]))
+        result.assert_eval(np.arange(25.0).reshape(5, 5))
+
+        # Constant indices, unknown array shape: proved through joint uniqueness.
+        x = pt.matrix("x")
+        rows, cols = (pt.constant(i) for i in np.tril_indices(5))
+        result = RewriteTester([x], [pt.exp(x)[rows, cols]])
+        result.assert_graph(pt.exp(x[rows, cols]))
+        result.assert_eval(np.arange(25.0).reshape(5, 5))
+
     def test_blockwise(self):
         class CoreTestOp(Op):
             itypes = [dvector, dvector]
@@ -755,6 +785,21 @@ class TestSubtensorOfAlloc:
         out = pt.alloc(val, 5, 3)[:, idx]
         rewritten = rewrite_graph(out, **self.rewrite_kw)
         assert_equal_computations([rewritten], [out], strict_dtype=False)
+
+    def test_jointly_unique_adv_indices_lift(self):
+        """Indices that each repeat but pair up to distinct coordinates
+        (tril_indices) don't enlarge val, so the read lifts through Alloc."""
+        val = pt.matrix("val", shape=(5, 5))
+        rows, cols = (pt.constant(i) for i in np.tril_indices(5))
+
+        result = RewriteTester(
+            [val],
+            [pt.alloc(val, 5, 5)[rows, cols]],
+            include=("ShapeOpt", "canonicalize", "specialize"),
+            exclude=("local_replace_AdvancedSubtensor",),
+        )
+        result.assert_graph(val[rows, cols], strict_dtype=False)
+        result.assert_eval(np.arange(25.0).reshape(5, 5))
 
     def test_negative_step_idx_to_slice(self):
         """Negative-step constant arange ``[7, 5, 3, 1]`` rewrites to ``x[7::-2]``."""


### PR DESCRIPTION
We had heuristics that work per-axis, but we should reason about the advanced indices together since they interact. E.g., tril_indices, would fail the per-axis checks, as each index (row, col) is larger than the respective axis and contains duplicates. But jointly they index less than the full array and don't have duplicates, so we want to lift it through Elemwise and the like.

Shows up in https://github.com/pymc-devs/pymc/pull/8297