### PR TITLE
Cast constant ARange bounds to Op dtype in JAX backend

### DIFF
--- a/pytensor/link/jax/dispatch/tensor_basic.py
+++ b/pytensor/link/jax/dispatch/tensor_basic.py
@@ -71,7 +71,10 @@ def jax_funcify_ARange(op, node, **kwargs):
             case (Subtensor(), shape_var, *_) if isinstance(shape_var.owner_op, Shape):
                 constant_args.append(None)
             case _ if isinstance(arg, Constant):
-                constant_args.append(arg.value)
+                # Cast to the Op's dtype: PyTensor types integer literals (e.g. 0/1 arange
+                # start/step) as int8, and jnp.arange bounds-checks stop against the argument dtype,
+                # overflowing for stop > 127.
+                constant_args.append(np.asarray(arg.value, op.dtype))
             case _:
                 # TODO: This might be failing without need (e.g., if arg = shape(x)[-1] + 1)!
                 raise NotImplementedError(ARANGE_CONCRETE_VALUE_ERROR)

--- a/tests/link/jax/test_tensor_basic.py
+++ b/tests/link/jax/test_tensor_basic.py
@@ -89,6 +89,16 @@ def test_arange_nonconcrete():
         compare_jax_and_py([a], [out], [a_test_value])
 
 
+def test_arange_shape_bound_over_int8():
+    """A shape-derived arange bound above 127 must not be downcast to int8.
+
+    Regression test for https://github.com/pymc-devs/pytensor/issues/2296
+    """
+    x = vector("x")
+    out = ptb.arange(x.shape[-1])
+    compare_jax_and_py([x], [out], [np.zeros(200)], jax_mode="JAX")
+
+
 def test_jax_Join():
     a = matrix("a")
     b = matrix("b")


### PR DESCRIPTION
Closes #2296