### PR TITLE
Fix typos in comments and docstrings

### DIFF
--- a/pytensor/compile/builders.py
+++ b/pytensor/compile/builders.py
@@ -610,7 +610,7 @@ class OpFromGraph(HasInnerFunction, Op):
                     f"Need to override {nin} gradients, got {len(custom_input_grads)}",
                     custom_input_grads,
                 )
-            # compute non-overriding downsteam grads from upstreams grads
+            # compute non-overriding downstream grads from upstreams grads
             # it's normal some input may be disconnected, thus the 'ignore'
             wrt = [
                 lin

--- a/pytensor/configdefaults.py
+++ b/pytensor/configdefaults.py
@@ -942,7 +942,7 @@ def add_optimizer_configvars():
         "are allowed, but it makes the compilation faster."
         "The interaction of which one give the lower peak memory usage is"
         "complicated and not predictable, so if you are close to the peak"
-        "memory usage, triyng both could give you a small gain.",
+        "memory usage, trying both could give you a small gain.",
         EnumStr("regular", ["fast"]),
         in_c_key=False,
     )

--- a/pytensor/graph/features.py
+++ b/pytensor/graph/features.py
@@ -657,7 +657,7 @@ class FullHistory(Feature):
                 check=False,
             )
 
-        # Remove history changes caused by the foward/backward!
+        # Remove history changes caused by the forward/backward!
         self.bw = self.bw[:history_len]
         self.fw = self.fw[:history_len]
         self.pointer = pointer

--- a/pytensor/graph/rewriting/basic.py
+++ b/pytensor/graph/rewriting/basic.py
@@ -2400,7 +2400,7 @@ class EquilibriumGraphRewriter(NodeProcessingGraphRewriter):
                     for node_rewriter in self.node_tracker.get_trackers(node.op):
                         nb = change_tracker.nb_imported
                         t_rewrite = time.perf_counter()
-                        # Tracks are already enfoced by `self.node_tracker.get_trackers`
+                        # Tracks are already enforced by `self.node_tracker.get_trackers`
                         node_rewriter_change = self.process_node(
                             fgraph, node, node_rewriter, enforce_tracks=False
                         )

--- a/pytensor/graph/utils.py
+++ b/pytensor/graph/utils.py
@@ -119,7 +119,7 @@ def add_tag_trace[T: "Apply" | "Variable"](thing: T, user_line: int | None = Non
         skips = []
 
     tr = simple_extract_stack(limit=user_line, skips=skips)
-    # Different python version use different sementic for
+    # Different python version use different semantic for
     # limit. python 2.7 include the call to extrack_stack. The -1 get
     # rid of it.
 

--- a/pytensor/link/c/basic.py
+++ b/pytensor/link/c/basic.py
@@ -1490,7 +1490,7 @@ class CLinker(Linker):
             if not len(fgraph.clients[var])
         )
 
-        # crystalize the signature and version
+        # crystallize the signature and version
         sig = tuple(sig)
         version = tuple(version)
         for v in version:

--- a/pytensor/link/c/cmodule.py
+++ b/pytensor/link/c/cmodule.py
@@ -444,7 +444,7 @@ def get_module_hash(src_code: str, key) -> str:
         to_hash += list(map(str, key[0]))
     c_link_key = key[1]
     # Currently, in order to catch potential bugs early, we are very
-    # convervative about the structure of the key and raise an exception
+    # conservative about the structure of the key and raise an exception
     # if it does not match exactly what we expect. In the future we may
     # modify this behavior to be less strict and be able to accommodate
     # changes to the key in an automatic way.
@@ -1562,11 +1562,11 @@ class ModuleCache:
                             continue
                     age = time_now - last_access_time(path)
 
-                    # In normal case, the processus that created this
-                    # directory will delete it. However, if this processus
+                    # In normal case, the process that created this
+                    # directory will delete it. However, if this process
                     # crashes, it will not be cleaned up.
                     # As we don't know if this directory is still used,
-                    # we wait one week and suppose that the processus
+                    # we wait one week and suppose that the process
                     # crashed, and we take care of the clean-up.
                     if age > min_age:
                         to_del.append(os.path.join(self.dirname, filename))

--- a/pytensor/link/jax/linker.py
+++ b/pytensor/link/jax/linker.py
@@ -135,7 +135,7 @@ class JAXLinker(JITLinker):
         for n in self.fgraph.inputs:
             sinput = storage_map[n]
             if isinstance(sinput[0], Generator):
-                # Neet to convert Generator into JAX PRNGkey
+                # Need to convert Generator into JAX PRNGkey
                 sinput[0] = jax_typify(sinput[0])
             thunk_inputs.append(sinput)
 

