### PR TITLE
Specialize scalar graphs in numba backend

### DIFF
--- a/pytensor/compile/builders.py
+++ b/pytensor/compile/builders.py
@@ -65,17 +65,28 @@ def infer_shape(outs, inputs, input_shapes):
 
 
 def construct_nominal_fgraph(
-    inputs: Sequence[Variable], outputs: Sequence[Variable]
+    inputs: Sequence[Variable],
+    outputs: Sequence[Variable],
+    *,
+    replace: dict[Variable, Variable] | None = None,
 ) -> FunctionGraph:
     """Construct an inner-`FunctionGraph` with ordered nominal inputs.
 
     Raises ``MissingInputError`` if ``outputs`` implicitly depend on a variable
     that is neither a `Constant` nor listed in ``inputs`` (including shared
     variables, which must be passed explicitly).
+
+    ``replace`` folds an extra substitution into the same clone that nominalizes
+    the inputs, so a caller can rewrite some leaves (e.g. a tensor into
+    ``tensor_from_scalar`` of a scalar input) without a separate clone. Its keys
+    are exempt from the missing-input check and its values may reference
+    ``inputs``.
     """
+    replace = replace or {}
     dummy_inputs = [inp.type() for inp in inputs]
-    for var in graph_inputs(outputs, inputs):
-        if var in inputs or isinstance(var, Constant):
+    provided = set(inputs) | set(replace)
+    for var in graph_inputs(outputs, provided):
+        if var in provided or isinstance(var, Constant):
             continue
         if isinstance(var, SharedVariable):
             raise MissingInputError(
@@ -84,7 +95,13 @@ def construct_nominal_fgraph(
             )
         raise MissingInputError(f"NominalGraph is missing an input: {var}")
 
-    replacements = dict(zip(inputs, dummy_inputs, strict=True))
+    input_to_dummy = dict(zip(inputs, dummy_inputs, strict=True))
+    # ``replace`` values may reference ``inputs``; rewrite them onto the dummies
+    # so the whole substitution happens in the single clone below.
+    replacements = {
+        k: clone_replace([v], replace=input_to_dummy)[0] for k, v in replace.items()
+    }
+    replacements.update(input_to_dummy)
 
     # ``outputs`` must be mutable ``Apply`` graphs; a caller holding a frozen
     # graph thaws it first (``FrozenFunctionGraph.unfreeze``).
@@ -217,6 +234,7 @@ class OpFromGraph(HasInnerFunction, Op):
         strict: bool = False,
         name: str | None = None,
         destroy_map: dict[int, tuple[int, ...]] | None = None,
+        fgraph: FrozenFunctionGraph | None = None,
         **kwargs,
     ):
         """
@@ -313,11 +331,17 @@ class OpFromGraph(HasInnerFunction, Op):
 
         self.is_inline = inline
 
-        inner_fgraph = construct_nominal_fgraph(inputs, outputs)
-        # The inner graph is stored immutable. The default freeze (no dedup)
-        # keeps distinct buffers for inplace ``destroy_map`` ops; structural
-        # folding would alias them. See ``FunctionGraph.freeze``.
-        self.fgraph = inner_fgraph.freeze()
+        if fgraph is not None:
+            # Caller supplies an already-nominalized frozen inner graph (built,
+            # e.g., with construct_nominal_fgraph + a substitution). ``inputs``/
+            # ``outputs`` are still passed for the outer input/output types.
+            self.fgraph = fgraph
+        else:
+            inner_fgraph = construct_nominal_fgraph(inputs, outputs)
+            # The inner graph is stored immutable. The default freeze (no dedup)
+            # keeps distinct buffers for inplace ``destroy_map`` ops; structural
+            # folding would alias them. See ``FunctionGraph.freeze``.
+            self.fgraph = inner_fgraph.freeze()
 
         # `compile_kwargs` used to control how the inner graph was compiled.
         # That is now the job of the `ofg_inner_graph` rewrite (which

--- a/pytensor/link/numba/dispatch/elemwise.py
+++ b/pytensor/link/numba/dispatch/elemwise.py
@@ -53,6 +53,7 @@ from pytensor.tensor.blas import BatchedDot
 from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
 from pytensor.tensor.math import Argmax, Dot, MulWithoutZeros
 from pytensor.tensor.rewriting.fused_elemwise import FusedElemwise
+from pytensor.tensor.rewriting.scalarize import ScalarCAReduce
 
 
 @singledispatch
@@ -256,6 +257,7 @@ def create_multiaxis_reducer(
     ndim,
     acc_dtype=None,
     out_dtype,
+    scalar_out=False,
 ):
     r"""Construct a function that reduces multiple axes.
 
@@ -444,7 +446,15 @@ def create_multiaxis_reducer(
 
     if n_kept == 0:
         # Full reduction: Use scalar accumulation
-        if complex_to_real:
+        if scalar_out:
+            # Hand the accumulator out as a scalar rather than boxing it in a 0-d
+            # array, saving one heap allocation per fully-reduced output.
+            return_obj = (
+                f"{out_dtype_str}(res.real)"
+                if complex_to_real
+                else f"{out_dtype_str}(res)"
+            )
+        elif complex_to_real:
             return_obj = f"np.array(res).real.astype({out_dtype_str})"
         else:
             return_obj = f"np.array(res, dtype={out_dtype_str})"
@@ -1021,7 +1031,7 @@ def numba_funcify_FusedElemwise(op, node, **kwargs):
 
 
 @register_funcify_and_cache_key(CAReduce)
-def numba_funcify_CAReduce(op, node, **kwargs):
+def numba_funcify_CAReduce(op, node, scalar_out=False, **kwargs):
     axes = op.axis
     if axes is None:
         axes = list(range(node.inputs[0].ndim))
@@ -1041,10 +1051,11 @@ def numba_funcify_CAReduce(op, node, **kwargs):
         ndim=ndim,
         acc_dtype=acc_dtype,
         out_dtype=out_dtype,
+        scalar_out=scalar_out,
     )
     careduce_fn = numba_basic.numba_njit(careduce_py_fn, boundscheck=False)
 
-    cache_version = 4
+    cache_version = 5
     careduce_key = sha256(
         str(
             (
@@ -1054,11 +1065,21 @@ def numba_funcify_CAReduce(op, node, **kwargs):
                 out_dtype,
                 acc_dtype,
                 op.scalar_op.identity,
+                # Selects a register value vs a 0-d array in the generated source.
+                scalar_out,
                 cache_version,
             )
         ).encode()
     ).hexdigest()
     return careduce_fn, careduce_key
+
+
+@register_funcify_and_cache_key(ScalarCAReduce)
+def numba_funcify_ScalarCAReduce(op, node, **kwargs):
+    [careduce_node] = [n for n in op.fgraph.apply_nodes if isinstance(n.op, CAReduce)]
+    return numba_funcify_CAReduce(
+        careduce_node.op, careduce_node, scalar_out=True, **kwargs
+    )
 
 
 @register_funcify_default_op_cache_key(DimShuffle)

--- a/pytensor/link/numba/dispatch/elemwise.py
+++ b/pytensor/link/numba/dispatch/elemwise.py
@@ -912,8 +912,12 @@ def _build_reduce_impl_src(nout, post_specs, const_positions, n_outer):
         kept_axes, out_dtype, cast_needed = spec
         np_dtype = "bool_" if out_dtype == "bool" else out_dtype
         if not kept_axes:
