### PR TITLE
Fix broadcast check on IncSubtensor with boolean masks

### DIFF
--- a/pytensor/link/jax/dispatch/subtensor.py
+++ b/pytensor/link/jax/dispatch/subtensor.py
@@ -59,8 +59,8 @@ def jax_funcify_IncSubtensor(op, node, **kwargs):
         if len(indices) == 1:
             indices = indices[0]
 
-        if isinstance(op, AdvancedIncSubtensor) and op.idx_list == (0,):
-            op._check_runtime_broadcasting(node, x, y, indices)
+        if isinstance(op, AdvancedIncSubtensor):
+            op._check_runtime_broadcast_of_vector_index(node, x, y, indices)
 
         return jax_fn(x, indices, y)
 

--- a/pytensor/link/mlx/dispatch/subtensor.py
+++ b/pytensor/link/mlx/dispatch/subtensor.py
@@ -97,8 +97,7 @@ def mlx_funcify_AdvancedIncSubtensor(op, node, **kwargs):
             return x.at[indices].add(y)
 
     def advancedincsubtensor(x, y, *ilist, mlx_fn=mlx_fn):
-        if op.idx_list == (0,):
-            op._check_runtime_broadcasting(node, x, y, ilist[0])
+        op._check_runtime_broadcast_of_vector_index(node, x, y, ilist[0])
 
         return mlx_fn(x, ilist, y)
 

--- a/pytensor/link/pytorch/dispatch/subtensor.py
+++ b/pytensor/link/pytorch/dispatch/subtensor.py
@@ -63,8 +63,6 @@ def pytorch_funcify_IncSubtensor(op, node, **kwargs):
         def set_subtensor(x, y, *flattened_indices):
             indices = indices_from_subtensor(flattened_indices, idx_list)
             check_negative_steps(indices)
-            if op.idx_list == (0,):
-                op._check_runtime_broadcasting(node, x, y, indices[0])
             if not inplace:
                 x = x.clone()
             x[indices] = y
@@ -77,8 +75,6 @@ def pytorch_funcify_IncSubtensor(op, node, **kwargs):
         def inc_subtensor(x, y, *flattened_indices):
             indices = indices_from_subtensor(flattened_indices, idx_list)
             check_negative_steps(indices)
-            if op.idx_list == (0,):
-                op._check_runtime_broadcasting(node, x, y, indices[0])
             if not inplace:
                 x = x.clone()
             x[indices] += y
@@ -98,8 +94,7 @@ def pytorch_funcify_AdvancedIncSubtensor(op, node, **kwargs):
         def adv_set_subtensor(x, y, *flattened_indices):
             indices = indices_from_subtensor(flattened_indices, idx_list)
             check_negative_steps(indices)
-            if op.idx_list == (0,):
-                op._check_runtime_broadcasting(node, x, y, indices[0])
+            op._check_runtime_broadcast_of_vector_index(node, x, y, indices[0])
             if not inplace:
                 x = x.clone()
             x[indices] = y.type_as(x)
@@ -112,8 +107,7 @@ def pytorch_funcify_AdvancedIncSubtensor(op, node, **kwargs):
         def adv_inc_subtensor_no_duplicates(x, y, *flattened_indices):
             indices = indices_from_subtensor(flattened_indices, idx_list)
             check_negative_steps(indices)
-            if op.idx_list == (0,):
-                op._check_runtime_broadcasting(node, x, y, indices[0])
+            op._check_runtime_broadcast_of_vector_index(node, x, y, indices[0])
             if not inplace:
                 x = x.clone()
             x[indices] += y.type_as(x)
@@ -131,8 +125,7 @@ def pytorch_funcify_AdvancedIncSubtensor(op, node, **kwargs):
             indices = indices_from_subtensor(flattened_indices, idx_list)
             # Not needed because slices aren't supported in this path
             # check_negative_steps(indices)
-            if op.idx_list == (0,):
-                op._check_runtime_broadcasting(node, x, y, indices[0])
+            op._check_runtime_broadcast_of_vector_index(node, x, y, indices[0])
             if not inplace:
                 x = x.clone()
             x.index_put_(indices, y.type_as(x), accumulate=True)

--- a/pytensor/tensor/subtensor.py
+++ b/pytensor/tensor/subtensor.py
@@ -2445,29 +2445,32 @@ class AdvancedIncSubtensor(BaseSubtensor, COp):
     def c_code_cache_version(self):
         return (2,)
 
-    def _check_runtime_broadcasting(self, node, x, y, idx) -> None:
-        """Raise if ``y`` would silently broadcast against the leading-axis update.
+    def _check_runtime_broadcast_of_vector_index(self, node, x, y, idx) -> None:
+        """Raise if ``x[idx] (+)= y`` would broadcast ``y`` at runtime.
 