--- a/pytensor/link/numba/dispatch/vectorize_codegen.py
+++ b/pytensor/link/numba/dispatch/vectorize_codegen.py
@@ -612,7 +612,7 @@ def make_loop_call(
             *safe,
         )
         if core_scalar and core_ndim == 0:
-            # Retrive scalar item at index
+            # Retrieve scalar item at index
             read_val = builder.load(read_ptr)
             # read_val.set_metadata("alias.scope", input_scope_set)
             # read_val.set_metadata("noalias", output_scope_set)

--- a/pytensor/scan/__init__.py
+++ b/pytensor/scan/__init__.py
@@ -33,7 +33,7 @@ functions: ``scan()``, ``map()``, ``reduce()``, ``foldl()``,
 
 """
 
-__docformat__ = "restructedtext en"
+__docformat__ = "restructuredtext en"
 __authors__ = (
     "Razvan Pascanu "
     "Frederic Bastien "

--- a/pytensor/scan/basic.py
+++ b/pytensor/scan/basic.py
@@ -524,7 +524,7 @@ def scan(
                     )
                 outs_info[i]["taps"] = [-1]
             elif outs_info[i].get("taps", None) is not None:
-                # Check that taps are valid (< 0 and all dfferent)
+                # Check that taps are valid (< 0 and all different)
                 taps = outs_info[i]["taps"]
                 if len(taps) > len(set(taps)):
                     raise ValueError(

--- a/pytensor/scan/rewriting/inner_graph.py
+++ b/pytensor/scan/rewriting/inner_graph.py
@@ -237,7 +237,7 @@ def numba_rewrite_scan_inner_graph(linker, op, node, inner, *, mode):
 
     Because the last untraced updates are returned as is, the inner function is not allowed to
     alias sequences, non_sequences, or other untraced inputs and outputs (violates the outer alias restriction).
-    Untraced updates are not allowed to alias traced reads (risks corruption by subsequent overwrittes),
+    Untraced updates are not allowed to alias traced reads (risks corruption by subsequent overwrites),
     but can alias traced updates, since the immediate copy to their buffer that follows, will break the alias.
 
     Because untraced inputs are immediately discarded (and protected from alias with other updates),

--- a/pytensor/scan/rewriting/trace.py
+++ b/pytensor/scan/rewriting/trace.py
@@ -597,7 +597,7 @@ def scan_reduce_trace_rewrite(
     buffers before grad() is called, the gradient will be silently wrong.
     TODO: Use a subclass that raises explicitly on `L_op`
 
-    Paramaters
+    Parameters
     ----------
     backend_supports_output_pre_allocation: bool
         When the backend supports output pre-allocation Scan must keep buffers

--- a/pytensor/xtensor/type.py
+++ b/pytensor/xtensor/type.py
@@ -429,7 +429,7 @@ class XTensorVariable(Variable[_XTensorTypeType, OptionalApplyType]):
 
     @property
     def broadcastable(self):
-        # The concept of broadcastable is not revelant for XTensorVariables, but part of the codebase may request it
+        # The concept of broadcastable is not relevant for XTensorVariables, but part of the codebase may request it
         return self.type.broadcastable
 
     # DataArray contents


### PR DESCRIPTION
Fix spelling mistakes found with codespell across several source files. No logic is changed.

- `pytensor/configdefaults.py`: `triyng` → `trying`
- `pytensor/graph/features.py`: `foward` → `forward`
- `pytensor/graph/utils.py`: `sementic` → `semantic`
- `pytensor/graph/rewriting/basic.py`: `enfoced` → `enforced`
- `pytensor/scan/__init__.py`: `restructedtext` → `restructuredtext`
- `pytensor/scan/basic.py`: `dfferent` → `different`
- `pytensor/scan/rewriting/trace.py`: `Paramaters` → `Parameters`
- `pytensor/scan/rewriting/inner_graph.py`: `overwrittes` → `overwrites`
- `pytensor/compile/builders.py`: `downsteam` → `downstream`
- `pytensor/link/c/cmodule.py`: `convervative` → `conservative`; `processus` → `process` (three occurrences — French/Latin form snuck into English comments)
- `pytensor/link/c/basic.py`: `crystalize` → `crystallize`
- `pytensor/link/jax/linker.py`: `Neet` → `Need`
- `pytensor/link/numba/dispatch/vectorize_codegen.py`: `Retrive` → `Retrieve`
- `pytensor/xtensor/type.py`: `revelant` → `relevant`