### PR TITLE
Remove AdvancedSubtensor1 and AdvancedIncSubtensor1 Ops

### DIFF
--- a/doc/library/sparse/index.rst
+++ b/doc/library/sparse/index.rst
@@ -292,5 +292,3 @@ List of Implemented Operations
 
 .. automodule:: pytensor.sparse.basic
     :members:
-
-.. autofunction:: pytensor.sparse.sparse_grad

--- a/pytensor/link/jax/dispatch/subtensor.py
+++ b/pytensor/link/jax/dispatch/subtensor.py
@@ -1,9 +1,7 @@
 from pytensor.link.jax.dispatch.basic import jax_funcify
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
-    AdvancedIncSubtensor1,
     AdvancedSubtensor,
-    AdvancedSubtensor1,
     IncSubtensor,
     Subtensor,
     indices_from_subtensor,
@@ -32,7 +30,6 @@ slice length.
 
 @jax_funcify.register(Subtensor)
 @jax_funcify.register(AdvancedSubtensor)
-@jax_funcify.register(AdvancedSubtensor1)
 def jax_funcify_Subtensor(op, node, **kwargs):
     def subtensor(x, *ilists):
         indices = indices_from_subtensor(ilists, op.idx_list)
@@ -46,7 +43,6 @@ def jax_funcify_Subtensor(op, node, **kwargs):
 
 @jax_funcify.register(IncSubtensor)
 @jax_funcify.register(AdvancedIncSubtensor)
-@jax_funcify.register(AdvancedIncSubtensor1)
 def jax_funcify_IncSubtensor(op, node, **kwargs):
     if getattr(op, "set_instead_of_inc", False):
 
@@ -63,7 +59,7 @@ def jax_funcify_IncSubtensor(op, node, **kwargs):
         if len(indices) == 1:
             indices = indices[0]
 
-        if isinstance(op, AdvancedIncSubtensor1):
+        if isinstance(op, AdvancedIncSubtensor) and op.idx_list == (0,):
             op._check_runtime_broadcasting(node, x, y, indices)
 
         return jax_fn(x, indices, y)

--- a/pytensor/link/mlx/dispatch/subtensor.py
+++ b/pytensor/link/mlx/dispatch/subtensor.py
@@ -3,9 +3,7 @@ from copy import deepcopy
 from pytensor.link.mlx.dispatch.basic import mlx_funcify
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
-    AdvancedIncSubtensor1,
     AdvancedSubtensor,
-    AdvancedSubtensor1,
     IncSubtensor,
     Subtensor,
     indices_from_subtensor,
@@ -27,7 +25,6 @@ def mlx_funcify_Subtensor(op, node, **kwargs):
 
 
 @mlx_funcify.register(AdvancedSubtensor)
-@mlx_funcify.register(AdvancedSubtensor1)
 def mlx_funcify_AdvancedSubtensor(op, node, **kwargs):
     def advanced_subtensor(x, *ilists):
         indices = indices_from_subtensor(ilists, op.idx_list)
@@ -70,7 +67,6 @@ def mlx_funcify_IncSubtensor(op, node, **kwargs):
 
 
 @mlx_funcify.register(AdvancedIncSubtensor)
-@mlx_funcify.register(AdvancedIncSubtensor1)
 def mlx_funcify_AdvancedIncSubtensor(op, node, **kwargs):
     if op.set_instead_of_inc:
 
@@ -95,13 +91,13 @@ def mlx_funcify_AdvancedIncSubtensor(op, node, **kwargs):
         # functional scatter-add, mirroring JAX's `x.at[indices].add(y)`.
         # Plain `x[indices] += y` writes each destination once, dropping
         # repeated-index contributions (e.g. gradients of embedding lookups).
-        # `AdvancedIncSubtensor1` has no `ignore_duplicates` flag and always
-        # accumulates, like its `np.add.at`-based `perform`.
+        # This is the `ignore_duplicates=False` branch of `AdvancedIncSubtensor`,
+        # which accumulates like its `np.add.at`-based `perform`.
         def mlx_fn(x, indices, y):
             return x.at[indices].add(y)
 
     def advancedincsubtensor(x, y, *ilist, mlx_fn=mlx_fn):
-        if isinstance(op, AdvancedIncSubtensor1):
+        if op.idx_list == (0,):
             op._check_runtime_broadcasting(node, x, y, ilist[0])
 
         return mlx_fn(x, ilist, y)

--- a/pytensor/link/numba/dispatch/subtensor.py
+++ b/pytensor/link/numba/dispatch/subtensor.py
@@ -23,9 +23,7 @@ from pytensor.link.numba.dispatch.string_codegen import create_tuple_string
 from pytensor.tensor import TensorType, TensorVariable
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
-    AdvancedIncSubtensor1,
     AdvancedSubtensor,
-    AdvancedSubtensor1,
     IncSubtensor,
     Subtensor,
     indices_from_subtensor,
@@ -133,7 +131,7 @@ def subtensor_op_cache_key(op, **extra_fields):
             else:
                 idx_parts.append("i")
         key_parts.append(tuple(idx_parts))
-    if isinstance(op, IncSubtensor | AdvancedIncSubtensor | AdvancedIncSubtensor1):
+    if isinstance(op, IncSubtensor | AdvancedIncSubtensor):
         key_parts.append((op.inplace, op.set_instead_of_inc))
     if isinstance(op, AdvancedIncSubtensor):
         key_parts.append(op.ignore_duplicates)
@@ -142,7 +140,6 @@ def subtensor_op_cache_key(op, **extra_fields):
 
 @register_funcify_and_cache_key(Subtensor)
 @register_funcify_and_cache_key(IncSubtensor)
-@register_funcify_and_cache_key(AdvancedSubtensor1)
 def numba_funcify_default_subtensor(op, node, **kwargs):
     """Create a Python function that assembles and uses an index on an array."""
 
@@ -163,9 +160,7 @@ def numba_funcify_default_subtensor(op, node, **kwargs):
         else:
             raise ValueError(f"Unknown index type: {entry}")
 
-    set_or_inc = isinstance(
-        op, IncSubtensor | AdvancedIncSubtensor1 | AdvancedIncSubtensor
-    )
+    set_or_inc = isinstance(op, IncSubtensor | AdvancedIncSubtensor)
     index_start_idx = 1 + int(set_or_inc)
     op_indices = list(node.inputs[index_start_idx:])
     idx_list = op.idx_list
@@ -294,13 +289,8 @@ def numba_funcify_AdvancedSubtensor(op, node, **kwargs):
     )
 
 
-@register_funcify_and_cache_key(AdvancedIncSubtensor1)
-def numba_funcify_AdvancedIncSubtensor1(op, node, **kwargs):
-    return vector_integer_advanced_indexing(op, node=node, **kwargs)
-
-
 def vector_integer_advanced_indexing(
-    op: AdvancedSubtensor1 | AdvancedSubtensor | AdvancedIncSubtensor, node, **kwargs
+    op: AdvancedSubtensor | AdvancedIncSubtensor, node, **kwargs
 ):
     """Implement all forms of advanced indexing (and assignment) that combine basic and vector integer indices.
 
@@ -452,7 +442,7 @@ def vector_integer_advanced_indexing(
 
     """
 
-    if isinstance(op, AdvancedSubtensor1 | AdvancedSubtensor):
+    if isinstance(op, AdvancedSubtensor):
         x, *index_variables = node.inputs
     else:
         x, y, *index_variables = node.inputs
@@ -536,7 +526,7 @@ def vector_integer_advanced_indexing(
         ":" for _ in range(len(adv_indices_pos))
     ) + (", " + ", ".join(basic_indices) if basic_indices else "")
 
-    if isinstance(op, AdvancedSubtensor1 | AdvancedSubtensor):
+    if isinstance(op, AdvancedSubtensor):
         # Define transpose axis on the output to restore original meaning
         # After (potentially) having transposed advanced indexing dims to the front unlike numpy
         _final_axis_order = list(range(adv_idx_ndim, out.type.ndim))

--- a/pytensor/link/pytorch/dispatch/subtensor.py
+++ b/pytensor/link/pytorch/dispatch/subtensor.py
@@ -2,9 +2,7 @@ from pytensor.graph.basic import Constant
 from pytensor.link.pytorch.dispatch.basic import pytorch_funcify
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
-    AdvancedIncSubtensor1,
     AdvancedSubtensor,
-    AdvancedSubtensor1,
     IncSubtensor,
     Subtensor,
     indices_from_subtensor,
@@ -46,7 +44,6 @@ def pytorch_funcify_Subtensor(op, node, **kwargs):
     return subtensor
 
 
-@pytorch_funcify.register(AdvancedSubtensor1)
 @pytorch_funcify.register(AdvancedSubtensor)
 def pytorch_funcify_AdvSubtensor(op, node, **kwargs):
     def advsubtensor(x, *indices):
@@ -66,6 +63,8 @@ def pytorch_funcify_IncSubtensor(op, node, **kwargs):
         def set_subtensor(x, y, *flattened_indices):
             indices = indices_from_subtensor(flattened_indices, idx_list)
             check_negative_steps(indices)
+            if op.idx_list == (0,):
+                op._check_runtime_broadcasting(node, x, y, indices[0])
             if not inplace:
                 x = x.clone()
             x[indices] = y
@@ -78,6 +77,8 @@ def pytorch_funcify_IncSubtensor(op, node, **kwargs):
         def inc_subtensor(x, y, *flattened_indices):
             indices = indices_from_subtensor(flattened_indices, idx_list)
             check_negative_steps(indices)
+            if op.idx_list == (0,):
+                op._check_runtime_broadcasting(node, x, y, indices[0])
             if not inplace:
                 x = x.clone()
             x[indices] += y
@@ -87,7 +88,6 @@ def pytorch_funcify_IncSubtensor(op, node, **kwargs):
 
 
 @pytorch_funcify.register(AdvancedIncSubtensor)
-@pytorch_funcify.register(AdvancedIncSubtensor1)
 def pytorch_funcify_AdvancedIncSubtensor(op, node, **kwargs):
     idx_list = op.idx_list
     inplace = op.inplace
@@ -98,8 +98,8 @@ def pytorch_funcify_AdvancedIncSubtensor(op, node, **kwargs):
         def adv_set_subtensor(x, y, *flattened_indices):
             indices = indices_from_subtensor(flattened_indices, idx_list)
             check_negative_steps(indices)
-            if isinstance(op, AdvancedIncSubtensor1):
-                op._check_runtime_broadcasting(node, x, y, indices)
+            if op.idx_list == (0,):
+                op._check_runtime_broadcasting(node, x, y, indices[0])
             if not inplace:
                 x = x.clone()
             x[indices] = y.type_as(x)
@@ -112,8 +112,8 @@ def pytorch_funcify_AdvancedIncSubtensor(op, node, **kwargs):
         def adv_inc_subtensor_no_duplicates(x, y, *flattened_indices):
             indices = indices_from_subtensor(flattened_indices, idx_list)
             check_negative_steps(indices)
-            if isinstance(op, AdvancedIncSubtensor1):
-                op._check_runtime_broadcasting(node, x, y, indices)
+            if op.idx_list == (0,):
+                op._check_runtime_broadcasting(node, x, y, indices[0])
             if not inplace:
                 x = x.clone()
             x[indices] += y.type_as(x)
@@ -131,6 +131,8 @@ def pytorch_funcify_AdvancedIncSubtensor(op, node, **kwargs):
             indices = indices_from_subtensor(flattened_indices, idx_list)
             # Not needed because slices aren't supported in this path
             # check_negative_steps(indices)
+            if op.idx_list == (0,):
+                op._check_runtime_broadcasting(node, x, y, indices[0])
             if not inplace:
                 x = x.clone()
             x.index_put_(indices, y.type_as(x), accumulate=True)

--- a/pytensor/sparse/__init__.py
+++ b/pytensor/sparse/__init__.py
@@ -3,33 +3,3 @@ from pytensor.sparse.basic import *
 from pytensor.sparse.math import *
 from pytensor.sparse.sharedvar import sparse_constructor as shared
 from pytensor.sparse.type import SparseTensorType, _is_sparse
-
-
-def sparse_grad(var):
-    """This function return a new variable whose gradient will be
-    stored in a sparse format instead of dense.
-
-    Currently only variable created by AdvancedSubtensor1 is supported.
-    i.e. a_tensor_var[an_int_vector].
-
-    .. versionadded:: 0.6rc4
-    """
-    from pytensor.tensor.subtensor import AdvancedSubtensor, AdvancedSubtensor1
-
-    if not (
-        var.owner and isinstance(var.owner.op, AdvancedSubtensor | AdvancedSubtensor1)
-    ):
-        raise TypeError(
-            "Sparse gradient is only implemented for AdvancedSubtensor and AdvancedSubtensor1"
-        )
-
-    x = var.owner.inputs[0]
-    indices = var.owner.inputs[1:]
-
-    if len(indices) > 1:
-        raise TypeError(
-            "Sparse gradient is only implemented for single advanced indexing"
-        )
-
-    ret = AdvancedSubtensor1(sparse_grad=True)(x, indices[0])
-    return ret

--- a/pytensor/sparse/basic.py
+++ b/pytensor/sparse/basic.py
@@ -1909,7 +1909,7 @@ class ConstructSparseFromList(Op):
         idx_list = inputs[2:]
 
         gx = g_output
-        gy = pytensor.tensor.subtensor.advanced_subtensor1(g_output, *idx_list)
+        gy = pytensor.tensor.subtensor.advanced_subtensor(g_output, *idx_list)
 
         return [gx, gy, *(disconnected_type() for _ in range(len(idx_list)))]
 

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -1766,7 +1766,6 @@ class Alloc(COp):
         from pytensor.tensor.blas import CGemv, CGer, Gemv, Ger
         from pytensor.tensor.subtensor import (
             AdvancedIncSubtensor,
-            AdvancedIncSubtensor1,
             IncSubtensor,
             Subtensor,
         )
@@ -1797,13 +1796,7 @@ class Alloc(COp):
                 idx == 0
                 and isinstance(
                     client_op,
-                    IncSubtensor
-                    | AdvancedIncSubtensor1
-                    | AdvancedIncSubtensor
-                    | Gemv
-                    | CGemv
-                    | Ger
-                    | CGer,
+                    IncSubtensor | AdvancedIncSubtensor | Gemv | CGemv | Ger | CGer,
                 )
             ):
                 # Ops that will work inplace on the Alloc. So if they

