### PR TITLE
Fix linspace retstep dtype handling

### DIFF
--- a/pytensor/tensor/extra_ops.py
+++ b/pytensor/tensor/extra_ops.py
@@ -1710,6 +1710,10 @@ def linspace(
         axis=axis,
     )
 
+    if retstep:
+        samples, step = ls
+        return samples.astype(dtype), step
+
     return ls.astype(dtype)
 
 

--- a/tests/tensor/test_extra_ops.py
+++ b/tests/tensor/test_extra_ops.py
@@ -1356,6 +1356,22 @@ def test_space_ops(op, dtype, start, stop, num_samples, endpoint, axis):
     )
 
 
+@pytest.mark.parametrize("dtype", [None, "int64", "floatX"])
+def test_linspace_retstep(dtype):
+    dtype = dtype if dtype != "floatX" else config.floatX
+    samples, step = pt.linspace(0, 1, num=3, retstep=True, dtype=dtype)
+
+    result = function(inputs=[], outputs=[samples, step], mode="FAST_COMPILE")()
+    assert result is not None
+    actual_samples, actual_step = result
+    expected_samples, expected_step = np.linspace(
+        0, 1, num=3, retstep=True, dtype=dtype
+    )
+
+    np.testing.assert_allclose(actual_samples, expected_samples)
+    np.testing.assert_allclose(actual_step, expected_step)
+
+
 def test_concat_with_broadcast():
     rng = np.random.default_rng()
     a = pt.tensor("a", shape=(1, 3, 5))

--- a/tests/tensor/test_extra_ops.py
+++ b/tests/tensor/test_extra_ops.py
@@ -1356,18 +1356,18 @@ def test_space_ops(op, dtype, start, stop, num_samples, endpoint, axis):
     )
 
 
-@pytest.mark.parametrize("dtype", [None, "int64", "floatX"])
+@pytest.mark.parametrize("dtype", [None, "int64"])
 def test_linspace_retstep(dtype):
-    dtype = dtype if dtype != "floatX" else config.floatX
     samples, step = pt.linspace(0, 1, num=3, retstep=True, dtype=dtype)
-
-    result = function(inputs=[], outputs=[samples, step], mode="FAST_COMPILE")()
-    assert result is not None
-    actual_samples, actual_step = result
     expected_samples, expected_step = np.linspace(
         0, 1, num=3, retstep=True, dtype=dtype
     )
 
+    assert samples.dtype == (config.floatX if dtype is None else dtype)
+    # step is never cast to `dtype`
+    assert step.dtype == expected_step.dtype
+
+    actual_samples, actual_step = function([], [samples, step])()
     np.testing.assert_allclose(actual_samples, expected_samples)
     np.testing.assert_allclose(actual_step, expected_step)
 


### PR DESCRIPTION
## Description

`linspace(..., retstep=True)` now casts only the generated samples instead of calling `astype` on the returned tuple. The step keeps NumPy-compatible floating-point precision.

## Related Issue
- [x] Closes #1297
- [ ] Related to #

## Checklist
- [x] Checked that the pre-commit linting/style checks pass
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a relevant logical change

## Type of change
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