-            # Full reduction → 0-d array of the single accumulated value.
-            code.append(f"{sym} = np.array({src}.ravel()[0], dtype=np.{np_dtype})")
+            # Full reduction: squeeze the size-1 keepdims buffer to a 0-d view,
+            # the same strided view a DimShuffle squeeze emits -- no ravel() copy.
+            expr = f"as_strided({src}, shape=(), strides=())"
+            if cast_needed:
+                expr = f"{expr}.astype(np.{np_dtype})"
+            code.append(f"{sym} = {expr}")
         else:
             shape_expr = create_tuple_string(
                 tuple(f"{src}.shape[{k}]" for k in kept_axes)

--- a/pytensor/link/numba/dispatch/elemwise.py
+++ b/pytensor/link/numba/dispatch/elemwise.py
@@ -54,7 +54,7 @@ from pytensor.tensor.blas import BatchedDot
 from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
 from pytensor.tensor.math import Argmax, Dot, MulWithoutZeros
 from pytensor.tensor.rewriting.fused_elemwise import FusedElemwise
-from pytensor.tensor.rewriting.scalarize import ScalarCAReduce
+from pytensor.tensor.rewriting.scalarize import ScalarCAReduce, ScalarizedElemwise
 
 
 @singledispatch
@@ -688,22 +688,51 @@ def create_axis_apply_fn(fn, axis, ndim, dtype):
 
 
 @register_funcify_and_cache_key(Elemwise)
+@register_funcify_and_cache_key(ScalarizedElemwise)
 def numba_funcify_Elemwise(op, node, **kwargs):
-    scalar_node = op.make_scalar_node(*node.inputs)
+    """Funcify an ``Elemwise`` loop, shared with ``ScalarizedElemwise``.
+
+    A ``ScalarizedElemwise`` is an ``Elemwise`` some of whose inputs are
+    ``ScalarType`` (loop-invariant): those positions go through ``_vectorized``'s
+    ``constant_inputs`` instead of being boxed into 0-d arrays and reloaded each
+    iteration. A plain ``Elemwise`` is the same machinery with no such positions.
+    """
+    if isinstance(op, ScalarizedElemwise):
+        [elemwise_node] = [
+            n for n in op.fgraph.apply_nodes if isinstance(n.op, Elemwise)
+        ]
+        elemwise_op = elemwise_node.op
+        const_positions = tuple(
+            p
+            for p in range(len(node.inputs))
+            if isinstance(node.inputs[p].type, ScalarType)
+        )
+        inplace_pattern = ()
+    else:
+        elemwise_node = node
+        elemwise_op = op
+        const_positions = ()
+        inplace_pattern = tuple(op.inplace_pattern.items())
+
+    scalar_node = elemwise_op.make_scalar_node(*elemwise_node.inputs)
     scalar_op_fn, scalar_cache_key = numba_funcify_and_cache_key(
-        op.scalar_op,
+        elemwise_op.scalar_op,
         node=scalar_node,
         **kwargs,
     )
 
     nin = len(node.inputs)
     nout = len(node.outputs)
-    core_op_fn = store_core_outputs(scalar_op_fn, nin=nin, nout=nout)
+    array_positions = [p for p in range(nin) if p not in frozenset(const_positions)]
+    core_op_fn = store_core_outputs(
+        scalar_op_fn, nin=nin, nout=nout, const_positions=const_positions
+    )
 
-    input_bc_patterns = tuple(inp.type.broadcastable for inp in node.inputs)
-    output_bc_patterns = tuple(out.type.broadcastable for out in node.outputs)
+    input_bc_patterns = tuple(
+        elemwise_node.inputs[p].type.broadcastable for p in array_positions
+    )
+    output_bc_patterns = tuple(out.type.broadcastable for out in elemwise_node.outputs)
     output_dtypes = tuple(out.type.dtype for out in node.outputs)
-    inplace_pattern = tuple(op.inplace_pattern.items())
     core_output_shapes = tuple(() for _ in range(nout))
 
     # numba doesn't support nested literals right now...
@@ -712,46 +741,79 @@ def numba_funcify_Elemwise(op, node, **kwargs):
     output_dtypes_enc = encode_literals(output_dtypes)
     inplace_pattern_enc = encode_literals(inplace_pattern)
 
-    # Pure python implementation, that will be used in tests
-    def elemwise(*inputs):
-        Elemwise._check_runtime_broadcast(node, inputs)
-        inputs_bc = np.broadcast_arrays(*inputs)
-        shape = inputs_bc[0].shape
+    if isinstance(op, ScalarizedElemwise):
+        # Python-mode fallback (Numba eval_python_only): run the inner fgraph
+        # faithfully, exactly like OpFromGraph.perform.
+        def elemwise(*outer_inputs):
+            res = op.fn(*outer_inputs)
+            return res[0] if len(res) == 1 else tuple(res)
+    else:
+        # Pure python implementation, that will be used in tests
+        def elemwise(*inputs):
+            Elemwise._check_runtime_broadcast(node, inputs)
+            inputs_bc = np.broadcast_arrays(*inputs)
+            shape = inputs_bc[0].shape
 
-        if len(output_dtypes) == 1:
-            output = np.empty(shape, dtype=output_dtypes[0])
-            for idx in np.ndindex(shape):
-                output[idx] = scalar_op_fn(*(inp[idx] for inp in inputs_bc))
-            return output
+            if len(output_dtypes) == 1:
+                output = np.empty(shape, dtype=output_dtypes[0])
+                for idx in np.ndindex(shape):
+                    output[idx] = scalar_op_fn(*(inp[idx] for inp in inputs_bc))
+                return output
 
-        else:
-            outputs = [np.empty(shape, dtype=dtype) for dtype in output_dtypes]
-            for idx in np.ndindex(shape):
-                outs_vals = scalar_op_fn(*(inp[idx] for inp in inputs_bc))
-                for out, out_val in zip(outputs, outs_vals):
-                    out[idx] = out_val
-            return outputs
+            else:
+                outputs = [np.empty(shape, dtype=dtype) for dtype in output_dtypes]
+                for idx in np.ndindex(shape):
+                    outs_vals = scalar_op_fn(*(inp[idx] for inp in inputs_bc))
+                    for out, out_val in zip(outputs, outs_vals):
+                        out[idx] = out_val
+                return outputs
 
-    @overload(elemwise)
-    def ov_elemwise(*inputs):
-        def impl(*inputs):
-            return _vectorized(
-                core_op_fn,
-                input_bc_patterns_enc,
-                output_bc_patterns_enc,
-                output_dtypes_enc,
-                inplace_pattern_enc,
-                True,  # allow_core_scalar
-                (),  # constant_inputs
-                inputs,
-                core_output_shapes,
-                NO_SIZE,
-                NO_INDEXED_INPUTS,
-                NO_INDEXED_OUTPUTS,
-                NO_REDUCE_OUTPUTS,
-            )
+    if not const_positions:
 
-        return impl
+        @overload(elemwise)
+        def ov_elemwise(*inputs):
+            def impl(*inputs):
+                return _vectorized(
+                    core_op_fn,
+                    input_bc_patterns_enc,
+                    output_bc_patterns_enc,
+                    output_dtypes_enc,
+                    inplace_pattern_enc,
+                    True,  # allow_core_scalar
+                    (),  # constant_inputs
+                    inputs,
+                    core_output_shapes,
+                    NO_SIZE,
+                    NO_INDEXED_INPUTS,
+                    NO_INDEXED_OUTPUTS,
+                    NO_REDUCE_OUTPUTS,
+                )
+
+            return impl
+    else:
+        # Const inputs must be split out of ``outer_inputs`` by static index,
+        # which the inline closure cannot do, so route through generated source.
+        impl_src = _build_reduce_impl_src(nout, [None] * nout, const_positions, nin)
+        impl_fn = compile_numba_function_src(
+            impl_src,
+            "fused_elemwise_impl",
+            {
+                **globals(),
+                "core_op_fn": core_op_fn,
+                "input_bc_patterns_enc": input_bc_patterns_enc,
+                "output_bc_patterns_enc": output_bc_patterns_enc,
+                "output_dtypes_enc": output_dtypes_enc,
+                "inplace_pattern_enc": inplace_pattern_enc,
+                "core_output_shapes": core_output_shapes,
+                "indexed_inputs_enc": NO_INDEXED_INPUTS,
+                "indexed_outputs_enc": NO_INDEXED_OUTPUTS,
+                "reduce_outputs_enc": NO_REDUCE_OUTPUTS,
+            },
+        )
+
+        @overload(elemwise, jit_options=_jit_options)
+        def ov_elemwise(*outer_inputs):
+            return impl_fn
 
     if scalar_cache_key is None:
         # If the scalar op cannot be cached, the Elemwise wrapper cannot be cached either
@@ -760,8 +822,12 @@ def numba_funcify_Elemwise(op, node, **kwargs):
         elemwise_key = str(
             (
                 type(op),
-                tuple(op.inplace_pattern.items()),
+                1,  # cache version
+                inplace_pattern,
+                const_positions,
                 input_bc_patterns,
+                output_bc_patterns,
+                output_dtypes,
                 scalar_cache_key,
             )
         )

--- a/pytensor/link/numba/dispatch/elemwise.py
+++ b/pytensor/link/numba/dispatch/elemwise.py
@@ -928,10 +928,17 @@ def _build_reduce_impl_src(nout, post_specs, const_positions, n_outer):
                     expr = f"{expr}.astype(np.{np_dtype})"
             code.append(f"{sym} = {expr}")
         else:
+            # Partial reduction: squeeze the size-1 reduced axes back out with the
+            # same as_strided trick DimShuffle uses -- pure stride arithmetic,
+            # whereas reshape emits a runtime numba_attempt_nocopy_reshape call and
+            # only works on contiguous input.
             shape_expr = create_tuple_string(
                 tuple(f"{src}.shape[{k}]" for k in kept_axes)
             )
-            expr = f"{src}.reshape({shape_expr})"
+            strides_expr = create_tuple_string(
+                tuple(f"{src}.strides[{k}]" for k in kept_axes)
+            )
+            expr = f"as_strided({src}, shape={shape_expr}, strides={strides_expr})"
             if cast_needed:
                 expr = f"{expr}.astype(np.{np_dtype})"
             code.append(f"{sym} = {expr}")
@@ -1141,7 +1148,7 @@ def numba_funcify_FusedElemwise(op, node, **kwargs):
         def ov_fused_elemwise_fn(*outer_inputs):
             return impl_fn
 
-    cache_version = 6
+    cache_version = 7
     if scalar_cache_key is None:
         key = None
     else:

--- a/pytensor/link/numba/dispatch/elemwise.py
+++ b/pytensor/link/numba/dispatch/elemwise.py
@@ -1039,13 +1039,16 @@ def numba_funcify_FusedElemwise(op, node, **kwargs):
             bc[ax] = True
         output_bc_patterns_list.append(tuple(bc))
         output_dtypes_list.append(str(np.dtype(acc_dtype)))
-        reduce_identities.append((i, _reduce_identity(identity, acc_dtype)))
         kept_axes = tuple(d for d in range(len(bc)) if d not in axes)
         out_dtype = node.outputs[i].type.dtype
         cast_needed = np.dtype(acc_dtype) != np.dtype(out_dtype)
         # A ScalarType fused output is a full reduction handed out as a scalar
         # (FuseElemwise wraps it in scalar_from_tensor) rather than a 0-d box.
         scalar_out = isinstance(node.outputs[i].type, ScalarType)
+        # With every axis reduced the accumulator is a single element and, being a
+        # scalar output, never escapes -- so its buffer can live on the stack.
+        on_stack = scalar_out and not kept_axes
+        reduce_identities.append((i, _reduce_identity(identity, acc_dtype), on_stack))
         post_specs.append((kept_axes, out_dtype, cast_needed, scalar_out))
 
     output_bc_patterns = tuple(output_bc_patterns_list)
@@ -1138,12 +1141,12 @@ def numba_funcify_FusedElemwise(op, node, **kwargs):
         def ov_fused_elemwise_fn(*outer_inputs):
             return impl_fn
 
-    cache_version = 5
+    cache_version = 6
     if scalar_cache_key is None:
         key = None
     else:
         # Include each output's scalar-vs-array kind: a ScalarType reduced output
-        # generates a different (scalar-returning) reduction epilogue.
+        # generates a different (scalar-returning, stack-buffer) reduction epilogue.
         out_kinds = tuple(isinstance(o.type, ScalarType) for o in node.outputs)
         reduced_key = tuple(
             (type(r[0]).__name__, r[1], str(np.dtype(r[3]))) if r is not None else None

--- a/pytensor/link/numba/dispatch/elemwise.py
+++ b/pytensor/link/numba/dispatch/elemwise.py
@@ -45,6 +45,7 @@ from pytensor.scalar.basic import (
     Maximum,
     Minimum,
     Mul,
+    ScalarType,
     Sub,
     TrueDiv,
     add,
@@ -784,14 +785,30 @@ def _reduce_identity(identity, acc_dtype):
     return acc_dtype.type(identity)
 
 
-def _build_reduce_impl_src(nout, post_specs):
-    """Build the ``@overload`` impl source for a fused op with reduction outputs.
+def _build_reduce_impl_src(nout, post_specs, const_positions, n_outer):
+    """Build the ``@overload`` impl source for a fused op.
 
     Calls ``_vectorized`` (which produces a keepdims, size-1-on-reduced-axes
     buffer in ``acc_dtype``) then, per reduction output, squeezes the reduced
     axes back out and casts to the true output dtype.  ``post_specs[i]`` is
     ``None`` for a passthrough output, else ``(kept_axes, out_dtype, cast_needed)``.
+
+    ``const_positions`` lists the outer input positions that are ``ScalarType``
+    and so are handed to ``_vectorized`` as loop-invariant ``constant_inputs``
+    rather than as arrays to be iterated.
     """
+    const_set = frozenset(const_positions)
+    if const_positions:
+        const_expr = create_tuple_string(
+            tuple(f"outer_inputs[{p}]" for p in const_positions)
+        )
+        array_expr = create_tuple_string(
+            tuple(f"outer_inputs[{p}]" for p in range(n_outer) if p not in const_set)
+        )
+    else:
+        const_expr = "()"
+        array_expr = "outer_inputs"
+
     code: list[str | CODE_TOKEN] = [
         "def fused_elemwise_impl(*outer_inputs):",
         CODE_TOKEN.INDENT,
@@ -803,8 +820,8 @@ def _build_reduce_impl_src(nout, post_specs):
         "output_dtypes_enc,",
         "inplace_pattern_enc,",
         "True,",
-        "(),",
-        "outer_inputs,",
+        f"{const_expr},",
+        f"{array_expr},",
         "core_output_shapes,",
         "NO_SIZE,",
         "indexed_inputs_enc,",
@@ -898,11 +915,29 @@ def numba_funcify_FusedElemwise(op, node, **kwargs):
             accumulate_into_slice(_op, out, inner)
         )
 
+    # A ScalarType elemwise input is loop-invariant: it carries one value for the
+    # whole iteration space, so it goes through ``constant_inputs`` instead of
+    # being materialised as an array and re-loaded every iteration.  Everything
+    # keyed by elemwise input position (bc patterns, indexed reads, inplace
+    # aliasing) is stated over the array inputs only, so those positions remap.
+    const_positions = tuple(
+        p for p in range(nin_elemwise) if isinstance(node.inputs[p].type, ScalarType)
+    )
+    const_set = frozenset(const_positions)
+    array_positions = [p for p in range(nin_elemwise) if p not in const_set]
+    array_pos_map = {p: new_p for new_p, p in enumerate(array_positions)}
+
     core_op_fn = store_core_outputs(
-        scalar_op_fn, nin=nin_elemwise, nout=nout, accum_fns=accum_fns
+        scalar_op_fn,
+        nin=nin_elemwise,
+        nout=nout,
+        accum_fns=accum_fns,
+        const_positions=const_positions,
     )
 
-    input_bc_patterns = tuple(inp.type.broadcastable for inp in elemwise_node.inputs)
+    input_bc_patterns = tuple(
+        elemwise_node.inputs[p].type.broadcastable for p in array_positions
+    )
 
     # Reduction outputs keep their reduced axes as bc=True (size-1, keepdims) and
     # are accumulated in acc_dtype; post_specs squeezes + casts them back to the
@@ -933,7 +968,19 @@ def numba_funcify_FusedElemwise(op, node, **kwargs):
 
     output_bc_patterns = tuple(output_bc_patterns_list)
     output_dtypes = tuple(output_dtypes_list)
-    inplace_pattern = tuple(elemwise_node.op.inplace_pattern.items())
+    # A scalar input can be neither an inplace destination nor an indexed read
+    # source, so remapping onto array-only positions never drops an entry.
+    inplace_pattern = tuple(
+        (out_idx, array_pos_map[inp_idx])
+        for out_idx, inp_idx in elemwise_node.op.inplace_pattern.items()
+    )
+    if const_positions:
+        indexed_inputs = tuple(
+            None
+            if entry is None
+            else (tuple(array_pos_map[src] for src in entry[0]), *entry[1:])
+            for entry in indexed_inputs
+        )
     core_output_shapes = tuple(() for _ in range(nout))
 
     idx_broadcastable = tuple(
@@ -958,7 +1005,11 @@ def numba_funcify_FusedElemwise(op, node, **kwargs):
         res = op.fn(*outer_inputs)
         return res[0] if len(res) == 1 else tuple(res)
 
-    if not has_reductions:
+    # Const inputs must be split out of ``outer_inputs`` by static index, which the
+    # inline closure cannot do, so route through the generated source whenever
+    # there are const inputs (or reductions). The common no-const, no-reduction
+    # path keeps its simpler inline impl.
+    if not has_reductions and not const_positions:
 
         @overload(fused_elemwise_fn, jit_options=_jit_options)
         def ov_fused_elemwise_fn(*outer_inputs):
@@ -981,7 +1032,9 @@ def numba_funcify_FusedElemwise(op, node, **kwargs):
 
             return impl
     else:
-        impl_src = _build_reduce_impl_src(nout, post_specs)
+        impl_src = _build_reduce_impl_src(
+            nout, post_specs, const_positions, len(node.inputs)
+        )
         impl_fn = compile_numba_function_src(
             impl_src,
             "fused_elemwise_impl",

--- a/pytensor/link/numba/dispatch/elemwise.py
+++ b/pytensor/link/numba/dispatch/elemwise.py
@@ -857,7 +857,9 @@ def _build_reduce_impl_src(nout, post_specs, const_positions, n_outer):
     Calls ``_vectorized`` (which produces a keepdims, size-1-on-reduced-axes
     buffer in ``acc_dtype``) then, per reduction output, squeezes the reduced
     axes back out and casts to the true output dtype.  ``post_specs[i]`` is
-    ``None`` for a passthrough output, else ``(kept_axes, out_dtype, cast_needed)``.
+    ``None`` for a passthrough output, else
+    ``(kept_axes, out_dtype, cast_needed, scalar_out)``; ``scalar_out`` returns a
+    full reduction as a scalar register rather than a 0-d array.
 
     ``const_positions`` lists the outer input positions that are ``ScalarType``
     and so are handed to ``_vectorized`` as loop-invariant ``constant_inputs``
@@ -909,14 +911,21 @@ def _build_reduce_impl_src(nout, post_specs, const_positions, n_outer):
         if spec is None:
             code.append(f"{sym} = {src}")
             continue
-        kept_axes, out_dtype, cast_needed = spec
+        kept_axes, out_dtype, cast_needed, scalar_out = spec
         np_dtype = "bool_" if out_dtype == "bool" else out_dtype
         if not kept_axes:
-            # Full reduction: squeeze the size-1 keepdims buffer to a 0-d view,
-            # the same strided view a DimShuffle squeeze emits -- no ravel() copy.
-            expr = f"as_strided({src}, shape=(), strides=())"
-            if cast_needed:
-                expr = f"{expr}.astype(np.{np_dtype})"
+            if scalar_out:
+                # ScalarType output: take the single value out of the size-1
+                # buffer (ScalarFromTensor: .item()); no array to materialize.
+                expr = f"{src}.item()"
+                if cast_needed:
+                    expr = f"np.{np_dtype}({expr})"
+            else:
+                # Squeeze the size-1 keepdims buffer to a 0-d view, the same
+                # strided view a DimShuffle squeeze emits -- no ravel() copy.
+                expr = f"as_strided({src}, shape=(), strides=())"
+                if cast_needed:
+                    expr = f"{expr}.astype(np.{np_dtype})"
             code.append(f"{sym} = {expr}")
         else:
             shape_expr = create_tuple_string(
@@ -1034,7 +1043,10 @@ def numba_funcify_FusedElemwise(op, node, **kwargs):
         kept_axes = tuple(d for d in range(len(bc)) if d not in axes)
         out_dtype = node.outputs[i].type.dtype
         cast_needed = np.dtype(acc_dtype) != np.dtype(out_dtype)
-        post_specs.append((kept_axes, out_dtype, cast_needed))
+        # A ScalarType fused output is a full reduction handed out as a scalar
+        # (FuseElemwise wraps it in scalar_from_tensor) rather than a 0-d box.
+        scalar_out = isinstance(node.outputs[i].type, ScalarType)
+        post_specs.append((kept_axes, out_dtype, cast_needed, scalar_out))
 
     output_bc_patterns = tuple(output_bc_patterns_list)
     output_dtypes = tuple(output_dtypes_list)
@@ -1126,10 +1138,13 @@ def numba_funcify_FusedElemwise(op, node, **kwargs):
         def ov_fused_elemwise_fn(*outer_inputs):
             return impl_fn
 
-    cache_version = 4
+    cache_version = 5
     if scalar_cache_key is None:
         key = None
     else:
+        # Include each output's scalar-vs-array kind: a ScalarType reduced output
+        # generates a different (scalar-returning) reduction epilogue.
+        out_kinds = tuple(isinstance(o.type, ScalarType) for o in node.outputs)
         reduced_key = tuple(
             (type(r[0]).__name__, r[1], str(np.dtype(r[3]))) if r is not None else None
             for r in reduced_outputs
@@ -1145,6 +1160,7 @@ def numba_funcify_FusedElemwise(op, node, **kwargs):
                 idx_broadcastable,
                 indexed_outputs,
                 reduced_key,
+                out_kinds,
                 scalar_cache_key,
             )
         )

--- a/pytensor/link/numba/dispatch/subtensor.py
+++ b/pytensor/link/numba/dispatch/subtensor.py
@@ -21,6 +21,7 @@ from pytensor.link.numba.dispatch.basic import (
 from pytensor.link.numba.dispatch.compile_ops import numba_deepcopy
 from pytensor.link.numba.dispatch.string_codegen import create_tuple_string
 from pytensor.tensor import TensorType, TensorVariable
+from pytensor.tensor.rewriting.scalarize import ScalarSubtensor
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
     AdvancedSubtensor,
@@ -230,6 +231,14 @@ def {function_name}({", ".join(input_names)}):
         scalar_out=scalar_out,
     )
     return numba_basic.numba_njit(func, boundscheck=True), cache_key
+
+
+@register_funcify_and_cache_key(ScalarSubtensor)
+def numba_funcify_ScalarSubtensor(op, node, **kwargs):
+    [subtensor_node] = [n for n in op.fgraph.apply_nodes if isinstance(n.op, Subtensor)]
+    return numba_funcify_default_subtensor(
+        subtensor_node.op, subtensor_node, scalar_out=True, **kwargs
+    )
 
 
 @register_funcify_and_cache_key(AdvancedSubtensor)

--- a/pytensor/link/numba/dispatch/subtensor.py
+++ b/pytensor/link/numba/dispatch/subtensor.py
@@ -140,8 +140,13 @@ def subtensor_op_cache_key(op, **extra_fields):
 
 @register_funcify_and_cache_key(Subtensor)
 @register_funcify_and_cache_key(IncSubtensor)
-def numba_funcify_default_subtensor(op, node, **kwargs):
-    """Create a Python function that assembles and uses an index on an array."""
+def numba_funcify_default_subtensor(op, node, scalar_out=False, **kwargs):
+    """Create a Python function that assembles and uses an index on an array.
+
+    With ``scalar_out`` the result is returned as-is rather than through
+    ``np.asarray``. Every index is then a scalar, so the indexing already yields
+    a scalar and the wrap would only put that single value on the heap.
+    """
 
     def convert_indices(indices_iterator, entry):
         if isinstance(entry, int):
@@ -203,12 +208,13 @@ def numba_funcify_default_subtensor(op, node, **kwargs):
         index_prologue = ""
         index_body = f"z = {input_names[0]}[indices]"
 
+    return_src = "z" if scalar_out else "np.asarray(z)"
     subtensor_def_src = f"""
 def {function_name}({", ".join(input_names)}):
     {index_prologue}
     {indices_creation_src}
     {index_body}
-    return np.asarray(z)
+    return {return_src}
     """
 
     func = compile_numba_function_src(
@@ -217,7 +223,11 @@ def {function_name}({", ".join(input_names)}):
         global_env=globals() | {"np": np},
     )
     cache_key = subtensor_op_cache_key(
-        op, func="numba_funcify_default_subtensor", version=1
+        op,
+        func="numba_funcify_default_subtensor",
+        version=2,
+        # Selects a register value vs a 0-d array in the generated source.
+        scalar_out=scalar_out,
     )
     return numba_basic.numba_njit(func, boundscheck=True), cache_key
 

--- a/pytensor/link/numba/dispatch/tensor_basic.py
+++ b/pytensor/link/numba/dispatch/tensor_basic.py
@@ -9,7 +9,12 @@ from pytensor.link.numba.dispatch.basic import (
     register_funcify_and_cache_key,
     register_funcify_default_op_cache_key,
 )
-from pytensor.link.numba.dispatch.string_codegen import create_tuple_string
+from pytensor.link.numba.dispatch.string_codegen import (
+    CODE_TOKEN,
+    build_source_code,
+    create_tuple_string,
+)
+from pytensor.scalar.basic import ScalarType
 from pytensor.tensor.basic import (
     Alloc,
     AllocEmpty,
@@ -23,6 +28,7 @@ from pytensor.tensor.basic import (
     Split,
     TensorFromScalar,
 )
+from pytensor.tensor.rewriting.scalarize import ScalarJoin
 
 
 @register_funcify_default_op_cache_key(AllocEmpty)
@@ -115,14 +121,90 @@ def numba_funcify_ARange(op, **kwargs):
 
 
 @register_funcify_default_op_cache_key(Join)
-def numba_funcify_Join(op, **kwargs):
+def numba_funcify_Join(op, node, **kwargs):
     axis = op.axis
+
+    if node.outputs[0].type.ndim == 1:
+        # A 1-d join allocates the output and writes each input into it
+        # element-wise. This matches what ``np.concatenate`` lowers to (an
+        # element copy loop into a fresh contiguous buffer) but, unlike
+        # ``np.concatenate``, the dispatch can admit scalar/0-d inputs and so
+        # avoid boxing a scalar just to concatenate it.
+        dtype = np.dtype(node.outputs[0].type.dtype)
+        names = [f"i{i}" for i in range(len(node.inputs))]
+        length = " + ".join(f"{name}.shape[0]" for name in names)
+        code: list[str | CODE_TOKEN] = [
+            f"def join({', '.join(names)}):",
+            CODE_TOKEN.INDENT,
+            f"out = np.empty({length}, dtype=dtype)",
+            "offset = 0",
+        ]
+        for name in names:
+            code.extend(
+                [
+                    f"for k in range({name}.shape[0]):",
+                    CODE_TOKEN.INDENT,
+                    f"out[offset] = {name}[k]",
+                    "offset += 1",
+                    CODE_TOKEN.DEDENT,
+                ]
+            )
+        code.extend(["return out", CODE_TOKEN.DEDENT])
+        join = compile_numba_function_src(
+            build_source_code(code),
+            "join",
+            global_env=globals() | {"np": np, "dtype": dtype},
+        )
+        return numba_basic.numba_njit(join), 1
 
     @numba_basic.numba_njit
     def join(*tensors):
         return np.concatenate(tensors, axis)
 
-    return join
+    return join, 1
+
+
+@register_funcify_and_cache_key(ScalarJoin)
+def numba_funcify_ScalarJoin(op, node, **kwargs):
+    # Same allocate-and-write shape as the 1-d ``Join`` above, but each entry may
+    # be a bare scalar (which contributes a single element) rather than an array,
+    # so it is written directly without ever being boxed.
+    dtype = np.dtype(node.outputs[0].type.dtype)
+    is_scalar = [isinstance(inp.type, ScalarType) for inp in node.inputs]
+    names = [f"i{i}" for i in range(len(node.inputs))]
+    length = " + ".join(
+        "1" if scalar else f"{name}.shape[0]"
+        for name, scalar in zip(names, is_scalar, strict=True)
+    )
+    code: list[str | CODE_TOKEN] = [
+        f"def scalar_join({', '.join(names)}):",
+        CODE_TOKEN.INDENT,
+        f"out = np.empty({length}, dtype=dtype)",
+        "offset = 0",
+    ]
+    for name, scalar in zip(names, is_scalar, strict=True):
+        if scalar:
+            code.extend([f"out[offset] = {name}", "offset += 1"])
+        else:
+            code.extend(
+                [
+                    f"for k in range({name}.shape[0]):",
+                    CODE_TOKEN.INDENT,
+                    f"out[offset] = {name}[k]",
+                    "offset += 1",
+                    CODE_TOKEN.DEDENT,
+                ]
+            )
+    code.extend(["return out", CODE_TOKEN.DEDENT])
+    scalar_join = compile_numba_function_src(
+        build_source_code(code),
+        "scalar_join",
+        global_env=globals() | {"np": np, "dtype": dtype},
+    )
+    key = sha256(
+        str(("ScalarJoin", 1, str(dtype), tuple(is_scalar))).encode()
+    ).hexdigest()
+    return numba_basic.numba_njit(scalar_join), key
 
 
 @register_funcify_default_op_cache_key(Split)

--- a/pytensor/link/numba/dispatch/vectorize_codegen.py
+++ b/pytensor/link/numba/dispatch/vectorize_codegen.py
@@ -36,6 +36,7 @@ def store_core_outputs(
     nout: int,
     accum_fns: dict[int, Callable[[str, str], Sequence[str | CODE_TOKEN]]]
     | None = None,
+    const_positions: tuple[int, ...] = (),
 ) -> Callable:
     """Create a Numba function that wraps a core function and stores its vectorized outputs.
 
@@ -54,8 +55,18 @@ def store_core_outputs(
     ``["o1[...] += t1"]`` for a sum reduction, or the multi-line conditional for
     a max reduction).  Outputs absent from ``accum_fns`` are stored with ``=``.
     Both reductions and indexed ``inc`` writes go through this mechanism.
+
+    ``const_positions`` lists the input positions supplied as loop-invariant
+    ``constant_inputs``, which ``_vectorized`` passes ahead of the per-iteration
+    array values.  The generated signature is permuted to receive them first
+    while the call to ``core_op_fn`` keeps the original input order, so the inner
+    fgraph never has to be reordered.
     """
     if getattr(core_op_fn, "handles_out", False):
+        if const_positions:
+            raise NotImplementedError(
+                "constant_inputs are not supported for a handles_out core function"
+            )
         return core_op_fn
 
     accum_fns = accum_fns or {}
@@ -64,12 +75,18 @@ def store_core_outputs(
     outputs = [f"o{i}" for i in range(nout)]
     inner_outputs = [f"t{output}" for output in outputs]
 
+    const_set = frozenset(const_positions)
+    permuted_inputs = [f"i{i}" for i in const_positions] + [
+        f"i{i}" for i in range(nin) if i not in const_set
+    ]
+
     inp_signature = ", ".join(inputs)
+    permuted_signature = ", ".join(permuted_inputs)
     out_signature = ", ".join(outputs)
     inner_out_signature = ", ".join(inner_outputs)
 
     code: list[str | CODE_TOKEN] = [
-        f"def store_core_outputs({inp_signature}, {out_signature}):",
+        f"def store_core_outputs({permuted_signature}, {out_signature}):",
         CODE_TOKEN.INDENT,
         f"{inner_out_signature} = core_op_fn({inp_signature})",
     ]

--- a/pytensor/link/numba/dispatch/vectorize_codegen.py
+++ b/pytensor/link/numba/dispatch/vectorize_codegen.py
@@ -409,6 +409,32 @@ def compute_itershape(
     return shape
 
 
+def _make_stack_array(ctx, builder, arrtype, shape):
+    """Build a single-element array struct backed by a stack slot.
+
+    Used for full-reduction accumulators, whose buffer is statically one element
+    and never escapes the caller (the value is read straight back out as a
+    scalar).  ``_empty_nd_impl`` would put those on the heap, costing an NRT
+    allocation, an identity memset and a free to carry one register's worth of
+    data.  An ``alloca`` costs nothing and, not escaping, is promoted to a
+    register by LLVM.  ``meminfo`` is NULL, which numba's incref/decref already
+    tolerate (``numba.carray`` views are built the same way).
+    """
+    ll_dtype = ctx.get_data_type(arrtype.dtype)
+    data = cgutils.alloca_once(builder, ll_dtype)
+    itemsize = ctx.get_abi_sizeof(ll_dtype)
+    ary = arrayobj.make_array(arrtype)(ctx, builder)
+    arrayobj.populate_array(
+        ary,
+        data=data,
+        shape=[ir.IntType(64)(1)] * len(shape),
+        strides=[ir.IntType(64)(itemsize)] * len(shape),
+        itemsize=ir.IntType(64)(itemsize),
+        meminfo=None,
+    )
+    return ary
+
+
 def make_outputs(
     ctx: numba.core.base.BaseContext,
     builder: ir.IRBuilder,
@@ -421,6 +447,7 @@ def make_outputs(
     output_core_shapes: tuple,
     update_outputs: dict | None = None,
     reduce_identities: dict | None = None,
+    stack_outputs: frozenset[int] = frozenset(),
 ) -> tuple[list[ir.Value], list[types.Array]]:
     """Allocate output arrays for vectorized loop.
 
@@ -431,6 +458,10 @@ def make_outputs(
     outputs.  Such outputs are freshly allocated (size 1 on the reduced axes, via
     their ``bc=True`` pattern) and pre-filled with the reduction identity so the
     accumulating store in the loop reduces into them correctly.
+
+    ``stack_outputs`` holds the indices of those reduction outputs whose buffer
+    is statically a single element and does not escape; they go on the stack
+    rather than the heap (see ``_make_stack_array``).
     """
     output_arrays = []
     output_arry_types = []
@@ -459,7 +490,10 @@ def make_outputs(
             for length, bc_dim in zip(iter_shape, bc, strict=True)
         ]
         shape = batch_shape + core_shape
-        array = arrayobj._empty_nd_impl(ctx, builder, arrtype, shape)
+        if i in stack_outputs:
+            array = _make_stack_array(ctx, builder, arrtype, shape)
+        else:
+            array = arrayobj._empty_nd_impl(ctx, builder, arrtype, shape)
         if reduce_identities is not None and i in reduce_identities:
             # Pre-fill the freshly allocated (C-contiguous) buffer with the
             # reduction identity.  A flat scan over every element is valid
@@ -880,7 +914,7 @@ def _vectorized(
     ``((out_0, out_1), mode)`` means that index updates outputs out_0 and
     out_1 with *mode* ``"set"`` or ``"inc"``.
 
-    ``reduce_outputs`` lists ``(output_idx, identity)`` pairs for reduction
+    ``reduce_outputs`` lists ``(output_idx, identity, on_stack)`` triples for reduction
     outputs.  Such an output carries ``bc=True`` on its reduced axes; the buffer
     is allocated size 1 there, pre-filled with ``identity``, and the per-iteration
     store (baked into ``core_func`` via ``store_core_outputs``) accumulates into it.
@@ -907,7 +941,9 @@ def _vectorized(
     output_bc_patterns = _decode_literal(output_bc_patterns, "output_bc_patterns")
     output_dtypes = _decode_literal(output_dtypes, "output_dtypes")
     inplace_pattern = _decode_literal(inplace_pattern, "inplace_pattern")
-    reduce_identities = dict(_decode_literal(reduce_outputs, "reduce_outputs"))
+    reduce_outputs = _decode_literal(reduce_outputs, "reduce_outputs")
+    reduce_identities = {idx: ident for idx, ident, _ in reduce_outputs}
+    stack_outputs = frozenset(idx for idx, _, on_stack in reduce_outputs if on_stack)
     indexed_inputs, idx_broadcastable = _decode_literal(
         indexed_inputs, "indexed_inputs"
     )
@@ -1191,6 +1227,7 @@ def _vectorized(
             output_core_shapes,
             update_outputs=update_outputs_dict,
             reduce_identities=reduce_identities,
+            stack_outputs=stack_outputs,
         )
 
         core_signature = typingctx.resolve_function_type(

--- a/pytensor/tensor/rewriting/__init__.py
+++ b/pytensor/tensor/rewriting/__init__.py
@@ -13,6 +13,7 @@ import pytensor.tensor.rewriting.numba
 import pytensor.tensor.rewriting.ofg
 import pytensor.tensor.rewriting.optimize
 import pytensor.tensor.rewriting.reshape
+import pytensor.tensor.rewriting.scalarize
 import pytensor.tensor.rewriting.shape
 import pytensor.tensor.rewriting.special
 import pytensor.tensor.rewriting.subtensor

--- a/pytensor/tensor/rewriting/fused_elemwise.py
+++ b/pytensor/tensor/rewriting/fused_elemwise.py
@@ -7,7 +7,7 @@ indexing and inline accumulation, eliminating materialised intermediate arrays.
 """
 
 from pytensor.compile import optdb
-from pytensor.compile.builders import OpFromGraph
+from pytensor.compile.builders import OpFromGraph, construct_nominal_fgraph
 from pytensor.graph import node_rewriter
 from pytensor.graph.rewriting.basic import GraphRewriter, dfs_rewriter
 from pytensor.graph.rewriting.db import SequenceDB
@@ -22,12 +22,19 @@ from pytensor.scalar.basic import (
     Maximum,
     Minimum,
     Mul,
+    ScalarType,
+    get_scalar_type,
 )
 from pytensor.scalar.basic import (
     identity as scalar_identity,
 )
+from pytensor.tensor.basic import (
+    TensorFromScalar,
+    tensor_from_scalar,
+)
 from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
 from pytensor.tensor.rewriting.elemwise import InplaceElemwiseOptimizer
+from pytensor.tensor.rewriting.scalarize import ScalarizedElemwise
 from pytensor.tensor.shape import shape_padright
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
@@ -288,6 +295,38 @@ class FuseElemwise(GraphRewriter):
     """
 
     @staticmethod
+    def _unwrap_scalarized(fgraph, node, worklist):
+        """Inline a ``ScalarizedElemwise`` back to its plain ``Elemwise`` form.
+
+        Called only once a fusion has been found for it: each ``ScalarType`` input
+        is re-boxed with ``tensor_from_scalar`` (and the expand_dims the inner
+        graph applied) so the result is exactly the pre-scalarize
+        ``Elemwise(tensor_from_scalar(s), ...)``. The new node is queued so the
+        fusion re-anchors on it and the normal swallow carries the scalars back to
+        const -- i.e. the fusion ignores the boxing and uses the scalars directly.
+        """
+        op = node.op
+        [elemwise_node] = [
+            n for n in op.fgraph.apply_nodes if isinstance(n.op, Elemwise)
+        ]
+        new_inputs = []
+        for i, outer in enumerate(node.inputs):
+            if isinstance(outer.type, ScalarType):
+                box = tensor_from_scalar(outer)
+                ndim = elemwise_node.inputs[i].type.ndim
+                if ndim:
+                    box = box.dimshuffle(["x"] * ndim)
+                new_inputs.append(box)
+            else:
+                new_inputs.append(outer)
+        unwrapped = elemwise_node.op(*new_inputs, return_list=True)
+        fgraph.replace_all_validate(
+            list(zip(node.outputs, unwrapped, strict=True)),
+            reason="unwrap_scalarized",
+        )
+        worklist.append(unwrapped[0].owner)
+
+    @staticmethod
     def _extract_idx_axis_pairs(node, *, write=False):
         """Extract ``(idx_var, axis)`` pairs from an Advanced(Inc)Subtensor node.
 
@@ -429,9 +468,12 @@ class FuseElemwise(GraphRewriter):
         worklist = list(reversed(fgraph.toposort()))
         while worklist:
             node = worklist.pop()
-            if not isinstance(node.op, Elemwise):
-                continue
             if node not in fgraph.apply_nodes:
+                continue
+            # ScalarizedElemwise is an Elemwise that declared some inputs const; it
+            # anchors like any Elemwise. Once a fusion is found for it (below) it is
+            # inlined so the scalars flow straight into the fused loop as const.
+            if not isinstance(node.op, (Elemwise, ScalarizedElemwise)):
                 continue
 
             idx_groups = {}  # (idx_var, axis) -> (reads: list[int], writes: list[int])
@@ -558,6 +600,17 @@ class FuseElemwise(GraphRewriter):
                     extra_reduction = (out_idx, car_clients[1])
                     break
                 reduced_outputs[out_idx] = car_clients[0]
+
+            # A ScalarizedElemwise anchors like an Elemwise, but the code below
+            # reads node.op.scalar_op / inplace_pattern. Once the detections above
+            # have found something to fuse for it, inline it back to the plain
+            # Elemwise (scalars re-boxed) and re-anchor -- the swallow then carries
+            # the scalars into the fused loop as const. With nothing to fuse it is
+            # left scalarized, so its scalar inputs stay unboxed.
+            if isinstance(node.op, ScalarizedElemwise):
+                if idx_groups or reduced_outputs or extra_reduction is not None:
+                    self._unwrap_scalarized(fgraph, node, worklist)
+                continue
 
             # An output consumed by several eligible reductions: peel one reduction
             # per pass onto a duplicate output, until each reduction has its own copy
@@ -833,11 +886,55 @@ class FuseElemwise(GraphRewriter):
                 for key, (_, writes) in idx_groups.items()
             )
 
+            # Swallow loop-invariant TensorFromScalar inputs (from the scalarize
+            # pass) as ScalarType, so the value crosses into the loop as a scalar
+            # constant_input instead of a boxed array. The inner graph is built on
+            # a fresh scalar input whose ``tensor_from_scalar`` is folded into the
+            # single nominalizing clone; the real (possibly shared) value is bound
+            # only at the call, so a scalar feeding several fused positions is just
+            # the same value passed several times. An indexed-read or inplace
+            # destination must stay a real array.
+            destroyed = set(node.op.inplace_pattern.values())
+            inner_replace = {}
+            outer_scalars = {}
+            for i in range(len(node.inputs)):
+                if i in indexed_reads or i in destroyed:
+                    continue
+                outer_var = node.inputs[i]
+                behind = outer_var
+                if behind.owner is not None and isinstance(behind.owner.op, DimShuffle):
+                    behind = behind.owner.inputs[0]
+                if not (
+                    all(outer_var.type.broadcastable)
+                    and behind.owner is not None
+                    and isinstance(behind.owner.op, TensorFromScalar)
+                ):
+                    continue
+                inner_scalar = get_scalar_type(fgraph_inputs[i].type.dtype)()
+                replacement = tensor_from_scalar(inner_scalar)
+                if fgraph_inputs[i].type.ndim:
+                    replacement = replacement.dimshuffle(
+                        ["x"] * fgraph_inputs[i].type.ndim
+                    )
+                inner_replace[fgraph_inputs[i]] = replacement
+                fgraph_inputs[i] = inner_scalar
+                outer_scalars[i] = behind.owner.inputs[0]
+
             outer_inputs = []
             for i, inp in enumerate(fgraph_inputs):
+                if i in outer_scalars:
+                    outer_inputs.append(outer_scalars[i])
+                    continue
                 val = outer_write_targets.get(i, inp)
                 outer_inputs.append(val.copy() if i in copy_positions else val)
 
+            frozen = (
+                construct_nominal_fgraph(
+                    fgraph_inputs, fgraph_outputs, replace=inner_replace
+                ).freeze()
+                if inner_replace
+                else None
+            )
             new_outs = FusedElemwise(
                 fgraph_inputs,
                 fgraph_outputs,
@@ -845,6 +942,7 @@ class FuseElemwise(GraphRewriter):
                 indexed_inputs=indexed_inputs_spec,
                 indexed_outputs=indexed_outputs_spec,
                 reduced_outputs=reduced_spec,
+                fgraph=frozen,
             )(*outer_inputs, return_list=True)
 
             replacements = []

--- a/pytensor/tensor/rewriting/fused_elemwise.py
+++ b/pytensor/tensor/rewriting/fused_elemwise.py
@@ -29,12 +29,18 @@ from pytensor.scalar.basic import (
     identity as scalar_identity,
 )
 from pytensor.tensor.basic import (
+    ScalarFromTensor,
     TensorFromScalar,
+    scalar_from_tensor,
     tensor_from_scalar,
 )
 from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
+from pytensor.tensor.rewriting.basic import (
+    local_scalar_tensor_scalar,
+    local_tensor_scalar_tensor,
+)
 from pytensor.tensor.rewriting.elemwise import InplaceElemwiseOptimizer
-from pytensor.tensor.rewriting.scalarize import ScalarizedElemwise
+from pytensor.tensor.rewriting.scalarize import ScalarCAReduce, ScalarizedElemwise
 from pytensor.tensor.shape import shape_padright
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
@@ -839,6 +845,7 @@ class FuseElemwise(GraphRewriter):
             # reduced_spec carries the (scalar_op, axes, identity, acc_dtype) the
             # Numba backend reads to fuse the reduction into the loop instead.
             reduced_spec_by_idx = {}
+            scalarized_out_idxs = set()
             for out_idx, car_node in sorted(reduced_outputs.items()):
                 car_op = car_node.op
                 ndim = node.outputs[out_idx].type.ndim
@@ -858,7 +865,17 @@ class FuseElemwise(GraphRewriter):
                     car_op.scalar_op.identity,
                     acc_dtype,
                 )
-                fgraph_outputs[out_idx] = car_op(node.outputs[out_idx])
+                reduced = car_op(node.outputs[out_idx])
+                # A full reduction yields a single value; carrying it as a 0-d
+                # tensor costs one allocation per output. Hand it out as ScalarType
+                # and let the boundary cancel against a consuming ScalarFromTensor
+                # (see the boundary rewrites registered on fused_elemwise_optdb).
+                # The value is re-boxed at the replacement below, so a consumer that
+                # genuinely wants the tensor keeps exactly the box it always had.
+                if reduced.type.ndim == 0:
+                    scalarized_out_idxs.add(out_idx)
+                    reduced = scalar_from_tensor(reduced)
+                fgraph_outputs[out_idx] = reduced
 
             reduced_spec = (
                 tuple(
@@ -952,9 +969,14 @@ class FuseElemwise(GraphRewriter):
                         (write_targets[out_idx].outputs[0], new_outs[out_idx])
                     )
                 elif out_idx in reduced_outputs:
-                    replacements.append(
-                        (reduced_outputs[out_idx].outputs[0], new_outs[out_idx])
-                    )
+                    new_out = new_outs[out_idx]
+                    # Re-box a scalarized reduced output: the CAReduce it replaces
+                    # is a 0-d tensor, so the boundary must stay valid. A consuming
+                    # ScalarFromTensor cancels it (boundary rewrites below); anything
+                    # that wants the tensor keeps the one box it always had.
+                    if out_idx in scalarized_out_idxs:
+                        new_out = tensor_from_scalar(new_out)
+                    replacements.append((reduced_outputs[out_idx].outputs[0], new_out))
                 else:
                     replacements.append((node.outputs[out_idx], new_outs[out_idx]))
 
@@ -975,4 +997,57 @@ fused_elemwise_optdb.register(
     FuseElemwise(),
     "numba",
     position=1,
+)
+# Cancel the scalar/tensor boundaries introduced on scalarized reduction outputs:
+# tensor_from_scalar(FusedElemwise scalar) feeding a ScalarFromTensor collapses to
+# the bare scalar. Where a consumer wants the tensor, the box stays (never a loss).
+fused_elemwise_optdb.register(
+    "local_scalar_tensor_scalar",
+    dfs_rewriter(local_scalar_tensor_scalar, ignore_newtrees=True),
+    "numba",
+    position=2,
+)
+fused_elemwise_optdb.register(
+    "local_tensor_scalar_tensor",
+    dfs_rewriter(local_tensor_scalar_tensor, ignore_newtrees=True),
+    "numba",
+    position=3,
+)
+
+
+@node_rewriter([ScalarFromTensor])
+def wrap_scalar_careduce(fgraph, node):
+    """Fuse ``ScalarFromTensor(CAReduce(...))`` into a single scalar-valued Op.
+
+    A full reduction fusion did not absorb still accumulates into a register and
+    ends in ``np.array(res, ...)``, costing one allocation purely to carry the
+    value to a consuming ``ScalarFromTensor``. Hand the scalar out directly.
+    """
+    [reduced] = node.inputs
+    careduce_node = reduced.owner
+    if careduce_node is None or not isinstance(careduce_node.op, CAReduce):
+        return None
+    # Only a full reduction accumulates into a register; a partial one writes an
+    # array that has to exist anyway.
+    if reduced.type.ndim != 0:
+        return None
+    # A client that wants the 0-d tensor forces it onto the heap anyway, and
+    # wrapping would then run the whole reduction twice.
+    if any(
+        not isinstance(client.op, ScalarFromTensor)
+        for client, _ in fgraph.clients[reduced]
+        if client != "output"
+    ):
+        return None
+
+    inner_inputs = [inp.type() for inp in careduce_node.inputs]
+    inner_out = scalar_from_tensor(careduce_node.op(*inner_inputs))
+    return [ScalarCAReduce(inner_inputs, [inner_out])(*careduce_node.inputs)]
+
+
+fused_elemwise_optdb.register(
+    wrap_scalar_careduce.__name__,
+    dfs_rewriter(wrap_scalar_careduce, ignore_newtrees=True),
+    "numba",
+    position=6,
 )

--- a/pytensor/tensor/rewriting/fused_elemwise.py
+++ b/pytensor/tensor/rewriting/fused_elemwise.py
@@ -40,7 +40,11 @@ from pytensor.tensor.rewriting.basic import (
     local_tensor_scalar_tensor,
 )
 from pytensor.tensor.rewriting.elemwise import InplaceElemwiseOptimizer
-from pytensor.tensor.rewriting.scalarize import ScalarCAReduce, ScalarizedElemwise
+from pytensor.tensor.rewriting.scalarize import (
+    ScalarCAReduce,
+    Scalarize,
+    ScalarizedElemwise,
+)
 from pytensor.tensor.shape import shape_padright
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
@@ -1012,6 +1016,17 @@ fused_elemwise_optdb.register(
     dfs_rewriter(local_tensor_scalar_tensor, ignore_newtrees=True),
     "numba",
     position=3,
+)
+# The scalarized reduction outputs above are boundaries the pre-fusion scalarize
+# run (50.4) could not see, because fusion is what creates them. Run the same walk
+# again so consumers that take ScalarType -- ScalarizedElemwise, a size-1 Elemwise,
+# a Join -- swallow them instead of reading the re-box.
+fused_elemwise_optdb.register(
+    "scalarize_post_fusion",
+    Scalarize(),
+    "numba",
+    "scalarize",
+    position=4,
 )
 
 

--- a/pytensor/tensor/rewriting/scalarize.py
+++ b/pytensor/tensor/rewriting/scalarize.py
@@ -1,24 +1,26 @@
 """Scalarization graph rewriter.
 
-Propagates ``ScalarType`` so values that are logically single scalars are not
-boxed into 0-d arrays -- each box is one heap allocation per call, which
-dominates the small ``logp_dlogp`` graphs PyMC compiles.
+Removes heap allocations caused by boxing a logically-single value into a 0-d
+array. It works on **boundaries**: ``TensorFromScalar(s)`` is the boundary
+between the scalar world (below) and the tensor world (above). The pass is a
+single forward toposort that pushes each boundary downstream as far as it goes.
+Every op has one rule -- *what happens when a ``TensorFromScalar`` meets me?*:
 
-It is one graph rewriter because producer and consumer are decided
-independently, then matched. One toposort collects the ``wanted`` set (0-d
-values a consumer would take as a scalar, seen through free views like
-``DimShuffle``). Each wanted, producible output is *realised* as
-``tensor_from_scalar(scalar)`` -- type-preserving, so the scalar is shared and
-the graph stays valid -- and then every scalar-capable consumer *bypasses* the
-``tensor_from_scalar`` to take the scalar directly. One wanting consumer is
-enough: a box that survives is the same allocation the producer had anyway, so
-scalarizing is never a loss.
+* a **producer** (``Subtensor`` scalar-index, ``CAReduce`` full-reduction) creates
+  a boundary -- a scalar with a ``TensorFromScalar`` just below it;
+* a **consumer** (``Join``, and downstream Elemwise/fusion) swallows it;
+* ``Elemwise``/``Composite`` is **both**: it swallows its scalar inputs, and if
+  it ends up all-scalar it re-emits the ``scalar_op`` -- but only if a client will
+  swallow that too, else it keeps the array;
+* ``DimShuffle`` (expand/squeeze) is a free view: boundaries pass straight through.
 
-Scalar Ops are ``OpFromGraph``s wrapping the faithful tensor graph, so every
-backend still runs them via ``perform``; only Numba has the scalar dispatch.
+A boundary swallowed all the way cancels (no alloc); one that stops materializes
+as the single box the producer always had, so scalarizing is never a loss. Topo
+order carries the cascade, so there is no fixpoint.
 
-Only ``CAReduce`` (producer) and ``Join`` (consumer) are handled so far, inlined
-below; the day this branching hurts, lift it into a dispatch.
+Runs after Composite fusion and before inplace (an inplace destination is an
+array that survives scalarization), and before IndexedFusion -- so it never sees
+the ``FusedElemwise``. See ``spec_scalarize.md``.
 """
 
 from pytensor.compile import optdb
@@ -32,7 +34,8 @@ from pytensor.tensor.basic import (
     scalar_from_tensor,
     tensor_from_scalar,
 )
-from pytensor.tensor.elemwise import CAReduce, DimShuffle
+from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
+from pytensor.tensor.subtensor import Subtensor
 
 
 class ScalarCAReduce(OpFromGraph):
@@ -41,87 +44,132 @@ class ScalarCAReduce(OpFromGraph):
         return f"Scalar{node.op}"
 
 
+class ScalarSubtensor(OpFromGraph):
+    def __str__(self):
+        [node] = [n for n in self.fgraph.apply_nodes if isinstance(n.op, Subtensor)]
+        return f"Scalar{node.op}"
+
+
 class ScalarJoin(OpFromGraph):
     def __str__(self):
         return "ScalarJoin"
 
 
+# Op types that can swallow a scalar input (so a producer feeding one is worth
+# scalarizing). Elemwise swallows via its scalar_op / the mixed-Elemwise op.
+_SCALAR_CONSUMERS = (Join, Elemwise)
+
+
+def _scalar_behind(var):
+    """The scalar behind a ``TensorFromScalar`` (through free views), or None."""
+    if var.owner is not None and isinstance(var.owner.op, DimShuffle):
+        var = var.owner.inputs[0]
+    if var.owner is not None and isinstance(var.owner.op, TensorFromScalar):
+        return var.owner.inputs[0]
+    return None
+
+
+def _has_scalar_consumer(fgraph, var):
+    """Whether any client of ``var`` (through free views) can swallow a scalar."""
+    for client, _ in fgraph.clients[var]:
+        if client == "output":
+            continue
+        if isinstance(client.op, DimShuffle):
+            if _has_scalar_consumer(fgraph, client.outputs[0]):
+                return True
+        elif isinstance(client.op, _SCALAR_CONSUMERS):
+            return True
+    return False
+
+
 class Scalarize(GraphRewriter):
     def apply(self, fgraph):
-        toposort = fgraph.toposort()
-
-        # Decide: 0-d values a Join would take as a size-1 entry, peeled back
-        # through the free expand_dims to the producing value.
-        wanted = set()
-        for node in toposort:
-            if not (
-                isinstance(node.op, Join)
-                and node.op.axis == 0
-                and node.outputs[0].type.ndim == 1
-            ):
-                continue
-            for inp in node.inputs:
-                if inp.owner is not None and isinstance(inp.owner.op, DimShuffle):
-                    inp = inp.owner.inputs[0]
-                if inp.type.ndim == 0:
-                    wanted.add(inp)
-
-        # Realise: hand each wanted full reduction out as a scalar, re-boxed once
-        # with tensor_from_scalar so consumers that don't bypass stay valid.
-        # Same toposort -- deciding did not touch the graph.
-        for node in toposort:
-            if node not in fgraph.apply_nodes or node.outputs[0] not in wanted:
-                continue
-            if not isinstance(node.op, CAReduce):
-                continue
-            inner = [inp.type() for inp in node.inputs]
-            scalar = ScalarCAReduce(inner, [scalar_from_tensor(node.op(*inner))])(
-                *node.inputs
-            )
-            try:
-                fgraph.replace_all_validate(
-                    [(node.outputs[0], tensor_from_scalar(scalar))], reason="scalarize"
-                )
-            except InconsistencyError:
-                continue
-
-        # Bypass: a Join reads the scalar behind each tensor_from_scalar directly;
-        # a box no consumer bypasses DCEs away.
         for node in fgraph.toposort():
-            if node not in fgraph.apply_nodes or not isinstance(node.op, Join):
+            if node not in fgraph.apply_nodes:
                 continue
-            outer, inner, entries = [], [], []
-            found = False
-            for inp in node.inputs:
-                src = inp
-                if src.owner is not None and isinstance(src.owner.op, DimShuffle):
-                    src = src.owner.inputs[0]
-                if src.owner is not None and isinstance(src.owner.op, TensorFromScalar):
-                    v = src.owner.inputs[0].type()
-                    entries.append(tensor_from_scalar(v).dimshuffle("x"))
-                    outer.append(src.owner.inputs[0])
-                    found = True
-                else:
-                    v = inp.type()
-                    entries.append(v)
-                    outer.append(inp)
-                inner.append(v)
-            if not found:
+            op = node.op
+            replacement = None
+            if isinstance(op, Join) and op.axis == 0 and node.outputs[0].type.ndim == 1:
+                replacement = self._swallow_join(node)
+            elif isinstance(op, Subtensor) and node.outputs[0].type.ndim == 0:
+                replacement = self._emit_producer(fgraph, node, ScalarSubtensor)
+            elif isinstance(op, Elemwise):
+                scalars = [_scalar_behind(inp) for inp in node.inputs]
+                # A size-1 all-scalar Elemwise is a pure scalar computation: run
+                # the scalar op on the scalars and box only the output.
+                if len(node.outputs) == 1 and all(s is not None for s in scalars):
+                    self._pass_through_elemwise(fgraph, node, scalars)
+            if replacement is None:
                 continue
             try:
-                fgraph.replace_all_validate(
-                    [(node.outputs[0], ScalarJoin(inner, [join(0, *entries)])(*outer))],
-                    reason="scalarize",
-                )
+                fgraph.replace_all_validate(replacement, reason="scalarize")
             except InconsistencyError:
                 continue
+
+    @staticmethod
+    def _distribute(fgraph, out, scalar):
+        # Give each consumer its OWN TensorFromScalar box (the scalar value is
+        # shared, the boundary is not), so every downstream fused/elemwise input
+        # is single-client and swallows cleanly -- we build the graph we want, a
+        # cheap producer feeding N consumers is just N boxes.
+        for client, input_idx in list(fgraph.clients[out]):
+            if client == "output":
+                continue
+            box = tensor_from_scalar(scalar)
+            if out.type.ndim:
+                box = box.dimshuffle(["x"] * out.type.ndim)
+            fgraph.change_node_input(client, input_idx, box, reason="scalarize")
+
+    @staticmethod
+    def _emit_producer(fgraph, node, scalar_op_type):
+        # A producer creates a scalar with a boundary below it, but only if a
+        # client will swallow it (otherwise the box survives -- pure churn).
+        out = node.outputs[0]
+        if not _has_scalar_consumer(fgraph, out):
+            return None
+        inner = [inp.type() for inp in node.inputs]
+        scalar = scalar_op_type(inner, [scalar_from_tensor(node.op(*inner))])(
+            *node.inputs
+        )
+        Scalarize._distribute(fgraph, out, scalar)
+        return None
+
+    @staticmethod
+    def _pass_through_elemwise(fgraph, node, scalars):
+        # size-1 all-scalar Elemwise: swallow every scalar input, re-emit the
+        # scalar_op -- but only if a client will swallow it (else box survives).
+        out = node.outputs[0]
+        if not _has_scalar_consumer(fgraph, out):
+            return None
+        Scalarize._distribute(fgraph, out, node.op.scalar_op(*scalars))
+        return None
+
+    @staticmethod
+    def _swallow_join(node):
+        outer, inner, entries = [], [], []
+        found = False
+        for inp in node.inputs:
+            scalar = _scalar_behind(inp)
+            if scalar is None:
+                v = inp.type()
+                entries.append(v)
+                outer.append(inp)
+            else:
+                v = scalar.type()
+                entries.append(tensor_from_scalar(v).dimshuffle("x"))
+                outer.append(scalar)
+                found = True
+            inner.append(v)
+        if not found:
+            return None
+        return [(node.outputs[0], ScalarJoin(inner, [join(0, *entries)])(*outer))]
 
 
 optdb.register(
     "scalarize",
     Scalarize(),
     "numba",
-    # After fusion (position 100), so the fused reductions and the raveled
-    # gradient Join are in their final form before we scalarize them.
-    position=100.5,
+    # After Composite fusion (49), before inplace (50.5) -- inplace only touches
+    # the arrays that survive scalarization -- and before IndexedFusion (100).
+    position=50.4,
 )

--- a/pytensor/tensor/rewriting/scalarize.py
+++ b/pytensor/tensor/rewriting/scalarize.py
@@ -18,15 +18,20 @@ A boundary swallowed all the way cancels (no alloc); one that stops materializes
 as the single box the producer always had, so scalarizing is never a loss. Topo
 order carries the cascade, so there is no fixpoint.
 
-Runs after Composite fusion and before inplace (an inplace destination is an
-array that survives scalarization), and before IndexedFusion -- so it never sees
-the ``FusedElemwise``. See ``spec_scalarize.md``.
+Runs twice. First after Composite fusion and before inplace (an inplace
+destination is an array that survives scalarization) and before IndexedFusion, so
+it never sees the ``FusedElemwise``. Then again *after* IndexedFusion, because
+fusion creates boundaries of its own: it hands each full reduction out as a scalar
+and re-boxes it, and only a second walk can swallow those into the consumers. The
+second run is the only one that can meet an inplace node, hence the ``destroy_map``
+guard. See ``spec_scalarize.md``.
 """
 
 from pytensor.compile import optdb
 from pytensor.compile.builders import OpFromGraph
 from pytensor.graph.rewriting.basic import GraphRewriter
 from pytensor.graph.utils import InconsistencyError
+from pytensor.scalar.basic import ScalarType
 from pytensor.tensor.basic import (
     Join,
     TensorFromScalar,
@@ -72,7 +77,7 @@ class ScalarizedElemwise(OpFromGraph):
 
 # Op types that can swallow a scalar input (so a producer feeding one is worth
 # scalarizing). Elemwise swallows via its scalar_op / the mixed-Elemwise op.
-_SCALAR_CONSUMERS = (Join, Elemwise)
+_SCALAR_CONSUMERS = (Join, Elemwise, ScalarizedElemwise)
 
 
 def _scalar_behind(var):
@@ -104,7 +109,15 @@ class Scalarize(GraphRewriter):
                 continue
             op = node.op
             replacement = None
-            if isinstance(op, Join) and op.axis == 0 and node.outputs[0].type.ndim == 1:
+            if op.destroy_map:
+                # Rebuilding would silently drop the inplace the InplaceOptimizer
+                # chose; only the post-fusion run can meet one (inplace is 50.5).
+                continue
+            if isinstance(op, ScalarizedElemwise):
+                replacement = self._rescalarize(node)
+            elif (
+                isinstance(op, Join) and op.axis == 0 and node.outputs[0].type.ndim == 1
+            ):
                 replacement = self._swallow_join(node)
             elif isinstance(op, Subtensor) and node.outputs[0].type.ndim == 0:
                 replacement = self._emit_producer(fgraph, node, ScalarSubtensor)
@@ -124,7 +137,9 @@ class Scalarize(GraphRewriter):
                     if single:
                         self._pass_through_elemwise(fgraph, node, scalars)
                     else:
-                        replacement = self._emit_scalar_elemwise(node, scalars)
+                        replacement = self._emit_scalar_elemwise(
+                            op.scalar_op, node.outputs, scalars
+                        )
                 elif single or scalar_computation:
                     replacement = self._scalarize_elemwise(node, scalars)
             if replacement is None:
@@ -173,15 +188,15 @@ class Scalarize(GraphRewriter):
         return None
 
     @staticmethod
-    def _emit_scalar_elemwise(node, scalars):
+    def _emit_scalar_elemwise(scalar_op, outputs, scalars):
         # A multi-output pure scalar computation: apply the scalar op on the
         # scalars directly and box each 0-d output once. The single-output case
         # goes through _pass_through_elemwise (which distributes per consumer).
-        scalar_outs = node.op.scalar_op(*scalars)
+        scalar_outs = scalar_op(*scalars)
         if not isinstance(scalar_outs, list):
             scalar_outs = [scalar_outs]
         replacements = []
-        for out, scalar_out in zip(node.outputs, scalar_outs, strict=True):
+        for out, scalar_out in zip(outputs, scalar_outs, strict=True):
             box = tensor_from_scalar(scalar_out)
             if out.type.ndim:
                 box = box.dimshuffle(["x"] * out.type.ndim)
@@ -189,28 +204,76 @@ class Scalarize(GraphRewriter):
         return replacements
 
     @staticmethod
+    def _build_scalarized(elemwise_op, node_outputs, sources, ndims):
+        # ``sources`` pairs each position's outer variable with whether it enters
+        # as a scalar; ``ndims`` are the ranks the inner Elemwise expects, so each
+        # scalar is re-boxed to exactly the rank it replaces.
+        outer, inner, elemwise_inputs = [], [], []
+        for (source, is_scalar), ndim in zip(sources, ndims, strict=True):
+            dummy = source.type()
+            if is_scalar:
+                box = tensor_from_scalar(dummy)
+                if ndim:
+                    box = box.dimshuffle(["x"] * ndim)
+                elemwise_inputs.append(box)
+            else:
+                elemwise_inputs.append(dummy)
+            inner.append(dummy)
+            outer.append(source)
+        inner_outs = elemwise_op(*elemwise_inputs, return_list=True)
+        new_outs = ScalarizedElemwise(inner, inner_outs)(*outer, return_list=True)
+        return list(zip(node_outputs, new_outs, strict=True))
+
+    @staticmethod
     def _scalarize_elemwise(node, scalars):
         # Mixed Elemwise (some scalar inputs, some genuine arrays): keep it an
         # array op but carry the scalar inputs as ScalarType, so their 0-d boxes
         # vanish. The inner graph re-boxes each scalar with tensor_from_scalar so
         # it stays a faithful Elemwise; only Numba passes them as constant_inputs.
-        outer, inner, elemwise_inputs = [], [], []
-        for inp, scalar in zip(node.inputs, scalars):
+        sources = [
+            (inp, False) if scalar is None else (scalar, True)
+            for inp, scalar in zip(node.inputs, scalars, strict=True)
+        ]
+        ndims = [inp.type.ndim for inp in node.inputs]
+        return Scalarize._build_scalarized(node.op, node.outputs, sources, ndims)
+
+    @staticmethod
+    def _rescalarize(node):
+        # A ScalarizedElemwise built before fusion meets new boundaries after it:
+        # a FusedElemwise hands each full reduction out as ScalarType and re-boxes
+        # it, and those boxes land on consumers like this one. Pull them in as
+        # scalars too, so the re-box cancels.
+        [elemwise_node] = [
+            n for n in node.op.fgraph.apply_nodes if isinstance(n.op, Elemwise)
+        ]
+        sources, found = [], False
+        for inp in node.inputs:
+            if isinstance(inp.type, ScalarType):
+                sources.append((inp, True))
+                continue
+            scalar = _scalar_behind(inp)
             if scalar is None:
-                dummy = inp.type()
-                elemwise_inputs.append(dummy)
-                outer.append(inp)
+                sources.append((inp, False))
             else:
-                dummy = scalar.type()
-                box = tensor_from_scalar(dummy)
-                if inp.type.ndim:
-                    box = box.dimshuffle(["x"] * inp.type.ndim)
-                elemwise_inputs.append(box)
-                outer.append(scalar)
-            inner.append(dummy)
-        inner_outs = node.op(*elemwise_inputs, return_list=True)
-        new_outs = ScalarizedElemwise(inner, inner_outs)(*outer, return_list=True)
-        return list(zip(node.outputs, new_outs, strict=True))
+                sources.append((scalar, True))
+                found = True
+        if not found:
+            return None
+        if all(is_scalar for _, is_scalar in sources):
+            # Nothing is an array any more, so there is no vectorized loop left to
+            # run: this is a pure scalar computation and only its outputs get boxed.
+            # (A wider output would have no array to take its shape from.)
+            if not all(all(out.type.broadcastable) for out in node.outputs):
+                return None
+            return Scalarize._emit_scalar_elemwise(
+                elemwise_node.op.scalar_op,
+                node.outputs,
+                [source for source, _ in sources],
+            )
+        ndims = [inp.type.ndim for inp in elemwise_node.inputs]
+        return Scalarize._build_scalarized(
+            elemwise_node.op, node.outputs, sources, ndims
+        )
 
     @staticmethod
     def _swallow_join(node):

--- a/pytensor/tensor/rewriting/scalarize.py
+++ b/pytensor/tensor/rewriting/scalarize.py
@@ -108,14 +108,24 @@ class Scalarize(GraphRewriter):
                 replacement = self._swallow_join(node)
             elif isinstance(op, Subtensor) and node.outputs[0].type.ndim == 0:
                 replacement = self._emit_producer(fgraph, node, ScalarSubtensor)
-            elif isinstance(op, Elemwise) and len(node.outputs) == 1:
+            elif isinstance(op, Elemwise):
                 scalars = [_scalar_behind(inp) for inp in node.inputs]
-                if all(s is not None for s in scalars):
-                    # A size-1 all-scalar Elemwise is a pure scalar computation:
-                    # run the scalar op on the scalars and box only the output.
-                    self._pass_through_elemwise(fgraph, node, scalars)
-                elif any(s is not None for s in scalars):
-                    # Mixed: keep an array output, carry the scalars as ScalarType.
+                single = len(node.outputs) == 1
+                # All-size-1 outputs => a pure scalar computation, so it never
+                # needs its scalar inputs boxed -- even with several outputs.
+                scalar_computation = all(
+                    all(out.type.broadcastable) for out in node.outputs
+                )
+                if not any(s is not None for s in scalars):
+                    pass
+                elif all(s is not None for s in scalars):
+                    # Pure scalar computation: run the scalar op on the scalars,
+                    # box only the outputs (no input is boxed, no vectorized loop).
+                    if single:
+                        self._pass_through_elemwise(fgraph, node, scalars)
+                    else:
+                        replacement = self._emit_scalar_elemwise(node, scalars)
+                elif single or scalar_computation:
                     replacement = self._scalarize_elemwise(node, scalars)
             if replacement is None:
                 continue
@@ -161,6 +171,22 @@ class Scalarize(GraphRewriter):
             return None
         Scalarize._distribute(fgraph, out, node.op.scalar_op(*scalars))
         return None
+
+    @staticmethod
+    def _emit_scalar_elemwise(node, scalars):
+        # A multi-output pure scalar computation: apply the scalar op on the
+        # scalars directly and box each 0-d output once. The single-output case
+        # goes through _pass_through_elemwise (which distributes per consumer).
+        scalar_outs = node.op.scalar_op(*scalars)
+        if not isinstance(scalar_outs, list):
+            scalar_outs = [scalar_outs]
+        replacements = []
+        for out, scalar_out in zip(node.outputs, scalar_outs, strict=True):
+            box = tensor_from_scalar(scalar_out)
+            if out.type.ndim:
+                box = box.dimshuffle(["x"] * out.type.ndim)
+            replacements.append((out, box))
+        return replacements
 
     @staticmethod
     def _scalarize_elemwise(node, scalars):

--- a/pytensor/tensor/rewriting/scalarize.py
+++ b/pytensor/tensor/rewriting/scalarize.py
@@ -55,6 +55,21 @@ class ScalarJoin(OpFromGraph):
         return "ScalarJoin"
 
 
+class ScalarizedElemwise(OpFromGraph):
+    """An ``Elemwise`` some of whose inputs are ``ScalarType`` (loop-invariant).
+
+    Its inner graph is the faithful ``Elemwise(tensor_from_scalar(s), ...)``, so
+    every backend runs it via ``perform``; only Numba peels the scalar positions
+    off and hands them to ``_vectorized`` as ``constant_inputs`` -- so a scalar
+    param feeding an array Elemwise is never boxed into a 0-d array and reloaded
+    each iteration. The output is a normal array.
+    """
+
+    def __str__(self):
+        [node] = [n for n in self.fgraph.apply_nodes if isinstance(n.op, Elemwise)]
+        return f"Scalarized{node.op}"
+
+
 # Op types that can swallow a scalar input (so a producer feeding one is worth
 # scalarizing). Elemwise swallows via its scalar_op / the mixed-Elemwise op.
 _SCALAR_CONSUMERS = (Join, Elemwise)
@@ -93,12 +108,15 @@ class Scalarize(GraphRewriter):
                 replacement = self._swallow_join(node)
             elif isinstance(op, Subtensor) and node.outputs[0].type.ndim == 0:
                 replacement = self._emit_producer(fgraph, node, ScalarSubtensor)
-            elif isinstance(op, Elemwise):
+            elif isinstance(op, Elemwise) and len(node.outputs) == 1:
                 scalars = [_scalar_behind(inp) for inp in node.inputs]
-                # A size-1 all-scalar Elemwise is a pure scalar computation: run
-                # the scalar op on the scalars and box only the output.
-                if len(node.outputs) == 1 and all(s is not None for s in scalars):
+                if all(s is not None for s in scalars):
+                    # A size-1 all-scalar Elemwise is a pure scalar computation:
+                    # run the scalar op on the scalars and box only the output.
                     self._pass_through_elemwise(fgraph, node, scalars)
+                elif any(s is not None for s in scalars):
+                    # Mixed: keep an array output, carry the scalars as ScalarType.
+                    replacement = self._scalarize_elemwise(node, scalars)
             if replacement is None:
                 continue
             try:
@@ -143,6 +161,30 @@ class Scalarize(GraphRewriter):
             return None
         Scalarize._distribute(fgraph, out, node.op.scalar_op(*scalars))
         return None
+
+    @staticmethod
+    def _scalarize_elemwise(node, scalars):
+        # Mixed Elemwise (some scalar inputs, some genuine arrays): keep it an
+        # array op but carry the scalar inputs as ScalarType, so their 0-d boxes
+        # vanish. The inner graph re-boxes each scalar with tensor_from_scalar so
+        # it stays a faithful Elemwise; only Numba passes them as constant_inputs.
+        outer, inner, elemwise_inputs = [], [], []
+        for inp, scalar in zip(node.inputs, scalars):
+            if scalar is None:
+                dummy = inp.type()
+                elemwise_inputs.append(dummy)
+                outer.append(inp)
+            else:
+                dummy = scalar.type()
+                box = tensor_from_scalar(dummy)
+                if inp.type.ndim:
+                    box = box.dimshuffle(["x"] * inp.type.ndim)
+                elemwise_inputs.append(box)
+                outer.append(scalar)
+            inner.append(dummy)
+        inner_outs = node.op(*elemwise_inputs, return_list=True)
+        new_outs = ScalarizedElemwise(inner, inner_outs)(*outer, return_list=True)
+        return list(zip(node.outputs, new_outs, strict=True))
 
     @staticmethod
     def _swallow_join(node):

--- a/pytensor/tensor/rewriting/scalarize.py
+++ b/pytensor/tensor/rewriting/scalarize.py
@@ -1,0 +1,127 @@
+"""Scalarization graph rewriter.
+
+Propagates ``ScalarType`` so values that are logically single scalars are not
+boxed into 0-d arrays -- each box is one heap allocation per call, which
+dominates the small ``logp_dlogp`` graphs PyMC compiles.
+
+It is one graph rewriter because producer and consumer are decided
+independently, then matched. One toposort collects the ``wanted`` set (0-d
+values a consumer would take as a scalar, seen through free views like
+``DimShuffle``). Each wanted, producible output is *realised* as
+``tensor_from_scalar(scalar)`` -- type-preserving, so the scalar is shared and
+the graph stays valid -- and then every scalar-capable consumer *bypasses* the
+``tensor_from_scalar`` to take the scalar directly. One wanting consumer is
+enough: a box that survives is the same allocation the producer had anyway, so
+scalarizing is never a loss.
+
+Scalar Ops are ``OpFromGraph``s wrapping the faithful tensor graph, so every
+backend still runs them via ``perform``; only Numba has the scalar dispatch.
+
+Only ``CAReduce`` (producer) and ``Join`` (consumer) are handled so far, inlined
+below; the day this branching hurts, lift it into a dispatch.
+"""
+
+from pytensor.compile import optdb
+from pytensor.compile.builders import OpFromGraph
+from pytensor.graph.rewriting.basic import GraphRewriter
+from pytensor.graph.utils import InconsistencyError
+from pytensor.tensor.basic import (
+    Join,
+    TensorFromScalar,
+    join,
+    scalar_from_tensor,
+    tensor_from_scalar,
+)
+from pytensor.tensor.elemwise import CAReduce, DimShuffle
+
+
+class ScalarCAReduce(OpFromGraph):
+    def __str__(self):
+        [node] = [n for n in self.fgraph.apply_nodes if isinstance(n.op, CAReduce)]
+        return f"Scalar{node.op}"
+
+
+class ScalarJoin(OpFromGraph):
+    def __str__(self):
+        return "ScalarJoin"
+
+
+class Scalarize(GraphRewriter):
+    def apply(self, fgraph):
+        toposort = fgraph.toposort()
+
+        # Decide: 0-d values a Join would take as a size-1 entry, peeled back
+        # through the free expand_dims to the producing value.
+        wanted = set()
+        for node in toposort:
+            if not (
+                isinstance(node.op, Join)
+                and node.op.axis == 0
+                and node.outputs[0].type.ndim == 1
+            ):
+                continue
+            for inp in node.inputs:
+                if inp.owner is not None and isinstance(inp.owner.op, DimShuffle):
+                    inp = inp.owner.inputs[0]
+                if inp.type.ndim == 0:
+                    wanted.add(inp)
+
+        # Realise: hand each wanted full reduction out as a scalar, re-boxed once
+        # with tensor_from_scalar so consumers that don't bypass stay valid.
+        # Same toposort -- deciding did not touch the graph.
+        for node in toposort:
+            if node not in fgraph.apply_nodes or node.outputs[0] not in wanted:
+                continue
+            if not isinstance(node.op, CAReduce):
+                continue
+            inner = [inp.type() for inp in node.inputs]
+            scalar = ScalarCAReduce(inner, [scalar_from_tensor(node.op(*inner))])(
+                *node.inputs
+            )
+            try:
+                fgraph.replace_all_validate(
+                    [(node.outputs[0], tensor_from_scalar(scalar))], reason="scalarize"
+                )
+            except InconsistencyError:
+                continue
+
+        # Bypass: a Join reads the scalar behind each tensor_from_scalar directly;
+        # a box no consumer bypasses DCEs away.
+        for node in fgraph.toposort():
+            if node not in fgraph.apply_nodes or not isinstance(node.op, Join):
+                continue
+            outer, inner, entries = [], [], []
+            found = False
+            for inp in node.inputs:
+                src = inp
+                if src.owner is not None and isinstance(src.owner.op, DimShuffle):
+                    src = src.owner.inputs[0]
+                if src.owner is not None and isinstance(src.owner.op, TensorFromScalar):
+                    v = src.owner.inputs[0].type()
+                    entries.append(tensor_from_scalar(v).dimshuffle("x"))
+                    outer.append(src.owner.inputs[0])
+                    found = True
+                else:
+                    v = inp.type()
+                    entries.append(v)
+                    outer.append(inp)
+                inner.append(v)
+            if not found:
+                continue
+            try:
+                fgraph.replace_all_validate(
+                    [(node.outputs[0], ScalarJoin(inner, [join(0, *entries)])(*outer))],
+                    reason="scalarize",
+                )
+            except InconsistencyError:
+                continue
+
+
+optdb.register(
+    "scalarize",
+    Scalarize(),
+    "numba",
+    # After fusion (position 100), so the fused reductions and the raveled
+    # gradient Join are in their final form before we scalarize them.
+    position=100.5,
+)

--- a/tests/benchmarks/test_scalar_ops.py
+++ b/tests/benchmarks/test_scalar_ops.py
@@ -1,0 +1,133 @@
+"""Scalar-favorable validation graph for the scalar-carrying optimizations.
+
+The compiled `logp_dlogp`-shaped graph mirrors what PyMC builds: a single flat
+input vector is split by `Subtensor` into scalar parameters plus one vector
+parameter, an elementwise expression is reduced to a scalar `logp`, and the
+gradient of every parameter is joined back into one raveled `dlogp` vector.
+
+That shape stresses exactly the ops the scalar-carrying work targets:
+
+* scalar params extracted from the joined vector (``Subtensor`` -> scalar),
+* a fully-reduced scalar ``logp`` (``CAReduce`` / fused reduction -> scalar),
+* a raveled gradient mixing scalar and vector entries (``Join``).
+
+`build_scalar_favorable_graph` is importable so allocation-counting scripts can
+reuse the exact same graph the timing benchmark measures.
+"""
+
+import numpy as np
+import pytest
+
+from pytensor import Out, function, grad
+from pytensor.graph.replace import graph_replace
+from pytensor.tensor import as_tensor_variable, exp, join, scalar, vector
+
+
+def _reference_logp(theta, y, group_idx, n_groups):
+    """NumPy reference: value and gradient of the graph below, for validation."""
+    mu, sigma_log, sigma_group_log = theta[0], theta[1], theta[2]
+    offsets = theta[3:]
+    sigma = np.exp(sigma_log)
+    sigma_group = np.exp(sigma_group_log)
+    group_means = mu + sigma_group * offsets
+    resid = (y - group_means[group_idx]) / sigma
+    logp = -0.5 * (resid**2).sum() - y.size * sigma_log - 0.5 * (offsets**2).sum()
+    return logp
+
+
+def build_scalar_favorable_graph(n_obs, n_groups, seed=490):
+    """Return ``(joined, [logp, dlogp], test_value, y, group_idx)``.
+
+    ``joined`` is the single flat parameter vector of length ``n_groups + 3``
+    ordered ``[mu, sigma_log, sigma_group_log, *offsets]``. The observations
+    ``y`` and the group assignment ``group_idx`` are baked in as constants, as
+    the data is in a real ``logp_dlogp_function``.
+    """
+    rng = np.random.default_rng(seed)
+    y_np = rng.standard_normal(n_obs)
+    group_idx_np = rng.integers(0, n_groups, size=n_obs)
+
+    y = as_tensor_variable(y_np)
+    group_idx = as_tensor_variable(group_idx_np)
+
+    # Parameters as separate variables so `grad` produces one adjoint per
+    # parameter and the raveled gradient is a genuine mixed scalar/vector Join.
+    mu = scalar("mu")
+    sigma_log = scalar("sigma_log")
+    sigma_group_log = scalar("sigma_group_log")
+    offsets = vector("offsets", shape=(n_groups,))
+    params = [mu, sigma_log, sigma_group_log, offsets]
+
+    sigma = exp(sigma_log)
+    sigma_group = exp(sigma_group_log)
+    group_means = mu + sigma_group * offsets
+    resid = (y - group_means[group_idx]) / sigma
+    logp = -0.5 * (resid**2).sum() - n_obs * sigma_log - 0.5 * (offsets**2).sum()
+
+    grads = grad(logp, params)
+    dlogp = join(0, *[g.reshape((-1,)) for g in grads])
+
+    # Fold the separate parameters into one flat input, as PyMC does when it
+    # builds `logp_dlogp_function`: the scalar params become `Subtensor`s of the
+    # joined vector, the vector param a basic slice.
+    joined = vector("joined", shape=(n_groups + 3,))
+    replace = {
+        mu: joined[0],
+        sigma_log: joined[1],
+        sigma_group_log: joined[2],
+        offsets: joined[3:],
+    }
+    logp, dlogp = graph_replace([logp, dlogp], replace)
+
+    test_value = rng.standard_normal(n_groups + 3)
+    return joined, [logp, dlogp], test_value, y_np, group_idx_np
+
+
+def _build_fn(mode, n_obs, n_groups):
+    joined, outs, test_value, y_np, group_idx_np = build_scalar_favorable_graph(
+        n_obs, n_groups
+    )
+    fn = function(
+        [joined],
+        [Out(o, borrow=True) for o in outs],
+        mode=mode,
+        trust_input=True,
+    )
+    return fn, test_value, y_np, group_idx_np
+
+
+def _validate(fn, test_value, y_np, group_idx_np, n_groups):
+    logp_val, dlogp_val = fn(test_value)
+    ref_logp = _reference_logp(test_value, y_np, group_idx_np, n_groups)
+    np.testing.assert_allclose(logp_val, ref_logp, rtol=1e-8)
+
+    # Central finite differences of the reference logp validate the gradient.
+    eps = 1e-6
+    fd = np.empty_like(test_value)
+    for i in range(test_value.size):
+        step = np.zeros_like(test_value)
+        step[i] = eps
+        fd[i] = (
+            _reference_logp(test_value + step, y_np, group_idx_np, n_groups)
+            - _reference_logp(test_value - step, y_np, group_idx_np, n_groups)
+        ) / (2 * eps)
+    np.testing.assert_allclose(dlogp_val, fd, rtol=1e-4, atol=1e-4)
+
+
+# Small stresses fixed per-call overhead (boxing/allocation); large exposes the
+# per-element scaling.
+SIZES = [(100, 5), (10_000, 100)]
+
+
+@pytest.mark.parametrize("n_obs, n_groups", SIZES, ids=lambda s: str(s))
+def test_scalar_favorable_benchmark_numba(n_obs, n_groups, benchmark):
+    fn, test_value, y_np, group_idx_np = _build_fn("NUMBA", n_obs, n_groups)
+    _validate(fn, test_value, y_np, group_idx_np, n_groups)
+    benchmark(fn, test_value)
+
+
+@pytest.mark.parametrize("n_obs, n_groups", SIZES, ids=lambda s: str(s))
+def test_scalar_favorable_benchmark_c(n_obs, n_groups, benchmark):
+    fn, test_value, y_np, group_idx_np = _build_fn("CVM", n_obs, n_groups)
+    _validate(fn, test_value, y_np, group_idx_np, n_groups)
+    benchmark(fn, test_value)


### PR DESCRIPTION
- **Add Numba scalarization rewriter (CAReduce producer, Join consumer)**
- **Numba: accept ScalarType FusedElemwise inputs via constant_inputs**
- **Allow OpFromGraph to take a pre-built frozen inner fgraph**
- **Numba: scalarize scalar-index Subtensor to ScalarSubtensor**
- **Numba: scalarize mixed Elemwise via ScalarizedElemwise**
- **Numba: scalarize multi-output size-1 Composites**
- **Numba: squeeze the fused full-reduction epilogue instead of ravel**
- **Numba: hand fully-reduced FusedElemwise outputs out as scalars**
- **Numba: keep full-reduction accumulators on the stack**
- **Numba: squeeze partial fused reductions with as_strided, not reshape**
