### PR TITLE
Fix several regressions caused by last release

### DIFF
--- a/pytensor/compile/builders.py
+++ b/pytensor/compile/builders.py
@@ -8,8 +8,7 @@ from collections.abc import Callable, Sequence
 from copy import copy
 from functools import partial
 
-from pytensor.compile.io import In, Out
-from pytensor.compile.mode import get_mode
+from pytensor.compile.inner_function import HasInnerFunction
 from pytensor.compile.sharedvalue import SharedVariable
 from pytensor.gradient import DisconnectedType, disconnected_type, grad, pushforward
 from pytensor.graph.basic import (
@@ -20,7 +19,7 @@ from pytensor.graph.basic import (
 )
 from pytensor.graph.fg import FrozenFunctionGraph, FunctionGraph
 from pytensor.graph.null_type import NullType
-from pytensor.graph.op import HasInnerGraph, Op, io_connection_pattern
+from pytensor.graph.op import Op, io_connection_pattern
 from pytensor.graph.replace import clone_replace
 from pytensor.graph.traversal import graph_inputs
 from pytensor.graph.utils import MissingInputError
@@ -114,7 +113,7 @@ def construct_nominal_fgraph(
     return fgraph
 
 
-class OpFromGraph(Op, HasInnerGraph):
+class OpFromGraph(HasInnerFunction, Op):
     r"""Create an Op from inputs and outputs lists of variables.
 
     The signature is similar to :func:`pytensor.function` and the resulting Op's perform will do
@@ -839,50 +838,6 @@ class OpFromGraph(Op, HasInnerGraph):
                 idx += nb
 
         return ret
-
-    @property
-    def fn(self):
-        """Lazily compile the inner function graph."""
-        if getattr(self, "_fn", None) is not None:
-            return self._fn
-
-        # ``op.fgraph`` is already backend-optimized (inplace included): the
-        # ``ofg_inner_graph`` rewrite ran the backend optimizer on it during the
-        # outer compile. So we only need to link it. The linker forces
-        # ``minimum_compile`` back in via its ``required_rewrites``, and (for an
-        # inner graph) ``minimum_compile`` *is* that inner-graph rewrite -- so we
-        # exclude ``compile_inner_graph`` to stop it re-baking an already-baked
-        # graph. ``prepare_fgraph`` still inserts the boundary deepcopies; passing
-        # ``fgraph=`` avoids a re-clone. Unused inputs (e.g. rng, size) and
-        # internal-only inplace ops are expected and tolerated.
-        mode = (
-            get_mode(None)
-            .clone(optimizer="minimum_compile")
-            .excluding("compile_inner_graph")
-        )
-        unfrozen_fgraph = self.fgraph.unfreeze()
-        self._fn = mode.function_maker(
-            [In(inp, borrow=True) for inp in unfrozen_fgraph.inputs],
-            [Out(out, borrow=True) for out in unfrozen_fgraph.outputs],
-            mode,
-            fgraph=unfrozen_fgraph,
-            accept_inplace=True,
-            on_unused_input="ignore",
-        ).create()
-        self._fn.trust_input = True
-
-        return self._fn
-
-    @property
-    def inner_inputs(self):
-        # A list (not the frozen tuple) so callers that concatenate inner
-        # inputs/outputs keep list semantics. Read-only views of the immutable
-        # graph; manipulating them requires a fresh/unfrozen graph.
-        return list(self.fgraph.inputs)
-
-    @property
-    def inner_outputs(self):
-        return list(self.fgraph.outputs)
 
     def clone(self):
         # The inner graph is immutable (a frozen ``FunctionGraph``), so there is

--- a/pytensor/compile/inner_function.py
+++ b/pytensor/compile/inner_function.py
@@ -1,0 +1,84 @@
+"""Shared machinery for `Op`\\s that execute a lazily linked inner function."""
+
+from typing import TYPE_CHECKING
+
+from pytensor.compile.io import In, Out
+from pytensor.compile.mode import Mode
+from pytensor.graph.fg import FrozenFunctionGraph, FunctionGraph
+from pytensor.graph.op import HasInnerGraph
+from pytensor.graph.rewriting.basic import SequentialGraphRewriter
+from pytensor.link.basic import Linker
+
+
+if TYPE_CHECKING:
+    from pytensor.compile.function.types import Function
+
+
+def link_only_mode(linker: str | Linker) -> Mode:
+    """A `Mode` that links a graph without rewriting it at all.
+
+    The bare rewriter also bypasses the ``minimum_compile`` pass the linker
+    would otherwise force onto a database query.
+    """
+    return Mode(linker, SequentialGraphRewriter())
+
+
+class HasInnerFunction(HasInnerGraph):
+    """`HasInnerGraph` op whose ``perform`` runs a lazily linked inner function.
+
+    The frozen inner graph was already baked for the backend by the
+    ``compile_inner_graph`` rewrites during the outer compile, so linking it
+    needs no further rewrites (see `link_only_mode`).
+
+    The linker never comes from the config default mode: ``perform`` only runs
+    under the py/c backend family -- JIT backends (numba/jax/...) funcify
+    ``op.fgraph`` directly and never call ``perform`` -- so a JIT default must
+    not win, and the JIT inner-graph rewrites were never applied to this graph.
+    """
+
+    _fn = None
+    fgraph: FrozenFunctionGraph
+
+    def link_mode(self, impl: str | None) -> Mode:
+        """The `Mode` to link the inner function with, given a thunk ``impl``."""
+        return link_only_mode("cvm" if impl == "c" else "vm")
+
+    def link_fgraph(self, fgraph: FunctionGraph, mode: Mode) -> "Function":
+        """Link an already-baked inner ``fgraph`` under ``mode``, no rewrites."""
+        fn = mode.function_maker(
+            [In(inp) for inp in fgraph.inputs],
+            [Out(out) for out in fgraph.outputs],
+            mode,
+            fgraph=fgraph,
+            accept_inplace=True,
+            on_unused_input="ignore",
+        ).create()
+        fn.trust_input = True
+        return fn
+
+    def compile_fn(self, mode: Mode) -> "Function":
+        """Build the inner function under ``mode`` (override to massage the graph)."""
+        return self.link_fgraph(self.fgraph.unfreeze(), mode)
+
+    @property
+    def fn(self) -> "Function":
+        if self._fn is None:
+            self._fn = self.compile_fn(self.link_mode(None))
+        return self._fn
+
+    def make_thunk(self, node, storage_map, compute_map, no_recycling, impl=None):
+        if self._fn is None:
+            self._fn = self.compile_fn(self.link_mode(impl))
+        return super().make_thunk(
+            node, storage_map, compute_map, no_recycling, impl=impl
+        )
+
+    @property
+    def inner_inputs(self):
+        # Read-only views of the immutable inner graph, as lists so callers
+        # that concatenate inputs/outputs keep list semantics.
+        return list(self.fgraph.inputs)
+
+    @property
+    def inner_outputs(self):
+        return list(self.fgraph.outputs)

--- a/pytensor/compile/mode.py
+++ b/pytensor/compile/mode.py
@@ -305,7 +305,7 @@ class Mode:
     def __init__(
         self,
         linker: str | Linker | None = None,
-        optimizer: str | RewriteDatabaseQuery = "default",
+        optimizer: str | RewriteDatabaseQuery | GraphRewriter = "default",
         db: RewriteDatabase = None,
     ):
         if linker is None:

--- a/pytensor/link/numba/dispatch/elemwise.py
+++ b/pytensor/link/numba/dispatch/elemwise.py
@@ -122,8 +122,12 @@ def scalar_in_place_fn_IntDiv(op, idx, res, arr):
 
 @scalar_in_place_fn.register(Maximum)
 def scalar_in_place_fn_Maximum(op, idx, res, arr):
+    # `arr != arr` catches NaN, which the comparison alone would drop; once the
+    # accumulator is NaN neither clause fires again, so NaN sticks (numpy
+    # semantics, matching the C backend). For integer dtypes LLVM folds the
+    # always-false clause away.
     return [
-        f"if {res}[{idx}] < {arr}:",
+        f"if {res}[{idx}] < {arr} or {arr} != {arr}:",
         CODE_TOKEN.INDENT,
         f"{res}[{idx}] = {arr}",
         CODE_TOKEN.DEDENT,
@@ -132,8 +136,9 @@ def scalar_in_place_fn_Maximum(op, idx, res, arr):
 
 @scalar_in_place_fn.register(Minimum)
 def scalar_in_place_fn_Minimum(op, idx, res, arr):
+    # See NaN comment in scalar_in_place_fn_Maximum
     return [
-        f"if {res}[{idx}] > {arr}:",
+        f"if {res}[{idx}] > {arr} or {arr} != {arr}:",
         CODE_TOKEN.INDENT,
         f"{res}[{idx}] = {arr}",
         CODE_TOKEN.DEDENT,
@@ -840,7 +845,7 @@ def numba_funcify_CAReduce(op, node, **kwargs):
     )
     careduce_fn = numba_basic.numba_njit(careduce_py_fn, boundscheck=False)
 
-    cache_version = 3
+    cache_version = 4
     careduce_key = sha256(
         str(
             (

--- a/pytensor/link/numba/dispatch/elemwise.py
+++ b/pytensor/link/numba/dispatch/elemwise.py
@@ -374,8 +374,11 @@ def create_multiaxis_reducer(
         else:
             identity = np.iinfo(acc_dtype).min
 
-    # Make sure it has the correct dtype
-    identity = getattr(np, acc_dtype.name)(identity)
+    # Make sure it has the correct dtype. Cast through ``astype`` rather than the
+    # scalar constructor so a negative identity (``-1`` for bitwise AND) wraps
+    # into an unsigned acc_dtype like C does instead of raising: ``np.uint64(-1)``
+    # is out of range, but ``-1`` cast to uint64 is all-ones -- the AND identity.
+    identity = np.asarray(identity).astype(acc_dtype)[()]
 
     kept_axes = [i for i in range(ndim) if i not in axes]
     n_kept = len(kept_axes)

--- a/pytensor/scan/op.py
+++ b/pytensor/scan/op.py
@@ -59,6 +59,7 @@ from pytensor import tensor as pt
 from pytensor.compile.aliasing import add_supervisor_to_fgraph
 from pytensor.compile.builders import construct_nominal_fgraph, infer_shape
 from pytensor.compile.debug.profiling import register_profiler_printer
+from pytensor.compile.inner_function import HasInnerFunction, link_only_mode
 from pytensor.compile.io import In, Out
 from pytensor.compile.mode import Mode, get_mode
 from pytensor.configdefaults import config
@@ -76,7 +77,7 @@ from pytensor.graph.basic import (
 )
 from pytensor.graph.features import NoOutputFromInplace
 from pytensor.graph.fg import FrozenFunctionGraph, FunctionGraph
-from pytensor.graph.op import HasInnerGraph, Op, io_connection_pattern
+from pytensor.graph.op import Op, io_connection_pattern
 from pytensor.graph.replace import clone_replace
 from pytensor.graph.traversal import graph_inputs
 from pytensor.graph.type import HasShape
@@ -835,7 +836,7 @@ class ScanMethodsMixin:
                     )
 
 
-class Scan(Op, ScanMethodsMixin, HasInnerGraph):
+class Scan(HasInnerFunction, Op, ScanMethodsMixin):
     r"""An `Op` implementing `for` and `while` loops.
 
     This `Op` has an "inner-graph" that represents the steps performed during
@@ -1542,12 +1543,26 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
 
         return wrapped_inputs, wrapped_outputs
 
-    @property
-    def fn(self):
-        """Lazily compile the inner function graph."""
-        if getattr(self, "_fn", None) is not None:
-            return self._fn
+    def link_mode(self, impl):
+        # ``self.mode`` is a deprecated per-op override, respected when given:
+        # its linker is used as-is. Otherwise the default py/c rule applies,
+        # except FAST_COMPILE forces the pure-python VM.
+        mode = self.mode
+        if mode in (None, "FAST_RUN"):
+            return super().link_mode(impl)
+        if mode == "FAST_COMPILE":
+            return link_only_mode(VMLinker(use_cloop=False, c_thunks=False))
+        linker = get_mode(mode).clone(link_kwargs=dict(allow_gc=self.allow_gc)).linker
+        # Scan's python/cython perform sets preallocated MIT-MOT updates through
+        # the VM, which only a VMLinker provides.
+        if any(self.mitmots_preallocated) and not isinstance(linker, VMLinker):
+            raise NotImplementedError(
+                "Python/Cython implementation of Scan with preallocated MIT-MOT "
+                f"outputs requires a VMLinker, got {linker}"
+            )
+        return link_only_mode(linker)
 
+    def compile_fn(self, mode):
         # Compile a throwaway copy of the (already math-optimized) inner graph.
         # The canonical inner graph is immutable; linking setup (MIT-MOT update
         # wrapping, supervisor) and any inplace happen on this transient.
@@ -1565,45 +1580,10 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         elif self.profile:
             profile = self.profile
 
-        # ``inner_fgraph`` is already backend-optimized (inplace included):
-        # ``scan_inner_graph`` ran the backend optimizer on it during the outer
-        # compile. So we only need to link it (``prepare_fgraph`` still inserts the
-        # boundary deepcopies). The linker forces ``minimum_compile`` back in via
-        # its ``required_rewrites``, and (for an inner graph) ``minimum_compile``
-        # *is* that inner-graph rewrite -- so we exclude ``compile_inner_graph`` to
-        # stop it re-baking an already-baked graph. Only the linker choice depends
-        # on ``self.mode``.
-        mode = self.mode
-        if mode in (None, "FAST_RUN"):
-            mode_instance = Mode("cvm", "minimum_compile").excluding(
-                "compile_inner_graph"
-            )
-        elif mode == "FAST_COMPILE":
-            mode_instance = Mode(
-                VMLinker(use_cloop=False, c_thunks=False), "minimum_compile"
-            ).excluding("compile_inner_graph")
-        else:
-            mode_instance = (
-                get_mode(mode)
-                .clone(
-                    optimizer="minimum_compile",
-                    link_kwargs=dict(allow_gc=self.allow_gc),
-                    message=f"{self.name or 'Scan'} sub profile",
-                )
-                .excluding("compile_inner_graph")
-            )
-            # Scan python and cython perform relies on the VM being able to set updates for preallocated MIT-MOT,
-            # which only the VMs produced by VMLinker do
-            if any(self.mitmots_preallocated) and not isinstance(
-                mode_instance.linker, VMLinker
-            ):
-                raise NotImplementedError(
-                    f"Python/Cython implementation of Scan with preallocated MIT-MOT outputs requires a VMLinker, got {mode_instance.linker}"
-                )
-        self._fn = mode_instance.function_maker(
+        return mode.function_maker(
             wrapped_inputs,
             wrapped_outputs,
-            mode=mode_instance,
+            mode=mode,
             # The (already-optimized) inner graph may carry inplace ops baked in
             # by scan_inner_graph; prepare_fgraph has already attached the
             # DestroyHandler + Supervisor, so accept them here.
@@ -1612,19 +1592,6 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
             on_unused_input="ignore",
             fgraph=inner_fgraph,
         ).create()
-
-        return self._fn
-
-    @property
-    def inner_inputs(self):
-        # A list (not the frozen tuple) so the many ``inner_*`` slicing helpers
-        # and their callers keep list semantics. These are read-only views of the
-        # immutable graph; rewrites that rebuild a Scan must ``unfreeze`` first.
-        return list(self.fgraph.inputs)
-
-    @property
-    def inner_outputs(self):
-        return list(self.fgraph.outputs)
 
     def clone(self) -> "Scan":
         # The inner graph is immutable (a frozen ``FunctionGraph``), so there is
@@ -1685,6 +1652,11 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         # Before building the thunk, validate that the inner graph is
         # coherent
         self.validate_inner_graph()
+
+        # Lazily link the inner function for this thunk's backend (see
+        # ``HasInnerFunction``); Scan drives the resulting VM itself below.
+        if self._fn is None:
+            self._fn = self.compile_fn(self.link_mode(impl))
 
         # Setting up all my variables in what I believe is a more Cython
         # friendly form

--- a/pytensor/tensor/optimize.py
+++ b/pytensor/tensor/optimize.py
@@ -6,15 +6,13 @@ from functools import singledispatch
 import numpy as np
 
 import pytensor.scalar as ps
-from pytensor.compile.maker import function
-from pytensor.compile.mode import get_mode
+from pytensor.compile.inner_function import HasInnerFunction
 from pytensor.gradient import DisconnectedType, grad, jacobian
 from pytensor.graph.basic import Apply, Constant
 from pytensor.graph.fg import FrozenFunctionGraph, FunctionGraph
 from pytensor.graph.null_type import NullType
 from pytensor.graph.op import (
     ComputeMapType,
-    HasInnerGraph,
     Op,
     StorageMapType,
     io_connection_pattern,
@@ -164,7 +162,37 @@ def _find_optimization_parameters(
     ]
 
 
-class ScipyWrapperOp(Op, HasInnerGraph):
+def _tensorize_scalar_parameters(
+    objective: TensorVariable, args: list[Variable]
+) -> tuple[TensorVariable, list[Variable], list[Variable]]:
+    """Replace ``ScalarType`` parameters with equivalent ``TensorType`` inputs.
+
+    scipy hands every value to the objective as a numpy array, and stores/forwards
+    a ``ScalarType`` value as a bare python float -- which no C thunk accepts under
+    ``trust_input``. Re-expressing such a parameter as a 0-d ``TensorType`` input
+    (reconstructed inside the graph with ``scalar_from_tensor``) makes the op
+    boundary array-typed, so scipy passes a preserved 0-d ndarray. Returns the
+    rewritten objective, the inner-graph parameters, and the matching outer inputs.
+    """
+    replacements: dict[Variable, Variable] = {}
+    inner_args: list[Variable] = []
+    outer_args: list[Variable] = []
+    for arg in args:
+        if isinstance(arg.type, ScalarType):
+            inner = tensor(name=arg.name, shape=(), dtype=arg.type.dtype)
+            replacements[arg] = scalar_from_tensor(inner)
+            inner_args.append(inner)
+            outer_args.append(tensor_from_scalar(arg))
+        else:
+            inner_args.append(arg)
+            outer_args.append(arg)
+
+    if replacements:
+        [objective] = graph_replace([objective], replacements)
+    return objective, inner_args, outer_args
+
+
+class ScipyWrapperOp(HasInnerFunction, Op):
     """Shared logic for scipy optimization ops.
 
     The inner graph is held frozen (immutable) as ``self.fgraph``, so the
@@ -178,56 +206,11 @@ class ScipyWrapperOp(Op, HasInnerGraph):
     # of the same type for eq/hash. Subclasses override.
     _scipy_props: tuple[str, ...] = ()
 
-    def build_fn(self):
-        """
-        This is overloaded because scipy converts scalar inputs to lists, changing the return type. The
-        wrapper function logic is there to handle this.
-        """
-        fgraph = self.fgraph.unfreeze()
-        # ``optimize_inner_graph`` already baked this graph for the active backend
-        # (inplace included), exactly like ``OpFromGraph``. So we only link it --
-        # ``minimum_compile`` excluding ``compile_inner_graph`` (the rewrite that
-        # already ran); ``prepare_fgraph`` still inserts the boundary deepcopies.
-        # ``accept_inplace`` admits the baked inplace ops; backend optimization can
-        # leave a declared input unused (e.g. a folded core-shape vector), hence
-        # ``on_unused_input="ignore"``.
-        self._fn = fn = function(
-            fgraph.inputs,
-            fgraph.outputs,
-            mode=get_mode(None)
-            .clone(optimizer="minimum_compile")
-            .excluding("compile_inner_graph"),
-            accept_inplace=True,
-            trust_input=True,
-            on_unused_input="ignore",
-        )
-
-        # Do this reassignment to see the compiled graph in the dprint
-        # self.fgraph = fn.maker.fgraph
-
-        self._fn_wrapped = LRUCache1(fn)
-
-    @property
-    def fn(self):
-        if self._fn is None:
-            self.build_fn()
-        return self._fn
-
     @property
     def fn_wrapped(self):
         if self._fn_wrapped is None:
-            self.build_fn()
+            self._fn_wrapped = LRUCache1(self.fn)
         return self._fn_wrapped
-
-    @property
-    def inner_inputs(self):
-        # A list (not the frozen tuple) so callers that concatenate inner
-        # inputs/outputs keep list semantics.
-        return list(self.fgraph.inputs)
-
-    @property
-    def inner_outputs(self):
-        return list(self.fgraph.outputs)
 
     def _prop_values(self):
         return tuple(getattr(self, name) for name in self._scipy_props)
@@ -280,7 +263,7 @@ class ScipyWrapperOp(Op, HasInnerGraph):
         impl: str | None,
     ):
         """Trigger the compilation of the inner fgraph so it shows in the dprint before the first call"""
-        self.build_fn()
+        self.fn
 
     def make_node(self, *inputs):
         assert len(inputs) == len(self.inner_inputs)
@@ -305,7 +288,7 @@ def rewrite_optimize_inner_graph(linker, op, node, inner, *, mode):
 
 
 class ScipyScalarWrapperOp(ScipyWrapperOp):
-    def build_fn(self):
+    def compile_fn(self, mode):
         # We need to adjust the graph to work with what scipy will be passing into the inner function --
         # always scalar array of float64 type
         fgraph = self.fgraph.unfreeze()
@@ -315,23 +298,9 @@ class ScipyScalarWrapperOp(ScipyWrapperOp):
 
         new_outputs = graph_replace(fgraph.outputs, {x: new_x})
 
-        # See ``ScipyWrapperOp.build_fn``: the graph is already baked, so link
-        # it (the scipy boundary wrapping above links alongside the baked body).
-        self._fn = fn = function(
-            [new_root_x, *args],
-            new_outputs,
-            mode=get_mode(None)
-            .clone(optimizer="minimum_compile")
-            .excluding("compile_inner_graph"),
-            accept_inplace=True,
-            trust_input=True,
-            on_unused_input="ignore",
+        return self.link_fgraph(
+            FunctionGraph([new_root_x, *args], new_outputs, clone=False), mode
         )
-
-        # Do this reassignment to see the compiled graph in the dprint
-        # self.fgraph = fn.maker.fgraph
-
-        self._fn_wrapped = LRUCache1(fn)
 
     def compute_implicit_gradients(
         self,
@@ -407,33 +376,20 @@ class ScipyScalarWrapperOp(ScipyWrapperOp):
 
 
 class ScipyVectorWrapperOp(ScipyWrapperOp):
-    def build_fn(self):
+    def compile_fn(self, mode):
         # We need to adjust the graph to work with what scipy will be passing into the inner function --
         # always a vector array with size of at least 1
         if self.inner_inputs[0].type.shape != ():
-            return super().build_fn()
+            return super().compile_fn(mode)
 
         fgraph = self.fgraph.unfreeze()
         x, *args = fgraph.inputs
         new_root_x = x[None].type()
         new_x = new_root_x.squeeze()
         new_outputs = graph_replace(fgraph.outputs, {x: new_x})
-        # See ``ScipyWrapperOp.build_fn``: the graph is already baked, so link
-        # it (the scipy boundary wrapping above links alongside the baked body).
-        self._fn = fn = function(
-            [new_root_x, *args],
-            new_outputs,
-            mode=get_mode(None)
-            .clone(optimizer="minimum_compile")
-            .excluding("compile_inner_graph"),
-            accept_inplace=True,
-            trust_input=True,
-            on_unused_input="ignore",
+        return self.link_fgraph(
+            FunctionGraph([new_root_x, *args], new_outputs, clone=False), mode
         )
-
-        # Do this reassignment to see the compiled graph in the dprint
-        # self.fgraph = fn.maker.fgraph
-        self._fn_wrapped = LRUCache1(fn)
 
     def compute_implicit_gradients(
         self,
@@ -698,6 +654,7 @@ def minimize_scalar(
         value, based on the requested convergence criteria.
     """
     args = _find_optimization_parameters(objective, x)
+    objective, args, outer_args = _tensorize_scalar_parameters(objective, args)
 
     minimize_scalar_op = MinimizeScalarOp(
         x,
@@ -707,7 +664,7 @@ def minimize_scalar(
         optimizer_kwargs=optimizer_kwargs,
     )
 
-    solution, success = minimize_scalar_op(x, *args)
+    solution, success = minimize_scalar_op(x, *outer_args)
 
     return solution, success
 
@@ -905,6 +862,7 @@ def minimize(
 
     packed_input, packed_shapes, objective = pack_inputs_of_objective(objective, x)
     args = _find_optimization_parameters(objective, packed_input)
+    objective, args, outer_args = _tensorize_scalar_parameters(objective, args)
 
     minimize_op = MinimizeOp(
         packed_input,
@@ -917,7 +875,7 @@ def minimize(
         optimizer_kwargs=optimizer_kwargs,
     )
 
-    solution, success = minimize_op(packed_input, *args)
+    solution, success = minimize_op(packed_input, *outer_args)
 
     if packed_shapes is not None:
         solution = unpack(solution, packed_shapes)
@@ -1065,6 +1023,7 @@ def root_scalar(
         Boolean indicating whether the root-finding was successful. If True, the solution is a root of the equation
     """
     args = _find_optimization_parameters(equation, variable)
+    equation, args, outer_args = _tensorize_scalar_parameters(equation, args)
 
     root_scalar_op = RootScalarOp(
         variable,
@@ -1076,7 +1035,7 @@ def root_scalar(
         optimizer_kwargs=optimizer_kwargs,
     )
 
-    solution, success = root_scalar_op(variable, *args)
+    solution, success = root_scalar_op(variable, *outer_args)
 
     return solution, success
 
@@ -1139,7 +1098,7 @@ class RootOp(ScipyVectorWrapperOp):
         )
         return f"{self.__class__.__name__}({str_args})"
 
-    def build_fn(self):
+    def compile_fn(self, mode):
         fgraph = self.fgraph.unfreeze()
         variables, *args = fgraph.inputs
         outputs = fgraph.outputs
@@ -1157,23 +1116,9 @@ class RootOp(ScipyVectorWrapperOp):
 
             new_outputs = graph_replace(outputs, {variables: new_variables})
 
-        # See ``ScipyWrapperOp.build_fn``: the graph is already baked, so link
-        # it (the scipy boundary wrapping above links alongside the baked body).
-        self._fn = fn = function(
-            [new_root_variables, *args],
-            new_outputs,
-            mode=get_mode(None)
-            .clone(optimizer="minimum_compile")
-            .excluding("compile_inner_graph"),
-            accept_inplace=True,
-            trust_input=True,
-            on_unused_input="ignore",
+        return self.link_fgraph(
+            FunctionGraph([new_root_variables, *args], new_outputs, clone=False), mode
         )
-
-        # Do this reassignment to see the compiled graph in the dprint
-        # self.fgraph = fn.maker.fgraph
-
-        self._fn_wrapped = LRUCache1(fn)
 
     def perform(self, node, inputs, outputs):
         global optimize
@@ -1260,6 +1205,7 @@ def root(
         equations, variables
     )
     args = _find_optimization_parameters(equations, packed_variables)
+    equations, args, outer_args = _tensorize_scalar_parameters(equations, args)
 
     root_op = RootOp(
         packed_variables,
@@ -1271,7 +1217,7 @@ def root(
         use_vectorized_jac=use_vectorized_jac,
     )
 
-    solution, success = root_op(packed_variables, *args)
+    solution, success = root_op(packed_variables, *outer_args)
     if packed_shapes is not None:
         solution = unpack(solution, packed_shapes)
 

--- a/pytensor/tensor/random/rewriting/numba.py
+++ b/pytensor/tensor/random/rewriting/numba.py
@@ -2,7 +2,7 @@ from pytensor.compile import optdb
 from pytensor.configdefaults import config
 from pytensor.graph import node_rewriter
 from pytensor.graph.rewriting.basic import copy_stack_trace, dfs_rewriter
-from pytensor.graph.traversal import applys_between
+from pytensor.graph.traversal import ancestors
 from pytensor.tensor import as_tensor, constant
 from pytensor.tensor.basic import cast
 from pytensor.tensor.random.basic import (
@@ -87,11 +87,16 @@ def introduce_explicit_core_shape_rv(fgraph, node):
     else:
         core_shape = as_tensor(core_shape)
 
+    # ``get_non_recursive_shape`` reads only this node's own inputs, so any
+    # RandomVariable in the core-shape graph is itself an input and gets blocked
+    # here -- it is computed before the node, so reading its shape needs no extra
+    # draw (e.g. a random ``mean`` whose trailing dim is the core shape). Only a
+    # RandomVariable reachable *past* the inputs would force a duplicate draw.
+    node_inputs = frozenset(node.inputs)
     if any(
-        isinstance(node.op, RandomVariable)
-        for node in applys_between(node.inputs, [core_shape])
+        var not in node_inputs and isinstance(var.owner_op, RandomVariable)
+        for var in ancestors([core_shape], blockers=node_inputs)
     ):
-        # If the RandomVariable shows up in the shape graph we can't introduce the core shape
         return None
 
     [core_shape] = simplify_core_shape_graphs([core_shape], fgraph)

--- a/pytensor/tensor/rewriting/indexed_elemwise.py
+++ b/pytensor/tensor/rewriting/indexed_elemwise.py
@@ -405,7 +405,11 @@ class FuseIndexedElemwise(GraphRewriter):
             s_outputs.append(s_outputs[out_idx])
 
         new_scalar_op = Composite(s_inputs, s_outputs)
-        new_node = Elemwise(new_scalar_op).make_node(*node.inputs)
+        # Duplicates are appended after the original outputs, so the node's
+        # inplace pattern carries over unchanged (duplicates get no entries).
+        new_node = Elemwise(new_scalar_op, dict(node.op.inplace_pattern)).make_node(
+            *node.inputs
+        )
         return new_node, dup_map
 
     @staticmethod
@@ -595,35 +599,13 @@ class FuseIndexedElemwise(GraphRewriter):
                 worklist.append(node)
                 continue
 
-            indexed_reads = {i for reads, _ in idx_groups.values() for i in reads}
-
-            # If any inplace targets an indexed-read input,
-            # strip and re-run inplace with those inputs protected
-            if any(
-                inp_idx in indexed_reads for inp_idx in node.op.inplace_pattern.values()
-            ):
-                stripped_node = Elemwise(node.op.scalar_op).make_node(*node.inputs)
-                fgraph.replace_all(
-                    zip(node.outputs, stripped_node.outputs),
-                    reason="fuse_indexed_elemwise_strip_inplace",
-                )
-                protected = frozenset(stripped_node.inputs[i] for i in indexed_reads)
-                # try_inplace_on_node does its own fgraph.replace_all internally,
-                # so the returned node is already in the fgraph
-                new_inplace_node = InplaceElemwiseOptimizer().try_inplace_on_node(
-                    fgraph,
-                    stripped_node,
-                    reason="fuse_indexed_elemwise_inplace_read_buffers",
-                    extra_protected_inputs=protected,
-                )
-                worklist.append(new_inplace_node)
-                continue
-
             # If any indexed-write output also has other consumers,
             # duplicate it via Composite so the write replaces the duplicate
             # while the original stays available for non-write consumers.
             # We still avoid one extra write loop,
-            # even if we can't skip the output materialization altogether
+            # even if we can't skip the output materialization altogether.
+            # This runs before the strip-inplace pass below, so an inplace on the
+            # materialized original survives the fusion.
             def _has_non_write_clients(out_idx):
                 update = write_targets[out_idx]
                 for c, _ in fgraph.clients[node.outputs[out_idx]]:
@@ -664,12 +646,55 @@ class FuseIndexedElemwise(GraphRewriter):
                 worklist.append(new_node)
                 continue
 
+            indexed_reads = {i for reads, _ in idx_groups.values() for i in reads}
+
+            # If any inplace targets an indexed-read input, or claims an indexed-write
+            # output (the loop writes the result to the write buffer instead, so the
+            # input destruction would happen only in the Python-mode fallback,
+            # undeclared by the outer destroy map), strip and re-run inplace with
+            # those inputs protected and outputs excluded. The duplication above ran
+            # first, so write-target outputs here are sole-client.
+            if any(
+                inp_idx in indexed_reads for inp_idx in node.op.inplace_pattern.values()
+            ) or any(out_idx in write_targets for out_idx in node.op.inplace_pattern):
+                stripped_node = Elemwise(node.op.scalar_op).make_node(*node.inputs)
+                fgraph.replace_all(
+                    zip(node.outputs, stripped_node.outputs),
+                    reason="fuse_indexed_elemwise_strip_inplace",
+                )
+                optimizer = InplaceElemwiseOptimizer()
+                protected = optimizer._get_protected_inputs(fgraph)
+                protected.update(stripped_node.inputs[i] for i in indexed_reads)
+                # Candidates are plain-Elemwise (output, input) pairs; exclude
+                # outputs the fusion is about to consume as indexed writes
+                candidate_pairs = [
+                    pair
+                    for pair in optimizer.filter_candidate_pairs(
+                        fgraph, stripped_node, protected
+                    )
+                    if pair[0][0] not in write_targets
+                ]
+                # try_inplace_on_node does its own fgraph.replace_all internally,
+                # so the returned node is already in the fgraph
+                new_inplace_node = optimizer.try_inplace_on_node(
+                    fgraph,
+                    stripped_node,
+                    candidate_pairs=candidate_pairs,
+                    reason="fuse_indexed_elemwise_inplace_read_buffers",
+                )
+                worklist.append(new_inplace_node)
+                continue
+
             idx_vars = [idx for idx, _axis in idx_groups]
 
+            # The strip-inplace pass above guarantees that indexed-write outputs
+            # carry no inplace
+            assert not any(
+                out_idx in write_targets for out_idx in node.op.inplace_pattern
+            )
             fgraph_destroy_map = {
                 out_idx: [inp_idx]
                 for out_idx, inp_idx in node.op.inplace_pattern.items()
-                if out_idx not in write_targets
             }
 
             # Fgraph inputs: substitute indexed sources back to their

--- a/pytensor/tensor/rewriting/indexed_elemwise.py
+++ b/pytensor/tensor/rewriting/indexed_elemwise.py
@@ -368,6 +368,12 @@ class FuseIndexedElemwise(GraphRewriter):
         pairs = []
         for axis, entry in enumerate(op.idx_list):
             if isinstance(entry, slice):
+                # The fused loop substitutes the full source array and iterates
+                # non-indexed axes wholesale, so it can only carry a full slice.
+                # A bounded/stepped basic slice would change the axis extent or
+                # offset, which it can't represent -- don't fuse.
+                if entry != slice(None):
+                    return None
                 continue
             idx = idx_vars[entry]
             if not isinstance(idx, TensorVariable) or idx.type.dtype == "bool":

--- a/pytensor/tensor/rewriting/indexed_elemwise.py
+++ b/pytensor/tensor/rewriting/indexed_elemwise.py
@@ -9,14 +9,17 @@ eliminating materialised intermediate arrays.
 from pytensor.compile import optdb
 from pytensor.compile.builders import OpFromGraph
 from pytensor.graph import node_rewriter
+from pytensor.graph.basic import Constant
 from pytensor.graph.rewriting.basic import GraphRewriter, dfs_rewriter
 from pytensor.graph.rewriting.db import SequenceDB
 from pytensor.graph.rewriting.unify import OpPattern
 from pytensor.graph.utils import InconsistencyError
 from pytensor.printing import op_debug_information
 from pytensor.scalar.basic import Composite
+from pytensor.tensor.basic import MakeVector
 from pytensor.tensor.elemwise import DimShuffle, Elemwise
 from pytensor.tensor.rewriting.elemwise import InplaceElemwiseOptimizer
+from pytensor.tensor.rewriting.subtensor import _is_shape_of_x_at
 from pytensor.tensor.shape import Reshape, shape_padright
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
@@ -95,6 +98,51 @@ def _unwrap_axis_swapped_subtensor1(fgraph, var):
     return source, idx_var, axis
 
 
+def _unwrap_reshaped_take(fgraph, reshape_node):
+    """Unwrap ``Reshape(AdvancedSubtensor1(x, idx), S)`` into an ND take.
+
+    Matches any reshape that regroups only the taken axis: the leading and
+    trailing entries of ``S`` must provably pass through ``source``'s dims
+    (``transform_take``'s flatten+reshape form is the common instance). The
+    regrouped block becomes the ND index, so ``x[idx].reshape(S)`` turns into
+    ``x[idx.reshape(S[axis:...])]`` — the index reshape raises on exactly the
+    sizes the original reshape would have raised on. Returns
+    ``(source, nd_idx, axis)``, or ``None`` if the node doesn't match.
+    """
+    result = _unwrap_axis_swapped_subtensor1(fgraph, reshape_node.inputs[0])
+    if result is None:
+        return None
+    source, idx, axis = result
+
+    shape_input = reshape_node.inputs[1]
+    if isinstance(shape_input, Constant):
+        entries = [int(v) for v in shape_input.data]
+    elif shape_input.owner is not None and isinstance(shape_input.owner.op, MakeVector):
+        entries = list(shape_input.owner.inputs)
+    else:
+        return None
+
+    n_trail = source.type.ndim - axis - 1
+    k = len(entries) - axis - n_trail
+    if k < 2:
+        return None
+
+    def passes_through(entry, dim):
+        if isinstance(entry, int):
+            return source.type.shape[dim] == entry
+        return _is_shape_of_x_at(entry, source, dim)
+
+    if not all(passes_through(entries[d], d) for d in range(axis)):
+        return None
+    if not all(
+        passes_through(entries[axis + k + t], axis + 1 + t) for t in range(n_trail)
+    ):
+        return None
+
+    nd_idx = idx.reshape(entries[axis : axis + k])
+    return source, nd_idx, axis
+
+
 @node_rewriter([OpPattern(DimShuffle, is_transpose=True)])
 def undo_take_dimshuffle_for_fusion(fgraph, node):
     """Undo ``DimShuffle(AdvancedSubtensor1(DimShuffle(x), idx))`` -> ``AdvancedSubtensor(x, :, ..., idx, :, ...)``.
@@ -106,7 +154,7 @@ def undo_take_dimshuffle_for_fusion(fgraph, node):
     on the correct axis.
 
     See also ``undo_take_reshape_for_fusion`` which handles the analogous
-    Reshape+flatten pattern for ND indices.
+    Reshape pattern for ND indices.
     """
     # Outer DimShuffle must be consumed only by a single Elemwise
     clients = fgraph.clients[node.outputs[0]]
@@ -130,12 +178,14 @@ def undo_take_dimshuffle_for_fusion(fgraph, node):
 
 @node_rewriter([Reshape])
 def undo_take_reshape_for_fusion(fgraph, node):
-    """Undo ``Reshape(AdvancedSubtensor1(x, flatten(idx)), shape)`` for ND indices.
+    """Rewrite ``Reshape(AdvancedSubtensor1(x, idx), S)`` into an ND take.
 
-    ``transform_take`` rewrites ``x[mat_idx]`` (ND integer index) into
-    ``AdvancedSubtensor1(x, mat_idx.ravel()).reshape(mat_idx.shape + ...)``,
-    possibly with DimShuffle axis-swaps for non-zero axes.  This rewrite
-    undoes that so ``FuseIndexedElemwise`` can absorb the ND index directly.
+    Turns a take whose result is reshaped only along the taken axis into a
+    single ``AdvancedSubtensor`` with an ND index, so ``FuseIndexedElemwise``
+    can absorb the indexing directly.  Covers the ``transform_take`` normal
+    form for ND indices (``x[mat_idx]`` becomes ``x[mat_idx.ravel()].reshape(
+    mat_idx.shape + ...)``) but also any equivalent regrouping; see
+    ``_unwrap_reshaped_take`` for the exact conditions.
     """
     [reshape_out] = node.outputs
 
@@ -147,25 +197,16 @@ def undo_take_reshape_for_fusion(fgraph, node):
     if not isinstance(client_node.op, Elemwise):
         return None
 
-    result = _unwrap_axis_swapped_subtensor1(fgraph, node.inputs[0])
+    result = _unwrap_reshaped_take(fgraph, node)
     if result is None:
         return None
-    source, flat_idx, axis = result
+    source, nd_idx, axis = result
 
-    # The index input to AdvancedSubtensor1 must be Reshape{1}(mat_idx, [-1]) (flatten)
-    if flat_idx.owner is None or not isinstance(flat_idx.owner.op, Reshape):
-        return None
-    if flat_idx.owner.op.ndim != 1:
-        return None
-    mat_idx = flat_idx.owner.inputs[0]
-    if mat_idx.ndim < 2:
-        return None
-
-    # Build AdvancedSubtensor: source[:, ..., mat_idx, :, ...]
+    # Build AdvancedSubtensor: source[:, ..., nd_idx, :, ...]
     src_ndim = source.type.ndim
     idx_list = [slice(None)] * src_ndim
     idx_list[axis] = 0  # pointer to the single index variable
-    new_out = AdvancedSubtensor(idx_list=idx_list)(source, mat_idx)
+    new_out = AdvancedSubtensor(idx_list=idx_list)(source, nd_idx)
     return [new_out]
 
 

--- a/pytensor/tensor/rewriting/optimize.py
+++ b/pytensor/tensor/rewriting/optimize.py
@@ -23,7 +23,7 @@ from pytensor.tensor.rewriting.basic import register_canonicalize
 def c_rewrite_optimize_inner_graph(linker, op, node, inner, *, mode):
     # Same contract as ``OpFromGraph``: inputs (the optimization variable + args)
     # must not be mutated, so they are protected; inplace may still be baked
-    # between purely internal buffers. ``build_fn`` then only links this graph.
+    # between purely internal buffers. ``compile_fn`` then only links this graph.
     # The Supervisor is needed even with no mutable inputs: it is the feature that
     # vetoes input-destroying inplace rewrites while ``mode.optimizer`` runs them.
     input_specs = [In(x, borrow=True, mutable=False) for x in inner.inputs]
@@ -38,7 +38,7 @@ def c_rewrite_optimize_inner_graph(linker, op, node, inner, *, mode):
 def jit_rewrite_optimize_inner_graph(linker, op, node, inner, *, mode):
     # JIT backends manage memory themselves, so leave the inner graph functional.
     # (Unlike ``OpFromGraph`` under numba, no deepcopies are baked in either: a
-    # scipy op is never funcified -- it always perform-links via ``build_fn``,
+    # scipy op is never funcified -- it always perform-links via ``compile_fn``,
     # whose ``FunctionMaker`` pass inserts the boundary deepcopies.)
     mode.excluding("inplace").optimizer.rewrite(inner)
 

--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -1105,6 +1105,9 @@ def local_set_to_inc_subtensor(fgraph, node):
     AdvancedIncSubtensor1(x, x[ilist]+other, ilist, set_instead_of_inc=True) ->
     AdvancedIncSubtensor1(x, other, ilist, set_instead_of_inc=False)
 
+    Only valid when ``ilist`` is duplicate-free: a dense set is last-wins while an
+    inc accumulates, so duplicate indices would over-count.
+
     TODO FIXME: Why doesn't this apply to all `*IncSubtensor*` `Op`\s?  If it
     did this wouldn't need to also be included in the "specialize" pass.
 
@@ -1132,6 +1135,11 @@ def local_set_to_inc_subtensor(fgraph, node):
         return
     if subn.inputs[1] != node.inputs[2] or subn.inputs[0] != node.inputs[0]:
         return
+    # set->inc is only valid when ilist is duplicate-free: ``set(x[ilist] + other)``
+    # is last-wins at repeated positions, while ``inc(other)`` would accumulate the
+    # contributions of every occurrence and over-count them.
+    if not _has_unique_indices(fgraph, node.inputs[2]):
+        return
     ret = advanced_inc_subtensor1(node.inputs[0], other, node.inputs[2])
 
     copy_stack_trace(node.outputs, ret)
@@ -1150,8 +1158,11 @@ def local_add_of_sparse_write(fgraph, node):
     Adding it to another tensor is equivalent to incrementing in place, which
     avoids materialising the dense sparse representation.
 
-    Also handles ``zeros[idx].inc(v)`` when ``idx`` is duplicate-free, since
-    with unique indices inc is semantically equivalent to set.
+    The ``zeros[idx].inc(v)`` form is rewritten unconditionally: inc applies the
+    same per-position delta whether the base is zeros (then added to ``x``) or
+    ``x`` itself, so duplicate indices accumulate identically on both sides. Only
+    the ``zeros[idx].set(v)`` form needs duplicate-free indices, since a dense set
+    is last-wins and collapsing it to an inc would over-count repeats.
     """
     for i, sparse_candidate in enumerate(node.inputs):
         if not (
@@ -1174,11 +1185,21 @@ def local_add_of_sparse_write(fgraph, node):
         ):
             continue
 
-        # An inc into zeros is only equivalent to a set when indices are
-        # duplicate-free. Basic (slice/scalar) indexing is always unique;
-        # advanced integer-array indices must be checked.
-        if not inner_op.set_instead_of_inc and not isinstance(inner_op, IncSubtensor):
-            if not all(_has_unique_indices(fgraph, idx) for idx in idx_vars):
+        # Only the set->inc conversion needs duplicate-free indices. An inc into
+        # zeros and the resulting inc into ``other`` apply the same per-position
+        # delta (accumulating any duplicates identically), so ``x + zeros[idx].inc(v)
+        # -> x[idx].inc(v)`` holds for any indices. A dense set, by contrast, is
+        # last-wins, so collapsing it to an inc would over-count repeated
+        # positions. Basic (slice/scalar) IncSubtensor is always unique; advanced
+        # integer-array set indices must be checked, weighing only the advanced
+        # indices and not the flattened slice bounds.
+        if inner_op.set_instead_of_inc and not isinstance(inner_op, IncSubtensor):
+            adv_idxs = [
+                idx
+                for idx in indices_from_subtensor(idx_vars, inner_op.idx_list)
+                if isinstance(idx, TensorVariable) and idx.type.ndim > 0
+            ]
+            if not all(_has_unique_indices(fgraph, idx) for idx in adv_idxs):
                 continue
 
         others = [node.inputs[j] for j in range(len(node.inputs)) if j != i]
@@ -1191,7 +1212,7 @@ def local_add_of_sparse_write(fgraph, node):
         else:
             new_op = inner_op
         r = new_op(other, v, *idx_vars)
-        copy_stack_trace(node.outputs[0], r)
+        copy_stack_trace([node.outputs[0], sparse_candidate], r)
         return [r]
 
     return None
@@ -2370,9 +2391,15 @@ def local_write_of_write_same_indices(fgraph, node):
         # Basic indexing (slices/scalars) is always duplicate-free.
         # For advanced indexing, per-axis uniqueness is conservative but
         # sufficient: it guarantees no duplicates in the joint cross-product
-        # after broadcasting.
+        # after broadcasting. Weigh only the advanced indices, not the flattened
+        # slice bounds.
         if not isinstance(node.op, IncSubtensor):
-            if not all(_has_unique_indices(fgraph, v) for v in outer_idx_vars):
+            adv_idxs = [
+                idx
+                for idx in indices_from_subtensor(outer_idx_vars, node.op.idx_list)
+                if isinstance(idx, TensorVariable) and idx.type.ndim > 0
+            ]
+            if not all(_has_unique_indices(fgraph, idx) for idx in adv_idxs):
                 return
         new_val = a + b
         if (

--- a/tests/compile/test_builders.py
+++ b/tests/compile/test_builders.py
@@ -21,11 +21,15 @@ from pytensor.graph.fg import FunctionGraph
 from pytensor.graph.rewriting.basic import MergeOptimizer
 from pytensor.graph.rewriting.utils import rewrite_graph
 from pytensor.graph.utils import MissingInputError
+from pytensor.link.vm import VMLinker
 from pytensor.printing import debugprint
+from pytensor.scan.basic import scan
 from pytensor.tensor.basic import constant
 from pytensor.tensor.math import dot, exp, sigmoid
 from pytensor.tensor.math import round as pt_round
 from pytensor.tensor.math import sum as pt_sum
+from pytensor.tensor.random.basic import normal
+from pytensor.tensor.random.type import random_generator_type
 from pytensor.tensor.rewriting.shape import ShapeOptimizer
 from pytensor.tensor.shape import specify_shape
 from pytensor.tensor.type import (
@@ -795,3 +799,45 @@ OpFromGraph{inline=False} [id A]
 
     for truth, out in zip(exp_res.split("\n"), lines, strict=True):
         assert truth.strip() == out.strip()
+
+
+@config.change_flags(mode="NUMBA")
+def test_inner_fn_never_uses_jit_default_mode():
+    # The lazily-linked inner fn stays in the py/c backend family regardless of
+    # the config default mode (NUMBA here): ``perform`` only ever runs under that
+    # family -- JIT backends funcify ``op.fgraph`` directly -- and the inner graph
+    # was baked for py/c, not for the JIT backend.
+    x = vector("x")
+
+    # Direct access links with the python VM (no C compilation)
+    op = OpFromGraph([x], [x + 1])
+    linker = op.fn.maker.mode.linker
+    assert isinstance(linker, VMLinker) and not linker.use_cloop
+
+    # Executed through an outer (cvm) function, the perform path still links a VM
+    fn = function([x], op(x), mode=Mode(linker="cvm", optimizer=None))
+    [node] = [n for n in fn.maker.fgraph.apply_nodes if isinstance(n.op, OpFromGraph)]
+    np.testing.assert_allclose(fn([1.0, 2.0]), [2.0, 3.0])
+    assert isinstance(node.op.fn.maker.mode.linker, VMLinker)
+
+    # The impl -> linker rule: an explicit C request uses cvm, everything else vm
+    assert op.link_mode("c").linker.use_cloop
+    assert not op.link_mode("py").linker.use_cloop
+    assert not op.link_mode(None).linker.use_cloop
+
+
+@config.change_flags(mode="NUMBA")
+def test_perform_with_inner_scan_rvs():
+    # A Scan inside the inner graph carries raw RandomVariables that only the
+    # JIT inner-graph rewrites could handle; ``perform``-based execution must
+    # therefore not compile the inner fn for a JIT default mode.
+    rng = random_generator_type("rng")
+    xs, _ = scan(
+        fn=lambda rng: normal(rng=rng, return_next_rng=True)[1],
+        non_sequences=[rng],
+        n_steps=2,
+    )
+    op = OpFromGraph([rng], [xs])
+    out = op(shared(np.random.default_rng(0)))
+    fn = function([], out, mode=Mode(linker="py", optimizer=None))
+    assert fn().shape == (2,)

--- a/tests/link/numba/test_elemwise.py
+++ b/tests/link/numba/test_elemwise.py
@@ -10,7 +10,7 @@ from pytensor import config, function
 from pytensor.compile import get_mode
 from pytensor.compile.ops import deep_copy_op
 from pytensor.gradient import grad
-from pytensor.scalar import Composite, float64
+from pytensor.scalar import Composite, and_, float64, or_, xor
 from pytensor.scalar import add as scalar_add
 from pytensor.tensor import blas, matrix, tensor3
 from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
@@ -381,6 +381,18 @@ def test_CAReduce_acc_complex_out_float(axis):
     x = matrix("x", dtype="complex128")
     out = x.sum(dtype="float64", axis=axis)
     test_x = np.array([[1 + 0.5j, 2 - 0.5j], [3 + 0.5j, 4 - 0.5j]], dtype="complex128")
+    compare_numba_and_py([x], [out], [test_x])
+
+
+@pytest.mark.parametrize("dtype", ("uint8", "uint32", "int16"))
+@pytest.mark.parametrize("scalar_op", (and_, or_, xor), ids=("and", "or", "xor"))
+def test_CAReduce_bitwise(scalar_op, dtype):
+    # Bitwise AND has identity -1, which must wrap into an unsigned acc_dtype
+    # instead of raising when coerced (regression: np.uint64(-1) overflowed).
+    x = pt.vector("x", dtype=dtype)
+    out = CAReduce(scalar_op, axis=None)(x)
+    hi = min(int(np.iinfo(dtype).max), 2**16)
+    test_x = np.random.default_rng(1).integers(0, hi, size=9).astype(dtype)
     compare_numba_and_py([x], [out], [test_x])
 
 

--- a/tests/link/numba/test_elemwise.py
+++ b/tests/link/numba/test_elemwise.py
@@ -552,6 +552,15 @@ def test_Argmax(x, axes, exc):
         )
 
 
+@pytest.mark.parametrize("reduce_fn", [ptm.max, ptm.min], ids=["max", "min"])
+@pytest.mark.parametrize("axis", [None, 0], ids=str)
+def test_max_min_nan_propagation(reduce_fn, axis):
+    x = pt.matrix("x", dtype="float64")
+    x_test_value = rng.random(size=(3, 2))
+    x_test_value[1, 1] = np.nan
+    compare_numba_and_py([x], [reduce_fn(x, axis=axis)], [x_test_value])
+
+
 def test_elemwise_inplace_out_type():
     # Create a graph with an elemwise
     # Ravel failes if the elemwise output type is reported incorrectly

--- a/tests/link/numba/test_indexed_elemwise.py
+++ b/tests/link/numba/test_indexed_elemwise.py
@@ -5,6 +5,7 @@ import pytest
 
 import pytensor.tensor as pt
 from pytensor import Mode, function, get_mode
+from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.rewriting.indexed_elemwise import IndexedElemwise
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor1,
@@ -359,6 +360,71 @@ class TestIndexedWriteFusion:
         np.testing.assert_allclose(
             fn(xv, yv, tv.copy()), fn_u(xv, yv, tv.copy()), rtol=1e-10
         )
+
+    def test_write_of_inplace_elemwise(self):
+        """Inplace must not survive on a write-target output.
+
+        The loop writes the elementwise result to the write buffer, never to the
+        inplaced input, so a surviving inner inplace entry would destroy the dot
+        intermediate undeclared in the Python-mode fallback.
+        """
+        rng = np.random.default_rng(9)
+        idx = rng.integers(8, size=30).astype(np.int64)
+        x = pt.matrix("x", shape=(30, 4))
+        y = pt.matrix("y", shape=(4, 4))
+        z = pt.matrix("z", shape=(30, 4))
+        t = pt.matrix("t", shape=(8, 4))
+        out = t[idx].inc((x @ y) * z)
+        fn, fn_u = fused_and_unfused([x, y, z, t], out)
+        assert_fused(fn)
+        [node] = [
+            n for n in fn.maker.fgraph.toposort() if isinstance(n.op, IndexedElemwise)
+        ]
+        assert not any(
+            n.op.inplace_pattern
+            for n in node.op.fgraph.toposort()
+            if isinstance(n.op, Elemwise)
+        )
+        xv, yv, zv, tv = (
+            rng.normal(size=(30, 4)),
+            rng.normal(size=(4, 4)),
+            rng.normal(size=(30, 4)),
+            rng.normal(size=(8, 4)),
+        )
+        np.testing.assert_allclose(
+            fn(xv, yv, zv, tv.copy()), fn_u(xv, yv, zv, tv.copy()), rtol=1e-10
+        )
+
+    def test_write_with_direct_use_keeps_inplace(self):
+        """Inplace survives on an output that is both written and used directly.
+
+        The write-and-direct duplication keeps the original output materialized
+        (the write consumes a duplicate), so the inplace claimed on the dot
+        intermediate stays valid and must not be stripped.
+        """
+        rng = np.random.default_rng(10)
+        idx = rng.integers(8, size=30).astype(np.int64)
+        x = pt.matrix("x", shape=(30, 4))
+        y = pt.matrix("y", shape=(4, 4))
+        z = pt.matrix("z", shape=(30, 4))
+        t = pt.matrix("t", shape=(8, 4))
+        w = (x @ y) * z
+        fn, fn_u = fused_and_unfused([x, y, z, t], [t[idx].inc(w), w])
+        assert_fused(fn)
+        [node] = [
+            n for n in fn.maker.fgraph.toposort() if isinstance(n.op, IndexedElemwise)
+        ]
+        # Two destroy entries: the write buffer, and the dot intermediate kept
+        # inplace by the materialized output
+        assert len(node.op.destroy_map) == 2
+        xv, yv, zv, tv = (
+            rng.normal(size=(30, 4)),
+            rng.normal(size=(4, 4)),
+            rng.normal(size=(30, 4)),
+            rng.normal(size=(8, 4)),
+        )
+        for res, res_u in zip(fn(xv, yv, zv, tv.copy()), fn_u(xv, yv, zv, tv.copy())):
+            np.testing.assert_allclose(res, res_u, rtol=1e-10)
 
     def test_set_subtensor(self):
         rng = np.random.default_rng(42)

--- a/tests/link/numba/test_indexed_elemwise.py
+++ b/tests/link/numba/test_indexed_elemwise.py
@@ -603,6 +603,45 @@ class TestShapeValidation:
         with pytest.raises(Exception):
             fn(np.zeros(100), np.zeros(1, dtype=np.int64), np.zeros(5))
 
+    def test_no_fusion_with_bounded_basic_slice_read(self):
+        """Regression: a bounded basic slice on a non-indexed axis can't be
+        carried by the fused loop, which substitutes the full source array and
+        iterates non-indexed axes wholesale. Fusing ``x[1:4, idx]`` dropped the
+        ``1:4`` offset and iterated x's full axis 0 against y's, raising at
+        runtime. The slice must block fusion and results stay correct."""
+        rng = np.random.default_rng(2202)
+        x = pt.matrix("x", shape=(6, 6))
+        y = pt.matrix("y", shape=(3, 3))
+        idx = pt.constant(np.array([0, 2, 4]))
+
+        out = x[1:4, idx] + y
+        fn = function([x, y], out, mode=NUMBA_MODE, trust_input=True)
+        assert not any(
+            isinstance(n.op, IndexedElemwise) for n in fn.maker.fgraph.toposort()
+        )
+
+        ref = function([x, y], out, mode=NUMBA_NO_FUSION, trust_input=True)
+        xv, yv = rng.normal(size=(6, 6)), rng.normal(size=(3, 3))
+        np.testing.assert_allclose(fn(xv, yv), ref(xv, yv), rtol=1e-10)
+
+    def test_no_fusion_with_bounded_basic_slice_write(self):
+        """As above for an indexed write: a bounded basic slice on the write
+        target's non-indexed axis must block fusion."""
+        rng = np.random.default_rng(2203)
+        t = pt.matrix("t", shape=(6, 6))
+        y = pt.matrix("y", shape=(3, 3))
+        idx = pt.constant(np.array([0, 2, 4]))
+
+        out = t[1:4, idx].set(pt.exp(y))
+        fn = function([t, y], out, mode=NUMBA_MODE, trust_input=True)
+        assert not any(
+            isinstance(n.op, IndexedElemwise) for n in fn.maker.fgraph.toposort()
+        )
+
+        ref = function([t, y], out, mode=NUMBA_NO_FUSION, trust_input=True)
+        tv, yv = rng.normal(size=(6, 6)), rng.normal(size=(3, 3))
+        np.testing.assert_allclose(fn(tv.copy(), yv), ref(tv.copy(), yv), rtol=1e-10)
+
     def test_loop_shape_regression(self):
         """
         Regression test for https://github.com/pymc-devs/pytensor/issues/2201

--- a/tests/link/numba/test_indexed_elemwise.py
+++ b/tests/link/numba/test_indexed_elemwise.py
@@ -122,6 +122,28 @@ class TestIndexedReadFusion:
         iv = rng.integers(100, size=(10, 5)).astype(np.int64)
         np.testing.assert_allclose(fn(xv, iv), fn_u(xv, iv), rtol=1e-10)
 
+    def test_regrouped_gather(self):
+        """Gather over a (3, 4) index, regrouped to runtime shape (s0, s1).
+
+        A detection that assumed the reshape restores the index shape would
+        rewrite this to x[mat] — shape (3, 4, 5) instead of the requested
+        (2, 6, 5). _unwrap_reshaped_take builds the (s0, s1) index from the
+        reshape target instead, so the regrouping fuses and stays correct.
+        """
+        rng = np.random.default_rng(15)
+        x = pt.matrix("x", shape=(8, 5))
+        mat = pt.matrix("mat", dtype="int64", shape=(3, 4))
+        s0, s1 = pt.lscalar("s0"), pt.lscalar("s1")
+        out = pt.exp(x[mat.reshape((-1,))].reshape((s0, s1, x.shape[1])))
+        fn, fn_u = fused_and_unfused([x, mat, s0, s1], out)
+        assert_fused(fn)
+        xv = rng.normal(size=(8, 5))
+        mv = rng.integers(0, 8, size=(3, 4))
+        res = fn(xv, mv, np.int64(2), np.int64(6))
+        res_u = fn_u(xv, mv, np.int64(2), np.int64(6))
+        assert res.shape == res_u.shape == (2, 6, 5)
+        np.testing.assert_allclose(res, res_u, rtol=1e-10)
+
     def test_nd_index_broadcast(self):
         """Broadcastable 2D index (shape (1, C)) broadcasts against direct input."""
         rng = np.random.default_rng(42)

--- a/tests/link/numba/test_random.py
+++ b/tests/link/numba/test_random.py
@@ -743,6 +743,28 @@ def test_repeated_args():
     assert final_node.inputs[-2] is final_node.inputs[-1]
 
 
+def test_core_shape_from_random_input():
+    """A RV whose core shape reads the shape of another RV feeding it.
+
+    ``introduce_explicit_core_shape_rv`` must still wrap such a RV: the RV in the
+    core-shape graph (here the random ``mean``, whose runtime-only trailing dim is
+    the core shape) is computed before the node anyway, so reading its shape needs
+    no extra draw. Regression test for the previously over-conservative bail.
+    """
+    rng = shared(np.random.default_rng(123))
+    n = pt.scalar("n", dtype=int)
+    # Random mean whose trailing (core) dim is only known at runtime
+    mean = ptr.normal(size=(2, n), rng=rng)
+    x = ptr.multivariate_normal(mean=mean, cov=pt.eye(n), rng=rng)
+
+    fn = function([n], x, mode="NUMBA")
+    # Both RVs are wrapped -- no raw RandomVariable survives to funcify
+    assert not any(
+        isinstance(node.op, ptr.RandomVariable) for node in fn.maker.fgraph.apply_nodes
+    )
+    assert fn(3).shape == (2, 3)
+
+
 def test_rv_fallback():
     """Test that random variables can fallback to object mode."""
 

--- a/tests/tensor/rewriting/test_subtensor.py
+++ b/tests/tensor/rewriting/test_subtensor.py
@@ -218,8 +218,10 @@ def test_local_add_of_sparse_write():
     """``x + set(zeros, v, idx) -> inc(x, v, idx)``: avoid materialising
     the dense sparse representation when adding a sparse set into a base.
 
-    Also covers ``x + inc(zeros, v, idx)`` when ``idx`` is duplicate-free,
-    since then inc-into-zeros is equivalent to set-into-zeros.
+    The set form needs duplicate-free ``idx`` (a dense set is last-wins). The
+    inc form ``x + inc(zeros, v, idx)`` is rewritten unconditionally: inc applies
+    the same per-position delta on both sides, so duplicates accumulate
+    identically.
     """
     sparse_rewriter = in2out(local_add_of_sparse_write, name="add_of_sparse_write")
 
@@ -227,18 +229,30 @@ def test_local_add_of_sparse_write():
     v = vector("v")
     idx = ivector("idx")
 
-    # set-into-zeros is always rewritten.
-    out = x + pt.zeros(x.shape)[idx].set(v)
-    expected = x[idx].inc(v)
-    rewritten = rewrite_graph(out)
-    utt.assert_equal_computations([rewritten], [expected], strict_dtype=False)
+    # set-into-zeros with a provably unique index is rewritten: a dense set into
+    # zeros equals a sparse inc only when each position is written exactly once.
+    cst = np.array([1, 3])
+    out = x + pt.zeros(x.shape)[cst].set(v)
+    rewritten = rewrite_graph(out, include=[], custom_rewrite=sparse_rewriter)
+    utt.assert_equal_computations([rewritten], [x[cst].inc(v)], strict_dtype=False)
 
-    f = function([x, v, idx], out)
-    f_ref = function([x, v, idx], out, mode=Mode(linker="py", optimizer=None))
+    f = function([x, v], out)
+    f_ref = function([x, v], out, mode=Mode(linker="py", optimizer=None))
     dx = np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=config.floatX)
     dv = np.array([10.0, 20.0], dtype=config.floatX)
-    didx = np.array([1, 3], dtype="int32")
-    np.testing.assert_allclose(f(dx, dv, didx), f_ref(dx, dv, didx))
+    np.testing.assert_allclose(f(dx, dv), f_ref(dx, dv))
+
+    # set-into-zeros with a possibly-duplicated index is left alone: a dense set
+    # is last-wins, while a sparse inc would accumulate at repeated positions.
+    # ``assert_eval`` with a duplicated index pins the soundness independently of
+    # the graph check: a wrongly-collapsed inc would accumulate at the repeated
+    # position (index 1 -> 2 + 10 + 20 instead of 2 + 20).
+    out_set_unsafe = x + pt.zeros(x.shape)[idx].set(v)
+    result = utt.RewriteTester(
+        [x, v, idx], [out_set_unsafe], include=[], custom_rewrite=sparse_rewriter
+    )
+    result.assert_graph(out_set_unsafe)
+    result.assert_eval(dx, dv, np.array([1, 1], dtype="int32"))
 
     # inc-into-zeros with unique constant indices is rewritten.
     out_inc = x + pt.zeros(x.shape)[np.array([1, 3])].inc(v)
@@ -248,13 +262,16 @@ def test_local_add_of_sparse_write():
     )
 
     # inc-into-zeros with a non-constant (potentially duplicated) index is
-    # left alone.  Run the rewrite in isolation so other simplifications
-    # don't obscure what happens.
-    out_unsafe = x + pt.zeros(x.shape)[idx].inc(v)
-    rewritten_unsafe = rewrite_graph(
-        out_unsafe, include=[], custom_rewrite=sparse_rewriter
+    # rewritten unconditionally: inc accumulates the same per-position delta
+    # whether the base is zeros (then added to x) or x itself. ``assert_eval``
+    # with a duplicated index pins the soundness: index 1 -> 2 + 10 + 20 on both
+    # the original and the rewritten graph.
+    out_dup = x + pt.zeros(x.shape)[idx].inc(v)
+    result_dup = utt.RewriteTester(
+        [x, v, idx], [out_dup], include=[], custom_rewrite=sparse_rewriter
     )
-    utt.assert_equal_computations([rewritten_unsafe], [out_unsafe])
+    result_dup.assert_graph(x[idx].inc(v))
+    result_dup.assert_eval(dx, dv, np.array([1, 1], dtype="int32"))
 
     # Basic (scalar) inc-into-zeros is trivially unique and should be rewritten.
     s = iscalar("s")
@@ -264,6 +281,21 @@ def test_local_add_of_sparse_write():
     )
     utt.assert_equal_computations(
         [rewritten_basic], [x[s].inc(v[0])], strict_dtype=False
+    )
+
+    # A bounded slice flattens its (symbolic) bounds into the index variables;
+    # those must not be mistaken for advanced indices. With a leading slice and a
+    # unique advanced index the sparse write still collapses.
+    X = matrix("X")
+    w = matrix("w")
+    u = pt.constant(np.array([0, 2], dtype="int32"))
+    lo, hi = iscalar("lo"), iscalar("hi")
+    out_slice = X + pt.zeros(X.shape)[lo:hi, u].set(w)
+    rewritten_slice = rewrite_graph(
+        out_slice, include=[], custom_rewrite=sparse_rewriter
+    )
+    utt.assert_equal_computations(
+        [rewritten_slice], [X[lo:hi, u].inc(w)], strict_dtype=False
     )
 
 
@@ -1744,6 +1776,23 @@ class TestWriteOfWriteSameIndices:
         rewritten = rewrite_graph(out, include=("canonicalize", "specialize"))
         utt.assert_equal_computations([rewritten], [inc_subtensor(zeros[:stop], a + b)])
 
+    def test_inc_of_set_advanced_with_slice_rewritten(self):
+        """A bounded slice flattens its (symbolic) bounds into the index
+        variables; those must not be mistaken for advanced indices and block the
+        uniqueness check. With a leading slice and a unique advanced index the
+        inc-of-set still collapses to ``x[lo:hi, idx].set(a + b)``."""
+        x = tensor3("x", dtype="float64")
+        a = matrix("a", dtype="float64")
+        b = matrix("b", dtype="float64")
+        lo, hi = iscalar("lo"), iscalar("hi")
+        idx = pt.constant(np.array([0, 2], dtype="int32"))
+
+        out = inc_subtensor(set_subtensor(x[lo:hi, idx], a)[lo:hi, idx], b)
+        rewritten = rewrite_graph(out, include=("canonicalize", "specialize"))
+        utt.assert_equal_computations(
+            [rewritten], [set_subtensor(x[lo:hi, idx], a + b)]
+        )
+
     def test_inc_of_set_advanced_non_unique_not_rewritten(self):
         """Inc-of-set requires unique indices; duplicate constant indices
         on advanced axes block the rewrite."""
@@ -2068,6 +2117,52 @@ def test_local_set_to_inc_subtensor():
     # before and after optimization.
     assert check_stack_trace(f1, ops_to_check=AdvancedIncSubtensor1)
     assert check_stack_trace(f2, ops_to_check="all")
+
+
+def test_local_set_to_inc_subtensor_duplicate_indices():
+    """``set(x[idx] + other)`` collapses to ``inc(x, other, idx)`` only when
+    ``idx`` is duplicate-free: a dense set is last-wins while inc accumulates, so
+    with repeated indices the inc form over-counts. The rewrite must not fire on a
+    possibly-duplicated symbolic index, and a wrongly-collapsed inc would diverge
+    at the repeated position (index 1 -> 20 + 1 + 2 instead of 20 + 2)."""
+    v = vector("v")
+    other = vector("other")
+    idx = ivector("idx")
+
+    out = set_subtensor(v[idx], v[idx] + other)
+
+    mode = (
+        get_default_mode()
+        .including(
+            "local_replace_AdvancedSubtensor",
+            "local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1",
+        )
+        .excluding("fuse_indexed_into_elemwise")
+    )
+    f = function([v, other, idx], out, mode=mode)
+
+    # The symbolic index is not provably unique, so the set survives.
+    assert all(
+        n.op.set_instead_of_inc
+        for n in f.maker.fgraph.toposort()
+        if isinstance(n.op, AdvancedIncSubtensor1)
+    )
+
+    # Soundness pinned against a no-rewrite reference at a duplicated index.
+    dv = np.array([10.0, 20.0, 30.0], dtype=v.dtype)
+    dother = np.array([1.0, 2.0], dtype=v.dtype)
+    didx = np.array([1, 1], dtype="int32")
+    f_ref = function([v, other, idx], out, mode=Mode(linker="py", optimizer=None))
+    np.testing.assert_allclose(f(dv, dother, didx), f_ref(dv, dother, didx))
+
+    # A constant duplicated index is also left alone.
+    out_const = set_subtensor(v[[1, 1]], v[[1, 1]] + other)
+    f_const = function([v, other], out_const, mode=mode)
+    assert all(
+        n.op.set_instead_of_inc
+        for n in f_const.maker.fgraph.toposort()
+        if isinstance(n.op, AdvancedIncSubtensor1)
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/tensor/test_optimize.py
+++ b/tests/tensor/test_optimize.py
@@ -475,8 +475,11 @@ def test_optimize_grad_scalar_arg(optimize_op):
     obj = tensor_from_scalar((scalar_from_tensor(x) + theta_scalar) ** 2)
     x0, _ = optimize_op(obj, x)
 
-    # Confirm theta is a direct input to the node
-    assert x0.owner.inputs[1] is theta_scalar
+    # Confirm theta reaches the node. Scalar-typed parameters are wrapped as a
+    # tensor at the op boundary (so scipy, which deals in arrays, gets an
+    # ndarray), hence theta_scalar shows up under a tensor_from_scalar wrapper.
+    node_arg = x0.owner.inputs[1]
+    assert node_arg.owner is not None and node_arg.owner.inputs[0] is theta_scalar
 
     grad_wrt_theta = pt.grad(x0, theta)
     np.testing.assert_allclose(grad_wrt_theta.eval({x: np.pi, theta: np.e}), -1)


### PR DESCRIPTION
Also fixes a couple others that had been sitting on dev branches

- **Fix NaN propagation in Numba CAReduce max/min reductions**
- **Fix unsound x[idx].set -> x[idx].inc rewrites with non-uinque indices**
- **Don't fuse indexed reads/writes through a non-empty basic slice**
- **Strip Elemwise inplace from fused indexed-write outputs**
- **Soundly recognize reshaped takes when undoing transform_take**
- **Fix Numba CAReduce of bitwise AND over unsigned integers**
- **InnerGraph Ops: do not fallback to config mode linkers in python/cvm paths**
- **Don't bail numba core-shape rewrite on RVs that already feed the node**