-        Applies to the leading integer-vector form; ``y`` must already match the
-        indexed shape rather than being broadcast at runtime.
+        Only the single integer vector index form is checked, where the update
+        must have shape ``(idx.shape[0], *x.shape[1:])``. Other index forms
+        (boolean masks, multidimensional or multiple indices) are left to the
+        numpy-like broadcasting of the underlying implementation.
         """
-        if y.ndim > 0:
-            y_pt_bcast = node.inputs[1].broadcastable
+        if self.idx_list != (0,):
+            return
+        idx_type = node.inputs[2].type
+        if idx_type.ndim != 1 or idx_type.dtype == "bool":
+            return
 
-            if not y_pt_bcast[0] and y.shape[0] == 1 and y.shape[0] != idx.shape[0]:
-                # Attempting to broadcast with index
-                raise ValueError(self._runtime_broadcast_error_msg)
-            if any(
-                not y_bcast and y_dim == 1 and y_dim != x_dim
-                for y_bcast, y_dim, x_dim in zip(
-                    reversed(y_pt_bcast),
-                    reversed(y.shape),
-                    reversed(x.shape),
-                    strict=False,
-                )
-            ):
-                # Attempting to broadcast with buffer
-                raise ValueError(self._runtime_broadcast_error_msg)
+        y_static_bcast = node.inputs[1].type.broadcastable
+        expected_shape = (idx.shape[0], *x.shape[1:])
+        if any(
+            not y_bcast and y_dim == 1 and expected_dim != 1
+            for y_bcast, y_dim, expected_dim in zip(
+                reversed(y_static_bcast),
+                reversed(y.shape),
+                reversed(expected_shape),
+                strict=False,
+            )
+        ):
+            raise ValueError(self._runtime_broadcast_error_msg)
 
     def __init__(
         self,
@@ -2510,8 +2513,7 @@ class AdvancedIncSubtensor(BaseSubtensor, COp):
     def perform(self, node, inputs, out_):
         x, y, *index_variables = inputs
 
-        if self.idx_list == (0,):
-            self._check_runtime_broadcasting(node, x, y, index_variables[0])
+        self._check_runtime_broadcast_of_vector_index(node, x, y, index_variables[0])
 
         full_indices = unflatten_index_variables(index_variables, self.idx_list)
 

--- a/tests/tensor/test_subtensor.py
+++ b/tests/tensor/test_subtensor.py
@@ -1413,13 +1413,20 @@ class TestSubtensor(utt.OptimizationTestMixin):
     @pytest.mark.parametrize("func", (advanced_inc_subtensor1, advanced_set_subtensor1))
     def test_advanced1_inc_runtime_broadcast(self, func):
         y = matrix("y", dtype="float64", shape=(None, None))
+        idx = lvector("idx")
 
         x = ptb.zeros((10, 5))
         idxs = np.repeat(np.arange(10), 2)
-        out = func(x, y, idxs)
+        out = func(x, y, idx)
 
-        f = function([y], out)
-        f(np.ones((20, 5)))  # Fine
+        f = function([y, idx], out)
+        f(np.ones((20, 5)), idxs)  # Fine
+
+        # A length-one index is an exact fit for a length-one update, not a broadcast
+        expected = np.zeros((10, 5))
+        expected[1] = 1.0
+        assert_array_equal(f(np.ones((1, 5)), np.array([1])), expected)
+
         err_message = (
             "(Runtime broadcasting not allowed\\. AdvancedIncSubtensor was asked"
             "|The number of indices and values must match)"
@@ -1431,13 +1438,42 @@ class TestSubtensor(utt.OptimizationTestMixin):
             if numba_linker
             else pytest.raises(ValueError, match=err_message)
         ):
-            f(np.ones((1, 5)))
+            f(np.ones((1, 5)), idxs)
         with (
             nullcontext()
             if numba_linker
             else pytest.raises(ValueError, match=err_message)
         ):
-            f(np.ones((20, 1)))
+            f(np.ones((20, 1)), idxs)
+
+    @pytest.mark.xfail(reason="Runtime broadcasting is only checked for a vector index")
+    @pytest.mark.parametrize("idx_dtype", ("bool", "int64"))
+    def test_advanced_set_runtime_broadcast_unchecked_indices(self, idx_dtype):
+        """These index forms should be checked too, but we only kept the original AdvancedIncSubtensor1 check.
+
+        Rewrites are off to keep `bool_idx_to_nonzero` from turning the mask into
+        integer positions before it reaches the Op.
+        """
+        x = vector("x", dtype="float64", shape=(None,))
+        y = vector("y", dtype="float64", shape=(None,))
+        idx = (
+            vector("idx", dtype="bool", shape=(None,))
+            if idx_dtype == "bool"
+            else lmatrix("idx")
+        )
+
+        out = advanced_set_subtensor(x, y, idx)
+        f = function([x, y, idx], out, mode=Mode(linker="py", optimizer=None))
+
+        idx_val = (
+            np.array([True, True, True, False, False])
+            if idx_dtype == "bool"
+            else np.array([[0, 1], [2, 3]])
+        )
+        with pytest.raises(
+            ValueError, match=r"Runtime broadcasting not allowed\. AdvancedIncSubtensor"
+        ):
+            f(np.zeros(5), np.ones(1), idx_val)
 
     def test_adv_constant_arg(self):
         # Test case provided (and bug detected, gh-607) by John Salvatier


### PR DESCRIPTION
When we replaced AdvancedSetSubtensor1 -> AdvacedSubtensor1 we moved the runtime check on the first axis (not yet full runtime check), but we didn't gate correctly on whether that first vector index is a integer or a bool, for bool it's not the shape that matters it's the entries == 1 (aka sum()).

For now I keep just the old check conditions. We'll extend the runtime broadcasting to be exhaustive but I want to delay more breaking changes for now