### PR TITLE
Fix TypedListConstant.signature() being unhashable and uncomparable

### DIFF
--- a/pytensor/typed_list/basic.py
+++ b/pytensor/typed_list/basic.py
@@ -64,6 +64,20 @@ class TypedListConstant(_typed_list_py_operators, Constant):
 
     """
 
+    def signature(self):
+        """Return a hashable, safely comparable signature.
+
+        The base `Constant.signature` returns ``(self.type, self.data)``, but
+        ``data`` is a Python list of (usually) arrays, which is unhashable and
+        compares elementwise. Delegate to the signature of the inner type's
+        constants instead.
+        """
+        ttype = self.type.ttype
+        return (
+            self.type,
+            tuple(ttype.constant_type(ttype, d).signature() for d in self.data),
+        )
+
 
 TypedListType.constant_type = TypedListConstant
 

--- a/tests/typed_list/test_basic.py
+++ b/tests/typed_list/test_basic.py
@@ -9,6 +9,7 @@ import pytensor.typed_list
 from pytensor import sparse
 from pytensor.tensor.type import (
     TensorType,
+    dvector,
     integer_dtypes,
     matrix,
     scalar,
@@ -27,6 +28,7 @@ from pytensor.typed_list.basic import (
     Length,
     Remove,
     Reverse,
+    TypedListConstant,
     make_list,
 )
 from pytensor.typed_list.type import TypedListType
@@ -594,3 +596,23 @@ class TestMakeList:
             assert (m == n).all()
         for m, n in zip(fz(X, Y), [X, Y], strict=True):
             assert (m == n).all()
+
+
+class TestTypedListConstant:
+    def test_signature_is_hashable_and_comparable(self):
+        """A TypedListConstant signature must support == and hash().
+
+        The base ``Constant.signature`` returns ``(type, data)`` where ``data``
+        is a list of arrays, which raises on both operations.
+        """
+        list_type = TypedListType(dvector)
+        data = [np.array([1.0, 2.0]), np.array([3.0, 4.0])]
+        c1 = TypedListConstant(list_type, data)
+        c2 = TypedListConstant(list_type, [d.copy() for d in data])
+        c3 = TypedListConstant(list_type, [np.array([1.0, 2.0]), np.array([3.0, 5.0])])
+
+        assert c1.signature() == c2.signature()
+        assert hash(c1.signature()) == hash(c2.signature())
+        assert c1.signature() != c3.signature()
+        assert c1.equals(c2)
+        assert not c1.equals(c3)


### PR DESCRIPTION
## Description

`TypedListConstant` inherited the base `Constant.signature()`, which returns `(self.type, self.data)`. For a typed list, `data` is a Python list of arrays, so the signature raised on both operations it exists to support:

```python
c1.signature() == c2.signature()  # ValueError: truth value of an array with more than one element is ambiguous
hash(c1.signature())              # TypeError: unhashable type: 'list'
```

Since `signature()` backs value-based equality and hashing (`merge_signature`, `AtomicVariable.equals`, `FrozenApply` interning), `Constant.equals()` on two typed list constants raised too. It now delegates to the inner type's constant signatures and returns a plain tuple, mirroring `ScalarConstant`/`TensorConstant`.

This addresses problem 2 of #2044; the other items there (bare `Constant()` instantiations, constructor dispatch) are left alone.

## Related Issue
- [ ] Closes #
- [x] Related to #2044

## Checklist
- [x] Checked that the pre-commit linting/style checks pass
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a relevant logical change

## Type of change
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
