### PR TITLE
Fix rewrites that were relaxed from Advanced(Inc)Subtensor1 Op but relied on their restrictions

### DIFF
--- a/pytensor/tensor/rewriting/subtensor.py
+++ b/pytensor/tensor/rewriting/subtensor.py
@@ -76,7 +76,6 @@ from pytensor.tensor.subtensor import (
     _is_provably_non_negative,
     _is_provably_positive,
     _non_consecutive_adv_indexing,
-    advanced_inc_subtensor,
     as_index_literal,
     flatten_index_variables,
     get_canonical_form_slice,
@@ -1104,11 +1103,13 @@ def local_useless_inc_subtensor(fgraph, node):
 @register_specialize
 @node_rewriter([AdvancedIncSubtensor])
 def local_set_to_inc_subtensor(fgraph, node):
-    r"""
-    AdvancedIncSubtensor(x, x[ilist]+other, ilist, set_instead_of_inc=True) ->
-    AdvancedIncSubtensor(x, other, ilist, set_instead_of_inc=False)
+    r"""Set of a read at the same indices: ``x[idx].set(x[idx] + other)``.
 
-    Only valid when ``ilist`` is duplicate-free: a dense set is last-wins while an
+    .. code::
+
+        x[idx].set(x[idx] + other) -> x[idx].inc(other)
+
+    Only valid when ``idx`` is duplicate-free: a dense set is last-wins while an
     inc accumulates, so duplicate indices would over-count.
 
     TODO FIXME: Why doesn't this apply to all `*IncSubtensor*` `Op`\s?  If it
@@ -1136,14 +1137,30 @@ def local_set_to_inc_subtensor(fgraph, node):
         other = addn.inputs[0]
     else:
         return
-    if subn.inputs[1] != node.inputs[2] or subn.inputs[0] != node.inputs[0]:
+    # The read has to gather exactly the positions the write stores to: same base,
+    # same axes, same indices. `idx_list` must be compared too -- it is what pins
+    # the indices to their axes, so without it a read of ``x[:, i]`` would match a
+    # write to ``x[i]``.
+    if (
+        subn.inputs[0] != node.inputs[0]
+        or subn.op.idx_list != node.op.idx_list
+        or subn.inputs[1:] != node.inputs[2:]
+    ):
         return
-    # set->inc is only valid when ilist is duplicate-free: ``set(x[ilist] + other)``
-    # is last-wins at repeated positions, while ``inc(other)`` would accumulate the
-    # contributions of every occurrence and over-count them.
-    if not _index_provably_unique(node.inputs[2], fgraph):
+    # set->inc is only valid when the written positions are duplicate-free:
+    # ``set(x[idx] + other)`` is last-wins at repeated positions, while
+    # ``inc(other)`` would accumulate the contributions of every occurrence and
+    # over-count them.
+    indices = indices_from_subtensor(node.inputs[2:], node.op.idx_list)
+    if not _advanced_indices_jointly_unique(indices, fgraph):
         return
-    ret = advanced_inc_subtensor(node.inputs[0], other, node.inputs[2])
+    new_op = type(node.op)(
+        idx_list=node.op.idx_list,
+        inplace=node.op.inplace,
+        set_instead_of_inc=False,
+        ignore_duplicates=node.op.ignore_duplicates,
+    )
+    ret = new_op(node.inputs[0], other, *node.inputs[2:])
 
     copy_stack_trace(node.outputs, ret)
 
@@ -1339,52 +1356,6 @@ def local_convert_negative_indices(fgraph, node):
     new_subtensor = x[tuple(new_idxs)]
     copy_stack_trace(node.outputs, new_subtensor)
     return [new_subtensor]
-
-
-@register_canonicalize
-@register_specialize
-@node_rewriter([AdvancedSubtensor])
-def local_useless_AdvancedSubtensor1(fgraph, node):
-    """Remove a leading-axis vector take that selects the full input.
-
-    The full input is taken when the index is equivalent to
-    ``arange(0, input.shape[0], 1)`` using either an explicit list/vector or
-    the `ARange` `Op`.
-
-    """
-    if node.op.idx_list != (0,):
-        # Only the leading integer-vector take (x[ilist])
-        return
-
-    # This optimization needs ShapeOpt and fgraph.shape_feature
-    if not hasattr(fgraph, "shape_feature"):
-        return
-
-    shape_feature = fgraph.shape_feature
-
-    # get length of the indexed tensor along the first axis
-    try:
-        length = get_scalar_constant_value(
-            shape_feature.get_shape(node.inputs[0], 0), only_process_constants=True
-        )
-    except NotScalarConstantError:
-        return False
-
-    # get index (which must be a vector by definition)
-    idx = node.inputs[1]
-
-    # `idx` must be equivalent to [0,1,...,shape[0] - 1] to qualify for
-    # this optimization
-    if isinstance(idx, Constant):
-        idx = idx.value
-        if len(idx) != length:
-            return False
-        if np.any(idx != np.arange(length)):
-            return False
-    else:
-        return False
-
-    return [node.inputs[0]]
 
 
 def _arange_index_to_slice(idx):
@@ -2343,8 +2314,7 @@ def local_write_of_write_same_indices(fgraph, node):
     base, a, *inner_idx_vars = inner_x.owner.inputs
 
     # Same indices: idx_list (slice specs) must match and all index
-    # variables must be identical.  AdvancedIncSubtensor1 has a fixed
-    # class-level idx_list = (0,) so the comparison is trivially true.
+    # variables must be identical.
     if node.op.idx_list != inner_x.owner.op.idx_list:
         return
     if not all(o is i for o, i in zip(outer_idx_vars, inner_idx_vars, strict=True)):

--- a/pytensor/tensor/rewriting/subtensor_lift.py
+++ b/pytensor/tensor/rewriting/subtensor_lift.py
@@ -1062,6 +1062,11 @@ def local_subtensor_make_vector(fgraph, node):
             except NotScalarConstantError:
                 pass
         elif idx.ndim == 1 and isinstance(idx, Constant):
+            if idx.type.dtype == "bool":
+                # A boolean mask selects the entries it is True at, which is not
+                # what mapping it to positions below would read it as. Leave it
+                # for `bool_idx_to_nonzero` to turn into integer positions.
+                return False
             values = list(map(int, list(idx.value)))
             if len(values) == 1:
                 ret = expand_dims(x.owner.inputs[values[0]], axis=0)

--- a/tests/tensor/rewriting/test_subtensor.py
+++ b/tests/tensor/rewriting/test_subtensor.py
@@ -307,9 +307,7 @@ class TestIndexProvablyUniqueArange:
 class TestLocalUselessSubtensor:
     x = matrix("x")
     s = ps.int32("s")
-    mode = mode_opt.including(
-        "local_useless_subtensor", "local_useless_AdvancedSubtensor1"
-    )
+    mode = mode_opt.including("local_useless_subtensor", "local_adv_idx_to_slice")
 
     @pytest.mark.parametrize(
         "idx",
@@ -2250,6 +2248,63 @@ def test_local_set_to_inc_subtensor_duplicate_indices():
         for n in f_const.maker.fgraph.toposort()
         if isinstance(n.op, AdvancedIncSubtensor)
     )
+
+
+def test_local_set_to_inc_subtensor_indexed_axis():
+    """The collapsed inc must keep indexing the axis the set wrote to. ``idx_list``
+    is what pins an index to its axis, so a read of ``x[:, i]`` matching a write to
+    ``x[i]`` would transpose the update."""
+    x = matrix("x", shape=(3, 3))
+    other = matrix("other", shape=(3, 3))
+    i = pt.constant(np.array([2, 0, 1]))
+
+    result = utt.RewriteTester([x, other], [x[:, i].set(x[:, i] + other)])
+    result.assert_graph(x[:, i].inc(other))
+    result.assert_eval(np.zeros((3, 3)), np.arange(9.0).reshape(3, 3))
+
+
+@pytest.mark.parametrize(
+    "rows, cols, collapses",
+    [
+        # No axis is duplicate-free on its own, but the joint pairs (0,2), (1,2)
+        # are distinct, so accumulating is safe.
+        ([0, 1], [2, 2], True),
+        # The joint pairs (1,2), (1,2) repeat: an inc would double-count.
+        ([1, 1], [2, 2], False),
+    ],
+)
+def test_local_set_to_inc_subtensor_multiple_indices(rows, cols, collapses):
+    """With several advanced indices the written positions are the broadcast tuples
+    of the entries, so joint uniqueness governs the collapse. The indices also have
+    to survive it: rebuilding with only the first would write the wrong positions."""
+    x = matrix("x", shape=(3, 3))
+    other = vector("other", shape=(2,))
+    rows = pt.constant(np.array(rows))
+    cols = pt.constant(np.array(cols))
+
+    out = x[rows, cols].set(x[rows, cols] + other)
+    result = utt.RewriteTester([x, other], [out])
+    if collapses:
+        result.assert_graph(x[rows, cols].inc(other))
+    else:
+        result.assert_graph(out)
+    result.assert_eval(np.arange(9.0).reshape(3, 3), np.array([100.0, 200.0]))
+
+
+def test_local_adv_idx_to_slice_boolean_mask():
+    """A boolean mask is a single index on the leading axis just like an integer
+    vector, but selects where it is True rather than by position, so the arange
+    reasoning must not be applied to it."""
+    x = matrix("x", shape=(5, 2))
+    mask = np.zeros((5, 2), dtype=bool)
+    mask[2, 0] = True
+    mask[3, 1] = True
+
+    # `o3` rather than the default `canonicalize`: the rewrites that read a
+    # leading-axis index only run once the shape feature is in place.
+    result = utt.RewriteTester([x], [x[mask]], include="o3")
+    result.assert_graph(x[mask])
+    result.assert_eval(np.arange(10.0).reshape(5, 2))
 
 
 @pytest.mark.parametrize(

--- a/tests/tensor/rewriting/test_subtensor_lift.py
+++ b/tests/tensor/rewriting/test_subtensor_lift.py
@@ -986,7 +986,7 @@ class TestLocalSubtensorMakeVector:
         r = f(0, 1, 2)
         assert r[0] == 0 and r[1] == 2
 
-    def test_AdvancedSubtensor1_idx(self):
+    def test_AdvancedSubtensor_idx(self):
         x, y, z = lscalars("xyz")
         v = make_vector(x, y, z)
         f = function([x, y, z], v[[0, 2]], mode=self.mode)
@@ -997,6 +997,23 @@ class TestLocalSubtensorMakeVector:
         assert len(prog[0].inputs) == 2
         r = f(0, 1, 2)
         assert r[0] == 0 and r[1] == 2
+
+    @pytest.mark.parametrize(
+        "mask", [[True, True, True], [True, False, True], [False, True, False]]
+    )
+    def test_AdvancedSubtensor_boolean_mask_idx(self, mask):
+        """A boolean mask selects the entries it is True at, not the positions
+        ``int(True)``/``int(False)`` would name, so it is left alone here and
+        handed to `bool_idx_to_nonzero` instead."""
+        x, y, z = lscalars("xyz")
+        v = make_vector(x, y, z)
+        out = v[np.array(mask)]
+
+        result = RewriteTester(
+            [x, y, z], [out], include=None, custom_rewrite=local_subtensor_make_vector
+        )
+        result.assert_graph(out)
+        result.assert_eval(0, 1, 2)
 
     def test_MakeVector_idx(self):
         x, y, z, q = lscalars("xyzq")


### PR DESCRIPTION
AdvancedSubtensor1 / AdvancedIncSubtensor1 guaranteed a single 1-D integerindex on the leading axis. Three rewrites retargeted onto the general Ops still relied on that; the last two returned wrong results silently.

- local_useless_AdvancedSubtensor1 gated on idx_list == (0,), which a boolean  mask also satisfies, and crashed comparing it against arange. Deleted:  local_adv_idx_to_slice already covers the arange take.
- local_set_to_inc_subtensor ignored idx_list and compared only the first index, so a read of x[:, i] matched a write to x[i] and the collapsed inc hit the wrong axis. It now compares and rebuilds with all of them, gated on _advanced_indices_jointly_unique.
- local_subtensor_make_vector mapped a constant index through int(), reading a  boolean mask as the positions 0/1. Left for bool_idx_to_nonzero instead.

Regression from #2294 