### PR TITLE
Add RandomVariable support to MLX backend

### DIFF
--- a/pytensor/link/mlx/dispatch/__init__.py
+++ b/pytensor/link/mlx/dispatch/__init__.py
@@ -17,4 +17,5 @@ import pytensor.link.mlx.dispatch.extra_ops
 import pytensor.link.mlx.dispatch.pad
 import pytensor.link.mlx.dispatch.sort
 import pytensor.link.mlx.dispatch.linalg
+import pytensor.link.mlx.dispatch.random
 # isort: on

--- a/pytensor/link/mlx/dispatch/basic.py
+++ b/pytensor/link/mlx/dispatch/basic.py
@@ -5,6 +5,10 @@ from types import NoneType
 
 import mlx.core as mx
 import numpy as np
+from numpy.random import Generator
+from numpy.random.bit_generator import (  # type: ignore[attr-defined]
+    _coerce_to_uint32_array,
+)
 
 from pytensor.compile.builders import OpFromGraph
 from pytensor.compile.mode import MLX
@@ -144,6 +148,14 @@ def mlx_typify_bool(data, **kwargs):
 @mlx_typify.register(np.complexfloating)
 def mlx_typify_numpy_scalar(data, **kwargs):
     return _nan_safe_constant(np.asarray(data))
+
+
+@mlx_typify.register(Generator)
+def mlx_typify_Generator(rng, **kwargs):
+    # An ``mx.random`` key is a pair of ``uint32`` (like JAX). We seed it from
+    # the NumPy bit generator state so sampling is reproducible from the seed.
+    key = _coerce_to_uint32_array(rng.bit_generator.state["state"]["state"])[:2]
+    return mx.array(key, dtype=mx.uint32)
 
 
 @singledispatch

