### PR TITLE
Move transformer LLM notebook to case studies

### DIFF
--- a/doc/gallery/applications/tiny_transformer_llm.ipynb
+++ b/doc/gallery/applications/tiny_transformer_llm.ipynb
@@ -387,7 +387,7 @@
         "\n",
         "    out = ptx.dot(attn, v, dim=\"time_k\")\n",
         "    assert out.dims == (\"time_q\", \"batch\", \"head\", \"hd\")\n",
-        "    out = ptx.stack(out, embd=(\"head\", \"hd\"))\n",
+        "    out = out.stack(embd=(\"head\", \"hd\"))\n",
         "    assert out.dims == (\"time_q\", \"batch\", \"embd\")\n",
         "    out = ptx.dot(out, Wproj, dim=\"embd\").rename(time_q=\"time\", embd_out=\"embd\")\n",
         "    return out.transpose(\"batch\", \"time\", \"embd\").values\n",

--- a/pytensor/xtensor/__init__.py
+++ b/pytensor/xtensor/__init__.py
@@ -1,14 +1,7 @@
 import pytensor.xtensor.rewriting
 from pytensor.xtensor import linalg, math, random, signal
 from pytensor.xtensor.math import dot, where
-from pytensor.xtensor.shape import (
-    broadcast,
-    concat,
-    full_like,
-    ones_like,
-    stack,
-    zeros_like,
-)
+from pytensor.xtensor.shape import broadcast, concat, full_like, ones_like, zeros_like
 from pytensor.xtensor.type import (
     as_xtensor,
     xtensor,


### PR DESCRIPTION
And undo change in `stack` discoverability.

We follow xarray organization, and they don't place stack as a root level function. The "idiomatic" way is to use `var.stack` method. https://docs.xarray.dev/en/latest/api/top-level.html