--- a/pytensor/tensor/extra_ops.py
+++ b/pytensor/tensor/extra_ops.py
@@ -42,7 +42,7 @@ from pytensor.tensor.math import (
 from pytensor.tensor.math import max as pt_max
 from pytensor.tensor.math import sum as pt_sum
 from pytensor.tensor.shape import Shape_i
-from pytensor.tensor.subtensor import advanced_inc_subtensor1, set_subtensor
+from pytensor.tensor.subtensor import advanced_inc_subtensor, set_subtensor
 from pytensor.tensor.type import TensorType, dvector, int_dtypes, integer_dtypes
 from pytensor.tensor.utils import normalize_reduce_axis
 from pytensor.tensor.variable import TensorVariable
@@ -528,10 +528,10 @@ def bincount(x, weights=None, minlength=None, assert_nonneg=False):
     # since out[x] raises an exception if the indices (x) are int8.
     if weights is None:
         out = ptb.zeros([max_value], dtype=x.dtype)
-        out = advanced_inc_subtensor1(out, 1, x)
+        out = advanced_inc_subtensor(out, 1, x)
     else:
         out = ptb.zeros([max_value], dtype=weights.dtype)
-        out = advanced_inc_subtensor1(out, weights, x)
+        out = advanced_inc_subtensor(out, weights, x)
     return out
 
 

--- a/pytensor/tensor/random/rewriting/basic.py
+++ b/pytensor/tensor/random/rewriting/basic.py
@@ -21,7 +21,6 @@ from pytensor.tensor.rewriting.basic import (
 from pytensor.tensor.shape import Shape, Shape_i
 from pytensor.tensor.subtensor import (
     AdvancedSubtensor,
-    AdvancedSubtensor1,
     Subtensor,
     indices_from_subtensor,
 )
@@ -196,7 +195,7 @@ def local_dimshuffle_rv_lift(fgraph, node):
     }
 
 
-@node_rewriter([Subtensor, AdvancedSubtensor1, AdvancedSubtensor])
+@node_rewriter([Subtensor, AdvancedSubtensor])
 def local_subtensor_rv_lift(fgraph, node):
     """Lift a ``*Subtensor`` through ``RandomVariable`` inputs.
 

--- a/pytensor/tensor/rewriting/fused_elemwise.py
+++ b/pytensor/tensor/rewriting/fused_elemwise.py
@@ -1,7 +1,7 @@
 """Fuse indexed reads/writes and reductions into Elemwise iteration loops.
 
 Introduces ``FusedElemwise``, an ``OpFromGraph`` that wraps
-``AdvancedSubtensor1`` + ``Elemwise`` + ``AdvancedIncSubtensor1`` / ``CAReduce``
+``AdvancedSubtensor`` + ``Elemwise`` + ``AdvancedIncSubtensor`` / ``CAReduce``
 subgraphs so the Numba backend can generate a single loop with indirect
 indexing and inline accumulation, eliminating materialised intermediate arrays.
 """
@@ -9,10 +9,8 @@ indexing and inline accumulation, eliminating materialised intermediate arrays.
 from pytensor.compile import optdb
 from pytensor.compile.builders import OpFromGraph
 from pytensor.graph import node_rewriter
-from pytensor.graph.basic import Constant
 from pytensor.graph.rewriting.basic import GraphRewriter, dfs_rewriter
 from pytensor.graph.rewriting.db import SequenceDB
-from pytensor.graph.rewriting.unify import OpPattern
 from pytensor.graph.utils import InconsistencyError
 from pytensor.printing import op_debug_information
 from pytensor.scalar.basic import (
@@ -28,16 +26,12 @@ from pytensor.scalar.basic import (
 from pytensor.scalar.basic import (
     identity as scalar_identity,
 )
-from pytensor.tensor.basic import MakeVector
 from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
 from pytensor.tensor.rewriting.elemwise import InplaceElemwiseOptimizer
-from pytensor.tensor.rewriting.subtensor import _is_shape_of_x_at
-from pytensor.tensor.shape import Reshape, shape_padright
+from pytensor.tensor.shape import shape_padright
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
-    AdvancedIncSubtensor1,
     AdvancedSubtensor,
-    AdvancedSubtensor1,
 )
 from pytensor.tensor.variable import TensorVariable
 
@@ -61,183 +55,15 @@ def _view_root(view_i, var):
     return var
 
 
-def _unwrap_axis_swapped_subtensor1(fgraph, var):
-    """Unwrap ``AdvancedSubtensor1`` with optional ``DimShuffle`` axis-swap.
-
-    Detects two patterns (all intermediates must be single-client):
-
-    - ``AdvancedSubtensor1(source, idx)`` → ``(source, idx, 0)``
-    - ``DimShuffle{swap}(AdvancedSubtensor1(DimShuffle{swap}(source), idx))``
-      → ``(source, idx, axis)`` where *axis* is the non-zero swapped axis.
-    """
-    if var.owner is None:
-        return None
-
-    # Bare AdvancedSubtensor1 on axis 0
-    if isinstance(var.owner.op, AdvancedSubtensor1):
-        if len(fgraph.clients[var]) != 1:
-            return None
-        return var.owner.inputs[0], var.owner.inputs[1], 0
-
-    # Check for axis-swap DimShuffle wrapping AdvancedSubtensor1
-    if not isinstance(var.owner.op, DimShuffle) or not var.owner.op.is_transpose:
-        return None
-
-    # Find the swapped axis: exactly two positions differ from identity
-    order = var.owner.op.new_order
-    swapped = [i for i, o in enumerate(order) if o != i]
-    if len(swapped) != 2:
-        return None
-    ax_a, ax_b = swapped
-    if order[ax_a] != ax_b or order[ax_b] != ax_a:
-        return None
-    axis = max(ax_a, ax_b)  # the non-zero axis (0 was swapped to axis)
-
-    # Inner must be a single-client AdvancedSubtensor1
-    asub1_out = var.owner.inputs[0]
-    if len(fgraph.clients[asub1_out]) != 1:
-        return None
-    match asub1_out.owner_op_and_inputs:
-        case AdvancedSubtensor1(), inner_ds_var, idx_var:
-            pass
-        case _:
-            return None
-
-    # AdvancedSubtensor1's input must be a single-client inverse DimShuffle (same swap)
-    if len(fgraph.clients[inner_ds_var]) != 1:
-        return None
-    match inner_ds_var.owner_op_and_inputs:
-        case DimShuffle(is_transpose=True, new_order=new_order), source:
-            if new_order != tuple(order):
-                return None
-        case _:
-            return None
-
-    return source, idx_var, axis
-
-
-def _unwrap_reshaped_take(fgraph, reshape_node):
-    """Unwrap ``Reshape(AdvancedSubtensor1(x, idx), S)`` into an ND take.
-
-    Matches any reshape that regroups only the taken axis: the leading and
-    trailing entries of ``S`` must provably pass through ``source``'s dims
-    (``transform_take``'s flatten+reshape form is the common instance). The
-    regrouped block becomes the ND index, so ``x[idx].reshape(S)`` turns into
-    ``x[idx.reshape(S[axis:...])]`` — the index reshape raises on exactly the
-    sizes the original reshape would have raised on. Returns
-    ``(source, nd_idx, axis)``, or ``None`` if the node doesn't match.
-    """
-    result = _unwrap_axis_swapped_subtensor1(fgraph, reshape_node.inputs[0])
-    if result is None:
-        return None
-    source, idx, axis = result
-
-    shape_input = reshape_node.inputs[1]
-    if isinstance(shape_input, Constant):
-        entries = [int(v) for v in shape_input.data]
-    elif shape_input.owner is not None and isinstance(shape_input.owner.op, MakeVector):
-        entries = list(shape_input.owner.inputs)
-    else:
-        return None
-
-    n_trail = source.type.ndim - axis - 1
-    k = len(entries) - axis - n_trail
-    if k < 2:
-        return None
-
-    def passes_through(entry, dim):
-        if isinstance(entry, int):
-            return source.type.shape[dim] == entry
-        return _is_shape_of_x_at(entry, source, dim)
-
-    if not all(passes_through(entries[d], d) for d in range(axis)):
-        return None
-    if not all(
-        passes_through(entries[axis + k + t], axis + 1 + t) for t in range(n_trail)
-    ):
-        return None
-
-    nd_idx = idx.reshape(entries[axis : axis + k])
-    return source, nd_idx, axis
-
-
-@node_rewriter([OpPattern(DimShuffle, is_transpose=True)])
-def undo_take_dimshuffle_for_fusion(fgraph, node):
-    """Undo ``DimShuffle(AdvancedSubtensor1(DimShuffle(x), idx))`` -> ``AdvancedSubtensor(x, :, ..., idx, :, ...)``.
-
-    The ``local_replace_AdvancedSubtensor`` specialize rewrite converts
-    ``x[:, idx]`` into ``x.T[idx].T`` (axis-swap + AdvancedSubtensor1 +
-    axis-swap).  This rewrite undoes that when the result feeds a single
-    Elemwise, so ``FuseElemwise`` can absorb the indexing directly
-    on the correct axis.
-
-    See also ``undo_take_reshape_for_fusion`` which handles the analogous
-    Reshape pattern for ND indices.
-    """
-    # Outer DimShuffle must be consumed only by a single Elemwise
-    clients = fgraph.clients[node.outputs[0]]
-    if len(clients) != 1:
-        return None
-    client_node, _client_idx = clients[0]
-    if not isinstance(client_node.op, Elemwise):
-        return None
-
-    result = _unwrap_axis_swapped_subtensor1(fgraph, node.outputs[0])
-    if result is None:
-        return None
-    source, idx_var, axis = result
-
-    # Build AdvancedSubtensor: x[:, ..., idx, :, ...]
-    idx_list = [slice(None)] * (axis + 1)
-    idx_list[axis] = 0  # pointer to the single index variable
-    new_out = AdvancedSubtensor(idx_list=idx_list)(source, idx_var)
-    return [new_out]
-
-
-@node_rewriter([Reshape])
-def undo_take_reshape_for_fusion(fgraph, node):
-    """Rewrite ``Reshape(AdvancedSubtensor1(x, idx), S)`` into an ND take.
-
-    Turns a take whose result is reshaped only along the taken axis into a
-    single ``AdvancedSubtensor`` with an ND index, so ``FuseElemwise``
-    can absorb the indexing directly.  Covers the ``transform_take`` normal
-    form for ND indices (``x[mat_idx]`` becomes ``x[mat_idx.ravel()].reshape(
-    mat_idx.shape + ...)``) but also any equivalent regrouping; see
-    ``_unwrap_reshaped_take`` for the exact conditions.
-    """
-    [reshape_out] = node.outputs
-
-    # Must feed a single Elemwise (or chain to one via another pre-fusion rewrite)
-    clients = fgraph.clients[reshape_out]
-    if len(clients) != 1:
-        return None
-    client_node, _ = clients[0]
-    if not isinstance(client_node.op, Elemwise):
-        return None
-
-    result = _unwrap_reshaped_take(fgraph, node)
-    if result is None:
-        return None
-    source, nd_idx, axis = result
-
-    # Build AdvancedSubtensor: source[:, ..., nd_idx, :, ...]
-    src_ndim = source.type.ndim
-    idx_list = [slice(None)] * src_ndim
-    idx_list[axis] = 0  # pointer to the single index variable
-    new_out = AdvancedSubtensor(idx_list=idx_list)(source, nd_idx)
-    return [new_out]
-
-
 @node_rewriter([CAReduce])
 def wrap_reduced_gather_in_elemwise(fgraph, node):
     """Wrap a reduction of a bare indexed read in an identity Elemwise.
 
-    ``FuseElemwise`` anchors on Elemwise nodes, so ``sum(x[idx])`` — with no
-    elementwise computation between the gather and the reduction — would leave
+    ``FuseElemwise`` anchors on Elemwise nodes, so ``sum(x[idx])`` -- with no
+    elementwise computation between the gather and the reduction -- would leave
     the gather materialized. ``Elemwise(identity)`` gives the fusion an anchor:
     gather, identity and reduction collapse into one fused loop (the identity is
-    a no-op inside the loop body). Runs before the ``undo_take`` rewrites, which
-    require the indexed read to feed an Elemwise.
+    a no-op inside the loop body).
     """
     if not isinstance(node.op.scalar_op, _REDUCE_SCALAR_OPS):
         return None
@@ -245,18 +71,11 @@ def wrap_reduced_gather_in_elemwise(fgraph, node):
     if inp.owner is None or len(fgraph.clients[inp]) != 1:
         return None
 
-    owner_op = inp.owner.op
-    if isinstance(owner_op, AdvancedSubtensor):
-        # Only integer-index forms the fusion can absorb; on boolean masks or
-        # mixed patterns the identity Elemwise would survive as a useless copy.
-        is_gather = FuseElemwise._extract_idx_axis_pairs(inp.owner) is not None
-    elif isinstance(owner_op, Reshape):
-        # The reshaped-take form undo_take_reshape_for_fusion normalizes
-        is_gather = _unwrap_reshaped_take(fgraph, inp.owner) is not None
-    else:
-        # Bare AdvancedSubtensor1 or the axis-swap DimShuffle-wrapped form
-        is_gather = _unwrap_axis_swapped_subtensor1(fgraph, inp) is not None
-    if not is_gather:
+    # Only integer-index gather forms the fusion can absorb; on boolean masks or
+    # mixed patterns the identity Elemwise would survive as a useless copy.
+    if not isinstance(inp.owner.op, AdvancedSubtensor):
+        return None
+    if FuseElemwise._extract_idx_axis_pairs(inp.owner) is None:
         return None
 
     return [node.op(Elemwise(scalar_identity)(inp))]
@@ -284,26 +103,12 @@ fused_elemwise_optdb.register(
     position=-0.5,
 )
 
-fused_elemwise_optdb.register(
-    "undo_take_dimshuffle_for_fusion",
-    dfs_rewriter(undo_take_dimshuffle_for_fusion),
-    "numba",
-    position=0,
-)
-
-fused_elemwise_optdb.register(
-    "undo_take_reshape_for_fusion",
-    dfs_rewriter(undo_take_reshape_for_fusion),
-    "numba",
-    position=0.5,
-)
-
 
 class FusedElemwise(OpFromGraph):
     """Fuse indexed reads and updates into a single Elemwise iteration loop.
 
-    Absorbs ``AdvancedSubtensor1`` (indexed reads on inputs) and
-    ``AdvancedIncSubtensor1`` (indexed updates on outputs) into one loop,
+    Absorbs ``AdvancedSubtensor`` (indexed reads on inputs) and
+    ``AdvancedIncSubtensor`` (indexed updates on outputs) into one loop,
     avoiding materialisation of intermediate arrays.
 
     Inner fgraph contains the unfused subgraph.
@@ -473,8 +278,8 @@ def _op_debug_information_FusedElemwise(op, node):
 class FuseElemwise(GraphRewriter):
     """Fuse indexed reads and indexed updates into Elemwise loops.
 
-    Absorbs single-client ``AdvancedSubtensor1`` on inputs (indexed reads)
-    and single-client ``AdvancedIncSubtensor1`` on outputs (indexed updates)
+    Absorbs single-client ``AdvancedSubtensor`` on inputs (indexed reads)
+    and single-client ``AdvancedIncSubtensor`` on outputs (indexed updates)
     into the Elemwise iteration, avoiding intermediate arrays.
 
     Supports multiple index arrays: e.g. ``x[idx_a] + y[idx_b]`` produces
@@ -498,15 +303,11 @@ class FuseElemwise(GraphRewriter):
         """
         op = node.op
         if not write:
-            if isinstance(op, AdvancedSubtensor1):
-                return [(node.inputs[1], 0)]
             if isinstance(op, AdvancedSubtensor):
                 n_skip = 1
             else:
                 return None
         else:
-            if isinstance(op, AdvancedIncSubtensor1):
-                return [(node.inputs[2], 0)]
             if isinstance(op, AdvancedIncSubtensor):
                 n_skip = 2
             else:
@@ -681,8 +482,7 @@ class FuseElemwise(GraphRewriter):
                 inc_clients = [
                     (c, ci)
                     for c, ci in clients
-                    if ci == 1
-                    and isinstance(c.op, AdvancedIncSubtensor1 | AdvancedIncSubtensor)
+                    if ci == 1 and isinstance(c.op, AdvancedIncSubtensor)
                 ]
                 if len(inc_clients) != 1:
                     # TODO: support multiple writes from the same Elemwise output via Composite duplication

--- a/pytensor/tensor/rewriting/shape.py
+++ b/pytensor/tensor/rewriting/shape.py
@@ -43,7 +43,6 @@ from pytensor.tensor.shape import (
 )
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
-    AdvancedIncSubtensor1,
     IncSubtensor,
     Subtensor,
 )
@@ -925,7 +924,7 @@ def local_lift_specify_shape_inc_subtensor(fgraph, node):
     inc_x, *specified_shape = node.inputs
     if isinstance(
         (inc_op := inc_x.owner_op),
-        IncSubtensor | AdvancedIncSubtensor1 | AdvancedIncSubtensor,
+        IncSubtensor | AdvancedIncSubtensor,
     ):
         x, y, *idx_vars = inc_x.owner.inputs
         new_x = specify_shape(x, specified_shape)

--- a/pytensor/tensor/rewriting/special.py
+++ b/pytensor/tensor/rewriting/special.py
@@ -6,7 +6,6 @@ from pytensor.tensor.rewriting.basic import register_stabilize
 from pytensor.tensor.special import Softmax, log_softmax
 from pytensor.tensor.subtensor import (
     AdvancedSubtensor,
-    AdvancedSubtensor1,
     Subtensor,
 )
 from pytensor.tensor.type import values_eq_approx_remove_inf
@@ -15,7 +14,6 @@ from pytensor.tensor.type import values_eq_approx_remove_inf
 subtensor_ops = (
     Subtensor,
     AdvancedSubtensor,
-    AdvancedSubtensor1,
 )
 
 

--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -4,7 +4,6 @@ from itertools import pairwise, zip_longest
 
 import numpy as np
 
-import pytensor
 from pytensor import compile
 from pytensor.assumptions.core import UNIQUE_INDICES, check_assumption
 from pytensor.compile import optdb
@@ -68,27 +67,21 @@ from pytensor.tensor.shape import (
     Shape_i,
     shape_padleft,
     shape_padright,
-    shape_tuple,
 )
-from pytensor.tensor.sharedvar import TensorSharedVariable
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
-    AdvancedIncSubtensor1,
     AdvancedSubtensor,
-    AdvancedSubtensor1,
     IncSubtensor,
     Subtensor,
     _is_provably_non_negative,
     _is_provably_positive,
     _non_consecutive_adv_indexing,
-    advanced_inc_subtensor1,
-    advanced_subtensor1,
+    advanced_inc_subtensor,
     as_index_literal,
     flatten_index_variables,
     get_canonical_form_slice,
     get_constant_idx,
     get_slice_elements,
-    inc_subtensor,
     indices_from_subtensor,
     unflatten_index_variables,
 )
@@ -112,102 +105,12 @@ def register_useless(lopt, *tags, **kwargs):
         return lopt
 
 
-def transform_take(a, indices, axis):
-    r"""Transform ``arr[:,:,:,indices,...]``-like operations into single-dimensional, vector index operations.
-
-    This effectively converts certain `AdvancedSubtensor` `Op`\s into a
-    combination of `AdvancedSubtensor1`, `Dimshuffle`, and `Reshape` `Op`\s,
-    which can be more efficient.
-
-    Parameters
-    ----------
-    a : TensorVariable
-        The source array.
-    indices : TensorVariable, ndarray, list, tuple
-        The indices of the values to extract.
-    axis : int
-        The axis over which to select values. By default, the flattened
-        input array is used.
-
-    """
-    a = pytensor.tensor.as_tensor_variable(a)
-    indices = pytensor.tensor.as_tensor_variable(indices)
-    # We can use the more efficient `AdvancedSubtensor1` if `indices` is a vector
-    if indices.ndim == 1:
-        if axis == 0:
-            return advanced_subtensor1(a, indices)
-        else:
-            shuffle = list(range(a.ndim))
-            shuffle[0] = axis
-            shuffle[axis] = 0
-            res = advanced_subtensor1(a.dimshuffle(shuffle), indices).dimshuffle(
-                shuffle
-            )
-            return res
-
-    # We can reshape and flatten the indices in order to use an
-    # `AdvancedSubtensor1` `Op` per the above
-    indices_shape = shape_tuple(indices)
-    a_shape = shape_tuple(a)
-
-    shape_parts = [
-        a_shape[:axis],
-        indices_shape,
-        a_shape[axis + 1 :],
-    ]
-
-    shape_parts = [sp for sp in shape_parts if len(sp) > 0]
-
-    assert len(shape_parts) > 0
-
-    if len(shape_parts) > 1:
-        shape = pytensor.tensor.concatenate(shape_parts)
-    elif len(shape_parts) == 1:
-        shape = shape_parts[0]
-    else:
-        shape = ()
-
-    ndim = a.ndim + indices.ndim - 1
-
-    return transform_take(a, indices.flatten(), axis).reshape(shape, ndim=ndim)
-
-
 def is_full_slice(x):
     warnings.warn(
         "The function is deprecated, use x==slice(None) instead.",
         DeprecationWarning,
     )
     return x == slice(None)
-
-
-def get_advsubtensor_axis(indices):
-    """Determine the axis at which an array index is applied.
-
-    This only works for ``take``-like indices: e.g. ``x[:, :, idx, ...]``.  For
-    the above example, `get_advsubtensor_axis` would return ``2``.  If it
-    encounters anything other than a set of `indices` containing full slices
-    and an array/tensor index, it will return ``None``.
-
-    """
-    found_idx = False
-    axis = 0
-    for idx in indices:
-        if not found_idx and idx == slice(None):
-            # Preceding full slices
-            axis += 1
-        elif found_idx and not idx == slice(None):
-            # We don't handle multiple indices
-            return
-        elif found_idx and idx == slice(None):
-            # Trailing full slices
-            continue
-        else:
-            found_idx = True
-
-    if isinstance(
-        indices[axis], TensorConstant | TensorVariable | TensorSharedVariable
-    ):
-        return axis
 
 
 def _constant_has_unique_indices(idx) -> bool:
@@ -521,65 +424,6 @@ def _idx_to_int_array(idx):
     except NotScalarConstantError:
         return None
     return np.arange(n, dtype=np.int64) + off_val
-
-
-@register_specialize
-@node_rewriter([AdvancedSubtensor])
-def local_replace_AdvancedSubtensor(fgraph, node):
-    r"""
-    This rewrite converts expressions like ``X[..., y]`` into ``X.T[y].T``, for
-    a vector ``y``, and ``X[z, ...]`` into ``X[z.flatten()].reshape(...)``, for a
-    matrix ``z``.
-
-    These rewrites replace `AdvancedSubtensor`\s with the more efficient
-    `AdvancedSubtensor1` and `Subtensor` `Op`\s.
-    """
-
-    indexed_var, *index_variables = node.inputs
-    indices = indices_from_subtensor(index_variables, node.op.idx_list)
-    axis = get_advsubtensor_axis(indices)
-
-    if axis is None or indices[axis].dtype == "bool":
-        # Booleans aren't handled
-        return
-
-    new_res = transform_take(indexed_var, indices[axis], axis)
-    copy_stack_trace(node.outputs[0], new_res)
-    return [new_res]
-
-
-@register_specialize
-@node_rewriter([AdvancedIncSubtensor])
-def local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1(fgraph, node):
-    r"""Replace `AdvancedIncSubtensor`\s with `AdvancedIncSubtensor1`\s.
-
-    This is only done when there's a single vector index.
-    """
-
-    if node.op.ignore_duplicates:
-        # `AdvancedIncSubtensor1` does not ignore duplicate index values
-        return
-
-    res, val, *index_variables = node.inputs
-    indices = indices_from_subtensor(index_variables, node.op.idx_list)
-
-    axis = get_advsubtensor_axis(indices)
-
-    if axis is None or indices[axis].dtype == "bool":
-        # Booleans aren't currently handled by `AdvancedIncSubtensor1`
-        return
-
-    new_subtensor = transform_take(res, indices[axis], axis)
-
-    new_res = inc_subtensor(
-        new_subtensor,
-        val,
-        inplace=node.op.inplace,
-        set_instead_of_inc=node.op.set_instead_of_inc,
-        ignore_duplicates=False,
-    )
-    copy_stack_trace(node.outputs[0], new_res)
-    return [new_res]
 
 
 def _is_shape_of_x_at(var, x, axis):
