### PR TITLE
feat: Add pt.multiply as an alias for pt.mul (NumPy compatibility)

### DIFF
--- a/pytensor/tensor/math.py
+++ b/pytensor/tensor/math.py
@@ -2936,6 +2936,9 @@ def mul(a, *other_terms):
     # see decorator for function body
 
 
+multiply = mul
+
+
 def variadic_mul(*args):
     """Mul that accepts arbitrary number of inputs, including zero or one."""
     if not args:
@@ -4330,6 +4333,7 @@ __all__ = [
     "minimum",
     "mod",
     "mul",
+    "multiply",
     "nan_to_num",
     "neg",
     "neq",

--- a/tests/tensor/test_math.py
+++ b/tests/tensor/test_math.py
@@ -102,6 +102,7 @@ from pytensor.tensor.math import (
     minimum,
     mod,
     mul,
+    multiply,
     nan_to_num,
     neg,
     neq,
@@ -3972,3 +3973,14 @@ def test_median(ndim, axis):
 
     assert np.allclose(result_odd, expected_odd)
     assert np.allclose(result_even, expected_even)
+
+
+def test_multiply():
+    x = vector()
+    y = vector()
+    z = multiply(x, y)
+    f = function([x, y], z)
+    a = np.array([1.0, 2.0, 3.0])
+    b = np.array([4.0, 5.0, 6.0])
+    assert np.allclose(f(a, b), a * b)
+

--- a/tests/tensor/test_math.py
+++ b/tests/tensor/test_math.py
@@ -3983,4 +3983,3 @@ def test_multiply():
     a = np.array([1.0, 2.0, 3.0])
     b = np.array([4.0, 5.0, 6.0])
     assert np.allclose(f(a, b), a * b)
-


### PR DESCRIPTION
Closes #1096

### Description
This PR resolves #1096 by adding `multiply` as an alias for `mul` in `pytensor/tensor/math.py` and exporting it in `__all__`.
This brings the PyTensor API in closer alignment and compatibility with the NumPy API (which supports `np.multiply`).

### Changes
- Defined `multiply = mul` in `pytensor/tensor/math.py`.
- Added `"multiply"` to the `__all__` list in `pytensor/tensor/math.py`.
- Added a unit test `test_multiply()` in `tests/tensor/test_math.py` verifying that `multiply` behaves correctly and identically to standard multiplication.