### PR TITLE
Add gradient (pullback) to Min Op

### DIFF
--- a/pytensor/tensor/math.py
+++ b/pytensor/tensor/math.py
@@ -468,6 +468,23 @@ class Min(NonZeroDimsCAReduce):
         axis = kwargs.get("axis", self.axis)
         return type(self)(axis=axis)
 
+    def pullback(self, inputs, outputs, output_grads):
+        # The strict sense mathematical gradient of the minimum function is
+        # not calculated here for it is not defined at every point where some
+        # coordinates are identical. However, since the latter set has null
+        # Lebesgue measure, the result may be interpreted as weak gradient.
+        [x] = inputs
+        [out] = outputs
+        [g_out] = output_grads
+
+        axis = tuple(range(x.ndim)) if self.axis is None else self.axis
+        out_pad = expand_dims(out, axis)
+        g_out_pad = expand_dims(g_out, axis)
+
+        # Set the grad to the correct position.
+        g_x = eq(out_pad, x) * g_out_pad
+        return (g_x,)
+
 
 def max(x, axis=None, keepdims=False):
     """

--- a/tests/tensor/test_math.py
+++ b/tests/tensor/test_math.py
@@ -42,6 +42,7 @@ from pytensor.tensor.math import (
     Argmax,
     Dot,
     Max,
+    Min,
     Prod,
     ProdWithoutZeros,
     Sum,
@@ -1421,6 +1422,39 @@ class TestMinMax:
 
         utt.verify_grad(lambda v: min(v.flatten()), [data])
         check_grad_min(data, eval_outputs(grad(min(n.flatten()), n)))
+
+    def test_grad_Min(self):
+        """Test that the Min Op has a working gradient directly, not just via min()."""
+        data = random(2, 3)
+        n = as_tensor_variable(data)
+
+        def check_grad_Min(data, min_grad_data, axis=None):
+            # This work only for axis in [0, None]
+            assert axis in [0, None]
+            z = np.zeros_like(data)
+            z = z.flatten()
+            argmin = np.argmin(data, axis=axis)
+            if argmin.ndim == 0:
+                z[np.argmin(data, axis=axis)] += 1
+            else:
+                for id, v in enumerate(argmin):
+                    z[v * np.prod(data.shape[data.ndim - 1 : axis : -1]) + id] += 1
+
+            z = z.reshape(data.shape)
+            assert np.all(min_grad_data == z)
+
+        # test grad of Min
+        # axis is the last one
+        utt.verify_grad(lambda v: Min(axis=-1)(v).sum(), [data])
+
+        utt.verify_grad(lambda v: Min(axis=[0])(v).sum(), [data])
+        check_grad_Min(data, eval_outputs(grad(Min(axis=0)(n).sum(), n)), axis=0)
+
+        utt.verify_grad(lambda v: Min(axis=[1])(v).sum(), [data])
+        # check_grad_Min(data,eval_outputs(grad(Min(axis=1)(n).sum(), n)),axis=1)
+
+        utt.verify_grad(lambda v: Min(axis=None)(v.flatten()).sum(), [data])
+        check_grad_Min(data, eval_outputs(grad(Min(axis=None)(n.flatten()).sum(), n)))
 
     def _grad_list(self):
         # Test the gradient when we have multiple axis at the same time.


### PR DESCRIPTION
## Description

The `Min` Op inherits from `CAReduce` -> `L_op`, which raises `NotImplementedError` — silently breaking gradient-based samplers such as NUTS. The `min()` function already worked around this via `-max(-x)`, but direct `Min` Op usage (e.g., via xtensor) failed.

## Fix

Add a `pullback` method to `Min` identical to `Max.pullback`. The subgradient of min and max are mathematically the same: assign the incoming gradient to the input positions that achieve the extreme value.

## Changes

- `pytensor/tensor/math.py`: Add `pullback` method to `Min` class
- `tests/tensor/test_math.py`: Add `test_grad_Min` that verifies `Min` Op directly has a working gradient (not just via the `min()` function wrapper)

## Related

- pymc-marketing PR: https://github.com/pymc-labs/pymc-marketing/pull/2638