@@ -1258,11 +1102,11 @@ def local_useless_inc_subtensor(fgraph, node):
 
 @register_canonicalize
 @register_specialize
-@node_rewriter([AdvancedIncSubtensor1])
+@node_rewriter([AdvancedIncSubtensor])
 def local_set_to_inc_subtensor(fgraph, node):
     r"""
-    AdvancedIncSubtensor1(x, x[ilist]+other, ilist, set_instead_of_inc=True) ->
-    AdvancedIncSubtensor1(x, other, ilist, set_instead_of_inc=False)
+    AdvancedIncSubtensor(x, x[ilist]+other, ilist, set_instead_of_inc=True) ->
+    AdvancedIncSubtensor(x, other, ilist, set_instead_of_inc=False)
 
     Only valid when ``ilist`` is duplicate-free: a dense set is last-wins while an
     inc accumulates, so duplicate indices would over-count.
@@ -1282,11 +1126,11 @@ def local_set_to_inc_subtensor(fgraph, node):
     subn = None
     other = None
 
-    if addn.inputs[0].owner and isinstance(addn.inputs[0].owner.op, AdvancedSubtensor1):
+    if addn.inputs[0].owner and isinstance(addn.inputs[0].owner.op, AdvancedSubtensor):
         subn = addn.inputs[0].owner
         other = addn.inputs[1]
     elif addn.inputs[1].owner and isinstance(
-        addn.inputs[1].owner.op, AdvancedSubtensor1
+        addn.inputs[1].owner.op, AdvancedSubtensor
     ):
         subn = addn.inputs[1].owner
         other = addn.inputs[0]
@@ -1299,7 +1143,7 @@ def local_set_to_inc_subtensor(fgraph, node):
     # contributions of every occurrence and over-count them.
     if not _index_provably_unique(node.inputs[2], fgraph):
         return
-    ret = advanced_inc_subtensor1(node.inputs[0], other, node.inputs[2])
+    ret = advanced_inc_subtensor(node.inputs[0], other, node.inputs[2])
 
     copy_stack_trace(node.outputs, ret)
 
@@ -1328,7 +1172,7 @@ def local_add_of_sparse_write(fgraph, node):
             sparse_candidate.owner
             and isinstance(
                 sparse_candidate.owner.op,
-                IncSubtensor | AdvancedIncSubtensor1 | AdvancedIncSubtensor,
+                IncSubtensor | AdvancedIncSubtensor,
             )
         ):
             continue
@@ -1499,15 +1343,19 @@ def local_convert_negative_indices(fgraph, node):
 
 @register_canonicalize
 @register_specialize
-@node_rewriter([AdvancedSubtensor1])
+@node_rewriter([AdvancedSubtensor])
 def local_useless_AdvancedSubtensor1(fgraph, node):
-    """Remove `AdvancedSubtensor1` if it takes the full input.
+    """Remove a leading-axis vector take that selects the full input.
 
-    In the `AdvancedSubtensor1` case, the full input is taken when the indices
-    are equivalent to ``arange(0, input.shape[0], 1)`` using either an explicit
-    list/vector or the `ARange` `Op`.
+    The full input is taken when the index is equivalent to
+    ``arange(0, input.shape[0], 1)`` using either an explicit list/vector or
+    the `ARange` `Op`.
 
     """
+    if node.op.idx_list != (0,):
+        # Only the leading integer-vector take (x[ilist])
+        return
+
     # This optimization needs ShapeOpt and fgraph.shape_feature
     if not hasattr(fgraph, "shape_feature"):
         return
@@ -1586,7 +1434,7 @@ def _arange_index_to_slice(idx):
 
 @register_canonicalize
 @register_specialize
-@node_rewriter([AdvancedSubtensor, AdvancedSubtensor1])
+@node_rewriter([AdvancedSubtensor])
 def local_adv_idx_to_diagonal(fgraph, node):
     """Rewrite paired-arange advanced indices to ``base.diagonal(...)``.
 
@@ -1703,7 +1551,7 @@ def local_adv_idx_to_diagonal(fgraph, node):
 
 @register_canonicalize("shape_unsafe")
 @register_specialize("shape_unsafe")
-@node_rewriter([AdvancedSubtensor, AdvancedSubtensor1])
+@node_rewriter([AdvancedSubtensor])
 def local_adv_idx_to_slice(fgraph, node):
     """Rewrite a single arange-shaped advanced index to a basic slice.
 
@@ -1900,7 +1748,7 @@ def local_IncSubtensor_serialize(fgraph, node):
             i.owner
             and isinstance(
                 i.owner.op,
-                IncSubtensor | AdvancedIncSubtensor1 | AdvancedIncSubtensor,
+                IncSubtensor | AdvancedIncSubtensor,
             )
             and i.type.is_super(o_type)
             and len(fgraph.clients[i]) == 1
@@ -1982,12 +1830,11 @@ compile.optdb.register(
 )
 
 
-@node_rewriter([AdvancedIncSubtensor1], inplace=True)
-def local_inplace_AdvancedIncSubtensor1(fgraph, node):
+@node_rewriter([AdvancedIncSubtensor], inplace=True)
+def local_inplace_AdvancedIncSubtensor(fgraph, node):
     if node.op.inplace:
-        return
-
-    x, y, idx = node.inputs
+        return False
+    x, y, *idxs = node.inputs
     if fgraph.has_destroyers([x]):
         # In this case we can't operate inplace, but if x is just an alloc of zeros
         # We're better off duplicating it and then acting on it inplace.
@@ -1999,36 +1846,13 @@ def local_inplace_AdvancedIncSubtensor1(fgraph, node):
             x = x.owner.clone().outputs[0]
         else:
             return None  # Inplace isn't valid
-
-    new_op = node.op.clone_inplace()
-    new_node = new_op(x, y, idx)
-    copy_stack_trace(node.outputs, new_node)
-    return [new_node]
-
-
-compile.optdb.register(
-    "local_inplace_AdvancedIncSubtensor1",
-    WalkingGraphRewriter(
-        local_inplace_AdvancedIncSubtensor1,
-        failure_callback=WalkingGraphRewriter.warn_inplace,
-    ),
-    "fast_run",
-    "inplace",
-    position=70.6,
-)
-
-
-@node_rewriter([AdvancedIncSubtensor], inplace=True)
-def local_inplace_AdvancedIncSubtensor(fgraph, node):
-    if node.op.inplace:
-        return False
     new_op = type(node.op)(
         node.op.idx_list,
         inplace=True,
         set_instead_of_inc=node.op.set_instead_of_inc,
         ignore_duplicates=node.op.ignore_duplicates,
     )
-    new_node = new_op(*node.inputs)
+    new_node = new_op(x, y, *idxs)
     copy_stack_trace(node.outputs, new_node)
     return [new_node]
 