--- a/pytensor/link/mlx/dispatch/random.py
+++ b/pytensor/link/mlx/dispatch/random.py
@@ -1,0 +1,122 @@
+from functools import singledispatch
+
+import mlx.core as mx
+
+import pytensor.tensor.random.basic as ptr
+from pytensor.graph import Constant
+from pytensor.link.mlx.dispatch.basic import convert_dtype_to_mlx, mlx_funcify
+from pytensor.tensor.type_other import NoneTypeT
+
+
+SIZE_NOT_COMPATIBLE = """MLX random variables require a statically known `size`, since shapes must be
+concrete when tracing with `mx.compile`. Provide a constant size:
+
+>>> import pytensor.tensor as pt
+>>> x_rv = pt.random.normal(0, 1, size=(3, 2))
+
+or ensure the sampled variable has a static shape.
+"""
+
+
+@mlx_funcify.register(ptr.RandomVariable)
+def mlx_funcify_RandomVariable(op: ptr.RandomVariable, node, **kwargs):
+    """MLX implementation of random variables."""
+    rv = node.outputs[1]
+    out_dtype = convert_dtype_to_mlx(rv.type.dtype)
+    static_shape = rv.type.shape
+    batch_ndim = op.batch_ndim(node)
+
+    static_size = static_shape[:batch_ndim]
+    if None in static_size:
+        # Sometimes size can be constant folded during rewrites,
+        # without the RandomVariable node being updated with new static types
+        size_param = op.size_param(node)
+        if isinstance(size_param, Constant) and not isinstance(
+            size_param.type, NoneTypeT
+        ):
+            static_size = tuple(size_param.data)
+
+    if None in static_size:
+        raise NotImplementedError(SIZE_NOT_COMPATIBLE)
+
+    static_size = tuple(int(s) for s in static_size)
+    sample_fn = mlx_sample_fn(op, node=node)
+
+    def random_variable(rng, size, *parameters):
+        new_rng, sampling_key = mx.random.split(rng, 2)
+        sample = sample_fn(sampling_key, static_size, out_dtype, *parameters)
+        return (new_rng, sample)
+
+    return random_variable
+
+
+@singledispatch
+def mlx_sample_fn(op, node):
+    name = op.name
+    raise NotImplementedError(
+        f"No MLX implementation for the given distribution: {name}"
+    )
+
+
+@mlx_sample_fn.register(ptr.NormalRV)
+def mlx_sample_fn_normal(op, node):
+    def sample_fn(key, size, dtype, loc, scale):
+        return loc + mx.random.normal(shape=size, dtype=dtype, key=key) * scale
+
+    return sample_fn
+
+
+@mlx_sample_fn.register(ptr.LaplaceRV)
+def mlx_sample_fn_laplace(op, node):
+    def sample_fn(key, size, dtype, loc, scale):
+        return loc + mx.random.laplace(shape=size, dtype=dtype, key=key) * scale
+
+    return sample_fn
+
+
+@mlx_sample_fn.register(ptr.GumbelRV)
+def mlx_sample_fn_gumbel(op, node):
+    def sample_fn(key, size, dtype, loc, scale):
+        return loc + mx.random.gumbel(shape=size, dtype=dtype, key=key) * scale
+
+    return sample_fn
+
+
+@mlx_sample_fn.register(ptr.UniformRV)
+def mlx_sample_fn_uniform(op, node):
+    def sample_fn(key, size, dtype, low, high):
+        return mx.random.uniform(low=low, high=high, shape=size, dtype=dtype, key=key)
+
+    return sample_fn
+
+
+@mlx_sample_fn.register(ptr.IntegersRV)
+def mlx_sample_fn_integers(op, node):
+    def sample_fn(key, size, dtype, low, high):
+        # `mx.random.randint` truncates towards zero, so a negative `low` would
+        # never be sampled. Draw from `[0, high - low)` and shift instead. The
+        # shift can upcast the result, so cast back to the requested dtype.
+        draw = low + mx.random.randint(
+            low=0, high=high - low, shape=size, dtype=dtype, key=key
+        )
+        return draw.astype(dtype)
+
+    return sample_fn
+
+
+@mlx_sample_fn.register(ptr.BernoulliRV)
+def mlx_sample_fn_bernoulli(op, node):
+    def sample_fn(key, size, dtype, p):
+        return mx.random.bernoulli(p=p, shape=size, key=key).astype(dtype)
+
+    return sample_fn
+
+
+@mlx_sample_fn.register(ptr.CategoricalRV)
+def mlx_sample_fn_categorical(op, node):
+    def sample_fn(key, size, dtype, p):
+        # MLX `categorical` applies a softmax over `logits`, so pass `log(p)`.
+        logits = mx.log(p)
+        return mx.random.categorical(logits, shape=size, key=key).astype(dtype)
+
+    return sample_fn

--- a/pytensor/link/mlx/linker.py
+++ b/pytensor/link/mlx/linker.py
@@ -1,3 +1,6 @@
+import warnings
+
+from pytensor.compile.sharedvalue import SharedVariable, shared
 from pytensor.link.basic import JITLinker
 
 
@@ -18,7 +21,7 @@ class MLXLinker(JITLinker):
         self.gen_functors = []
         self.use_compile = use_compile
 
-    def fgraph_convert(self, fgraph, **kwargs):
+    def fgraph_convert(self, fgraph, input_storage, storage_map, **kwargs):
         """Convert a PyTensor FunctionGraph to an MLX-compatible function.
 
         Parameters
@@ -32,9 +35,64 @@ class MLXLinker(JITLinker):
             An MLX-compatible function
         """
         from pytensor.link.mlx.dispatch import mlx_funcify
