### PR TITLE
Stabilize special function in fast_compile

### DIFF
--- a/pytensor/compile/mode.py
+++ b/pytensor/compile/mode.py
@@ -242,7 +242,9 @@ optdb.register(
 )  # 'fast_run', 'fast_compile')
 
 # replace unstable subgraphs
-optdb.register("stabilize", EquilibriumDB(), "fast_run", position=1.5)
+# In fast_compile only the rewrites tagged "fast_compile" are included: those needed for the
+# scipy/numpy look-alike helpers to be stable. Naive forms get no such promise.
+optdb.register("stabilize", EquilibriumDB(), "fast_run", "fast_compile", position=1.5)
 
 optdb.register(
     "Print1.51",

--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -2693,7 +2693,7 @@ def local_log1p(fgraph, node):
         return [broadcast_like_elemwise(new_out, node, fgraph=fgraph, stack_trace=True)]
 
 
-@register_stabilize
+@register_stabilize("fast_compile")
 @register_specialize
 @node_rewriter([log])
 def local_log_add_exp(fgraph, node):
@@ -2724,7 +2724,7 @@ def local_log_add_exp(fgraph, node):
             return [ret]
 
 
-@register_stabilize
+@register_stabilize("fast_compile")
 @register_specialize
 @node_rewriter([log])
 def local_log_sum_exp(fgraph, node):

--- a/pytensor/tensor/rewriting/special.py
+++ b/pytensor/tensor/rewriting/special.py
@@ -66,7 +66,7 @@ def local_logsoftmax(fgraph, node):
     return [ret]
 
 
-@register_stabilize("symbolic_op_recognition")
+@register_stabilize("symbolic_op_recognition", "fast_compile")
 @node_rewriter([true_div])
 def local_softmax_stabilize(fgraph, node):
     """Detect exp(x) / sum(exp(x), keepdims=True) and replace with Softmax(x)."""

--- a/tests/tensor/rewriting/test_math.py
+++ b/tests/tensor/rewriting/test_math.py
@@ -5,6 +5,7 @@ from io import StringIO
 
 import numpy as np
 import pytest
+from scipy.special import logsumexp as scipy_logsumexp
 
 import pytensor
 import pytensor.scalar as ps
@@ -1173,12 +1174,9 @@ def test_log1p():
     assert [node.op for node in f.maker.fgraph.toposort()] == [log1p]
 
 
-def test_local_log_add_exp():
-    m = config.mode
-    if m == "FAST_COMPILE":
-        m = "FAST_RUN"
-    m = get_mode(m)
-    m = m.excluding("fusion")
+@pytest.mark.parametrize("mode", ["FAST_COMPILE", "FAST_RUN"])
+def test_local_log_add_exp(mode):
+    m = get_mode(mode).excluding("fusion")
     m = copy.copy(m)
     # No need to put them back as we have a new object
     m.check_isfinite = False
@@ -4079,13 +4077,12 @@ def test_local_expm1():
     )
 
 
-def compile_graph_log_sum_exp(x, axis, dimshuffle_op=None):
+def compile_graph_log_sum_exp(x, axis, dimshuffle_op=None, mode="FAST_RUN"):
     sum_exp = pt_sum(exp(x), axis=axis)
     if dimshuffle_op:
         sum_exp = dimshuffle_op(sum_exp)
     y = log(sum_exp)
-    MODE = get_default_mode().including("local_log_sum_exp")
-    return function([x], y, mode=MODE)
+    return function([x], y, mode=mode)
 
 
 def check_max_log_sum_exp(x, axis, dimshuffle_op=None):
@@ -4096,8 +4093,6 @@ def check_max_log_sum_exp(x, axis, dimshuffle_op=None):
         if hasattr(node.op, "scalar_op") and node.op.scalar_op == ps.basic.maximum:
             return
 
-        # In mode FAST_COMPILE, the rewrites don't replace the
-        # `Max` `Op`.
         if isinstance(node.op, Max):
             return
 
@@ -4144,21 +4139,26 @@ def test_local_log_sum_exp_near_one():
     assert np.allclose(naive_ret, rewritten_ret)
 
 
-def test_local_log_sum_exp_large():
-    """Test that the rewrite result is correct for extreme value 100."""
+@pytest.mark.parametrize("mode", ["FAST_COMPILE", "FAST_RUN"])
+@pytest.mark.parametrize(
+    "x_val", ([-800.0, 800.0], [-800.0, -805.0]), ids=["overflow", "underflow"]
+)
+def test_local_log_sum_exp_large(x_val, mode):
+    """Test that the rewrite result is correct for values the naive graph can't represent."""
     x = vector("x")
-    f = compile_graph_log_sum_exp(x, axis=0)
+    f = compile_graph_log_sum_exp(x, axis=0, mode=mode)
 
-    x_val = np.array([-100.0, 100.0]).astype(config.floatX)
+    x_val = np.array(x_val, dtype=config.floatX)
 
     rewritten_ret = f(x_val)