@@ -2048,14 +1872,14 @@ compile.optdb.register(
 # Register old name
 @register_canonicalize("local_incsubtensor_of_allocs")
 @register_stabilize("local_incsubtensor_of_allocs")
-@node_rewriter([IncSubtensor, AdvancedIncSubtensor, AdvancedIncSubtensor1])
+@node_rewriter([IncSubtensor, AdvancedIncSubtensor])
 def local_incsubtensor_of_zeros(fgraph, node):
     """
     IncSubtensor(x, zeros, idx) -> x
 
     """
     if (
-        isinstance(node.op, IncSubtensor | AdvancedIncSubtensor | AdvancedIncSubtensor1)
+        isinstance(node.op, IncSubtensor | AdvancedIncSubtensor)
         and not node.op.set_instead_of_inc
     ):
         x = node.inputs[0]
@@ -2130,7 +1954,7 @@ def local_setsubtensor_of_constants(fgraph, node):
 
 @register_canonicalize("shape_unsafe")
 @register_specialize("shape_unsafe")
-@node_rewriter([Subtensor, AdvancedSubtensor1, AdvancedSubtensor])
+@node_rewriter([Subtensor, AdvancedSubtensor])
 def local_read_of_write_same_indices(fgraph, node):
     """Read of a write at the same indices: ``x[idx].set/inc(v)[idx]``.
 
@@ -2152,11 +1976,9 @@ def local_read_of_write_same_indices(fgraph, node):
     - ``local_write_of_write_same_indices`` collapses nested write chains.
     """
     if isinstance(node.op, Subtensor):
-        write_type = IncSubtensor
-    elif isinstance(node.op, AdvancedSubtensor1):
-        write_type = AdvancedIncSubtensor1
+        write_type = (IncSubtensor,)
     else:
-        write_type = AdvancedIncSubtensor
+        write_type = (AdvancedIncSubtensor,)
 
     inner = node.inputs[0]
     if not (inner.owner and isinstance(inner.owner.op, write_type)):
@@ -2309,10 +2131,7 @@ def local_advanced_read_of_write_constant_indices(fgraph, node):
     - ``local_write_of_write_same_indices`` collapses nested write chains.
     """
     inner = node.inputs[0]
-    if not (
-        inner.owner
-        and isinstance(inner.owner.op, AdvancedIncSubtensor | AdvancedIncSubtensor1)
-    ):
+    if not (inner.owner and isinstance(inner.owner.op, AdvancedIncSubtensor)):
         return None
 
     inner_op = inner.owner.op
@@ -2485,7 +2304,7 @@ def local_advanced_read_of_write_constant_indices(fgraph, node):
 @register_canonicalize
 @register_stabilize
 @register_specialize
-@node_rewriter([IncSubtensor, AdvancedIncSubtensor1, AdvancedIncSubtensor])
+@node_rewriter([IncSubtensor, AdvancedIncSubtensor])
 def local_write_of_write_same_indices(fgraph, node):
     """Collapse nested write ops that share the same indices.
 
@@ -2561,12 +2380,9 @@ def local_write_of_write_same_indices(fgraph, node):
         new_val = a + b
         use_set = False
 
-    if isinstance(node.op, AdvancedIncSubtensor1):
-        new_op = AdvancedIncSubtensor1(set_instead_of_inc=use_set)
-    else:
-        # ignore_duplicates is deliberately not propagated: the merged op
-        # should use the safe np.add.at path (the default).
-        new_op = type(node.op)(idx_list=node.op.idx_list, set_instead_of_inc=use_set)
+    # ignore_duplicates is deliberately not propagated: the merged op
+    # should use the safe np.add.at path (the default).
+    new_op = type(node.op)(idx_list=node.op.idx_list, set_instead_of_inc=use_set)
     r = new_op(base, new_val, *outer_idx_vars)
     copy_stack_trace(node.outputs[0], r)
     return [r]
@@ -2576,7 +2392,7 @@ def local_write_of_write_same_indices(fgraph, node):
 @register_stabilize
 @register_canonicalize
 @register_useless
-@node_rewriter([IncSubtensor, AdvancedIncSubtensor, AdvancedIncSubtensor1])
+@node_rewriter([IncSubtensor, AdvancedIncSubtensor])
 def local_useless_inc_subtensor_alloc(fgraph, node):
     """
     Replaces an [Advanced]IncSubtensor[1], whose increment is an `alloc` of
@@ -2584,7 +2400,7 @@ def local_useless_inc_subtensor_alloc(fgraph, node):
     intermediate `alloc` where possible.
 
     """
-    if isinstance(node.op, IncSubtensor | AdvancedIncSubtensor | AdvancedIncSubtensor1):
+    if isinstance(node.op, IncSubtensor | AdvancedIncSubtensor):
         x, y, *index_variables = node.inputs
 
         if y.owner is not None and isinstance(y.owner.op, Alloc):
@@ -2606,8 +2422,6 @@ def local_useless_inc_subtensor_alloc(fgraph, node):
                 xi = Subtensor(node.op.idx_list)(x, *index_variables)
             elif isinstance(node.op, AdvancedIncSubtensor):
                 xi = AdvancedSubtensor(node.op.idx_list)(x, *index_variables)
-            elif isinstance(node.op, AdvancedIncSubtensor1):
-                xi = advanced_subtensor1(x, *index_variables)
             else:
                 raise Exception("Should never happen!")
 
@@ -2766,18 +2580,16 @@ def local_join_subtensors(fgraph, node):
 @node_rewriter(
     [
         Subtensor,
-        AdvancedSubtensor1,
         AdvancedSubtensor,
         IncSubtensor,
         AdvancedIncSubtensor,
-        AdvancedIncSubtensor1,
     ]
 )
 def local_uint_constant_indices(fgraph, node):
     """Convert constant indices to unsigned dtypes."""
 
     op = node.op
-    if isinstance(op, IncSubtensor | AdvancedIncSubtensor | AdvancedIncSubtensor1):
+    if isinstance(op, IncSubtensor | AdvancedIncSubtensor):
         x, y, *indices = node.inputs
     else:
         x, *indices = node.inputs

--- a/pytensor/tensor/rewriting/subtensor_lift.py
+++ b/pytensor/tensor/rewriting/subtensor_lift.py
@@ -66,7 +66,6 @@ from pytensor.tensor.special import Softmax, softmax
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
     AdvancedSubtensor,
-    AdvancedSubtensor1,
     Subtensor,
     _non_consecutive_adv_indexing,
     as_index_literal,
@@ -347,7 +346,7 @@ def local_subtensor_of_dot(fgraph, node):
 
 @register_canonicalize("shape_unsafe")
 @register_specialize("shape_unsafe")
-@node_rewriter([Subtensor, AdvancedSubtensor, AdvancedSubtensor1])
+@node_rewriter([Subtensor, AdvancedSubtensor])
 def local_subtensor_of_batch_dims(fgraph, node):
     """Lift a (basic or advanced) Subtensor through the batch dims of an Elemwise or Blockwise.
 
@@ -750,7 +749,7 @@ def lift_subtensor_through_alloc(fgraph, node):
 
     Push the read past Alloc so the broadcast happens at most once and
     indexing operates on ``val`` (smaller) where possible. Covers basic
-    ``Subtensor``, ``AdvancedSubtensor``, and ``AdvancedSubtensor1`` reads.
+    ``Subtensor`` and ``AdvancedSubtensor`` reads.
 
     On non-broadcast ``val`` dims an advanced index could expand ``val[idx]``
     past ``val.size``; only fire when the index is provably smaller or when
@@ -818,7 +817,7 @@ def local_basic_subtensor_of_alloc(fgraph, node):
 @register_useless
 @register_canonicalize
 @register_specialize
-@node_rewriter([Subtensor, AdvancedSubtensor, AdvancedSubtensor1])
+@node_rewriter([Subtensor, AdvancedSubtensor])
 def local_subtensor_of_alloc(fgraph, node):
     return lift_subtensor_through_alloc(fgraph, node)
 
@@ -1007,7 +1006,7 @@ def local_subtensor_SpecifyShape_lift(fgraph, node):
 @register_specialize
 @register_canonicalize("fast_compile")
 @register_useless
-@node_rewriter([Subtensor, AdvancedSubtensor1])
+@node_rewriter([Subtensor, AdvancedSubtensor])
 def local_subtensor_make_vector(fgraph, node):
     """Perform ``*Subtensor*`` operations on ``MakeVector`` outputs when the indices are constant.
 
@@ -1015,7 +1014,7 @@ def local_subtensor_make_vector(fgraph, node):
         [a,b,c][0] -> a
         [a,b,c][0:2] -> [a,b]
 
-    Replace all ``AdvancedSubtensor1`` and ``MakeVector`` cases like:
+    Replace all ``AdvancedSubtensor`` and ``MakeVector`` cases like:
         [a,b,c][[0,2]] -> [a,c]
 
     We can do this for constant indexes.
@@ -1046,7 +1045,7 @@ def local_subtensor_make_vector(fgraph, node):
 
         if isinstance(idx, int):
             idx = node.inputs[1]
-    elif isinstance(node.op, AdvancedSubtensor1):
+    elif isinstance(node.op, AdvancedSubtensor):
         idx = node.inputs[1]
 
     if isinstance(idx, Variable):
@@ -1064,7 +1063,10 @@ def local_subtensor_make_vector(fgraph, node):
                 pass
         elif idx.ndim == 1 and isinstance(idx, Constant):
             values = list(map(int, list(idx.value)))
-            ret = make_vector_op(*[x.owner.inputs[v] for v in values])
+            if len(values) == 1:
+                ret = expand_dims(x.owner.inputs[values[0]], axis=0)
+            else:
+                ret = make_vector_op(*[x.owner.inputs[v] for v in values])
             copy_stack_trace(node.outputs[0], ret)
             return [ret]
     elif isinstance(idx, slice):

--- a/pytensor/tensor/subtensor.py
+++ b/pytensor/tensor/subtensor.py
@@ -13,11 +13,8 @@ from pytensor import scalar as ps
 from pytensor.configdefaults import config
 from pytensor.gradient import DisconnectedType, disconnected_type
 from pytensor.graph.basic import Apply, Constant, Variable
-from pytensor.graph.op import Op
 from pytensor.graph.replace import _vectorize_node
-from pytensor.graph.utils import MethodNotDefined
 from pytensor.link.c.op import COp
-from pytensor.link.c.params_type import ParamsType
 from pytensor.printing import Printer, pprint, set_precedence
 from pytensor.scalar.basic import (
     Cast,
@@ -1872,468 +1869,51 @@ def _sum_grad_over_bcasted_dims(x, gx):
     return gx
 
 
-class AdvancedSubtensor1(COp):
+def advanced_subtensor1(x, ilist):
+    """Index ``x`` along its leading axis with an integer vector ``ilist``.
+
+    .. deprecated::
+        There is no dedicated ``AdvancedSubtensor1`` Op anymore; use the general
+        ``x[ilist]`` (`AdvancedSubtensor`), which carries the same C fast path.
     """
-    Implement x[ilist] where ilist is a vector of integers.
-
-    """
-
-    # sparse_grad doesn't go in here since it only affects the output
-    # of the grad() method.
-    __props__ = ()
-    idx_list = (0,)
-    _f16_ok = True
-    check_input = False
-
-    def __hash__(self):
-        return hash(type(self))
-
-    def __init__(self, sparse_grad=False):
-        self.sparse_grad = sparse_grad
-
-    def make_node(self, x, ilist):
-        x_ = as_tensor_variable(x)
-        ilist_ = as_tensor_variable(ilist)
-        if ilist_.type.dtype not in integer_dtypes:
-            raise TypeError("index must be integers")
-        if ilist_.type.ndim != 1:
-            raise TypeError("index must be vector")
-        if x_.type.ndim == 0:
-            raise TypeError("cannot index into a scalar")
-        out_shape = (ilist_.type.shape[0], *x_.type.shape[1:])
-        return Apply(self, [x_, ilist_], [TensorType(dtype=x.dtype, shape=out_shape)()])
-
-    def perform(self, node, inp, output_storage):
-        x, i = inp
-
-        # Numpy take is always slower when out is provided
-        # https://github.com/numpy/numpy/issues/28636
-        output_storage[0][0] = x.take(i, axis=0, out=None)
-
-    def connection_pattern(self, node):
-        _x, *index_variables = node.inputs
-        rval = [[True], *([False] for _ in index_variables)]
-
-        return rval
-
-    def pullback(self, inputs, outputs, output_grads):
-        x, ilist = inputs
-        (gz,) = output_grads
-        assert len(inputs) == 2
-        if self.sparse_grad:
-            if x.type.ndim != 2:
-                raise TypeError(
-                    "AdvancedSubtensor1: you can't take the sparse grad"
-                    " from a tensor with ndim != 2. ndim is " + str(x.type.ndim)
-                )
-
-            rval1 = pytensor.sparse.construct_sparse_from_list(x, gz, ilist)
-        else:
-            if x.dtype in discrete_dtypes:
-                # The output dtype is the same as x
-                gx = x.zeros_like(dtype=config.floatX)
-            elif x.dtype in complex_dtypes:
-                raise NotImplementedError("No support for complex grad yet")
-            else:
-                gx = x.zeros_like()
-            rval1 = advanced_inc_subtensor1(gx, gz, ilist)
-        return [rval1, *(disconnected_type() for _ in range(len(inputs) - 1))]
-
-    def pushforward(self, inputs, outputs, eval_points):
-        if isinstance(eval_points[0].type, DisconnectedType):
-            return [disconnected_type()]
-        _x, *index_variables = inputs
-        return self.make_node(eval_points[0], *index_variables).outputs
-
-    def infer_shape(self, node, ishapes):
-        x, ilist = ishapes
-        return [ilist + x[1:]]
-
-    def c_code(self, node, name, input_names, output_names, sub):
-        if self.__class__ is not AdvancedSubtensor1:
-            raise MethodNotDefined(
-                "c_code defined for AdvancedSubtensor1, not for child class",
-                type(self),
-            )
-        x, idxs = node.inputs
-        if self._idx_may_be_invalid(x, idxs):
-            mode = "NPY_RAISE"
-        else:
-            # We can know ahead of time that all indices are valid, so we can use a faster mode
-            mode = "NPY_WRAP"  # This seems to be faster than NPY_CLIP
-
-        a_name, i_name = input_names[0], input_names[1]
-        output_name = output_names[0]
-        fail = sub["fail"]
-        if mode == "NPY_RAISE":
-            # numpy_take always makes an intermediate copy if NPY_RAISE which is slower than just allocating a new buffer
-            # We can remove this special case after https://github.com/numpy/numpy/issues/28636
-            manage_pre_allocated_out = f"""
-                if ({output_name} != NULL) {{
-                    // Numpy TakeFrom is always slower when copying
-                    // https://github.com/numpy/numpy/issues/28636
-                    Py_CLEAR({output_name});
-                }}
-            """
-        else:
-            manage_pre_allocated_out = f"""
-                if ({output_name} != NULL) {{
-                    npy_intp nd = PyArray_NDIM({a_name}) + PyArray_NDIM({i_name}) - 1;
-                    if (PyArray_NDIM({output_name}) != nd) {{
-                        Py_CLEAR({output_name});
-                    }}
-                    else {{
-                        int i;
-                        npy_intp* shape = PyArray_DIMS({output_name});
-                        for (i = 0; i < PyArray_NDIM({i_name}); i++) {{
-                            if (shape[i] != PyArray_DIMS({i_name})[i]) {{
-                                Py_CLEAR({output_name});
-                                break;
-                            }}
-                        }}
-                        if ({output_name} != NULL) {{
-                            for (; i < nd; i++) {{
-                                if (shape[i] != PyArray_DIMS({a_name})[i-PyArray_NDIM({i_name})+1]) {{
-                                    Py_CLEAR({output_name});
-                                    break;
-                                }}
-                            }}
-                        }}
-                    }}
-                }}
-            """
-
-        return f"""
-            {manage_pre_allocated_out}
-            {output_name} = (PyArrayObject*)PyArray_TakeFrom(
-                        {a_name}, (PyObject*){i_name}, 0, {output_name}, {mode});
-            if ({output_name} == NULL) {fail};
-        """
-
-    def c_code_cache_version(self):
-        return (5,)
-
-    @staticmethod
-    def _idx_may_be_invalid(x, idx) -> bool:
-        if idx.type.shape[0] == 0:
-            # Empty index is always valid
-            return False
-
-        if x.type.shape[0] is None:
-            # We can't know if in index is valid if we don't know the length of x
-            return True
-
-        if not isinstance(idx, Constant):
-            # This is conservative, but we don't try to infer lower/upper bound symbolically
-            return True
-
-        shape0 = x.type.shape[0]
-        min_idx, max_idx = idx.data.min(), idx.data.max()
-        return not (min_idx >= 0 or min_idx >= -shape0) and (
-            max_idx < 0 or max_idx < shape0
-        )
-
-
-advanced_subtensor1 = AdvancedSubtensor1()
-
-
-class AdvancedIncSubtensor1(BaseSubtensor, COp):
-    """
-    Increments a subtensor using advanced slicing (list of index).
-
-    """
-
-    __props__ = (
-        "inplace",
-        "set_instead_of_inc",
+    warnings.warn(
+        "advanced_subtensor1 is deprecated; use advanced_subtensor(x, ilist) "
+        "(equivalently x[ilist]) instead.",
+        FutureWarning,
+        stacklevel=2,
     )
-    idx_list = (0,)
-    check_input = False
-    params_type = ParamsType(inplace=ps.bool, set_instead_of_inc=ps.bool)
+    return advanced_subtensor(x, ilist)
 
-    _runtime_broadcast_error_msg = (
-        "Runtime broadcasting not allowed. "
-        "AdvancedIncSubtensor1 was asked to broadcast the second input (y) along a dimension that was not marked as broadcastable. "
-        "If broadcasting was intended, use `specify_broadcastable` on the relevant dimension(s)."
+
+def advanced_inc_subtensor1(x, y, ilist):
+    """Increment ``x`` along its leading axis at integer-vector positions ``ilist``.
+
+    .. deprecated::
+        There is no dedicated ``AdvancedIncSubtensor1`` Op anymore; use the
+        general `AdvancedIncSubtensor`, which carries the same C fast path.
+    """
+    warnings.warn(
+        "advanced_inc_subtensor1 is deprecated; use advanced_inc_subtensor(x, y, ilist) "
+        "instead.",
+        FutureWarning,
+        stacklevel=2,
     )
-
-    def __init__(self, inplace=False, set_instead_of_inc=False):
-        self.inplace = bool(inplace)
-        self.set_instead_of_inc = bool(set_instead_of_inc)
-        if inplace:
-            self.destroy_map = {0: [0]}
-
-    def __hash__(self):
-        return hash(
-            (
-                type(self),
-                self.inplace,
-                self.set_instead_of_inc,
-            )
-        )
-
-    def clone_inplace(self):
-        return self.__class__(
-            inplace=True,
-            set_instead_of_inc=self.set_instead_of_inc,
-        )
-
-    def __str__(self):
-        if self.inplace:
-            msg = "inplace"
-        else:
-            msg = "no_inplace"
-        if self.set_instead_of_inc:
-            msg += ",set"
-        else:
-            msg += ",inc"
-
-        return self.__class__.__name__ + f"{{{msg}}}"
-
-    def make_node(self, x, y, ilist):
-        x_ = as_tensor_variable(x)
-        y_ = as_tensor_variable(y)
-        ilist_ = as_tensor_variable(ilist)
-
-        if ilist_.type.dtype not in integer_dtypes:
-            raise TypeError("index must be integers")
-        if ilist_.type.ndim != 1:
-            raise TypeError("index must be vector")
-        if x_.type.ndim == 0:
-            raise TypeError("cannot index into a scalar")
-        if y_.type.ndim > x_.type.ndim:
-            if self.set_instead_of_inc:
-                opname = "set"
-            else:
-                opname = "increment"
-            raise TypeError(
-                f"cannot {opname} x subtensor with ndim={x_.type.ndim} by y with ndim={y_.type.ndim}."
-            )
-
-        return Apply(self, [x_, y_, ilist_], [x_.type()])
-
-    def copy_of_x(self, x):
-        """
-        Parameters
-        ----------
-        x : string
-            Gives the name of a C variable pointing to an array.
-
-        Returns
-        -------
-        object
-            C code expression to make a copy of x.
-
-        Base class uses PyArrayObject *, subclasses may override for
-        different types of arrays.
-
-        """
-        # Parameters of PyArray_FromAny are:
-        # array
-        # dtype: we pass NULL to say any dtype is acceptable, so the existing
-        #        dtype will be copied
-        # min_depth: we pass 0 to have this parameter ignored
-        # max_depth: we pass 0 to have this parameter ignored
-        # requirements: here we pass NPY_ARRAY_ENSURECOPY to force a copy
-        # context: this is almost always NULL, I'm not sure what it's used for
-        return f"""(PyArrayObject*)PyArray_FromAny(py_{x}, NULL, 0, 0,
-                NPY_ARRAY_ENSURECOPY, NULL)"""
-
-    def c_code(self, node, name, input_names, output_names, sub):
-        x, y, idx = input_names
-        [out] = output_names
-        copy_of_x = self.copy_of_x(x)
-        params = sub["params"]
-        fail = sub["fail"]
-
-        x_, y_, idx_ = node.inputs
-        y_cdtype = y_.type.dtype_specs()[1]
-        idx_cdtype = idx_.type.dtype_specs()[1]
-        out_cdtype = node.outputs[0].type.dtype_specs()[1]
-        y_bcast = y_.type.broadcastable != idx_.type.broadcastable
-        if (
-            x_.type.ndim == 1
-            and y_.type.ndim == 1
-            and not y_bcast
-            and x_.type.dtype not in complex_dtypes
-            and y_.type.dtype not in complex_dtypes
-        ):
-            # Simple implementation for vector x, y cases
-            idx_may_be_neg = not (
-                # Empty idx needs no negative checks
-                idx_.type.shape[0] == 0
-                or (isinstance(idx_, Constant) and idx_.data.min() >= 0)
-            )
-            idx_may_be_invalid = AdvancedSubtensor1._idx_may_be_invalid(x_, idx_)
-            shape0 = x_.type.shape[0]
-            # This is used to make sure that when we trust the indices to be valid
-            # we are not fooled by a wrong static shape
-            # We mention x to the user in error messages but we work (and make checks) on out,
-            # which should be x or a copy of it
-            unexpected_shape0 = (
-                f"PyArray_SHAPE({out})[0] != {shape0}" if shape0 is not None else "0"
-            )
-
-            op = "=" if self.set_instead_of_inc else "+="
-            code = f"""
-            if ({params}->inplace)
-            {{
-                if ({x} != {out})
-                {{
-                    Py_XDECREF({out});
-                    Py_INCREF({x});
-                    {out} = {x};
-                }}
-            }}
-            else
-            {{
-                Py_XDECREF({out});
-                {out} = {copy_of_x};
-                if (!{out}) {{
-                    // Exception already set
-                    {fail}
-                }}
-            }}
-
-            if (PyArray_NDIM({out}) != 1) {{
-                PyErr_Format(PyExc_ValueError, "AdvancedIncSubtensor1: first input (x) ndim should be 1, got %d", PyArray_NDIM({out}));
-                {fail}
-            }}
-            if ({unexpected_shape0}) {{
-                PyErr_Format(PyExc_ValueError, "AdvancedIncSubtensor1: first input (x) shape should be {shape0}, got %d", PyArray_SHAPE({out})[0]);
-                {fail}
-            }}
-            if (PyArray_NDIM({idx}) != 1) {{
-                PyErr_Format(PyExc_ValueError, "AdvancedIncSubtensor1: indices ndim should be 1, got %d", PyArray_NDIM({idx}));
-                {fail}
-            }}
-            if (PyArray_NDIM({y}) != 1) {{
-                PyErr_Format(PyExc_ValueError, "AdvancedIncSubtensor1: second input (y) ndim should be 1, got %d", PyArray_NDIM({y}));
-                {fail}
-            }}
-            if (PyArray_SHAPE({y})[0] != PyArray_SHAPE({idx})[0]) {{
-                if ((PyArray_NDIM({y}) == 1) && (PyArray_SHAPE({y})[0] == 1)){{
-                    PyErr_Format(PyExc_ValueError, "{self._runtime_broadcast_error_msg}");
-                }} else {{
-                    PyErr_Format(PyExc_ValueError,
-                    "AdvancedIncSubtensor1: Shapes of second input (y) and indices do not match: %d, %d",
-                    PyArray_SHAPE({y})[0], PyArray_SHAPE({idx})[0]);
-                }}
-                {fail}
-            }}
-
-            {{
-                npy_intp out_shape0 = PyArray_SHAPE({out})[0];
-                {out_cdtype}* out_data = ({out_cdtype}*)PyArray_DATA({out});
-                {y_cdtype}* y_data = ({y_cdtype}*)PyArray_DATA({y});
-                {idx_cdtype}* idx_data = ({idx_cdtype}*)PyArray_DATA({idx});
-                npy_intp n = PyArray_SHAPE({idx})[0];
-                npy_intp out_jump = PyArray_STRIDES({out})[0] / PyArray_ITEMSIZE({out});
-                npy_intp y_jump = PyArray_STRIDES({y})[0] / PyArray_ITEMSIZE({y});
-                npy_intp idx_jump = PyArray_STRIDES({idx})[0] / PyArray_ITEMSIZE({idx});
-
-                for(int i = 0; i < n; i++){{
-                    {idx_cdtype} idx = idx_data[i * idx_jump];
-                    if ({int(idx_may_be_neg)}){{
-                        if (idx < 0) {{
-                            idx += out_shape0;
-                        }}
-                    }}
-                    if ({int(idx_may_be_invalid)}){{
-                        if ((idx < 0) || (idx >= out_shape0)) {{
-                            PyErr_Format(PyExc_IndexError,"index %d out of bounds for array with shape %d", idx_data[i * idx_jump], out_shape0);
-                            {fail}
-                        }}
-                    }}
-                    out_data[idx * out_jump] {op} y_data[i * y_jump];
-                }}
-
-            }}
-            """
-            return code
-
-        raise NotImplementedError
-
-    def c_code_cache_version(self):
-        return (10,)
-
-    def _check_runtime_broadcasting(
-        self, node: Apply, x: np.ndarray, y: np.ndarray, idx: np.ndarray
-    ) -> None:
-        if y.ndim > 0:
-            y_pt_bcast = node.inputs[1].broadcastable  # type: ignore
-
-            if not y_pt_bcast[0] and y.shape[0] == 1 and y.shape[0] != idx.shape[0]:
-                # Attempting to broadcast with index
-                raise ValueError(self._runtime_broadcast_error_msg)
-            if any(
-                not y_bcast and y_dim == 1 and y_dim != x_dim
-                for y_bcast, y_dim, x_dim in zip(
-                    reversed(y_pt_bcast),
-                    reversed(y.shape),
-                    reversed(x.shape),
-                    strict=False,
-                )
-            ):
-                # Attempting to broadcast with buffer
-                raise ValueError(self._runtime_broadcast_error_msg)
-
-    def perform(self, node, inputs, output_storage):
-        x, y, idx = inputs
-
-        if not self.inplace:
-            x = x.copy()
-
-        self._check_runtime_broadcasting(node, x, y, idx)
-
-        if self.set_instead_of_inc:
-            x[idx] = y
-        else:
-            # In Numpy, `x[idx] += y` doesn't work if the same index is present
-            # many times: it does it only once.
-            np.add.at(x, idx, y)
-
-        output_storage[0][0] = x
-
-    def infer_shape(self, node, ishapes):
-        x, _y, _ilist = ishapes
-        return [x]
-
-    def pushforward(self, inputs, outputs, eval_points):
-        if any(isinstance(t.type, DisconnectedType) for t in eval_points[:2]):
-            return [disconnected_type()]
-        _x, _y, *index_variables = inputs
-        return self.make_node(eval_points[0], eval_points[1], *index_variables).outputs
-
-    def connection_pattern(self, node):
-        rval = [[True], [True], [False]]
-        return rval
-
-    def pullback(self, inputs, outputs, output_grads):
-        (g_output,) = output_grads
-        x, y, idx_list = inputs
-        if x.dtype in discrete_dtypes:
-            # The output dtype is the same as x
-            gx = x.zeros_like(dtype=config.floatX)
-            if y.dtype in discrete_dtypes:
-                gy = y.zeros_like(dtype=config.floatX)
-            else:
-                gy = y.zeros_like()
-        elif x.dtype in complex_dtypes:
-            raise NotImplementedError("No support for complex grad yet")
-        else:
-            if self.set_instead_of_inc:
-                gx = advanced_set_subtensor1(g_output, y.zeros_like(), idx_list)
-            else:
-                gx = g_output
-            gy = advanced_subtensor1(g_output, idx_list)
-            gy = _sum_grad_over_bcasted_dims(y, gy)
-
-        return [gx, gy, disconnected_type()]
+    return advanced_inc_subtensor(x, y, ilist)
 
 
-advanced_inc_subtensor1 = AdvancedIncSubtensor1()
-advanced_set_subtensor1 = AdvancedIncSubtensor1(set_instead_of_inc=True)
+def advanced_set_subtensor1(x, y, ilist):
+    """Set ``x`` along its leading axis at integer-vector positions ``ilist``.
+
+    .. deprecated::
+        Use the general `AdvancedIncSubtensor` (``set_instead_of_inc=True``).
+    """
+    warnings.warn(
+        "advanced_set_subtensor1 is deprecated; use "
+        "advanced_inc_subtensor(x, y, ilist, set_instead_of_inc=True) instead.",
+        FutureWarning,
+        stacklevel=2,
+    )
+    return advanced_inc_subtensor(x, y, ilist, set_instead_of_inc=True)
 
 
 def as_tensor_index_variable(idx):
@@ -2355,11 +1935,74 @@ class AdvancedSubtensor(BaseSubtensor, COp):
     __props__ = ("idx_list",)
 
     def c_code_cache_version(self):
-        hv = Subtensor.helper_c_code_cache_version()
-        if hv:
-            return (3, hv)
+        return (0,)
+
+    def _take_axis(self):
+        """Axis of a single integer-array index taken with all other axes in full.
+
+        Returns the axis for ``take(x, idx, axis)`` (``PyArray_TakeFrom``), or
+        ``None`` if this is any other advanced-indexing pattern.
+        """
+        int_axes = [
+            i for i, entry in enumerate(self.idx_list) if isinstance(entry, int)
+        ]
+        if len(int_axes) != 1:
+            return None
+        [axis] = int_axes
+        if any(
+            entry != slice(None) for i, entry in enumerate(self.idx_list) if i != axis
+        ):
+            return None
+        return axis
+
+    def c_code(self, node, name, input_names, output_names, sub):
+        # A single integer-array index with every other axis taken in full is a
+        # `np.take` along that axis, which `PyArray_TakeFrom` implements directly
+        # (for an index of any dimensionality, on any axis). Every other pattern
+        # falls back to `perform`.
+        axis = self._take_axis()
+        if axis is None:
+            raise NotImplementedError
+        x, idx = node.inputs
+        if idx.type.dtype not in integer_dtypes:
+            raise NotImplementedError
+
+        if self._idx_may_be_invalid(x, idx, axis):
+            mode = "NPY_RAISE"
         else:
-            return ()
+            # Indices are known valid ahead of time, so use a faster mode
+            mode = "NPY_WRAP"  # This seems to be faster than NPY_CLIP
+
+        a_name, i_name = input_names[0], input_names[1]
+        out = output_names[0]
+        fail = sub["fail"]
+        return f"""
+            Py_XDECREF({out});
+            {out} = (PyArrayObject*)PyArray_TakeFrom(
+                        {a_name}, (PyObject*){i_name}, {axis}, NULL, {mode});
+            if ({out} == NULL) {fail};
+        """
+
+    @staticmethod
+    def _idx_may_be_invalid(x, idx, axis=0) -> bool:
+        """Whether ``take(x, idx, axis)`` may index out of bounds."""
+        if 0 in idx.type.shape:
+            # Empty index is always valid
+            return False
+
+        if x.type.shape[axis] is None:
+            # We can't know if the index is valid if we don't know x's length
+            return True
+
+        if not isinstance(idx, Constant):
+            # This is conservative, but we don't try to infer lower/upper bound symbolically
+            return True
+
+        shape_axis = x.type.shape[axis]
+        min_idx, max_idx = idx.data.min(), idx.data.max()
+        return not (min_idx >= 0 or min_idx >= -shape_axis) and (
+            max_idx < 0 or max_idx < shape_axis
+        )
 
     def make_node(self, x, *index_variables):
         if len(index_variables) != self.n_index_vars:
@@ -2629,7 +2272,7 @@ def vectorize_advanced_subtensor(op: AdvancedSubtensor, node, *batch_inputs):
     return type(op)(new_idx_list).make_node(batch_x, *batch_idxs)
 
 
-class AdvancedIncSubtensor(BaseSubtensor, Op):
+class AdvancedIncSubtensor(BaseSubtensor, COp):
     """Increments a subtensor using advanced indexing."""
 
     __props__ = (
@@ -2638,6 +2281,193 @@ class AdvancedIncSubtensor(BaseSubtensor, Op):
         "set_instead_of_inc",
         "ignore_duplicates",
     )
+
+    _runtime_broadcast_error_msg = (
+        "Runtime broadcasting not allowed. "
+        "AdvancedIncSubtensor was asked to broadcast the second input (y) along a dimension that was not marked as broadcastable. "
+        "If broadcasting was intended, use `specify_broadcastable` on the relevant dimension(s)."
+    )
+
+    def copy_of_x(self, x):
+        # Use the extracted C array rather than `py_{x}`: in the plain C linker,
+        # the `py_` object of an intermediate variable is never synced (it stays
+        # `Py_None`), so it can't be relied on outside the VM linkers.
+        return f"""(PyArrayObject*)PyArray_FromAny((PyObject*){x}, NULL, 0, 0,
+                NPY_ARRAY_ENSURECOPY, NULL)"""
+
+    def c_code(self, node, name, input_names, output_names, sub):
+        # The leading-axis integer-array update x[idx] (+)= y with 1-D x has a C
+        # impl for an index of any dimensionality (y must match idx element-wise);
+        # anything else falls back to `perform`.
+        if self.idx_list != (0,) or self.ignore_duplicates:
+            raise NotImplementedError
+        x_, y_, idx_ = node.inputs
+        y_bcast = y_.type.broadcastable != idx_.type.broadcastable
+        if not (
+            x_.type.ndim == 1
+            and not y_bcast
+            and idx_.type.ndim >= 1
+            and idx_.type.dtype in integer_dtypes
+            and x_.type.dtype not in complex_dtypes
+            and y_.type.dtype not in complex_dtypes
+        ):
+            raise NotImplementedError
+
+        x, y, idx = input_names
+        [out] = output_names
+        copy_of_x = self.copy_of_x(x)
+        fail = sub["fail"]
+
+        y_cdtype = y_.type.dtype_specs()[1]
+        idx_cdtype = idx_.type.dtype_specs()[1]
+        out_cdtype = node.outputs[0].type.dtype_specs()[1]
+        idx_may_be_neg = not (
+            any(length == 0 for length in idx_.type.shape)
+            or (isinstance(idx_, Constant) and idx_.data.min() >= 0)
+        )
+        idx_may_be_invalid = AdvancedSubtensor._idx_may_be_invalid(x_, idx_)
+        shape0 = x_.type.shape[0]
+        unexpected_shape0 = (
+            f"PyArray_SHAPE({out})[0] != {shape0}" if shape0 is not None else "0"
+        )
+        op = "=" if self.set_instead_of_inc else "+="
+
+        neg_and_bounds_check = f"""
+                if ({int(idx_may_be_neg)}){{
+                    if (idx < 0) {{
+                        idx += out_shape0;
+                    }}
+                }}
+                if ({int(idx_may_be_invalid)}){{
+                    if ((idx < 0) || (idx >= out_shape0)) {{
+                        PyErr_Format(PyExc_IndexError, "index %lld out of bounds for array with shape %lld", (long long)idx, (long long)out_shape0);
+        """
+        if idx_.type.ndim == 1:
+            # Tight contiguous-or-strided loop for the common vector index.
+            scatter = f"""
+        {{
+            {out_cdtype}* out_data = ({out_cdtype}*)PyArray_DATA({out});
+            {y_cdtype}* y_data = ({y_cdtype}*)PyArray_DATA({y});
+            {idx_cdtype}* idx_data = ({idx_cdtype}*)PyArray_DATA({idx});
+            npy_intp out_shape0 = PyArray_SHAPE({out})[0];
+            npy_intp n = PyArray_SHAPE({idx})[0];
+            npy_intp out_jump = PyArray_STRIDES({out})[0] / PyArray_ITEMSIZE({out});
+            npy_intp y_jump = PyArray_STRIDES({y})[0] / PyArray_ITEMSIZE({y});
+            npy_intp idx_jump = PyArray_STRIDES({idx})[0] / PyArray_ITEMSIZE({idx});
+
+            for(npy_intp i = 0; i < n; i++){{
+                {idx_cdtype} idx = idx_data[i * idx_jump];
+                {neg_and_bounds_check}
+                        {fail}
+                    }}
+                }}
+                out_data[idx * out_jump] {op} y_data[i * y_jump];
+            }}
+        }}
+        """
+        else:
+            # Multi-dimensional index: walk idx and y in lock-step (any strides).
+            scatter = f"""
+        {{
+            {out_cdtype}* out_data = ({out_cdtype}*)PyArray_DATA({out});
+            npy_intp out_shape0 = PyArray_SHAPE({out})[0];
+            npy_intp out_jump = PyArray_STRIDES({out})[0] / PyArray_ITEMSIZE({out});
+            PyArrayIterObject* idx_it = (PyArrayIterObject*)PyArray_IterNew((PyObject*){idx});
+            PyArrayIterObject* y_it = (PyArrayIterObject*)PyArray_IterNew((PyObject*){y});
+            if ((idx_it == NULL) || (y_it == NULL)) {{
+                Py_XDECREF(idx_it);
+                Py_XDECREF(y_it);
+                {fail}
+            }}
+            while (PyArray_ITER_NOTDONE(idx_it)) {{
+                {idx_cdtype} idx = *(({idx_cdtype}*)PyArray_ITER_DATA(idx_it));
+                {neg_and_bounds_check}
+                        Py_DECREF(idx_it);
+                        Py_DECREF(y_it);
+                        {fail}
+                    }}
+                }}
+                out_data[idx * out_jump] {op} *(({y_cdtype}*)PyArray_ITER_DATA(y_it));
+                PyArray_ITER_NEXT(idx_it);
+                PyArray_ITER_NEXT(y_it);
+            }}
+            Py_DECREF(idx_it);
+            Py_DECREF(y_it);
+        }}
+        """
+        inplace = int(self.inplace)
+        return f"""
+        if ({inplace})
+        {{
+            if ({x} != {out})
+            {{
+                Py_XDECREF({out});
+                Py_INCREF({x});
+                {out} = {x};
+            }}
+        }}
+        else
+        {{
+            Py_XDECREF({out});
+            {out} = {copy_of_x};
+            if (!{out}) {{
+                {fail}
+            }}
+        }}
+
+        if (PyArray_NDIM({out}) != 1) {{
+            PyErr_Format(PyExc_ValueError, "AdvancedIncSubtensor: first input (x) ndim should be 1, got %d", PyArray_NDIM({out}));
+            {fail}
+        }}
+        if ({unexpected_shape0}) {{
+            PyErr_Format(PyExc_ValueError, "AdvancedIncSubtensor: first input (x) shape should be {shape0}, got %d", PyArray_SHAPE({out})[0]);
+            {fail}
+        }}
+        if (PyArray_NDIM({y}) != PyArray_NDIM({idx})) {{
+            PyErr_Format(PyExc_ValueError, "AdvancedIncSubtensor: second input (y) ndim should match indices ndim, got %d and %d", PyArray_NDIM({y}), PyArray_NDIM({idx}));
+            {fail}
+        }}
+        for (int _adv_axis = 0; _adv_axis < PyArray_NDIM({idx}); _adv_axis++) {{
+            if (PyArray_SHAPE({y})[_adv_axis] != PyArray_SHAPE({idx})[_adv_axis]) {{
+                if (PyArray_SHAPE({y})[_adv_axis] == 1){{
+                    PyErr_Format(PyExc_ValueError, "{self._runtime_broadcast_error_msg}");
+                }} else {{
+                    PyErr_Format(PyExc_ValueError,
+                    "AdvancedIncSubtensor: Shapes of second input (y) and indices do not match along axis %d: %d, %d",
+                    _adv_axis, PyArray_SHAPE({y})[_adv_axis], PyArray_SHAPE({idx})[_adv_axis]);
+                }}
+                {fail}
+            }}
+        }}
+        {scatter}
+        """
+
+    def c_code_cache_version(self):
+        return (2,)
+
+    def _check_runtime_broadcasting(self, node, x, y, idx) -> None:
+        """Raise if ``y`` would silently broadcast against the leading-axis update.
+
+        Applies to the leading integer-vector form; ``y`` must already match the
+        indexed shape rather than being broadcast at runtime.
+        """
+        if y.ndim > 0:
+            y_pt_bcast = node.inputs[1].broadcastable
+
+            if not y_pt_bcast[0] and y.shape[0] == 1 and y.shape[0] != idx.shape[0]:
+                # Attempting to broadcast with index
+                raise ValueError(self._runtime_broadcast_error_msg)
+            if any(
+                not y_bcast and y_dim == 1 and y_dim != x_dim
+                for y_bcast, y_dim, x_dim in zip(
+                    reversed(y_pt_bcast),
+                    reversed(y.shape),
+                    reversed(x.shape),
+                    strict=False,
+                )
+            ):
+                # Attempting to broadcast with buffer
+                raise ValueError(self._runtime_broadcast_error_msg)
 
     def __init__(
         self,
@@ -2679,6 +2509,9 @@ class AdvancedIncSubtensor(BaseSubtensor, Op):
 
     def perform(self, node, inputs, out_):
         x, y, *index_variables = inputs
+
+        if self.idx_list == (0,):
+            self._check_runtime_broadcasting(node, x, y, index_variables[0])
 
         full_indices = unflatten_index_variables(index_variables, self.idx_list)
 
@@ -2922,21 +2755,6 @@ def inc_subtensor(
         )
         real_x, *index_variables = x.owner.inputs
         return the_op(real_x, y, *index_variables)
-    elif isinstance(x.owner.op, AdvancedSubtensor1):
-        real_x = x.owner.inputs[0]
-        ilist = x.owner.inputs[1]
-        if ignore_duplicates:
-            the_op = AdvancedIncSubtensor(
-                (0,),
-                inplace,
-                set_instead_of_inc=set_instead_of_inc,
-                ignore_duplicates=True,
-            )
-        else:
-            the_op = AdvancedIncSubtensor1(
-                inplace, set_instead_of_inc=set_instead_of_inc
-            )
-        return the_op(real_x, y, ilist)
     elif isinstance(x.owner.op, AdvancedSubtensor):
         real_x, *index_variables = x.owner.inputs
         the_op = AdvancedIncSubtensor(

--- a/pytensor/xtensor/rewriting/indexing.py
+++ b/pytensor/xtensor/rewriting/indexing.py
@@ -106,7 +106,7 @@ def _lower_index(node):
                 ):
                     # We can use basic indexing directly if no other index acts on this dimension
                     # This is an optimization that avoids creating an unnecessary arange tensor
-                    # and facilitates the use of the specialized AdvancedSubtensor1 when possible
+                    # and keeps the indexing as basic (rather than advanced) when possible
                     aligned_idxs.append(to_basic_idx(idx))
                     basic_idx_axis.append(out_dims.index(x_dim))
                 else:

--- a/tests/benchmarks/test_gather_fusion.py
+++ b/tests/benchmarks/test_gather_fusion.py
@@ -13,7 +13,7 @@ import pytensor.tensor as pt
 from pytensor import config
 from pytensor.compile.mode import get_mode
 from pytensor.tensor.rewriting.fused_elemwise import FusedElemwise
-from pytensor.tensor.subtensor import AdvancedIncSubtensor1, advanced_subtensor1
+from pytensor.tensor.subtensor import AdvancedIncSubtensor, advanced_subtensor1
 
 
 @pytest.fixture(
@@ -120,8 +120,7 @@ def write_benchmark_setup(request):
         isinstance(n.op, FusedElemwise) for n in fn_fused.maker.fgraph.toposort()
     ), "FusedElemwise not found in fused graph"
     assert not any(
-        isinstance(n.op, AdvancedIncSubtensor1)
-        for n in fn_fused.maker.fgraph.toposort()
+        isinstance(n.op, AdvancedIncSubtensor) for n in fn_fused.maker.fgraph.toposort()
     ), "AdvancedIncSubtensor1 still present in fused graph"
     assert not any(
         isinstance(n.op, FusedElemwise) for n in fn_unfused.maker.fgraph.toposort()

--- a/tests/link/jax/test_subtensor.py
+++ b/tests/link/jax/test_subtensor.py
@@ -41,7 +41,7 @@ def test_jax_Subtensor_constant():
 
     # Advanced indexing
     out_pt = pt_subtensor.advanced_subtensor1(x_pt, [1, 2])
-    assert isinstance(out_pt.owner.op, pt_subtensor.AdvancedSubtensor1)
+    assert isinstance(out_pt.owner.op, pt_subtensor.AdvancedSubtensor)
 
     compare_jax_and_py([x_pt], [out_pt], [x_np])
 

--- a/tests/link/mlx/test_subtensor.py
+++ b/tests/link/mlx/test_subtensor.py
@@ -60,7 +60,7 @@ def test_mlx_AdvancedSubtensor():
 
     # Advanced indexing with array indices
     out_pt = pt_subtensor.advanced_subtensor1(x_pt, [1, 2])
-    assert isinstance(out_pt.owner.op, pt_subtensor.AdvancedSubtensor1)
+    assert isinstance(out_pt.owner.op, pt_subtensor.AdvancedSubtensor)
     compare_mlx_and_py([x_pt], [out_pt], [x_np])
 
     # Multi-dimensional advanced indexing
@@ -168,7 +168,7 @@ def test_mlx_AdvancedIncSubtensor1_operations():
 
     # Create AdvancedIncSubtensor1 manually for set operation
     out_pt = pt_subtensor.advanced_set_subtensor1(x_pt, st_pt, indices)
-    assert isinstance(out_pt.owner.op, pt_subtensor.AdvancedIncSubtensor1)
+    assert isinstance(out_pt.owner.op, pt_subtensor.AdvancedIncSubtensor)
     assert out_pt.owner.op.set_instead_of_inc
     compare_mlx_and_py([], [out_pt], [])
 
@@ -241,7 +241,7 @@ def test_mlx_AdvancedIncSubtensor1_runtime_broadcast(func):
     x = pt.zeros((10, 5))
     idxs = np.repeat(np.arange(10), 2)  # 20 indices
     out = func(x, y, idxs)
-    assert isinstance(out.owner.op, pt_subtensor.AdvancedIncSubtensor1)
+    assert isinstance(out.owner.op, pt_subtensor.AdvancedIncSubtensor)
 
     f = function([y], out, mode=Mode(linker="mlx", optimizer=None))
     f(np.ones((20, 5), dtype=np.float32))  # correctly sized y works
@@ -295,7 +295,7 @@ def test_mlx_AdvancedIncSubtensor1_duplicate_indices(func):
     y = pt.vector("y", dtype="float32")
     idxs = np.array([0, 0, 0, 1], dtype=np.int64)
     out = func(x, y, idxs)
-    assert isinstance(out.owner.op, pt_subtensor.AdvancedIncSubtensor1)
+    assert isinstance(out.owner.op, pt_subtensor.AdvancedIncSubtensor)
 
     x_np = np.zeros(3, dtype=np.float32)
     y_np = np.ones(4, dtype=np.float32)
@@ -308,7 +308,7 @@ def test_mlx_AdvancedIncSubtensor1_duplicate_indices_edge_cases():
     y = pt.scalar("y", dtype="int32")
     idxs = np.array([-1, -1, 0, -1], dtype=np.int64)
     out = pt_subtensor.advanced_inc_subtensor1(x, y, idxs)
-    assert isinstance(out.owner.op, pt_subtensor.AdvancedIncSubtensor1)
+    assert isinstance(out.owner.op, pt_subtensor.AdvancedIncSubtensor)
 
     compare_mlx_and_py([x, y], [out], [np.zeros(3, dtype=np.int32), np.int32(2)])
 

--- a/tests/link/numba/test_fused_elemwise.py
+++ b/tests/link/numba/test_fused_elemwise.py
@@ -8,7 +8,7 @@ from pytensor import Mode, function, get_mode
 from pytensor.tensor.elemwise import CAReduce, Elemwise
 from pytensor.tensor.rewriting.fused_elemwise import FusedElemwise
 from pytensor.tensor.subtensor import (
-    AdvancedIncSubtensor1,
+    AdvancedIncSubtensor,
     AdvancedSubtensor,
 )
 
@@ -101,7 +101,7 @@ class TestIndexedReadFusion:
         np.testing.assert_allclose(fn(xv, iv, yv), fn_u(xv, iv, yv), rtol=1e-10)
 
     def test_nd_index_axis1(self):
-        """2D matrix index on axis 1 (via undo_take_reshape_for_fusion)."""
+        """2D matrix index on axis 1."""
         rng = np.random.default_rng(42)
         x = pt.matrix("x", shape=(3, 100))
         mat_idx = pt.matrix("mat_idx", dtype="int64", shape=(10, 5))
@@ -121,28 +121,6 @@ class TestIndexedReadFusion:
         xv = rng.normal(size=(100, 7))
         iv = rng.integers(100, size=(10, 5)).astype(np.int64)
         np.testing.assert_allclose(fn(xv, iv), fn_u(xv, iv), rtol=1e-10)
-
-    def test_regrouped_gather(self):
-        """Gather over a (3, 4) index, regrouped to runtime shape (s0, s1).
-
-        A detection that assumed the reshape restores the index shape would
-        rewrite this to x[mat] — shape (3, 4, 5) instead of the requested
-        (2, 6, 5). _unwrap_reshaped_take builds the (s0, s1) index from the
-        reshape target instead, so the regrouping fuses and stays correct.
-        """
-        rng = np.random.default_rng(15)
-        x = pt.matrix("x", shape=(8, 5))
-        mat = pt.matrix("mat", dtype="int64", shape=(3, 4))
-        s0, s1 = pt.lscalar("s0"), pt.lscalar("s1")
-        out = pt.exp(x[mat.reshape((-1,))].reshape((s0, s1, x.shape[1])))
-        fn, fn_u = fused_and_unfused([x, mat, s0, s1], out)
-        assert_fused(fn)
-        xv = rng.normal(size=(8, 5))
-        mv = rng.integers(0, 8, size=(3, 4))
-        res = fn(xv, mv, np.int64(2), np.int64(6))
-        res_u = fn_u(xv, mv, np.int64(2), np.int64(6))
-        assert res.shape == res_u.shape == (2, 6, 5)
-        np.testing.assert_allclose(res, res_u, rtol=1e-10)
 
     def test_nd_index_broadcast(self):
         """Broadcastable 2D index (shape (1, C)) broadcasts against direct input."""
@@ -276,7 +254,7 @@ class TestIndexedWriteFusion:
         # not the indexed axis. Read fusion may still create an
         # FusedElemwise, but the AdvancedIncSubtensor1 must remain outside.
         assert any(
-            isinstance(n.op, AdvancedIncSubtensor1) for n in fn.maker.fgraph.toposort()
+            isinstance(n.op, AdvancedIncSubtensor) for n in fn.maker.fgraph.toposort()
         )
         xv = rng.normal(size=(85,))
         yv = rng.normal(size=(10,))
@@ -292,7 +270,7 @@ class TestIndexedWriteFusion:
         out = target[idx].inc(pt.exp(x))
         fn, fn_u = fused_and_unfused([x, target], out)
         assert any(
-            isinstance(n.op, AdvancedIncSubtensor1) for n in fn.maker.fgraph.toposort()
+            isinstance(n.op, AdvancedIncSubtensor) for n in fn.maker.fgraph.toposort()
         )
         xv = rng.normal(size=(1,))
         tv = rng.normal(size=(5,))
@@ -321,7 +299,7 @@ class TestIndexedWriteFusion:
             assert_fused(fn)
         else:
             assert any(
-                isinstance(n.op, AdvancedIncSubtensor1)
+                isinstance(n.op, AdvancedIncSubtensor)
                 for n in fn.maker.fgraph.toposort()
             )
         xv = rng.normal(size=(10, 1))
@@ -352,14 +330,8 @@ class TestIndexedWriteFusion:
         slices = (slice(None),) * n_slices
         out = target[(*slices, idx)].inc(pt.exp(val))
 
-        mode = NUMBA_MODE.excluding(
-            "local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1"
-        )
-        mode_u = NUMBA_NO_FUSION.excluding(
-            "local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1"
-        )
-        fn = function([val, target], out, mode=mode, trust_input=True)
-        fn_u = function([val, target], out, mode=mode_u, trust_input=True)
+        fn = function([val, target], out, mode=NUMBA_MODE, trust_input=True)
+        fn_u = function([val, target], out, mode=NUMBA_NO_FUSION, trust_input=True)
         assert_fused(fn)
         valv = rng.normal(size=val_shape)
         tv = rng.normal(size=target_shape)
@@ -557,7 +529,7 @@ class TestIndexedWriteFusion:
         # The read fuses into a FusedElemwise; the aliasing write stays external.
         assert_fused(fn)
         assert any(
-            isinstance(n.op, AdvancedIncSubtensor1) for n in fn.maker.fgraph.toposort()
+            isinstance(n.op, AdvancedIncSubtensor) for n in fn.maker.fgraph.toposort()
         )
         xv = rng.normal(size=9)
         np.testing.assert_allclose(fn(xv), fn_u(xv), rtol=1e-10)
@@ -583,7 +555,7 @@ class TestIndexedWriteFusion:
         # The non-inplace write fuses fully -- no external AdvancedIncSubtensor1.
         assert_fused(fn)
         assert not any(
-            isinstance(n.op, AdvancedIncSubtensor1) for n in fn.maker.fgraph.toposort()
+            isinstance(n.op, AdvancedIncSubtensor) for n in fn.maker.fgraph.toposort()
         )
 
         # The inner write must destroy exactly the input the op's destroy_map names.

--- a/tests/link/numba/test_subtensor.py
+++ b/tests/link/numba/test_subtensor.py
@@ -7,9 +7,7 @@ import pytensor.tensor as pt
 from pytensor.tensor import as_tensor
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
-    AdvancedIncSubtensor1,
     AdvancedSubtensor,
-    AdvancedSubtensor1,
     IncSubtensor,
     Subtensor,
     advanced_inc_subtensor1,
@@ -60,13 +58,13 @@ def test_Subtensor(x, indices):
 def test_AdvancedSubtensor1(x, indices):
     """Test NumPy's advanced indexing in one dimension."""
     out_pt = advanced_subtensor1(x, *indices)