+        from pytensor.tensor.random.type import RandomType
+
+        shared_rng_inputs = [
+            inp
+            for inp in fgraph.inputs
+            if (isinstance(inp, SharedVariable) and isinstance(inp.type, RandomType))
+        ]
+
+        # Replace any shared RNG inputs so that their values can be updated in place
+        # without affecting the original RNG container. This is necessary because
+        # MLX does not accept Generators as inputs, and they will have to be typified
+        # into an mx.random key.
+        if shared_rng_inputs:
+            warnings.warn(
+                f"The RandomType SharedVariables {shared_rng_inputs} will not be used "
+                f"in the compiled MLX graph. Instead a copy will be used.",
+                UserWarning,
+            )
+            new_shared_rng_inputs = [
+                shared(inp.get_value(borrow=False)) for inp in shared_rng_inputs
+            ]
+
+            fgraph.replace_all(
+                zip(shared_rng_inputs, new_shared_rng_inputs, strict=True),
+                import_missing=True,
+                reason="MLXLinker.fgraph_convert",
+            )
+
+            for old_inp, new_inp in zip(
+                shared_rng_inputs, new_shared_rng_inputs, strict=True
+            ):
+                new_inp_storage = [new_inp.get_value(borrow=True)]
+                storage_map[new_inp] = new_inp_storage
+                old_inp_storage = storage_map.pop(old_inp)
+                # Find index of old_inp_storage in input_storage
+                for input_storage_idx, input_storage_item in enumerate(input_storage):
+                    # We have to establish equality based on identity because
+                    # input_storage may contain numpy arrays
+                    if input_storage_item is old_inp_storage:
+                        break
+                else:  # no break
+                    raise ValueError()
+                input_storage[input_storage_idx] = new_inp_storage
+                # We need to change the order of the inputs of the FunctionGraph
+                # so that the new input is in the same position as to old one,
+                # to align with the storage_map. We hope this is safe!
+                old_inp_fgrap_index = fgraph.inputs.index(old_inp)
+                fgraph.remove_input(
+                    old_inp_fgrap_index,
+                    reason="MLXLinker.fgraph_convert",
+                )
+                fgraph.inputs.remove(new_inp)
+                fgraph.inputs.insert(old_inp_fgrap_index, new_inp)
 
         return mlx_funcify(
             fgraph,
+            input_storage=input_storage,
+            storage_map=storage_map,
             **kwargs,
         )
 

