### PR TITLE
Fix numba CauchyRV loc/scale

### DIFF
--- a/pytensor/link/numba/dispatch/random.py
+++ b/pytensor/link/numba/dispatch/random.py
@@ -137,7 +137,7 @@ def numba_core_HalfNormalRV(op, node):
 def numba_core_CauchyRV(op, node):
     @numba_basic.numba_njit
     def random(rng, loc, scale):
-        return (loc + rng.standard_cauchy()) / scale
+        return loc + scale * rng.standard_cauchy()
 
     return random
 

--- a/tests/link/numba/test_random.py
+++ b/tests/link/numba/test_random.py
@@ -585,7 +585,7 @@ def test_aligned_RandomVariable(rv_op, dist_args, size):
                 ),
                 (
                     pt.dscalar(),
-                    np.array(1.0, dtype=np.float64),
+                    np.array(4.0, dtype=np.float64),
                 ),
             ],
             (2,),

--- a/tests/link/numba/test_random.py
+++ b/tests/link/numba/test_random.py
@@ -569,7 +569,7 @@ def test_aligned_RandomVariable(rv_op, dist_args, size):
                 ),
                 (
                     pt.dscalar(),
-                    np.array(1.0, dtype=np.float64),
+                    np.array(3.0, dtype=np.float64),
                 ),
             ],
             (2,),


### PR DESCRIPTION
Closes #2308.

The numba dispatch computed `(loc + z) / scale` instead of `loc + scale * z`, so the sampled variable had location `loc/scale` and scale `1/scale`.

```diff
-        return (loc + rng.standard_cauchy()) / scale
+        return loc + scale * rng.standard_cauchy()
```

`rng_fn_scipy` and the JAX dispatch were already correct, so only numba was affected — but it is the default linker. `logp` is untouched, so NUTS posteriors were fine; anything that *draws* was not, including `sample_prior_predictive` on a `HalfCauchy` prior (`HalfCauchyRV.rv_op` builds `abs(cauchy(0, beta))`).

## Tests

`test_unaligned_RandomVariable` is the only test checking these samplers against their distribution, and it has three cases. Two used a degenerate scale:

| case | was | now | |
|---|---|---|---|
| `cauchy` | `scale=1.0` | `scale=3.0` | catches the bug above: p=1.7e-08 → passes |
| `gumbel` | `scale=1.0` | `scale=4.0` | no bug, but was blind |
| `t` | `scale=np.pi` | unchanged | already fine |

At `scale=1`, `(loc ± z) / 1` is algebraically identical to `loc ± 1 * z`, so both the location and scale errors vanish together and Cramér–von Mises passes.

`GumbelRV` has a hand-written core too (`loc - scale * np.log(-np.log(U))`) and is correct, but was equally undetectable. Verified by injecting the analogous slip: the new case fails at p=7.2e-08 with it, passes without.

## Audit

Checked every hand-written numba core (`t`, `halfnormal`, `pareto`, `invgamma`, `gumbel`, `wald`) plus the default-path RVs against scipy with non-degenerate parameters. All match — `cauchy` was the only real bug.

`tests/link/numba/test_random.py`: 84 passed, 2 xfailed.

> Note for reviewers reproducing this: PyTensor reuses the cached compiled graph across source edits, so a naive before/after run shows both variants passing. The numbers above use a separate `base_compiledir` per run.