-    assert np.allclose(rewritten_ret, 100.0)
+    np.testing.assert_allclose(rewritten_ret, scipy_logsumexp(x_val), rtol=1e-5)
 
 
-def test_local_log_sum_exp_inf():
+@pytest.mark.parametrize("mode", ["FAST_COMPILE", "FAST_RUN"])
+def test_local_log_sum_exp_inf(mode):
     """Test that when max = +-inf, the rewritten output still works correctly."""
     x = vector("x")
-    f = compile_graph_log_sum_exp(x, axis=0)
+    f = compile_graph_log_sum_exp(x, axis=0, mode=mode)
 
     assert f([-np.inf, -np.inf]) == -np.inf
     assert f([np.inf, np.inf]) == np.inf

--- a/tests/tensor/test_special.py
+++ b/tests/tensor/test_special.py
@@ -160,6 +160,21 @@ def test_vectorize_softmax(op, constructor, core_axis, batch_axis):
     assert new_out.owner.op.axis == batch_axis
 
 
+@pytest.mark.parametrize("mode", ["FAST_COMPILE", "FAST_RUN"])
+@pytest.mark.parametrize(
+    "constructor, scipy_fn",
+    [(softmax, scipy_softmax), (log_softmax, scipy_log_softmax)],
+)
+def test_softmax_stability(constructor, scipy_fn, mode):
+    """The helpers must be stable in any mode, whatever graph they end up emitting."""
+    x = matrix("x")
+    x_val = np.array([[800.0, 805.0]], dtype=config.floatX)
+
+    f = function([x], constructor(x, axis=-1), mode=mode)
+
+    np.testing.assert_allclose(f(x_val), scipy_fn(x_val, axis=-1), rtol=1e-6)
+
+
 def test_poch():
     _z, _m = vectors("z", "m")
     actual_fn = function([_z, _m], poch(_z, _m))

--- a/tests/xtensor/test_math.py
+++ b/tests/xtensor/test_math.py
@@ -8,6 +8,7 @@ import inspect
 
 import numpy as np
 from scipy.special import logsumexp as scipy_logsumexp
+from scipy.special import softmax as scipy_softmax
 from xarray import DataArray
 
 import pytensor.scalar as ps
@@ -15,7 +16,7 @@ import pytensor.xtensor.math as pxm
 from pytensor import function
 from pytensor.scalar import ScalarOp
 from pytensor.xtensor.basic import rename
-from pytensor.xtensor.math import add, exp, logsumexp
+from pytensor.xtensor.math import add, exp, logsumexp, softmax
 from pytensor.xtensor.type import xtensor
 from tests.xtensor.util import (
     check_vectorization,
@@ -158,6 +159,7 @@ def test_cast():
         yc64.astype("float64")
 
 
+@pytest.mark.parametrize("mode", ["FAST_COMPILE", "FAST_RUN"])
 @pytest.mark.parametrize(
     ["shape", "dims", "axis"],
     [
@@ -166,17 +168,40 @@ def test_cast():
         ((3, 4), "b", 1),
     ],
 )
-def test_logsumexp(shape, dims, axis):
-    scipy_inp = np.zeros(shape)
-    scipy_out = scipy_logsumexp(scipy_inp, axis=axis)
+def test_logsumexp(shape, dims, axis, mode):
+    x = xtensor("x", dims=("a", "b"), shape=shape)
+    fn = function([x], logsumexp(x, dim=dims), mode=mode)
 
-    pytensor_inp = DataArray(scipy_inp, dims=("a", "b"))
-    f = function([], logsumexp(pytensor_inp, dim=dims))
-    pytensor_out = f()
+    # Offset the inputs so the naive log(sum(exp(x))) graph would overflow
+    x_test = xr_arange_like(x) + 800.0
 
-    np.testing.assert_array_almost_equal(
-        pytensor_out,
-        scipy_out,
+    np.testing.assert_allclose(
+        fn(x_test.values),
+        scipy_logsumexp(x_test.values, axis=axis),
+        rtol=1e-6,
+    )
+
+
+@pytest.mark.parametrize("mode", ["FAST_COMPILE", "FAST_RUN"])
+@pytest.mark.parametrize(
+    ["shape", "dims", "axis"],
+    [
+        ((3, 4), ("a", "b"), None),
+        ((3, 4), "a", 0),
+        ((3, 4), "b", 1),
+    ],
+)
+def test_softmax(shape, dims, axis, mode):
+    x = xtensor("x", dims=("a", "b"), shape=shape)
+    fn = function([x], softmax(x, dim=dims), mode=mode)
+
+    # Offset the inputs so the naive exp(x) / exp(x).sum() graph would overflow
+    x_test = xr_arange_like(x) + 800.0
+
+    np.testing.assert_allclose(
+        fn(x_test.values),
+        scipy_softmax(x_test.values, axis=axis),
+        rtol=1e-6,
     )
 
 


### PR DESCRIPTION
Closes #2288 

The compromise is: if the user writes code using helpers that resemble the stable scipy/numpy look-alike (e.g., pt.special.logsumexp), we make an effort to stabilize them in fast_compile (if the returned graph/op is not already the stable from, which it is for e.g., log1p).

We don't promise to stabilize the equivalent graphs written in naive form. If it happens to be stabilized today, because the naive form is the same those helpers return that's luck, not a promise.