--- a/tests/link/mlx/test_random.py
+++ b/tests/link/mlx/test_random.py
@@ -1,0 +1,122 @@
+import numpy as np
+import pytest
+
+import pytensor
+import pytensor.tensor as pt
+import pytensor.tensor.random.basic as ptr
+from pytensor.compile.maker import function
+from pytensor.compile.sharedvalue import shared
+from pytensor.tensor.random.utils import RandomStream
+
+
+mx = pytest.importorskip("mlx.core")
+
+
+@pytest.fixture(autouse=True)
+def _float32(monkeypatch):
+    monkeypatch.setattr(pytensor.config, "floatX", "float32")
+
+
+def compile_random_function(*args, mode="MLX", **kwargs):
+    with pytest.warns(
+        UserWarning, match=r"The RandomType SharedVariables \[.+\] will not be used"
+    ):
+        return function(*args, mode=mode, **kwargs)
+
+
+def test_random_updates():
+    """Successive calls draw new values and the original RNG is left untouched."""
+    original_value = np.random.default_rng(seed=98)
+    rng = shared(original_value, name="rng", borrow=False)
+    next_rng, x = ptr.normal(0, 1, size=(3,), rng=rng).owner.outputs
+
+    f = compile_random_function([], x, updates={rng: next_rng})
+    res1, res2 = np.array(f()), np.array(f())
+    assert not np.array_equal(res1, res2)
+
+    # The shared RNG content must not be overwritten by the MLX key conversion.
+    assert isinstance(rng.get_value(), np.random.Generator)
+    assert rng.get_value().bit_generator.state == original_value.bit_generator.state
+
+
+def test_random_RandomStream():
+    """Two successive calls of a compiled graph should return different values."""
+    srng = RandomStream(seed=123)
+    out = srng.normal() - srng.normal()
+    fn = compile_random_function([], out)
+    assert np.array(fn()) != np.array(fn())
+
+
+@pytest.mark.parametrize(
+    "dist, params, size, expected_dtype",
+    [
+        (ptr.normal, (2.0, 3.0), (5,), "float32"),
+        (ptr.uniform, (-1.0, 2.0), (5,), "float32"),
+        (ptr.laplace, (0.0, 1.0), (4,), "float32"),
+        (ptr.gumbel, (0.0, 1.0), (4,), "float32"),
+        (ptr.integers, (0, 10), (6,), "int64"),
+        (ptr.bernoulli, (0.7,), (8,), "int64"),
+    ],
+)
+def test_distribution_shape_and_dtype(dist, params, size, expected_dtype):
+    rng = shared(np.random.default_rng(0))
+    out = dist(*params, size=size, rng=rng)
+    assert out.type.dtype == expected_dtype
+
+    f = function([], out, mode="MLX")
+    res = np.array(f())
+    assert res.shape == size
+    assert res.dtype == np.dtype(expected_dtype)
+    assert np.isfinite(res).all()
+
+
+def test_categorical():
+    p = np.array([0.1, 0.3, 0.6], dtype="float32")
+    rng = shared(np.random.default_rng(0))
+    out = ptr.categorical(p, size=(100_000,), rng=rng)
+
+    f = function([], out, mode="MLX")
+    res = np.array(f())
+    assert res.shape == (100_000,)
+    assert set(np.unique(res).tolist()) <= {0, 1, 2}
+    freqs = np.array([(res == k).mean() for k in range(3)])
+    np.testing.assert_allclose(freqs, p, atol=0.01)
+
+
+def test_bernoulli_rate():
+    rng = shared(np.random.default_rng(0))
+    out = ptr.bernoulli(0.3, size=(100_000,), rng=rng)
+    res = np.array(function([], out, mode="MLX")())
+    assert set(np.unique(res).tolist()) <= {0, 1}
+    np.testing.assert_allclose(res.mean(), 0.3, atol=0.01)
+
+
+def test_integers_negative_low():
+    # MLX `randint` truncates towards zero; assert the full range is covered.
+    rng = shared(np.random.default_rng(0))
+    out = ptr.integers(-5, 5, size=(50_000,), rng=rng)
+    res = np.array(function([], out, mode="MLX")())
+    assert res.dtype == np.int64
+    assert set(np.unique(res).tolist()) == set(range(-5, 5))
+
+
+@pytest.mark.parametrize("size", [(), (2, 3)])
+def test_scalar_and_multidim_size(size):
+    rng = shared(np.random.default_rng(0))
+    res = np.array(function([], ptr.normal(0, 1, size=size, rng=rng), mode="MLX")())
+    assert res.shape == size
+
+
+def test_unimplemented_distribution_raises():
+    rng = shared(np.random.default_rng(0))
+    out = ptr.beta(1.0, 1.0, size=(3,), rng=rng)
+    with pytest.raises(NotImplementedError, match="No MLX implementation"):
+        function([], out, mode="MLX")
+
+
+def test_size_not_statically_known_raises():
+    x = pt.vector("x", dtype="float32")
+    rng = shared(np.random.default_rng(0))
+    out = ptr.normal(0, 1, size=x.shape, rng=rng)
+    with pytest.raises(NotImplementedError, match="statically known"):
+        function([x], out, mode="MLX")


### PR DESCRIPTION
## Issue

Compiling **any** graph that contains a `RandomVariable` for the MLX backend fails before it reaches the random op — it dies converting the RNG itself:

```
NotImplementedError: mlx_typify is not implemented for <class 'numpy.random._generator.Generator'>
```