-    assert isinstance(out_pt.owner.op, AdvancedSubtensor1)
+    assert isinstance(out_pt.owner.op, AdvancedSubtensor)
     compare_numba_and_py([], [out_pt], [])
 
 
 def test_AdvancedSubtensor1_out_of_bounds():
     out_pt = advanced_subtensor1(np.arange(3), [4])
-    assert isinstance(out_pt.owner.op, AdvancedSubtensor1)
+    assert isinstance(out_pt.owner.op, AdvancedSubtensor)
     with pytest.raises(IndexError):
         compare_numba_and_py([], [out_pt], [])
 
@@ -246,25 +244,25 @@ def test_IncSubtensor(x, y, indices):
 )
 def test_AdvancedIncSubtensor1(x, y, indices):
     out_pt = advanced_set_subtensor1(x, y, *indices)
-    assert isinstance(out_pt.owner.op, AdvancedIncSubtensor1)
+    assert isinstance(out_pt.owner.op, AdvancedIncSubtensor)
     compare_numba_and_py([], [out_pt], [])
 
     out_pt = advanced_inc_subtensor1(x, y, *indices)
-    assert isinstance(out_pt.owner.op, AdvancedIncSubtensor1)
+    assert isinstance(out_pt.owner.op, AdvancedIncSubtensor)
     compare_numba_and_py([], [out_pt], [])
 
     # With symbolic inputs
     x_pt = x.type()
     y_pt = y.type()
 
