### PR TITLE
CI hardening: make workflows statically verifiable (zizmor)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Wait before adopting freshly-published releases to reduce exposure to
+    # compromised or yanked versions (zizmor: dependabot-cooldown).
+    cooldown:
+      default-days: 7
     labels:
       - "GitHub CI/CD"
       - "no releasenotes"

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches: [main]
 
+permissions: {}
+
 jobs:
   mypy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         shell: bash -leo pipefail {0}

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches: [main]
 
+# Cancel superseded in-progress runs for the same PR/branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -14,6 +14,7 @@ permissions: {}
 
 jobs:
   mypy:
+    name: mypy
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/numba-upper-bound.yml
+++ b/.github/workflows/numba-upper-bound.yml
@@ -10,6 +10,11 @@ on:
     - cron: "0 8 * * 1"
   workflow_dispatch:
 
+# Serialize runs; don't cancel an in-progress commit/PR creation midway.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/numba-upper-bound.yml
+++ b/.github/workflows/numba-upper-bound.yml
@@ -19,6 +19,7 @@ permissions: {}
 
 jobs:
   bump:
+    name: bump
     runs-on: ubuntu-latest
     permissions:
       contents: write  # push the auto-bump branch

--- a/.github/workflows/numba-upper-bound.yml
+++ b/.github/workflows/numba-upper-bound.yml
@@ -10,13 +10,14 @@ on:
     - cron: "0 8 * * 1"
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   bump:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3

--- a/.github/workflows/numba-upper-bound.yml
+++ b/.github/workflows/numba-upper-bound.yml
@@ -16,8 +16,8 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write  # push the auto-bump branch
+      pull-requests: write  # open the bump PR
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -25,7 +25,7 @@ jobs:
     name: Check for changes
     runs-on: ubuntu-latest
     outputs:
-      should_run: ${{ steps.set_should_run.outputs.should_run }}
+      should_run: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && steps.filter.outputs.any_changed == 'true') }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -41,20 +41,6 @@ jobs:
               - 'pytensor/_version.py'
               - 'pytensor/scan_perform.pyx'
               - 'pytensor/scan_perform_ext.py'
-      - name: Set should_run output
-        id: set_should_run
-        run: |
-          if [[ "${{ github.event_name == 'release' || 
-                github.ref == 'refs/heads/main' ||
-                (
-                  github.event_name == 'pull_request'
-                  && steps.filter.outputs.any_changed == 'true'
-                )
-              }}" == "true" ]]; then
-            echo "should_run=true" >> $GITHUB_OUTPUT
-          else
-            echo "should_run=false" >> $GITHUB_OUTPUT
-          fi
 
   # The job to build precompiled pypi wheels.
   make_sdist:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -64,9 +64,8 @@ jobs:
       needs.check_changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     permissions:
-      # write id-token and attestations are required to attest build provenance
-      id-token: write
-      attestations: write
+      id-token: write  # required to attest build provenance
+      attestations: write  # required to attest build provenance
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -114,9 +113,8 @@ jobs:
       needs.check_changes.outputs.should_run == 'true'
     runs-on: ${{ matrix.platform }}
     permissions:
-      # write id-token and attestations are required to attest build provenance
-      id-token: write
-      attestations: write
+      id-token: write  # required to attest build provenance
+      attestations: write  # required to attest build provenance
     strategy:
       matrix:
         platform:
@@ -152,9 +150,8 @@ jobs:
       needs.check_changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     permissions:
-      # write id-token and attestations are required to attest build provenance
-      id-token: write
-      attestations: write
+      id-token: write  # required to attest build provenance
+      attestations: write  # required to attest build provenance
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -225,8 +222,7 @@ jobs:
     # workflow by requiring signoff from a maintainer.
     environment: release
     permissions:
-      # write id-token is required for trusted publishing (OIDC)
-      id-token: write
+      id-token: write  # required for trusted publishing (OIDC)
     needs: [check_dist]
     runs-on: ubuntu-latest
     # Don't publish from forks

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -22,6 +22,7 @@ permissions: {}
 
 jobs:
   check_changes:
+    name: Check for changes
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.set_should_run.outputs.should_run }}

--- a/.github/workflows/slow-tests-issue.yml
+++ b/.github/workflows/slow-tests-issue.yml
@@ -19,6 +19,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y zsh
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/slow-tests-issue.yml
+++ b/.github/workflows/slow-tests-issue.yml
@@ -14,7 +14,7 @@ jobs:
   update-comment:
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      issues: write  # required to update the slow-tests tracking issue body
     steps:
       - name: Install ZSH
         run: sudo apt-get update && sudo apt-get install -y zsh