Two pieces were missing (and a third the description didn't mention):

1. **No RNG typify.** `pytensor/link/mlx/dispatch/basic.py` registered `mlx_typify` for arrays, scalars, slices and `None`, but not for `numpy.random.Generator`. A shared RNG is an input to the compiled function, so MLX tried to `mlx_typify` it and fell through to `NotImplementedError`.
2. **No random dispatch module.** There was no `pytensor/link/mlx/dispatch/random.py`, so no `RandomVariable` op had an MLX lowering.
3. **No shared-RNG protection in the linker.** Unlike `JAXLinker`, `MLXLinker` did not replace shared RNG inputs, so the user's RNG shared variable would be silently overwritten by the typified MLX key.

Net effect: no in-graph sampling (categorical decoding, dropout, in-graph initialization).

### Self-contained reproducer (on `main`)

```python
import numpy as np, pytensor
import pytensor.tensor.random as ptr
pytensor.config.floatX = "float32"

rng = pytensor.shared(np.random.default_rng(0))
next_rng, draw = ptr.normal(0, 1, size=(3,), rng=rng).owner.outputs

# default backend: works
print(pytensor.function([], draw, updates=[(rng, next_rng)], mode=None)())

# MLX: fails at RNG conversion
pytensor.function([], draw, updates=[(rng, next_rng)], mode="MLX")
# -> NotImplementedError: mlx_typify is not implemented for ... Generator
```

## Solution

This PR mirrors the existing JAX backend, which is the canonical spec for RNG lowering:

- **`dispatch/basic.py`** — `mlx_typify.register(Generator)` seeds an `mx.random` key (a `uint32` pair) from the NumPy bit-generator state, mirroring `jax_typify_Generator`.
- **`dispatch/random.py`** (new) — `mlx_funcify_RandomVariable` threads the key with `mx.random.split` and returns `(next_rng, sample)`; a `singledispatch` `mlx_sample_fn` lowers `normal`, `uniform`, `laplace`, `gumbel`, `integers`, `bernoulli`, and `categorical`.
- **`linker.py`** — `MLXLinker.fgraph_convert` replaces shared RNG inputs with copies (with the same `UserWarning` as JAX), so the user's original `Generator` is never clobbered by the key conversion.

Two intentional, documented divergences (both verified correct):

- **`integers`** draws `low + randint(0, high - low)` and casts back to the requested dtype. MLX's `randint` truncates toward zero, so a naive `randint(low, high)` would *never* sample a negative `low`. This mirrors the loc-shift idiom the JAX backend already uses for loc/scale families.
- **`categorical`** passes `log(p)` (not JAX's `logit(p)`). Both MLX and JAX `categorical` apply a softmax over logits, so the correct unnormalized log-probabilities are `log(p)`. `softmax(log p) == p`; `softmax(logit(p))` does not, so JAX's `logit(p)` actually samples the wrong distribution.

`size` must be statically known (raises a clear `NotImplementedError` otherwise), because `mx.compile` requires concrete shapes — this covers the gap's use cases (categorical decoding, dropout, in-graph init).

## Why this is correct and not flaky

- **Mirrors the spec.** Conversion, key threading, and the shared-RNG replacement all follow the JAX backend rather than inventing a new mechanism.
- **Deterministic threading.** The RNG is threaded by returning a fresh split key (no closure-captured mutable state), so successive calls advance the stream and same-seed runs reproduce. `test_random_updates` and `test_random_RandomStream` assert this directly, and statistical tests use fixed seeds with wide tolerances (`atol=0.01` over 100k draws) so they are not seed-sensitive.
- **dtype preserved.** Discrete RVs cast to the graph's declared dtype; `test_integers_negative_low` locks `int64`, and the `integers` `.astype(dtype)` prevents the int64-bound/int32-draw upcast.
- **No regressions.** Full MLX suite green (`tests/link/mlx/`: 175 passed, 4 pre-existing xfails); 15 new tests in `tests/link/mlx/test_random.py`.

Distributions MLX does not expose natively (`beta`, `exponential`, `mvnormal`, `binomial`, `multinomial`, ...) raise a clear `NotImplementedError` from the `mlx_sample_fn` default; I'd suggest tracking those as a separate follow-up rather than bundling them here.

## Test plan

- [x] `pytest tests/link/mlx/test_random.py` (15 passed)
- [x] `pytest tests/link/mlx/` (175 passed, 4 xfailed — no regressions)
- [x] Reproducer above now samples on MLX with distinct draws across calls
- [x] `ruff check` / `ruff format` clean

AI assistance was used in preparing this change.

Made with [Cursor](https://cursor.com)