-    out_pt = AdvancedIncSubtensor1(inplace=True)(x_pt, y_pt, *indices)
-    assert isinstance(out_pt.owner.op, AdvancedIncSubtensor1)
+    out_pt = AdvancedIncSubtensor((0,), inplace=True)(x_pt, y_pt, *indices)
+    assert isinstance(out_pt.owner.op, AdvancedIncSubtensor)
     compare_numba_and_py([x_pt, y_pt], [out_pt], [x.data, y.data], inplace=True)
 
-    out_pt = AdvancedIncSubtensor1(set_instead_of_inc=True, inplace=True)(
+    out_pt = AdvancedIncSubtensor((0,), set_instead_of_inc=True, inplace=True)(
         x_pt, y_pt, *indices
     )
-    assert isinstance(out_pt.owner.op, AdvancedIncSubtensor1)
+    assert isinstance(out_pt.owner.op, AdvancedIncSubtensor)
     compare_numba_and_py([x_pt, y_pt], [out_pt], [x.data, y.data], inplace=True)
 
 

--- a/tests/link/pytorch/test_subtensor.py
+++ b/tests/link/pytorch/test_subtensor.py
@@ -53,7 +53,7 @@ def test_pytorch_AdvSubtensor():
     x_np = np.arange(np.prod(shape)).reshape(shape)
 
     out_pt = pt_subtensor.advanced_subtensor1(x_pt, [1, 2])
-    assert isinstance(out_pt.owner.op, pt_subtensor.AdvancedSubtensor1)
+    assert isinstance(out_pt.owner.op, pt_subtensor.AdvancedSubtensor)
     compare_pytorch_and_py([x_pt], [out_pt], [x_np])
 
     out_pt = x_pt[[1, 2], [2, 3]]

--- a/tests/sparse/test_basic.py
+++ b/tests/sparse/test_basic.py
@@ -59,12 +59,7 @@ from pytensor.sparse.variable import SparseConstant
 from pytensor.tensor.basic import MakeVector
 from pytensor.tensor.math import sum as pt_sum
 from pytensor.tensor.shape import Shape_i
-from pytensor.tensor.subtensor import (
-    AdvancedIncSubtensor,
-    AdvancedSubtensor1,
-)
 from pytensor.tensor.type import (
-    TensorType,
     float_dtypes,
     iscalar,
     ivector,
@@ -451,68 +446,6 @@ class TestSparseInferShape(utt.InferShapeTester):
             ],
             ConstructSparseFromList,
         )
-
-
-class TestConstructSparseFromList:
-    def test_adv_sub1_sparse_grad(self):
-        v = ivector()
-
-        m = matrix()
-
-        with pytest.raises(TypeError):
-            pytensor.sparse.sparse_grad(v)
-
-        with pytest.raises(TypeError):
-            sub = m[v, v]
-            pytensor.sparse.sparse_grad(sub)
-
-        # Assert we don't create a sparse grad by default
-        sub = m[v]
-        g = pytensor.grad(sub.sum(), m)
-        assert isinstance(g.owner.op, AdvancedIncSubtensor)
-
-        # Test that we create a sparse grad when asked
-        # USER INTERFACE
-        m = matrix()
-        v = ivector()
-        sub = pytensor.sparse.sparse_grad(m[v])
-        g = pytensor.grad(sub.sum(), m)
-        assert isinstance(g.owner.op, ConstructSparseFromList)
-
-        # Test that we create a sparse grad when asked
-        # Op INTERFACE
-        m = matrix()
-        v = ivector()
-        sub = AdvancedSubtensor1(sparse_grad=True)(m, v)
-        g = pytensor.grad(sub.sum(), m)
-        assert isinstance(g.owner.op, ConstructSparseFromList)
-
-        # Test the sparse grad
-        valm = np.random.random((5, 4)).astype(config.floatX)
-        valv = np.random.default_rng().integers(0, 5, 10)
-        m = matrix()
-        shared_v = pytensor.shared(valv)
-
-        def fn(m):
-            return pytensor.sparse.sparse_grad(m[shared_v])
-
-        verify_grad_sparse(fn, [valm])
-
-    def test_err(self):
-        for ndim in [1, 3]:
-            t = TensorType(dtype=config.floatX, shape=(None,) * ndim)()
-            v = ivector()
-            sub = t[v]
-
-            # Assert we don't create a sparse grad by default
-            g = pytensor.grad(sub.sum(), t)
-            assert isinstance(g.owner.op, AdvancedIncSubtensor)
-
-            # Test that we raise an error, as we can't create a sparse
-            # grad from tensors that don't have 2 dimensions.
-            sub = pytensor.sparse.sparse_grad(sub)
-            with pytest.raises(TypeError):
-                pytensor.grad(sub.sum(), t)
 
 
 class TestConversion:

--- a/tests/tensor/random/rewriting/test_basic.py
+++ b/tests/tensor/random/rewriting/test_basic.py
@@ -40,7 +40,7 @@ from pytensor.tensor.random.rewriting.basic import sidestep_unused_rng_consumer
 from pytensor.tensor.random.rewriting.numba import introduce_explicit_core_shape_rv
 from pytensor.tensor.random.type import random_generator_type
 from pytensor.tensor.rewriting.shape import ShapeFeature, ShapeOptimizer
-from pytensor.tensor.subtensor import AdvancedSubtensor, AdvancedSubtensor1, Subtensor
+from pytensor.tensor.subtensor import AdvancedSubtensor, Subtensor
 from pytensor.tensor.type import iscalar
 from pytensor.tensor.type_other import NoneConst
 
@@ -830,7 +830,7 @@ def test_Subtensor_lift(indices, lifted, dist_op, dist_params, size):
     )
 
     def is_subtensor_or_dimshuffle_subtensor(inp) -> bool:
-        subtensor_ops = Subtensor | AdvancedSubtensor | AdvancedSubtensor1
+        subtensor_ops = Subtensor | AdvancedSubtensor
         if isinstance(inp.owner.op, subtensor_ops):
             return True
         if isinstance(inp.owner.op, DimShuffle):
@@ -845,9 +845,7 @@ def test_Subtensor_lift(indices, lifted, dist_op, dist_params, size):
             if i.owner
         ), new_out.dprint(depth=3, print_type=True)
     else:
-        assert isinstance(
-            new_out.owner.op, AdvancedSubtensor | AdvancedSubtensor1 | Subtensor
-        )
+        assert isinstance(new_out.owner.op, AdvancedSubtensor | Subtensor)
         return
 
     f_base = function(

--- a/tests/tensor/rewriting/test_basic.py
+++ b/tests/tensor/rewriting/test_basic.py
@@ -82,7 +82,7 @@ from pytensor.tensor.shape import (
     specify_shape,
 )
 from pytensor.tensor.subtensor import (
-    AdvancedIncSubtensor1,
+    AdvancedIncSubtensor,
     Subtensor,
     advanced_inc_subtensor,
     advanced_inc_subtensor1,
@@ -405,8 +405,8 @@ class TestLocalUselessIncSubtensorAlloc:
         utt.assert_allclose(r1, r2)
 
         # Check stacktrace was copied over correctly after rewrite was applied
-        assert check_stack_trace(f1, ops_to_check=AdvancedIncSubtensor1)
-        assert check_stack_trace(f2, ops_to_check=AdvancedIncSubtensor1)
+        assert check_stack_trace(f1, ops_to_check=AdvancedIncSubtensor)
+        assert check_stack_trace(f2, ops_to_check=AdvancedIncSubtensor)
 
     def test_advanced_inc_subtensor1(self):
         x = vector("x")
@@ -436,7 +436,7 @@ class TestLocalUselessIncSubtensorAlloc:
 
         utt.assert_allclose(r1, r2)
 
-        assert check_stack_trace(f1, ops_to_check=AdvancedIncSubtensor1)
+        assert check_stack_trace(f1, ops_to_check=AdvancedIncSubtensor)
         assert check_stack_trace(f2, ops_to_check="all")
 
     def test_incsubtensor(self):

--- a/tests/tensor/rewriting/test_subtensor.py
+++ b/tests/tensor/rewriting/test_subtensor.py
@@ -13,8 +13,6 @@ from pytensor.configdefaults import config
 from pytensor.graph import FunctionGraph, rewrite_graph, vectorize_graph
 from pytensor.graph.basic import Constant, Variable, equal_computations
 from pytensor.graph.rewriting.basic import check_stack_trace, in2out, out2in
-from pytensor.graph.traversal import ancestors
-from pytensor.tensor import as_tensor
 from pytensor.tensor.basic import Alloc, ExtractDiag, _convert_to_int8
 from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.elemwise import Elemwise
@@ -27,7 +25,6 @@ from pytensor.tensor.rewriting.subtensor import (
     local_adv_idx_to_slice,
     local_blockwise_inc_subtensor,
     local_read_of_write_same_indices,
-    local_replace_AdvancedSubtensor,
     local_useless_slice,
     local_write_of_write_same_indices,
 )
@@ -37,9 +34,7 @@ from pytensor.tensor.shape import (
 )
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
-    AdvancedIncSubtensor1,
     AdvancedSubtensor,
-    AdvancedSubtensor1,
     IncSubtensor,
     Subtensor,
     advanced_inc_subtensor1,
@@ -67,68 +62,6 @@ mode_opt = config.mode
 if mode_opt == "FAST_COMPILE":
     mode_opt = "FAST_RUN"
 mode_opt = get_mode(mode_opt)
-
-
-@pytest.mark.parametrize(
-    ("indexer", "is_none"),
-    [
-        (lambda X, y, z: X[:, y, y], True),
-        (lambda X, y, z: X[y, y, :], True),
-        (lambda X, y, z: X[y], False),
-        (lambda X, y, z: X[:, y], False),
-        (lambda X, y, z: X[y, :], False),
-        (lambda X, y, z: X[:, y, :], False),
-        (lambda X, y, z: X[:, z, :], False),
-        (lambda X, y, z: X[:, z], False),
-        (lambda X, y, z: X[z, :], False),
-        (lambda X, y, z: X[:, z, :], False),
-    ],
-)
-def test_local_replace_AdvancedSubtensor(indexer, is_none):
-    rng = np.random.default_rng()
-    y_val = rng.integers(0, 4, size=(2,))
-    z_val = rng.integers(0, 4, size=(2, 2))
-    y = as_tensor(y_val).type()
-    z = as_tensor(z_val).type()
-
-    X_val = np.random.normal(size=(4, 4, 4))
-    X = tensor(dtype=np.float64, shape=(None, None, None), name="X")
-
-    Y = indexer(X, y, z)
-
-    res_pt = local_replace_AdvancedSubtensor.transform(None, Y.owner)
-
-    if is_none:
-        assert res_pt is None
-    else:
-        (res_pt,) = res_pt
-
-        assert not any(
-            isinstance(v.owner.op, AdvancedSubtensor)
-            for v in ancestors([res_pt])
-            if v.owner
-        )
-
-        inputs = [X, y, z]
-
-        res_fn = function(
-            inputs, res_pt, mode=Mode("py", None, None), on_unused_input="ignore"
-        )
-        exp_res_fn = function(
-            inputs, Y, mode=Mode("py", None, None), on_unused_input="ignore"
-        )
-
-        # Make sure that the expected result graph has an `AdvancedSubtensor`
-        assert any(
-            isinstance(v.owner.op, AdvancedSubtensor)
-            for v in exp_res_fn.maker.fgraph.variables
-            if v.owner
-        )
-
-        res_val = res_fn(X_val, y_val, z_val)
-        exp_res_val = exp_res_fn(X_val, y_val, z_val)
-
-        assert np.array_equal(res_val, exp_res_val)
 
 
 @pytest.mark.parametrize("s", [slice(None), slice(None, None, -1)])
@@ -578,10 +511,10 @@ class TestLocalUselessSubtensor:
             assert len(prog) == 2
         else:
             # Arange-with-offset indices get rewritten to a Subtensor slice;
-            # other advanced indices stay as AdvancedSubtensor1 (or get
+            # other advanced indices stay as AdvancedSubtensor (or get
             # absorbed into FusedElemwise by FuseElemwise).
             assert any(
-                isinstance(node.op, AdvancedSubtensor1 | Subtensor | FusedElemwise)
+                isinstance(node.op, AdvancedSubtensor | Subtensor | FusedElemwise)
                 for node in prog
             )
 
@@ -617,13 +550,7 @@ def test_local_subtensor_remove_broadcastable_index():
     f = function([x], [z1, z2, z3, z4, z5, z6, z7, z8], mode=mode)
     for elem in f.maker.fgraph.toposort():
         assert not isinstance(
-            elem.op,
-            Subtensor
-            | AdvancedSubtensor
-            | AdvancedSubtensor1
-            | IncSubtensor
-            | AdvancedIncSubtensor
-            | AdvancedIncSubtensor1,
+            elem.op, Subtensor | AdvancedSubtensor | IncSubtensor | AdvancedIncSubtensor
         )
     rng = np.random.default_rng(seed=utt.fetch_seed())
     xn = rng.random((5, 5))
@@ -686,15 +613,13 @@ class TestSubtensorIncSubtensor:
         cls.rng = np.random.default_rng(utt.fetch_seed())
         cls.mode = get_default_mode().including(
             "local_read_of_write_same_indices",
-            "local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1",
-            "local_replace_AdvancedSubtensor",
         )
 
     @pytest.mark.parametrize(
         "val, indices, optype",
         [
             (vector(), (iscalar(),), IncSubtensor),
-            (vector(), (ivector(),), AdvancedIncSubtensor1),
+            (vector(), (ivector(),), AdvancedIncSubtensor),
             (vector(), (ivector(), ivector()), AdvancedIncSubtensor),
         ],
     )
@@ -709,6 +634,31 @@ class TestSubtensorIncSubtensor:
         )
         assert isinstance(f.maker.fgraph.outputs[0].owner.op, optype)
         assert f.maker.fgraph.outputs[0].owner.op.inplace is True
+
+    def test_inplace_shared_zeros_alloc(self):
+        # When multiple IncSubtensor clients share the same Alloc of zeros,
+        # the Alloc is duplicated so that every client can operate inplace
+        idx = np.array([0, 1, 2, 0, 1, 2])
+        y1 = vector("y1", shape=(6,))
+        y2 = vector("y2", shape=(6,))
+        x = pt.zeros(3)
+        f = function(
+            [y1, y2],
+            [x[idx].inc(y1), x[idx].inc(y2)],
+            mode=self.mode.including("inplace"),
+        )
+        inc_ops = [
+            node.op
+            for node in f.maker.fgraph.apply_nodes
+            if isinstance(node.op, AdvancedIncSubtensor)
+        ]
+        assert len(inc_ops) == 2
+        assert all(op.inplace for op in inc_ops)
+        y1v = np.arange(6).astype(y1.type.dtype)
+        y2v = 10 * y1v
+        res1, res2 = f(y1v, y2v)
+        np.testing.assert_allclose(res1, np.bincount(idx, y1v))
+        np.testing.assert_allclose(res2, np.bincount(idx, y2v))
 
     def test_basic(self):
         # basic test
@@ -1390,8 +1340,6 @@ class TestReadOfWriteSameIndices:
     def setup_method(self):
         mode = get_default_mode()
         self.mode = mode.including(
-            "local_replace_AdvancedSubtensor",
-            "local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1",
             "local_read_of_write_same_indices",
         ).excluding("fusion", "fuse_indexed_into_elemwise")
 
@@ -1421,9 +1369,7 @@ class TestReadOfWriteSameIndices:
         res = f(dx, dy, didx)
         np.testing.assert_allclose(dy, res)
         topo = f.maker.fgraph.toposort()
-        assert not any(
-            isinstance(n.op, AdvancedIncSubtensor | AdvancedIncSubtensor1) for n in topo
-        )
+        assert not any(isinstance(n.op, AdvancedIncSubtensor) for n in topo)
 
     def test_inc_unique_constant_idx(self):
         x = matrix(dtype="float64")
@@ -1441,10 +1387,8 @@ class TestReadOfWriteSameIndices:
         np.add.at(expected, [0, 2, 3], dy)
         np.testing.assert_allclose(expected[[0, 2, 3]], f(dx, dy))
         topo = f.maker.fgraph.toposort()
-        assert not any(
-            isinstance(n.op, AdvancedIncSubtensor | AdvancedIncSubtensor1) for n in topo
-        )
-        assert check_stack_trace(f, ops_to_check=(AdvancedSubtensor1, Elemwise))
+        assert not any(isinstance(n.op, AdvancedIncSubtensor) for n in topo)
+        assert check_stack_trace(f, ops_to_check=(AdvancedSubtensor, Elemwise))
 
     def test_inc_jointly_unique_constant_idx(self):
         """Multiple advanced indices that are jointly (not per-axis) duplicate-free
@@ -1545,9 +1489,7 @@ class TestReadOfWriteSameIndices:
         np.add.at(expected, cidx_values, dy)
         np.testing.assert_allclose(expected[cidx_values], f(dx, dy))
         topo = f.maker.fgraph.toposort()
-        assert any(
-            isinstance(n.op, AdvancedIncSubtensor | AdvancedIncSubtensor1) for n in topo
-        )
+        assert any(isinstance(n.op, AdvancedIncSubtensor) for n in topo)
 
     def test_inc_symbolic_idx_not_rewritten(self):
         """Non-constant indices cannot be checked, so inc must not be rewritten."""
@@ -1567,9 +1509,7 @@ class TestReadOfWriteSameIndices:
         np.add.at(expected, didx, dy)
         np.testing.assert_allclose(expected[didx], f(dx, dy, didx))
         topo = f.maker.fgraph.toposort()
-        assert any(
-            isinstance(n.op, AdvancedIncSubtensor | AdvancedIncSubtensor1) for n in topo
-        )
+        assert any(isinstance(n.op, AdvancedIncSubtensor) for n in topo)
 
     def test_inc_asserted_unique_idx_rewritten(self):
         """A symbolic index asserted unique_indices is duplicate-free, so inc is rewritten."""
@@ -1588,7 +1528,6 @@ class TestReadOfWriteSameIndices:
                 "fusion",
                 "fuse_indexed_into_elemwise",
                 "inplace",
-                "local_replace_AdvancedSubtensor",
             ),
         )
         result.assert_graph(x[idx] + y)
@@ -1606,9 +1545,7 @@ class TestReadOfWriteSameIndices:
         f = function([x, y, idx], o, mode)
 
         topo = f.maker.fgraph.toposort()
-        assert any(
-            isinstance(n.op, AdvancedIncSubtensor1 | AdvancedIncSubtensor) for n in topo
-        )
+        assert any(isinstance(n.op, AdvancedIncSubtensor) for n in topo)
 
         dx = np.random.random((4, 5)).astype(config.floatX)
         dy = np.random.random((2, 5)).astype(config.floatX)
@@ -1663,7 +1600,6 @@ def test_slice_to_arange_roundtrip(sl):
 def test_slice_read_of_write():
     rw_kw = dict(
         include=("canonicalize", "specialize"),
-        exclude=("local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1",),
     )
     buf = pt.vector("buf", shape=(5,))
 
@@ -1707,8 +1643,6 @@ class TestReadOfWriteConstantIndices:
         # FAST_RUN ``local_slice_read_of_write`` would convert the basic
         # Subtensor back in specialize, but FAST_COMPILE skips that.
         self.mode = mode.including(
-            "local_replace_AdvancedSubtensor",
-            "local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1",
             "local_advanced_read_of_write_constant_indices",
         ).excluding("fusion", "local_adv_idx_to_slice")
 
@@ -1724,9 +1658,7 @@ class TestReadOfWriteConstantIndices:
         f = function([x, v], out, self.mode)
 
         topo = f.maker.fgraph.toposort()
-        assert not any(
-            isinstance(n.op, AdvancedIncSubtensor | AdvancedIncSubtensor1) for n in topo
-        )
+        assert not any(isinstance(n.op, AdvancedIncSubtensor) for n in topo)
 
         dx = np.random.random((4, 5))
         dv = np.random.random((3,))
@@ -1757,10 +1689,7 @@ class TestReadOfWriteConstantIndices:
             out = op(x[:, ca, cb], v)[:, ca, cb]
             f = function([x, v], out, self.mode)
             topo = f.maker.fgraph.toposort()
-            assert not any(
-                isinstance(n.op, AdvancedIncSubtensor | AdvancedIncSubtensor1)
-                for n in topo
-            )
+            assert not any(isinstance(n.op, AdvancedIncSubtensor) for n in topo)
             np.testing.assert_allclose(f(dx, dv), expected_fn(dx, dv))
 
         # Non-consecutive: numpy hoists adv to axis 0 → result shape (2, 4)
@@ -1772,10 +1701,7 @@ class TestReadOfWriteConstantIndices:
             out = op(x[ca, :, cb], v)[ca, :, cb]
             f = function([x, v], out, self.mode)
             topo = f.maker.fgraph.toposort()
-            assert not any(
-                isinstance(n.op, AdvancedIncSubtensor | AdvancedIncSubtensor1)
-                for n in topo
-            )
+            assert not any(isinstance(n.op, AdvancedIncSubtensor) for n in topo)
             np.testing.assert_allclose(f(dx, dv2), expected_fn(dx, dv2))
 
     def test_partial_coverage_set(self):
@@ -1801,7 +1727,7 @@ class TestReadOfWriteConstantIndices:
         out_zeros = set_subtensor(pt.zeros((4, 4))[write_a, write_b], v)[read_a, read_b]
         f_zeros = function([v], out_zeros, self.mode)
         assert not any(
-            isinstance(n.op, AdvancedIncSubtensor)
+            isinstance(n.op, AdvancedIncSubtensor) and len(n.op.idx_list) > 1
             for n in f_zeros.maker.fgraph.toposort()
         )
         np.testing.assert_allclose(f_zeros(dv), [10.0, 0.0, 30.0])
@@ -1811,7 +1737,8 @@ class TestReadOfWriteConstantIndices:
         out_x = set_subtensor(x[write_a, write_b], v)[read_a, read_b]
         f_x = function([x, v], out_x, self.mode)
         assert not any(
-            isinstance(n.op, AdvancedIncSubtensor) for n in f_x.maker.fgraph.toposort()
+            isinstance(n.op, AdvancedIncSubtensor) and len(n.op.idx_list) > 1
+            for n in f_x.maker.fgraph.toposort()
         )
         np.random.seed(0)
         dx = np.random.random((4, 4))
@@ -1835,7 +1762,10 @@ class TestReadOfWriteConstantIndices:
         f = function([x, v], out, self.mode)
 
         topo = f.maker.fgraph.toposort()
-        assert not any(isinstance(n.op, AdvancedIncSubtensor) for n in topo)
+        assert not any(
+            isinstance(n.op, AdvancedIncSubtensor) and len(n.op.idx_list) > 1
+            for n in topo
+        )
 
         np.random.seed(0)
         dx = np.random.random((4, 4))
@@ -1864,8 +1794,7 @@ class TestReadOfWriteConstantIndices:
         out = set_subtensor(x[pt.constant(write_idx)], v)[pt.constant(read_idx)]
         f = function([x, v], out, self.mode)
         assert not any(
-            isinstance(n.op, AdvancedIncSubtensor | AdvancedIncSubtensor1)
-            for n in f.maker.fgraph.toposort()
+            isinstance(n.op, AdvancedIncSubtensor) for n in f.maker.fgraph.toposort()
         )
         dx = np.arange(5.0)
         dv = np.array([10.0, 20.0, 30.0])
@@ -1986,14 +1915,7 @@ class TestWriteOfWriteSameIndices:
 
         topo = f.maker.fgraph.toposort()
         # Both writes must remain; rewrite can't prove uniqueness.
-        assert (
-            sum(
-                1
-                for n in topo
-                if isinstance(n.op, AdvancedIncSubtensor | AdvancedIncSubtensor1)
-            )
-            == 2
-        )
+        assert sum(1 for n in topo if isinstance(n.op, AdvancedIncSubtensor)) == 2
 
 
 class TestSubtensorAllocRewrites:
@@ -2116,7 +2038,7 @@ class TestSubtensorAllocRewrites:
         z = inc_subtensor(x[[0, 1, 2, 3]], y0)
         f = function([x, y], z, mode=self.mode)
         assert all(
-            not isinstance(n.op, AdvancedIncSubtensor1)
+            not isinstance(n.op, AdvancedIncSubtensor)
             for n in f.maker.fgraph.toposort()
         )
 
@@ -2127,7 +2049,7 @@ class TestSubtensorAllocRewrites:
         z = inc_subtensor(x[[0, 1, 2, 3]], y0.T)
         f = function([x, y], z, mode=mode_opt)
         assert all(
-            not isinstance(n.op, AdvancedIncSubtensor1)
+            not isinstance(n.op, AdvancedIncSubtensor)
             for n in f.maker.fgraph.toposort()
         )
 
@@ -2137,7 +2059,7 @@ class TestSubtensorAllocRewrites:
         z = inc_subtensor(x[[0, 1, 2, 3]], y0)
         f = function([x], z, mode=self.mode)
         assert all(
-            not isinstance(n.op, AdvancedIncSubtensor1)
+            not isinstance(n.op, AdvancedIncSubtensor)
             for n in f.maker.fgraph.toposort()
         )
 
@@ -2234,7 +2156,7 @@ def test_local_IncSubtensor_serialize():
             inp.owner
             and isinstance(
                 inp.owner.op,
-                IncSubtensor | AdvancedIncSubtensor | AdvancedIncSubtensor1,
+                IncSubtensor | AdvancedIncSubtensor,
             )
             for inp in a.inputs
         )
@@ -2247,7 +2169,6 @@ def test_local_IncSubtensor_serialize():
         ops_to_check=[
             IncSubtensor,
             AdvancedIncSubtensor,
-            AdvancedIncSubtensor1,
         ],
     )
 
@@ -2260,25 +2181,18 @@ def test_local_set_to_inc_subtensor():
     g = s + 3
     r = set_subtensor(s, g)
 
-    mode = (
-        get_default_mode()
-        .including(
-            "local_replace_AdvancedSubtensor",
-            "local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1",
-        )
-        .excluding("fuse_indexed_into_elemwise")
-    )
+    mode = get_default_mode().excluding("fuse_indexed_into_elemwise")
     moder = mode.excluding("local_set_to_inc_subtensor")
     modet = mode.including("local_set_to_inc_subtensor")
     f1 = function([v], r, mode=moder)
     f2 = function([v], r, mode=modet)
 
     advi1 = [
-        n for n in f1.maker.fgraph.toposort() if isinstance(n.op, AdvancedIncSubtensor1)
+        n for n in f1.maker.fgraph.toposort() if isinstance(n.op, AdvancedIncSubtensor)
     ]
 
     advi2 = [
-        n for n in f2.maker.fgraph.toposort() if isinstance(n.op, AdvancedIncSubtensor1)
+        n for n in f2.maker.fgraph.toposort() if isinstance(n.op, AdvancedIncSubtensor)
     ]
 
     # We only have SetSubtensor in f1
@@ -2295,7 +2209,7 @@ def test_local_set_to_inc_subtensor():
 
     # Finally, test that the stack trace is copied over properly,
     # before and after optimization.
-    assert check_stack_trace(f1, ops_to_check=AdvancedIncSubtensor1)
+    assert check_stack_trace(f1, ops_to_check=AdvancedIncSubtensor)
     assert check_stack_trace(f2, ops_to_check="all")
 
 
@@ -2311,21 +2225,14 @@ def test_local_set_to_inc_subtensor_duplicate_indices():
 
     out = set_subtensor(v[idx], v[idx] + other)
 
-    mode = (
-        get_default_mode()
-        .including(
-            "local_replace_AdvancedSubtensor",
-            "local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1",
-        )
-        .excluding("fuse_indexed_into_elemwise")
-    )
+    mode = get_default_mode().excluding("fuse_indexed_into_elemwise")
     f = function([v, other, idx], out, mode=mode)
 
     # The symbolic index is not provably unique, so the set survives.
     assert all(
         n.op.set_instead_of_inc
         for n in f.maker.fgraph.toposort()
-        if isinstance(n.op, AdvancedIncSubtensor1)
+        if isinstance(n.op, AdvancedIncSubtensor)
     )
 
     # Soundness pinned against a no-rewrite reference at a duplicated index.
@@ -2341,7 +2248,7 @@ def test_local_set_to_inc_subtensor_duplicate_indices():
     assert all(
         n.op.set_instead_of_inc
         for n in f_const.maker.fgraph.toposort()
-        if isinstance(n.op, AdvancedIncSubtensor1)
+        if isinstance(n.op, AdvancedIncSubtensor)
     )
 
 
@@ -2528,7 +2435,7 @@ def test_local_uint_constant_indices():
     z_fn = pytensor.function([x], z, mode=mode)
 
     subtensor_node = z_fn.maker.fgraph.outputs[0].owner
-    assert isinstance(subtensor_node.op, AdvancedSubtensor1)
+    assert isinstance(subtensor_node.op, AdvancedSubtensor)
     new_index = subtensor_node.inputs[1]
     assert isinstance(new_index, Constant)
     assert new_index.type.dtype == "uint8"
@@ -2582,7 +2489,7 @@ def test_local_uint_constant_indices():
     z_fn = pytensor.function([x, y], z, mode=mode)
 
     subtensor_node = z_fn.maker.fgraph.outputs[0].owner
-    assert isinstance(subtensor_node.op, AdvancedIncSubtensor1)
+    assert isinstance(subtensor_node.op, AdvancedIncSubtensor)
     new_index = subtensor_node.inputs[2]
     assert isinstance(new_index, Constant)
     assert new_index.type.dtype == "uint8"
@@ -2595,7 +2502,7 @@ def test_local_uint_constant_indices():
     z_fn = pytensor.function([x], z, mode=mode)
 
     subtensor_node = z_fn.maker.fgraph.outputs[0].owner
-    assert isinstance(subtensor_node.op, (AdvancedSubtensor, AdvancedSubtensor1))
+    assert isinstance(subtensor_node.op, AdvancedSubtensor)
     new_index = subtensor_node.inputs[1]
     assert isinstance(new_index, Constant)
     assert new_index.type.dtype == "uint8"
@@ -2914,7 +2821,6 @@ class TestArangeRewrites:
 
     rewrite_kw = dict(
         include=("canonicalize", "specialize"),
-        exclude=("local_replace_AdvancedSubtensor",),
     )
 
     @pytest.mark.parametrize("offset", [0, 2])
@@ -2975,7 +2881,7 @@ class TestArangeRewrites:
 
         ar = pt.arange(n, dtype="int64")
         arange_form = x[ar + offset] if offset else x[ar]
-        assert isinstance(arange_form.owner.op, AdvancedSubtensor | AdvancedSubtensor1)
+        assert isinstance(arange_form.owner.op, AdvancedSubtensor)
 
         folded = rewrite_graph(
             arange_form,
@@ -3057,10 +2963,8 @@ def test_cholesky_unconstrain_grad(exp_before_materialize):
 
     idx_types = (
         Subtensor,
-        AdvancedSubtensor1,
         AdvancedSubtensor,
         IncSubtensor,
-        AdvancedIncSubtensor1,
         AdvancedIncSubtensor,
         ExtractDiag,
     )

--- a/tests/tensor/rewriting/test_subtensor_lift.py
+++ b/tests/tensor/rewriting/test_subtensor_lift.py
@@ -60,7 +60,6 @@ from pytensor.tensor.shape import Shape_i, SpecifyShape, _shape
 from pytensor.tensor.special import softmax
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
-    AdvancedIncSubtensor1,
     AdvancedSubtensor,
     Subtensor,
 )
@@ -79,7 +78,6 @@ NO_OPTIMIZATION_MODE = Mode(linker="py", optimizer=None)
 class TestLocalSubtensorOfBatchDims:
     rewrite_kw = dict(
         include=("ShapeOpt", "canonicalize", "specialize"),
-        exclude=("local_replace_AdvancedSubtensor",),
         clone=True,
     )
 
@@ -607,7 +605,6 @@ class TestSubtensorOfAlloc:
 
     rewrite_kw = dict(
         include=("ShapeOpt", "canonicalize", "specialize"),
-        exclude=("local_replace_AdvancedSubtensor",),
         clone=True,
     )
 
@@ -1485,10 +1482,7 @@ class TestExtractDiagLiftPass:
 
         # The partial-coverage read at offset=3 keeps exactly one scatter write of pi.
         on_topo = f_on.maker.fgraph.toposort()
-        n_writes = sum(
-            isinstance(n.op, AdvancedIncSubtensor | AdvancedIncSubtensor1)
-            for n in on_topo
-        )
+        n_writes = sum(isinstance(n.op, AdvancedIncSubtensor) for n in on_topo)
         assert n_writes == 1
 
         for got, ref in zip(f_on(), f_off(), strict=True):

--- a/tests/tensor/test_subtensor.py
+++ b/tests/tensor/test_subtensor.py
@@ -29,9 +29,7 @@ from pytensor.tensor.math import sum as pt_sum
 from pytensor.tensor.shape import specify_broadcastable, specify_shape
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
-    AdvancedIncSubtensor1,
     AdvancedSubtensor,
-    AdvancedSubtensor1,
     IncSubtensor,
     Subtensor,
     _is_provably_non_negative,
@@ -85,8 +83,8 @@ from tests.tensor.utils import inplace_func, integers_ranged, random
 subtensor_ops = (
     Subtensor,
     IncSubtensor,
-    AdvancedSubtensor1,
-    AdvancedIncSubtensor1,
+    AdvancedSubtensor,
+    AdvancedIncSubtensor,
 )
 
 
@@ -421,8 +419,6 @@ class TestSubtensor(utt.OptimizationTestMixin):
         self.dtype = config.floatX
         mode = pytensor.compile.mode.get_default_mode()
         self.mode = mode.including(
-            "local_replace_AdvancedSubtensor",
-            "local_AdvancedIncSubtensor_to_AdvancedIncSubtensor1",
             "local_useless_subtensor",
         ).excluding("bool_idx_to_nonzero", "fuse_indexed_into_elemwise")
         self.fast_compile = config.mode == "FAST_COMPILE"
@@ -676,7 +672,7 @@ class TestSubtensor(utt.OptimizationTestMixin):
             (1, Subtensor, np.index_exp[..., 1, 2, 3]),
             (1, Subtensor, np.index_exp[1, ..., 2, 3]),
             (1, Subtensor, np.index_exp[1, 2, 3, ...]),
-            (3, DimShuffle, np.index_exp[..., [0, 2, 3]]),
+            (1, AdvancedSubtensor, np.index_exp[..., [0, 2, 3]]),
             (1, DimShuffle, np.index_exp[np.newaxis, ...]),
             (
                 # ``[1, 2]`` is folded to a basic slice by
@@ -961,7 +957,7 @@ class TestSubtensor(utt.OptimizationTestMixin):
             t = n[idx]
 
             val = self.eval_output_and_check(
-                t, op_type=AdvancedSubtensor1, mode=shape_safe_mode
+                t, op_type=AdvancedSubtensor, mode=shape_safe_mode
             )
             if isinstance(idx, list):
                 good = data[idx]
@@ -971,21 +967,9 @@ class TestSubtensor(utt.OptimizationTestMixin):
             assert np.allclose(val, good), (val, good)
 
             # Test reuse of output memory
-            if type(AdvancedSubtensor1) is AdvancedSubtensor1:
-                op = AdvancedSubtensor1()
-                # When idx is a TensorConstant.
-                if hasattr(idx, "data"):
-                    idx = idx.data
-                test_out = [[None]]
-                op.perform(None, [data, idx], test_out)
-                out1 = test_out[0][0]
-                op.perform(None, [data, idx], test_out)
-                out2 = test_out[0][0]
-                assert out1 is out2
-
             # test the grad
             gn = pytensor.grad(t.sum(), n)
-            g = self.function([], gn, op=AdvancedIncSubtensor1)
+            g = self.function([], gn, op=AdvancedIncSubtensor)
             utt.verify_grad(
                 lambda m: m[[1, 3]],
                 [np.random.random((5, 5)).astype(self.dtype)],
@@ -999,7 +983,7 @@ class TestSubtensor(utt.OptimizationTestMixin):
         idx = [2, 2, 0, 0, 1, 1]
         n = self.shared(data)
         t = n[self.shared(np.asarray(idx).astype("int64"))[::2]]
-        val = self.eval_output_and_check(t, op_type=AdvancedSubtensor1, length=2)
+        val = self.eval_output_and_check(t, op_type=AdvancedSubtensor, length=2)
         utt.assert_allclose(data[idx[::2]], val)
 
     def test_err_invalid_list(self):
@@ -1017,12 +1001,12 @@ class TestSubtensor(utt.OptimizationTestMixin):
         l = lvector()
         t = n[l]
 
-        f = self.function([l], t, op=AdvancedSubtensor1)
+        f = self.function([l], t, op=AdvancedSubtensor)
 
         g = self.function(
             [l],
             inc_subtensor(t, np.asarray([[1.0]], self.dtype)),
-            op=AdvancedIncSubtensor1,
+            op=AdvancedIncSubtensor,
         )
 
         for shp in [[0, 4], [0, -3], [-10]]:
@@ -1037,11 +1021,11 @@ class TestSubtensor(utt.OptimizationTestMixin):
         idx = lvector()
         t = n[idx]
 
-        f = self.function([idx], t, op=AdvancedSubtensor1)
+        f = self.function([idx], t, op=AdvancedSubtensor)
         topo = f.maker.fgraph.toposort()
         topo_ = [node for node in topo if not isinstance(node.op, DeepCopyOp)]
         assert len(topo_) == 1
-        assert isinstance(topo_[0].op, AdvancedSubtensor1)
+        assert isinstance(topo_[0].op, AdvancedSubtensor)
         f_0 = f([0])
         assert f_0.shape == (1, 3)
         assert np.allclose(f_0, v * 5)
@@ -1054,7 +1038,7 @@ class TestSubtensor(utt.OptimizationTestMixin):
         # Test the gradient
         c = t.sum()
         gn = pytensor.grad(c, n)
-        g = self.function([idx], gn, op=AdvancedIncSubtensor1)
+        g = self.function([idx], gn, op=AdvancedIncSubtensor)
         g_0 = g([0])
         assert g_0.shape == (1, 3)
         assert np.allclose(g_0, 1)
@@ -1103,12 +1087,9 @@ class TestSubtensor(utt.OptimizationTestMixin):
         h = set_subtensor(h[indexes], h[indexes])
         g = pytensor.grad(h.sum(), W)
         N = 2
-        if (
-            config.mode == "FAST_COMPILE"
-            and AdvancedIncSubtensor1 is AdvancedIncSubtensor1
-        ):
+        if config.mode == "FAST_COMPILE":
             N = 3
-        f = self.function([x], g, op=AdvancedIncSubtensor1, N=N)
+        f = self.function([x], g, op=AdvancedIncSubtensor, N=N)
 
         f(np.random.random((10, 10, 3, 3)).astype(self.dtype))
 
@@ -1120,11 +1101,11 @@ class TestSubtensor(utt.OptimizationTestMixin):
         assert idx.type.shape == (1,)
         t = n[idx]
 
-        f = self.function([idx], t, op=AdvancedSubtensor1)
+        f = self.function([idx], t, op=AdvancedSubtensor)
         topo = f.maker.fgraph.toposort()
         topo_ = [node for node in topo if not isinstance(node.op, DeepCopyOp)]
         assert len(topo_) == 1
-        assert isinstance(topo_[0].op, AdvancedSubtensor1)
+        assert isinstance(topo_[0].op, AdvancedSubtensor)
         f_0 = f([0])
         assert f_0.shape == (1, 3)
         assert np.allclose(f_0, 5)
@@ -1132,7 +1113,7 @@ class TestSubtensor(utt.OptimizationTestMixin):
         # Test the gradient
         c = t.sum()
         gn = pytensor.grad(c, n)
-        g = self.function([idx], gn, op=AdvancedIncSubtensor1)
+        g = self.function([idx], gn, op=AdvancedIncSubtensor)
         g_0 = g([0])
         assert g_0.shape == (4, 3)
         assert np.allclose(g_0[0], 1)
@@ -1188,16 +1169,16 @@ class TestSubtensor(utt.OptimizationTestMixin):
             idx_pt = shared(idx_np, shape=(1 if idx_np.shape[0] == 1 else None,))
             t = n[idx_pt]
             gn = pytensor.grad(pt_sum(exp(t)), n)
-            f = self.function([], [gn, gn.shape], op=AdvancedIncSubtensor1)
+            f = self.function([], [gn, gn.shape], op=AdvancedIncSubtensor)
             topo = f.maker.fgraph.toposort()
             if not self.fast_compile:
                 assert any(
-                    isinstance(node.op, AdvancedIncSubtensor1) and node.op.inplace
+                    isinstance(node.op, AdvancedIncSubtensor) and node.op.inplace
                     for node in topo
                 )
             else:
-                assert any(isinstance(node.op, AdvancedIncSubtensor1) for node in topo)
-            assert any(isinstance(node.op, AdvancedSubtensor1) for node in topo)
+                assert any(isinstance(node.op, AdvancedIncSubtensor) for node in topo)
+            assert any(isinstance(node.op, AdvancedSubtensor) for node in topo)
             gval, gshape = f()
             good = np.zeros_like(data)
             # don't work when the same index is used many time
@@ -1221,7 +1202,7 @@ class TestSubtensor(utt.OptimizationTestMixin):
 
             # Test shape of AdvancedIncSubtensor1 and AdvancedSubtensor1
             if not self.fast_compile:
-                ops = (AdvancedIncSubtensor1, AdvancedSubtensor1)
+                ops = (AdvancedIncSubtensor, AdvancedSubtensor)
             else:
                 ops = subtensor_ops
             if idx is idxs[0]:
@@ -1416,7 +1397,7 @@ class TestSubtensor(utt.OptimizationTestMixin):
             all_inputs_var,
             all_outputs_var,
             accept_inplace=True,
-            op=AdvancedIncSubtensor1,
+            op=AdvancedIncSubtensor,
             N=len(all_outputs_var),
         )
 
@@ -1440,7 +1421,7 @@ class TestSubtensor(utt.OptimizationTestMixin):
         f = function([y], out)
         f(np.ones((20, 5)))  # Fine
         err_message = (
-            "(Runtime broadcasting not allowed\\. AdvancedIncSubtensor1 was asked"
+            "(Runtime broadcasting not allowed\\. AdvancedIncSubtensor was asked"
             "|The number of indices and values must match)"
         )
         numba_linker = isinstance(f.maker.linker, NumbaLinker)
@@ -1849,9 +1830,9 @@ class TestAdvancedIncSubtensor1:
 
     @pytest.mark.parametrize("ignore_duplicates", [True, False])
     def test_inc_subtensor_AdvancedSubtensor1(self, ignore_duplicates):
-        x = AdvancedSubtensor1()(self.v, self.adv1q)
+        x = advanced_subtensor1(self.v, self.adv1q)
         a = inc_subtensor(x, self.v[self.adv1q], ignore_duplicates=ignore_duplicates)
-        assert isinstance(a.owner.op, AdvancedIncSubtensor1 | AdvancedIncSubtensor)
+        assert isinstance(a.owner.op, AdvancedIncSubtensor)
         assert getattr(a.owner.op, "ignore_duplicates", False) == ignore_duplicates
 
     def test_1d_inc_adv_selection(self):
@@ -2632,7 +2613,7 @@ class TestInferShape(utt.InferShapeTester):
                 )
             ],
             [admat_val, [[1, 2, 3, 4]]],
-            AdvancedIncSubtensor1,
+            AdvancedIncSubtensor,
         )
 
         aivec_val = [1, 3, 2]
@@ -2640,7 +2621,7 @@ class TestInferShape(utt.InferShapeTester):
             [admat, advec],
             [advanced_set_subtensor1(admat, advec, aivec_val)],
             [admat_val, [1, 2, 3, 4]],
-            AdvancedIncSubtensor1,
+            AdvancedIncSubtensor,
         )
 
         aivec_val = [0, 3, 0]
@@ -2648,7 +2629,7 @@ class TestInferShape(utt.InferShapeTester):
             [admat, adscal],
             [advanced_set_subtensor1(admat, adscal, aivec_val)],
             [admat_val, 1],
-            AdvancedIncSubtensor1,
+            AdvancedIncSubtensor,
         )
 
         adtens4 = dtensor4()
@@ -2663,7 +2644,7 @@ class TestInferShape(utt.InferShapeTester):
                 )
             ],
             [adtens4_val, [[[[1, 2, 3, 4, 5]]]]],
-            AdvancedIncSubtensor1,
+            AdvancedIncSubtensor,
             warn=False,
         )
 
@@ -2672,7 +2653,7 @@ class TestInferShape(utt.InferShapeTester):
             [adtens4, advec],
             [advanced_set_subtensor1(adtens4, advec, aivec_val)],
             [adtens4_val, [1, 2, 3, 4, 5]],
-            AdvancedIncSubtensor1,
+            AdvancedIncSubtensor,
         )
 
         aivec_val = [0, 3, 0]
@@ -2680,7 +2661,7 @@ class TestInferShape(utt.InferShapeTester):
             [adtens4, adscal],
             [advanced_set_subtensor1(adtens4, adscal, aivec_val)],
             [adtens4_val, 1],
-            AdvancedIncSubtensor1,
+            AdvancedIncSubtensor,
         )
 
         aivec_val = [2, 3]
@@ -2688,7 +2669,7 @@ class TestInferShape(utt.InferShapeTester):
             [admat, bdmat],
             [advanced_set_subtensor1(admat, bdmat, aivec_val)],
             [admat_val, [[1, 2, 3, 4], [5, 6, 7, 8]]],
-            AdvancedIncSubtensor1,
+            AdvancedIncSubtensor,
         )
 
         aivec_val = [1, 3, 2]
@@ -2696,7 +2677,7 @@ class TestInferShape(utt.InferShapeTester):
             [admat, advec],
             [advanced_set_subtensor1(admat, advec, aivec_val)],
             [admat_val, [1, 2, 3, 4]],
-            AdvancedIncSubtensor1,
+            AdvancedIncSubtensor,
         )
 
         aivec_val = [0, 3, 0]
@@ -2704,7 +2685,7 @@ class TestInferShape(utt.InferShapeTester):
             [admat, adscal],
             [advanced_set_subtensor1(admat, adscal, aivec_val)],
             [admat_val, 1],
-            AdvancedIncSubtensor1,
+            AdvancedIncSubtensor,
         )
 
         bdtens4 = dtensor4()
@@ -2718,7 +2699,7 @@ class TestInferShape(utt.InferShapeTester):
                 )
             ],
             [adtens4_val, [[[[1, 2, 3, 4, 5]]], [[[6, 7, 8, 9, 10]]]]],
-            AdvancedIncSubtensor1,
+            AdvancedIncSubtensor,
             warn=False,
         )
 
@@ -2727,7 +2708,7 @@ class TestInferShape(utt.InferShapeTester):
             [adtens4, advec],
             [advanced_set_subtensor1(adtens4, advec, aivec_val)],
             [adtens4_val, [1, 2, 3, 4, 5]],
-            AdvancedIncSubtensor1,
+            AdvancedIncSubtensor,
         )
 
         aivec_val = [0, 3, 0]
@@ -2735,7 +2716,7 @@ class TestInferShape(utt.InferShapeTester):
             [adtens4, adscal],
             [advanced_set_subtensor1(adtens4, adscal, aivec_val)],
             [adtens4_val, 2],
-            AdvancedIncSubtensor1,
+            AdvancedIncSubtensor,
         )
 
     def test_AdvancedIncSubtensor(self):


### PR DESCRIPTION
Use only the general AdvancedSubtensor / AdvancedIncSubtensor. The specialized
*1 Ops existed solely to carry a C fast path for the leading-axis integer-vector
form (x[vec] and x[vec] (+)= y). Fold it into the general Ops as guarded c_code
that falls back to perform outside the accelerated form: reads take the
PyArray_TakeFrom path for a single integer-array index with all other axes full
slices (any axis, any index ndim); writes take the scatter-loop path for a 1-D x
indexed by an integer array of any ndim (y matching the index element-wise).
Native-C coverage is unchanged-or-broader on both sides: reads hit C on
non-leading / any-ndim single-array takes directly, and the scatter now covers
multi-dim indices into a 1-D x -- including the gradient of take(x_1d, idx_nd),
which previously reached C only because a now-removed rewrite flattened the
forward read to a 1-D index.

- AdvancedSubtensor / AdvancedIncSubtensor gain the gated take/scatter c_code
  (AdvancedIncSubtensor promoted to a COp; it already had inplace, set, and
  ignore_duplicates). Runtime-broadcast checking is now applied consistently
  across perform, C, jax, mlx and pytorch instead of only on the *1 Ops.
- Retarget every rewrite and backend dispatch off the *1 classes; delete the
  *1-specific rewrites (inplace, the AdvancedIncSubtensor -> AdvancedIncSubtensor1
  conversion) now covered by the general ones.
- advanced_subtensor1 / advanced_inc_subtensor1 / advanced_set_subtensor1 are
  now thin deprecated shims (FutureWarning) building the general Op; internal
  callers migrated to the general helpers.
- Drop the unused sparse_grad flag and pytensor.sparse.sparse_grad helper.