--- a/.github/workflows/slow-tests-issue.yml
+++ b/.github/workflows/slow-tests-issue.yml
@@ -8,12 +8,13 @@ on:
   schedule:
     - cron: "0 */6 * * *"
 
-permissions:
-  issues: write
+permissions: {}
 
 jobs:
   update-comment:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Install ZSH
         run: sudo apt-get update && sudo apt-get install -y zsh

--- a/.github/workflows/slow-tests-issue.yml
+++ b/.github/workflows/slow-tests-issue.yml
@@ -17,6 +17,7 @@ permissions: {}
 
 jobs:
   update-comment:
+    name: update-comment
     runs-on: ubuntu-latest
     permissions:
       issues: write  # required to update the slow-tests tracking issue body

--- a/.github/workflows/slow-tests-issue.yml
+++ b/.github/workflows/slow-tests-issue.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: "0 */6 * * *"
 
+# Serialize runs; don't cancel an in-progress issue update midway.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Deny all permissions by default; jobs opt into the minimum they need.
+permissions: {}
+
 jobs:
   changes:
     name: "Check for changes"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       changes: ${{ steps.changes.outputs.src }}
     steps:
@@ -53,6 +58,8 @@ jobs:
     name: Check code style
     needs: changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ needs.changes.outputs.changes == 'true' }}
     strategy:
       matrix:
@@ -72,6 +79,8 @@ jobs:
       - changes
       - style
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     if: ${{ needs.changes.outputs.changes == 'true' && needs.style.result == 'success' }}
     strategy:
       fail-fast: false
@@ -215,6 +224,8 @@ jobs:
       - changes
       - style
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ needs.changes.outputs.changes == 'true' && needs.style.result == 'success' }}
     strategy:
       fail-fast: false
@@ -259,6 +270,8 @@ jobs:
   upload-coverage:
     runs-on: ubuntu-latest
     name: "Upload coverage"
+    permissions:
+      contents: read
     needs: [changes, all-checks]
     if: ${{ needs.changes.outputs.changes == 'true' && needs.all-checks.result == 'success' }}
     steps:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,4 +1,5 @@
-# https://github.com/woodruffw/zizmor
+# GitHub Actions security analysis via zizmor.
+# Recommended workflow from https://docs.zizmor.sh/integrations/
 name: zizmor GHA analysis
 
 on:
@@ -7,30 +8,28 @@ on:
   pull_request:
     branches: ["**"]
 
+# Cancel superseded in-progress runs for the same PR/branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   zizmor:
-    name: zizmor latest via PyPI
+    name: Run zizmor 🌈
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
+      security-events: write  # upload SARIF results to code scanning
+      contents: read  # checkout the repository
+      actions: read  # read workflow definitions during online audits
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
-      - uses: hynek/setup-cached-uv@4300ec2180bc77d705e626a34e381b81a4772c51 # v2.5.0
-
+      # Runs zizmor (version: latest), online audits enabled via the workflow
+      # token, and uploads SARIF to code scanning by default.
       - name: Run zizmor 🌈
-        run: uvx zizmor --format sarif . > results.sarif
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
-        with:
-          # Path to SARIF file relative to the root of the repository
-          sarif_file: results.sarif
-          # Optional category for the results
-          # Used to differentiate multiple results for one commit
-          category: zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7


### PR DESCRIPTION
Clears all 10 open code-scanning (zizmor) alerts, plus the pedantic-persona findings so the workflows are fully statically verifiable.

**"Hardening" here means making the workflows pass zizmor cleanly — not substantially changing runtime behavior.** Every change is either a no-op at runtime or a like-for-like refactor:

- `persist-credentials: false` on the slow-tests checkout (that job uses `github.token`, not the persisted git credential).
- Dependabot cooldown (7 days).
- Explicit least-privilege permissions: top-level `permissions: {}` + per-job grants (replaces the implicit broad default; behavior unchanged for the token scopes actually used).
- Same-line permission explanation comments.
- Concurrency blocks (`cancel-in-progress: true` on mypy; `false` on the scheduled slow-tests / numba-bump jobs so they're never killed mid-run).
- Explicit job names (name == id, so no check-run names change → required checks unaffected).
- zizmor.yml switched to the official `zizmorcore/zizmor-action` (defaults preserve current behavior).
- pypi.yml: compute `should_run` directly in the job output instead of an `echo`-to-`$GITHUB_OUTPUT` step (also drops the shell block carrying the benign template-injection finding).

One commit per fix type. Both zizmor personas (default + pedantic) report zero findings; pypi.yml and zizmor.yml verified against online audits too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
