### PR TITLE
Experimental MLIR (IREE llvm-cpu) backend feasibility spike

### DIFF
--- a/pytensor/compile/mode.py
+++ b/pytensor/compile/mode.py
@@ -29,6 +29,7 @@ from pytensor.link.basic import Linker, PerformLinker
 from pytensor.link.c.basic import CLinker, OpWiseCLinker
 from pytensor.link.jax.linker import JAXLinker
 from pytensor.link.mlx.linker import MLXLinker
+from pytensor.link.mlir.linker import MLIRLinker
 from pytensor.link.numba.linker import NumbaLinker
 from pytensor.link.pytorch.linker import PytorchLinker
 from pytensor.link.vm import VMLinker
@@ -53,6 +54,7 @@ predefined_linkers = {
     "pytorch": PytorchLinker(),
     "numba": NumbaLinker(),
     "mlx": MLXLinker(),
+    "mlir": MLIRLinker(),
 }
 
 
@@ -532,6 +534,11 @@ MLX = Mode(
     RewriteDatabaseQuery(include=["fast_run", "mlx"], exclude=["fusion"]),
 )
 
+MLIR = Mode(
+    MLIRLinker(),
+    RewriteDatabaseQuery(include=["fast_compile"], exclude=["fusion"]),
+)
+
 FAST_COMPILE = Mode(
     VMLinker(use_cloop=False, c_thunks=False),
     RewriteDatabaseQuery(include=["fast_compile", "py_only"]),
@@ -551,6 +558,7 @@ predefined_modes = {
     "NUMBA": NUMBA,
     "PYTORCH": PYTORCH,
     "MLX": MLX,
+    "MLIR": MLIR,
 }
 
 _CACHED_RUNTIME_MODES: dict[Any, Mode] = {}

--- a/pytensor/compile/mode.py
+++ b/pytensor/compile/mode.py
@@ -539,6 +539,11 @@ MLIR = Mode(
     RewriteDatabaseQuery(include=["fast_compile"], exclude=["fusion"]),
 )
 
+MLIR_METAL = Mode(
+    MLIRLinker(target_backend="metal-spirv"),
+    RewriteDatabaseQuery(include=["fast_compile"], exclude=["fusion"]),
+)
+
 FAST_COMPILE = Mode(
     VMLinker(use_cloop=False, c_thunks=False),
     RewriteDatabaseQuery(include=["fast_compile", "py_only"]),
@@ -559,6 +564,7 @@ predefined_modes = {
     "PYTORCH": PYTORCH,
     "MLX": MLX,
     "MLIR": MLIR,
+    "MLIR_METAL": MLIR_METAL,
 }
 
 _CACHED_RUNTIME_MODES: dict[Any, Mode] = {}

--- a/pytensor/configdefaults.py
+++ b/pytensor/configdefaults.py
@@ -50,6 +50,7 @@ def _filter_mode(val):
         "PYTORCH",
         "MLX",
         "MLIR",
+        "MLIR_METAL",
     ]
     if val in str_options:
         return val

--- a/pytensor/configdefaults.py
+++ b/pytensor/configdefaults.py
@@ -49,6 +49,7 @@ def _filter_mode(val):
         "NUMBA",
         "PYTORCH",
         "MLX",
+        "MLIR",
     ]
     if val in str_options:
         return val

--- a/pytensor/link/mlir/__init__.py
+++ b/pytensor/link/mlir/__init__.py
@@ -1,0 +1,1 @@
+from pytensor.link.mlir.linker import MLIRLinker

--- a/pytensor/link/mlir/dispatch/__init__.py
+++ b/pytensor/link/mlir/dispatch/__init__.py
@@ -1,0 +1,1 @@
+from pytensor.link.mlir.dispatch.basic import mlir_funcify, mlir_typify

--- a/pytensor/link/mlir/dispatch/basic.py
+++ b/pytensor/link/mlir/dispatch/basic.py
@@ -1,0 +1,511 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from functools import singledispatch
+
+import numpy as np
+
+from pytensor.compile.ops import DeepCopyOp
+from pytensor.graph import Constant
+from pytensor.graph.fg import AbstractFunctionGraph
+from pytensor.scalar.basic import Add, Mul, Second
+from pytensor.tensor.blas import Dot22
+from pytensor.tensor.elemwise import DimShuffle, Elemwise
+from pytensor.tensor.math import Dot
+
+
+MLIR_DTYPES = {"float32": "f32", "float64": "f64"}
+
+
+@dataclass(frozen=True)
+class MLIRModule:
+    text: str
+    entrypoint: str = "main"
+    output_count: int = 1
+    runtime_validator: Callable[..., None] | None = None
+
+
+def _typify_array(array):
+    if array.dtype.name not in MLIR_DTYPES:
+        raise TypeError(f"MLIR only supports float32 and float64 inputs, got {array.dtype}")
+    return array if array.ndim == 0 else np.ascontiguousarray(array)
+
+
+@singledispatch
+def mlir_typify(data, **kwargs):
+    return _typify_array(np.asarray(data))
+
+
+@mlir_typify.register(np.ndarray)
+def mlir_typify_ndarray(data, **kwargs):
+    return _typify_array(data)
+
+
+@singledispatch
+def mlir_funcify(op, node=None, emitter=None, **kwargs):
+    raise NotImplementedError(f"No MLIR conversion for the given Op: {op}")
+
+
+@mlir_funcify.register(AbstractFunctionGraph)
+def mlir_funcify_FunctionGraph(fgraph, **kwargs):
+    return _MLIREmitter(fgraph).emit()
+
+
+@mlir_funcify.register(Elemwise)
+def mlir_funcify_Elemwise(op, node, emitter, **kwargs):
+    emitter.emit_elemwise(node)
+
+
+@mlir_funcify.register(DimShuffle)
+def mlir_funcify_DimShuffle(op, node, emitter, **kwargs):
+    emitter.emit_dimshuffle(node)
+
+
+@mlir_funcify.register(DeepCopyOp)
+def mlir_funcify_DeepCopyOp(op, node, emitter, **kwargs):
+    emitter.emit_deepcopy(node)
+
+
+@mlir_funcify.register(Dot)
+@mlir_funcify.register(Dot22)
+def mlir_funcify_Dot22(op, node, emitter, **kwargs):
+    emitter.emit_dot22(node)
+
+
+class _MLIREmitter:
+    def __init__(self, fgraph):
+        self.fgraph = fgraph
+        self.nodes = fgraph.toposort()
+        self.body: list[str] = []
+        self.values = {}
+        self.counter = 0
+        self.index_constants = {}
+
+        for index, variable in enumerate(fgraph.inputs):
+            self._tensor_type(variable)
+            self.values[variable] = f"%arg{index}"
+
+    def emit(self):
+        for node in self.nodes:
+            mlir_funcify(node.op, node=node, emitter=self)
+
+        result_types = [self._tensor_type(output) for output in self.fgraph.outputs]
+        result_values = [self._value(output) for output in self.fgraph.outputs]
+        arguments = ", ".join(
+            f"{self.values[variable]}: {self._tensor_type(variable)}"
+            for variable in self.fgraph.inputs
+        )
+        results = ", ".join(result_types)
+        signature = f"({arguments})"
+        if result_types:
+            result_signature = results if len(result_types) == 1 else f"({results})"
+            signature = f"{signature} -> {result_signature}"
+
+        if result_values:
+            self.body.append(f"return {', '.join(result_values)} : {results}")
+        else:
+            self.body.append("return")
+
+        body = "\n".join(f"    {line}" for line in self.body)
+        return MLIRModule(
+            "\n".join(
+                (
+                    "module @pytensor_mlir {",
+                    f"  func.func @main{signature} {{",
+                    body,
+                    "  }",
+                    "}",
+                )
+            ),
+            output_count=len(result_values),
+            runtime_validator=self.validate_runtime_inputs,
+        )
+
+    def emit_elemwise(self, node):
+        if len(node.outputs) != 1:
+            raise NotImplementedError("MLIR Elemwise lowering requires one output")
+
+        output = node.outputs[0]
+        output_type = self._tensor_type(output)
+        rank = output.type.ndim
+        dtype = self._element_dtype(output)
+        if rank > 2:
+            raise NotImplementedError("MLIR Elemwise lowering supports tensors up to rank 2")
+
+        inputs = list(node.inputs)
+        for variable in inputs:
+            self._validate_elemwise_input(variable, output)
+
+        nonconstant_inputs = [variable for variable in inputs if not isinstance(variable, Constant)]
+        if not nonconstant_inputs:
+            raise NotImplementedError("MLIR Elemwise lowering requires a tensor input")
+
+        init = self._empty_for_elemwise_output(output, inputs)
+        input_maps = [self._elemwise_map(variable, output) for variable in nonconstant_inputs]
+        output_map = self._identity_map(rank)
+        iterator_types = ", ".join('"parallel"' for _ in range(rank))
+        input_names = ", ".join(self._value(variable) for variable in nonconstant_inputs)
+        input_types = ", ".join(self._tensor_type(variable) for variable in nonconstant_inputs)
+        result = self._fresh("value")
+        maps = ", ".join((*input_maps, output_map))
+        ins = f"ins({input_names} : {input_types}) "
+        self.body.append(
+            f"{result} = linalg.generic {{indexing_maps = [{maps}], "
+            f"iterator_types = [{iterator_types}]}} {ins}"
+            f"outs({init} : {output_type}) {{"
+        )
+
+        block_arguments = ", ".join(
+            [
+                *(f"%input{index}: {dtype}" for index in range(len(nonconstant_inputs))),
+                f"%output: {dtype}",
+            ]
+        )
+        self.body.append(f"  ^bb0({block_arguments}):")
+        block_values = iter(
+            f"%input{index}" for index in range(len(nonconstant_inputs))
+        )
+        scalar_inputs = []
+        for variable in inputs:
+            if isinstance(variable, Constant):
+                scalar_inputs.append(self._emit_constant(variable, dtype))
+            else:
+                scalar_inputs.append(next(block_values))
+        value = self._emit_scalar_op(node.op.scalar_op, scalar_inputs, dtype)
+        self.body.append(f"    linalg.yield {value} : {dtype}")
+        self.body.append(f"}} -> {output_type}")
+        self.values[output] = result
+
+    def emit_dimshuffle(self, node):
+        if len(node.inputs) != 1 or len(node.outputs) != 1:
+            raise NotImplementedError("MLIR DimShuffle lowering requires one input and one output")
+
+        input_variable = node.inputs[0]
+        output = node.outputs[0]
+        input_type = self._tensor_type(input_variable)
+        output_type = self._tensor_type(output)
+        if input_variable.type.ndim > 2 or output.type.ndim > 2:
+            raise NotImplementedError("MLIR DimShuffle lowering supports tensors up to rank 2")
+        if self._element_dtype(input_variable) != self._element_dtype(output):
+            raise TypeError("MLIR DimShuffle requires matching input and output dtypes")
+
+        new_order = node.op.new_order
+        init = self._empty_for_dimshuffle_output(output, input_variable, new_order)
+        input_map = self._dimshuffle_map(input_variable, output, new_order)
+        output_map = self._identity_map(output.type.ndim)
+        iterator_types = ", ".join('"parallel"' for _ in range(output.type.ndim))
+        result = self._fresh("value")
+        dtype = self._element_dtype(output)
+        self.body.append(
+            f"{result} = linalg.generic {{indexing_maps = [{input_map}, {output_map}], "
+            f"iterator_types = [{iterator_types}]}} "
+            f"ins({self._value(input_variable)} : {input_type}) "
+            f"outs({init} : {output_type}) {{"
+        )
+        self.body.append(f"  ^bb0(%input: {dtype}, %output: {dtype}):")
+        self.body.append(f"    linalg.yield %input : {dtype}")
+        self.body.append(f"}} -> {output_type}")
+        self.values[output] = result
+
+    def emit_deepcopy(self, node):
+        if len(node.inputs) != 1 or len(node.outputs) != 1:
+            raise NotImplementedError("MLIR DeepCopyOp lowering requires one input and one output")
+
+        input_variable = node.inputs[0]
+        output = node.outputs[0]
+        input_type = self._tensor_type(input_variable)
+        output_type = self._tensor_type(output)
+        if input_variable.type.ndim > 2 or output.type.ndim > 2:
+            raise NotImplementedError("MLIR DeepCopyOp lowering supports tensors up to rank 2")
+        dtype = self._element_dtype(output)
+        if self._element_dtype(input_variable) != dtype:
+            raise TypeError("MLIR DeepCopyOp requires matching input and output dtypes")
+
+        init = self._empty_for_output(
+            output,
+            {
+                axis: (input_variable, axis)
+                for axis, size in enumerate(output.type.shape)
+                if size is None
+            },
+        )
+        input_map = self._identity_map(output.type.ndim)
+        result = self._fresh("value")
+        iterator_types = ", ".join('"parallel"' for _ in range(output.type.ndim))
+        self.body.append(
+            f"{result} = linalg.generic {{indexing_maps = [{input_map}, {input_map}], "
+            f"iterator_types = [{iterator_types}]}} "
+            f"ins({self._value(input_variable)} : {input_type}) "
+            f"outs({init} : {output_type}) {{"
+        )
+        self.body.append(f"  ^bb0(%input: {dtype}, %output: {dtype}):")
+        self.body.append(f"    linalg.yield %input : {dtype}")
+        self.body.append(f"}} -> {output_type}")
+        self.values[output] = result
+
+    def emit_dot22(self, node):
+        if len(node.inputs) != 2 or len(node.outputs) != 1:
+            raise NotImplementedError("MLIR Dot22 lowering requires two inputs and one output")
+
+        lhs, rhs = node.inputs
+        if isinstance(lhs, Constant) or isinstance(rhs, Constant):
+            raise NotImplementedError("MLIR Dot lowering requires tensor inputs")
+        output = node.outputs[0]
+        lhs_type = self._tensor_type(lhs)
+        rhs_type = self._tensor_type(rhs)
+        output_type = self._tensor_type(output)
+        if (lhs.type.ndim, rhs.type.ndim, output.type.ndim) != (2, 2, 2):
+            raise NotImplementedError("MLIR Dot22 lowering requires rank-2 tensors")
+        dtype = self._element_dtype(output)
+        if self._element_dtype(lhs) != dtype or self._element_dtype(rhs) != dtype:
+            raise TypeError("MLIR Dot22 requires matching input and output dtypes")
+
+        init = self._empty_for_output(
+            output,
+            {0: (lhs, 0), 1: (rhs, 1)},
+        )
+        zero = self._fresh("zero")
+        self.body.append(f"{zero} = arith.constant 0.0 : {dtype}")
+        filled = self._fresh("filled")
+        self.body.append(
+            f"{filled} = linalg.fill ins({zero} : {dtype}) outs({init} : {output_type}) "
+            f"-> {output_type}"
+        )
+        result = self._fresh("value")
+        self.body.append(
+            f"{result} = linalg.matmul "
+            f"ins({self._value(lhs)}, {self._value(rhs)} : {lhs_type}, {rhs_type}) "
+            f"outs({filled} : {output_type}) -> {output_type}"
+        )
+        self.values[output] = result
+
+    def _emit_scalar_op(self, scalar_op, operands, dtype):
+        if isinstance(scalar_op, Second):
+            return operands[1]
+        if isinstance(scalar_op, Add):
+            operation = "arith.addf"
+        elif isinstance(scalar_op, Mul):
+            operation = "arith.mulf"
+        else:
+            raise NotImplementedError(f"MLIR Elemwise lowering does not support {scalar_op}")
+
+        value = operands[0]
+        for operand in operands[1:]:
+            result = self._fresh("scalar")
+            self.body.append(f"    {result} = {operation} {value}, {operand} : {dtype}")
+            value = result
+        return value
+
+    def _empty_for_elemwise_output(self, output, inputs):
+        sources = {}
+        output_rank = output.type.ndim
+        for output_axis, output_size in enumerate(output.type.shape):
+            if output_size is not None:
+                continue
+            for variable in inputs:
+                if isinstance(variable, Constant):
+                    continue
+                input_rank = variable.type.ndim
+                input_axis = output_axis - (output_rank - input_rank)
+                if input_axis < 0 or variable.type.shape[input_axis] == 1:
+                    continue
+                sources[output_axis] = (variable, input_axis)
+                break
+            else:
+                raise NotImplementedError(
+                    "MLIR could not determine a dynamic Elemwise output dimension"
+                )
+        return self._empty_for_output(output, sources)
+
+    def _empty_for_dimshuffle_output(self, output, input_variable, new_order):
+        sources = {
+            output_axis: (input_variable, input_axis)
+            for output_axis, input_axis in enumerate(new_order)
+            if isinstance(input_axis, int) and output.type.shape[output_axis] is None
+        }
+        return self._empty_for_output(output, sources)
+
+    def _empty_for_output(self, output, dimension_sources):
+        output_type = self._tensor_type(output)
+        dynamic_dimensions = []
+        for output_axis, output_size in enumerate(output.type.shape):
+            if output_size is not None:
+                continue
+            try:
+                source, source_axis = dimension_sources[output_axis]
+            except KeyError as error:
+                raise NotImplementedError(
+                    "MLIR could not determine a dynamic output dimension"
+                ) from error
+            dimension = self._fresh("dim")
+            self.body.append(
+                f"{dimension} = tensor.dim {self._value(source)}, {self._index(source_axis)} "
+                f": {self._tensor_type(source)}"
+            )
+            dynamic_dimensions.append(dimension)
+        init = self._fresh("init")
+        dimensions = ", ".join(dynamic_dimensions)
+        self.body.append(f"{init} = tensor.empty({dimensions}) : {output_type}")
+        return init
+
+    def validate_runtime_inputs(self, *inputs):
+        if len(inputs) != len(self.fgraph.inputs):
+            raise ValueError("MLIR received an unexpected number of inputs")
+
+        shapes = {}
+        for variable, value in zip(self.fgraph.inputs, inputs, strict=True):
+            shape = np.asarray(value).shape
+            if len(shape) != variable.type.ndim:
+                raise ValueError(f"MLIR expected rank {variable.type.ndim} for {variable}")
+            for actual, expected in zip(shape, variable.type.shape, strict=True):
+                if expected is not None and actual != expected:
+                    raise ValueError(f"MLIR expected shape {variable.type.shape} for {variable}")
+            shapes[variable] = shape
+
+        for node in self.nodes:
+            output = node.outputs[0]
+            if isinstance(node.op, Elemwise):
+                shape = self._runtime_elemwise_shape(node, shapes)
+            elif isinstance(node.op, DimShuffle):
+                input_shape = self._runtime_shape(node.inputs[0], shapes)
+                shape = tuple(
+                    1 if axis == "x" else input_shape[axis] for axis in node.op.new_order
+                )
+            elif isinstance(node.op, DeepCopyOp):
+                shape = self._runtime_shape(node.inputs[0], shapes)
+            elif isinstance(node.op, (Dot, Dot22)):
+                lhs_shape = self._runtime_shape(node.inputs[0], shapes)
+                rhs_shape = self._runtime_shape(node.inputs[1], shapes)
+                if lhs_shape[1] != rhs_shape[0]:
+                    raise ValueError("MLIR Dot requires matching inner dimensions")
+                shape = (lhs_shape[0], rhs_shape[1])
+            else:
+                raise NotImplementedError(f"No MLIR shape validation for {node.op}")
+            self._validate_runtime_output_shape(output, shape)
+            shapes[output] = shape
+
+    def _runtime_elemwise_shape(self, node, shapes):
+        output = node.outputs[0]
+        output_shape = []
+        for output_axis in range(output.type.ndim):
+            dimensions = []
+            for variable in node.inputs:
+                input_shape = self._runtime_shape(variable, shapes)
+                input_axis = output_axis - (output.type.ndim - len(input_shape))
+                if input_axis < 0 or variable.type.shape[input_axis] == 1:
+                    continue
+                dimensions.append(input_shape[input_axis])
+            if dimensions and any(dimension != dimensions[0] for dimension in dimensions[1:]):
+                raise ValueError(
+                    "Runtime broadcasting not allowed: a dynamic dimension differs "
+                    "from another input dimension."
+                )
+            output_shape.append(dimensions[0] if dimensions else 1)
+        return tuple(output_shape)
+
+    @staticmethod
+    def _runtime_shape(variable, shapes):
+        if isinstance(variable, Constant):
+            return np.asarray(variable.data).shape
+        return shapes[variable]
+
+    @staticmethod
+    def _validate_runtime_output_shape(variable, shape):
+        for actual, expected in zip(shape, variable.type.shape, strict=True):
+            if expected is not None and actual != expected:
+                raise ValueError(f"MLIR computed invalid shape {shape} for {variable}")
+
+    def _validate_elemwise_input(self, variable, output):
+        if isinstance(variable, Constant):
+            if np.asarray(variable.data).size != 1:
+                raise NotImplementedError(
+                    "MLIR Elemwise lowering only supports scalar or size-one constants"
+                )
+            return
+        self._tensor_type(variable)
+        if variable.type.ndim > output.type.ndim:
+            raise NotImplementedError("MLIR Elemwise input rank exceeds output rank")
+        if self._element_dtype(variable) != self._element_dtype(output):
+            raise TypeError("MLIR Elemwise requires matching input and output dtypes")
+
+    def _elemwise_map(self, variable, output):
+        output_rank = output.type.ndim
+        expressions = []
+        for input_axis, input_size in enumerate(variable.type.shape):
+            output_axis = output_rank - variable.type.ndim + input_axis
+            expressions.append("0" if input_size == 1 else f"d{output_axis}")
+        return self._affine_map(output_rank, expressions)
+
+    def _dimshuffle_map(self, input_variable, output, new_order):
+        expressions = []
+        for input_axis in range(input_variable.type.ndim):
+            try:
+                output_axis = new_order.index(input_axis)
+            except ValueError:
+                expressions.append("0")
+            else:
+                expressions.append(f"d{output_axis}")
+        return self._affine_map(output.type.ndim, expressions)
+
+    @staticmethod
+    def _affine_map(rank, expressions):
+        dimensions = ", ".join(f"d{index}" for index in range(rank))
+        return f"affine_map<({dimensions}) -> ({', '.join(expressions)})>"
+
+    def _identity_map(self, rank):
+        return self._affine_map(rank, [f"d{index}" for index in range(rank)])
+
+    def _emit_constant(self, variable, dtype):
+        data = np.asarray(variable.data)
+        if data.size != 1:
+            raise NotImplementedError("MLIR only supports size-one constants")
+        value = float(data.reshape(()))
+        if not np.isfinite(value):
+            raise NotImplementedError("MLIR only supports finite constants")
+        literal = repr(value)
+        if "e" in literal:
+            mantissa, exponent = literal.split("e")
+            if "." not in mantissa:
+                literal = f"{mantissa}.0e{exponent}"
+        constant = self._fresh("constant")
+        self.body.append(f"    {constant} = arith.constant {literal} : {dtype}")
+        return constant
+
+    def _tensor_type(self, variable):
+        try:
+            dtype = self._element_dtype(variable)
+            shape = variable.type.shape
+        except AttributeError as error:
+            raise TypeError(f"MLIR only supports TensorType values, got {variable.type}") from error
+        dimensions = "x".join("?" if size is None else str(size) for size in shape)
+        return f"tensor<{dimensions + 'x' if dimensions else ''}{dtype}>"
+
+    @staticmethod
+    def _element_dtype(variable):
+        try:
+            return MLIR_DTYPES[variable.type.dtype]
+        except KeyError as error:
+            raise TypeError(
+                f"MLIR only supports float32 and float64 tensors, got {variable.type.dtype}"
+            ) from error
+
+    def _value(self, variable):
+        try:
+            return self.values[variable]
+        except KeyError as error:
+            if isinstance(variable, Constant):
+                raise NotImplementedError("MLIR does not support a constant graph output") from error
+            raise ValueError(f"MLIR value was not emitted for {variable}") from error
+
+    def _index(self, value):
+        if value not in self.index_constants:
+            constant = self._fresh("index")
+            self.body.append(f"{constant} = arith.constant {value} : index")
+            self.index_constants[value] = constant
+        return self.index_constants[value]
+
+    def _fresh(self, prefix):
+        value = f"%{prefix}{self.counter}"
+        self.counter += 1
+        return value

--- a/pytensor/link/mlir/dispatch/basic.py
+++ b/pytensor/link/mlir/dispatch/basic.py
@@ -9,7 +9,8 @@ import numpy as np
 from pytensor.compile.ops import DeepCopyOp
 from pytensor.graph import Constant
 from pytensor.graph.fg import AbstractFunctionGraph
-from pytensor.scalar.basic import Add, Mul, Second
+from pytensor.scalar.basic import Add, Mul, Second, Sub
+from pytensor.scalar.math import Sigmoid
 from pytensor.tensor.blas import Dot22
 from pytensor.tensor.elemwise import DimShuffle, Elemwise
 from pytensor.tensor.math import Dot
@@ -28,7 +29,9 @@ class MLIRModule:
 
 def _typify_array(array):
     if array.dtype.name not in MLIR_DTYPES:
-        raise TypeError(f"MLIR only supports float32 and float64 inputs, got {array.dtype}")
+        raise TypeError(
+            f"MLIR only supports float32 and float64 inputs, got {array.dtype}"
+        )
     return array if array.ndim == 0 else np.ascontiguousarray(array)
 
 
@@ -131,22 +134,32 @@ class _MLIREmitter:
         rank = output.type.ndim
         dtype = self._element_dtype(output)
         if rank > 2:
-            raise NotImplementedError("MLIR Elemwise lowering supports tensors up to rank 2")
+            raise NotImplementedError(
+                "MLIR Elemwise lowering supports tensors up to rank 2"
+            )
 
         inputs = list(node.inputs)
         for variable in inputs:
             self._validate_elemwise_input(variable, output)
 
-        nonconstant_inputs = [variable for variable in inputs if not isinstance(variable, Constant)]
+        nonconstant_inputs = [
+            variable for variable in inputs if not isinstance(variable, Constant)
+        ]
         if not nonconstant_inputs:
             raise NotImplementedError("MLIR Elemwise lowering requires a tensor input")
 
         init = self._empty_for_elemwise_output(output, inputs)
-        input_maps = [self._elemwise_map(variable, output) for variable in nonconstant_inputs]
+        input_maps = [
+            self._elemwise_map(variable, output) for variable in nonconstant_inputs
+        ]
         output_map = self._identity_map(rank)
         iterator_types = ", ".join('"parallel"' for _ in range(rank))
-        input_names = ", ".join(self._value(variable) for variable in nonconstant_inputs)
-        input_types = ", ".join(self._tensor_type(variable) for variable in nonconstant_inputs)
+        input_names = ", ".join(
+            self._value(variable) for variable in nonconstant_inputs
+        )
+        input_types = ", ".join(
+            self._tensor_type(variable) for variable in nonconstant_inputs
+        )
         result = self._fresh("value")
         maps = ", ".join((*input_maps, output_map))
         ins = f"ins({input_names} : {input_types}) "
@@ -158,7 +171,10 @@ class _MLIREmitter:
 
         block_arguments = ", ".join(
             [
-                *(f"%input{index}: {dtype}" for index in range(len(nonconstant_inputs))),
+                *(
+                    f"%input{index}: {dtype}"
+                    for index in range(len(nonconstant_inputs))
+                ),
                 f"%output: {dtype}",
             ]
         )
@@ -179,14 +195,18 @@ class _MLIREmitter:
 
     def emit_dimshuffle(self, node):
         if len(node.inputs) != 1 or len(node.outputs) != 1:
-            raise NotImplementedError("MLIR DimShuffle lowering requires one input and one output")
+            raise NotImplementedError(
+                "MLIR DimShuffle lowering requires one input and one output"
+            )
 
         input_variable = node.inputs[0]
         output = node.outputs[0]
         input_type = self._tensor_type(input_variable)
         output_type = self._tensor_type(output)
         if input_variable.type.ndim > 2 or output.type.ndim > 2:
-            raise NotImplementedError("MLIR DimShuffle lowering supports tensors up to rank 2")
+            raise NotImplementedError(
+                "MLIR DimShuffle lowering supports tensors up to rank 2"
+            )
         if self._element_dtype(input_variable) != self._element_dtype(output):
             raise TypeError("MLIR DimShuffle requires matching input and output dtypes")
 
@@ -210,14 +230,18 @@ class _MLIREmitter:
 
     def emit_deepcopy(self, node):
         if len(node.inputs) != 1 or len(node.outputs) != 1:
-            raise NotImplementedError("MLIR DeepCopyOp lowering requires one input and one output")
+            raise NotImplementedError(
+                "MLIR DeepCopyOp lowering requires one input and one output"
+            )
 
         input_variable = node.inputs[0]
         output = node.outputs[0]
         input_type = self._tensor_type(input_variable)
         output_type = self._tensor_type(output)
         if input_variable.type.ndim > 2 or output.type.ndim > 2:
-            raise NotImplementedError("MLIR DeepCopyOp lowering supports tensors up to rank 2")
+            raise NotImplementedError(
+                "MLIR DeepCopyOp lowering supports tensors up to rank 2"
+            )
         dtype = self._element_dtype(output)
         if self._element_dtype(input_variable) != dtype:
             raise TypeError("MLIR DeepCopyOp requires matching input and output dtypes")
@@ -246,7 +270,9 @@ class _MLIREmitter:
 
     def emit_dot22(self, node):
         if len(node.inputs) != 2 or len(node.outputs) != 1:
-            raise NotImplementedError("MLIR Dot22 lowering requires two inputs and one output")
+            raise NotImplementedError(
+                "MLIR Dot22 lowering requires two inputs and one output"
+            )
 
         lhs, rhs = node.inputs
         if isinstance(lhs, Constant) or isinstance(rhs, Constant):
@@ -283,12 +309,32 @@ class _MLIREmitter:
     def _emit_scalar_op(self, scalar_op, operands, dtype):
         if isinstance(scalar_op, Second):
             return operands[1]
+        if isinstance(scalar_op, Sigmoid):
+            negative = self._fresh("scalar")
+            exponential = self._fresh("scalar")
+            one = self._fresh("scalar")
+            denominator = self._fresh("scalar")
+            result = self._fresh("scalar")
+            self.body.append(f"    {negative} = arith.negf {operands[0]} : {dtype}")
+            self.body.append(f"    {exponential} = math.exp {negative} : {dtype}")
+            self.body.append(f"    {one} = arith.constant 1.0 : {dtype}")
+            self.body.append(
+                f"    {denominator} = arith.addf {one}, {exponential} : {dtype}"
+            )
+            self.body.append(
+                f"    {result} = arith.divf {one}, {denominator} : {dtype}"
+            )
+            return result
         if isinstance(scalar_op, Add):
             operation = "arith.addf"
+        elif isinstance(scalar_op, Sub):
+            operation = "arith.subf"
         elif isinstance(scalar_op, Mul):
             operation = "arith.mulf"
         else:
-            raise NotImplementedError(f"MLIR Elemwise lowering does not support {scalar_op}")
+            raise NotImplementedError(
+                f"MLIR Elemwise lowering does not support {scalar_op}"
+            )
 
         value = operands[0]
         for operand in operands[1:]:
@@ -357,10 +403,14 @@ class _MLIREmitter:
         for variable, value in zip(self.fgraph.inputs, inputs, strict=True):
             shape = np.asarray(value).shape
             if len(shape) != variable.type.ndim:
-                raise ValueError(f"MLIR expected rank {variable.type.ndim} for {variable}")
+                raise ValueError(
+                    f"MLIR expected rank {variable.type.ndim} for {variable}"
+                )
             for actual, expected in zip(shape, variable.type.shape, strict=True):
                 if expected is not None and actual != expected:
-                    raise ValueError(f"MLIR expected shape {variable.type.shape} for {variable}")
+                    raise ValueError(
+                        f"MLIR expected shape {variable.type.shape} for {variable}"
+                    )
             shapes[variable] = shape
 
         for node in self.nodes:
@@ -370,7 +420,8 @@ class _MLIREmitter:
             elif isinstance(node.op, DimShuffle):
                 input_shape = self._runtime_shape(node.inputs[0], shapes)
                 shape = tuple(
-                    1 if axis == "x" else input_shape[axis] for axis in node.op.new_order
+                    1 if axis == "x" else input_shape[axis]
+                    for axis in node.op.new_order
                 )
             elif isinstance(node.op, DeepCopyOp):
                 shape = self._runtime_shape(node.inputs[0], shapes)
@@ -396,7 +447,9 @@ class _MLIREmitter:
                 if input_axis < 0 or variable.type.shape[input_axis] == 1:
                     continue
                 dimensions.append(input_shape[input_axis])
-            if dimensions and any(dimension != dimensions[0] for dimension in dimensions[1:]):
+            if dimensions and any(
+                dimension != dimensions[0] for dimension in dimensions[1:]
+            ):
                 raise ValueError(
                     "Runtime broadcasting not allowed: a dynamic dimension differs "
                     "from another input dimension."
@@ -477,7 +530,9 @@ class _MLIREmitter:
             dtype = self._element_dtype(variable)
             shape = variable.type.shape
         except AttributeError as error:
-            raise TypeError(f"MLIR only supports TensorType values, got {variable.type}") from error
+            raise TypeError(
+                f"MLIR only supports TensorType values, got {variable.type}"
+            ) from error
         dimensions = "x".join("?" if size is None else str(size) for size in shape)
         return f"tensor<{dimensions + 'x' if dimensions else ''}{dtype}>"
 
@@ -495,7 +550,9 @@ class _MLIREmitter:
             return self.values[variable]
         except KeyError as error:
             if isinstance(variable, Constant):
-                raise NotImplementedError("MLIR does not support a constant graph output") from error
+                raise NotImplementedError(
+                    "MLIR does not support a constant graph output"
+                ) from error
             raise ValueError(f"MLIR value was not emitted for {variable}") from error
 
     def _index(self, value):

--- a/pytensor/link/mlir/linker.py
+++ b/pytensor/link/mlir/linker.py
@@ -4,7 +4,7 @@ from pytensor.link.basic import JITLinker
 
 
 class MLIRLinker(JITLinker):
-    """A linker that lowers a FunctionGraph to an IREE CPU module."""
+    """A linker that lowers a FunctionGraph to an IREE target."""
 
     required_rewrites = ("minimum_compile",)
     incompatible_rewrites = (
@@ -15,7 +15,42 @@ class MLIRLinker(JITLinker):
         "scan_reduce_trace_prealloc",
     )
 
+    _target_options = {
+        "llvm-cpu": (
+            "local-task",
+            ("--iree-input-demote-f64-to-f32=false",),
+        ),
+        "metal-spirv": (
+            "metal",
+            (
+                "--iree-metal-target-platform=macos",
+                "--iree-input-demote-f64-to-f32=false",
+            ),
+        ),
+    }
+
+    def __init__(self, target_backend="llvm-cpu", *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        try:
+            self.runtime_driver, self.compile_args = self._target_options[target_backend]
+        except KeyError:
+            raise ValueError(f"Unsupported MLIR target backend: {target_backend}") from None
+        self.target_backend = target_backend
+
+    def accept(self, fgraph, no_recycling=None, profile=None):
+        if self.fgraph is not None and self.fgraph is not fgraph:
+            return type(self)(
+                target_backend=self.target_backend, allow_gc=self.allow_gc
+            ).accept(fgraph, no_recycling, profile)
+        return super().accept(fgraph, no_recycling, profile)
+
     def fgraph_convert(self, fgraph, **kwargs):
+        if self.target_backend == "metal-spirv" and any(
+            getattr(variable.type, "dtype", None) == "float64"
+            for variable in fgraph.variables
+        ):
+            raise TypeError("MLIR Metal only supports float32 graphs")
+
         from pytensor.link.mlir.dispatch import mlir_funcify
 
         return mlir_funcify(fgraph)
@@ -31,14 +66,17 @@ class MLIRLinker(JITLinker):
 
         from pytensor.link.mlir.dispatch import mlir_typify
 
+        if self.target_backend == "metal-spirv" and "f64" in module.text:
+            raise TypeError("MLIR Metal only supports float32 graphs")
+
         vmfb = iree.compiler.tools.compile_str(
             module.text,
-            target_backends=["llvm-cpu"],
-            extra_args=["--iree-input-demote-f64-to-f32=false"],
+            target_backends=[self.target_backend],
+            extra_args=self.compile_args,
         )
-        entrypoint = iree.runtime.load_vm_flatbuffer(vmfb, backend="llvm-cpu")[
-            module.entrypoint
-        ]
+        entrypoint = iree.runtime.load_vm_flatbuffer(
+            vmfb, driver=self.runtime_driver
+        )[module.entrypoint]
 
         def run(*inputs):
             runtime_inputs = tuple(mlir_typify(input) for input in inputs)

--- a/pytensor/link/mlir/linker.py
+++ b/pytensor/link/mlir/linker.py
@@ -1,0 +1,57 @@
+import numpy as np
+
+from pytensor.link.basic import JITLinker
+
+
+class MLIRLinker(JITLinker):
+    """A linker that lowers a FunctionGraph to an IREE CPU module."""
+
+    required_rewrites = ("minimum_compile",)
+    incompatible_rewrites = (
+        "cxx_only",
+        "BlasOpt",
+        "inplace",
+        "fusion",
+        "scan_reduce_trace_prealloc",
+    )
+
+    def fgraph_convert(self, fgraph, **kwargs):
+        from pytensor.link.mlir.dispatch import mlir_funcify
+
+        return mlir_funcify(fgraph)
+
+    def jit_compile(self, module):
+        try:
+            import iree.compiler.tools
+            import iree.runtime
+        except ModuleNotFoundError as error:
+            raise ImportError(
+                "MLIR mode requires iree-base-compiler and iree-base-runtime"
+            ) from error
+
+        from pytensor.link.mlir.dispatch import mlir_typify
+
+        vmfb = iree.compiler.tools.compile_str(
+            module.text,
+            target_backends=["llvm-cpu"],
+            extra_args=["--iree-input-demote-f64-to-f32=false"],
+        )
+        entrypoint = iree.runtime.load_vm_flatbuffer(vmfb, backend="llvm-cpu")[
+            module.entrypoint
+        ]
+
+        def run(*inputs):
+            runtime_inputs = tuple(mlir_typify(input) for input in inputs)
+            if module.runtime_validator is not None:
+                module.runtime_validator(*runtime_inputs)
+            result = entrypoint(*runtime_inputs)
+            if module.output_count == 0:
+                return None
+            if module.output_count == 1:
+                result = (result,)
+            return tuple(np.asarray(value).copy() for value in result)
+
+        return run
+
+    def create_thunk_inputs(self, storage_map):
+        return [storage_map[variable] for variable in self.fgraph.inputs]

--- a/scripts/benchmark_mlx_vs_mlir_metal.py
+++ b/scripts/benchmark_mlx_vs_mlir_metal.py
@@ -1,0 +1,392 @@
+# ruff: noqa: T201
+
+"""Benchmark equivalent PyTensor MLX and MLIR Metal float32 graphs on Apple Silicon.
+
+The timings intentionally include the host NumPy input to device and device to host
+output behavior visible to a PyTensor caller.  See the methodology printed by the
+script for what each timing column includes.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version
+from statistics import median
+from time import perf_counter
+
+import iree.runtime
+import mlx.core as mx
+import numpy as np
+
+import pytensor
+import pytensor.tensor as pt
+
+
+ATOL = 1e-5
+BATCH = 512
+COLD_SAMPLES = 5
+FEATURES = 256
+OUTPUTS = 64
+RTOL = 1e-5
+SEED = 20260729
+SMALL_COLUMNS = 192
+SMALL_ROWS = 128
+STEADY_CALLS_PER_REPEAT = 20
+STEADY_REPEATS = 9
+STEADY_WARMUP_CALLS = 3
+BACKENDS = ("MLX", "MLIR_METAL")
+
+
+@dataclass(frozen=True)
+class SymbolicGraph:
+    inputs: tuple
+    outputs: tuple
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    name: str
+    description: str
+    shapes: str
+    values: tuple[np.ndarray, ...]
+    build_graph: Callable[[], SymbolicGraph]
+
+
+@dataclass(frozen=True)
+class TimingResult:
+    case: str
+    backend: str
+    build_samples: tuple[float, ...]
+    first_call_samples: tuple[float, ...]
+    cold_total_samples: tuple[float, ...]
+    steady_call_samples: tuple[float, ...]
+
+
+def float32_values(
+    rng: np.random.Generator, *shapes: tuple[int, ...]
+) -> tuple[np.ndarray, ...]:
+    return tuple(rng.standard_normal(shape, dtype=np.float32) for shape in shapes)
+
+
+def make_elementwise_case(rng: np.random.Generator) -> BenchmarkCase:
+    shape = (SMALL_ROWS, SMALL_COLUMNS)
+    values = float32_values(rng, shape, shape, shape)
+
+    def build_graph() -> SymbolicGraph:
+        x = pt.matrix("elementwise_x", dtype="float32", shape=shape)
+        y = pt.matrix("elementwise_y", dtype="float32", shape=shape)
+        z = pt.matrix("elementwise_z", dtype="float32", shape=shape)
+        output = (x + y) * (z + x) + y * z
+        return SymbolicGraph((x, y, z), (output,))
+
+    return BenchmarkCase(
+        name="elementwise_chain",
+        description="(X + Y) * (Z + X) + Y * Z",
+        shapes=f"X, Y, Z: {shape}; output: {shape}",
+        values=values,
+        build_graph=build_graph,
+    )
+
+
+def make_matrix_case(rng: np.random.Generator) -> BenchmarkCase:
+    x_shape = (BATCH, FEATURES)
+    w_shape = (FEATURES, OUTPUTS)
+    b_shape = (OUTPUTS,)
+    output_shape = (BATCH, OUTPUTS)
+    values = float32_values(rng, x_shape, w_shape, b_shape, output_shape)
+
+    def build_graph() -> SymbolicGraph:
+        x = pt.matrix("matrix_x", dtype="float32", shape=x_shape)
+        w = pt.matrix("matrix_w", dtype="float32", shape=w_shape)
+        b = pt.vector("matrix_b", dtype="float32", shape=b_shape)
+        residual = pt.matrix("matrix_residual", dtype="float32", shape=output_shape)
+        output = (pt.dot(x, w) + b) * residual + residual
+        return SymbolicGraph((x, w, b, residual), (output,))
+
+    return BenchmarkCase(
+        name="matrix_bias_chain",
+        description="(X @ W + b) * residual + residual",
+        shapes=(
+            f"X: {x_shape}; W: {w_shape}; b: {b_shape}; residual/output: {output_shape}"
+        ),
+        values=values,
+        build_graph=build_graph,
+    )
+
+
+def make_logistic_vjp_case(rng: np.random.Generator) -> BenchmarkCase:
+    x_shape = (BATCH, FEATURES)
+    w_shape = (FEATURES, OUTPUTS)
+    b_shape = (OUTPUTS,)
+    output_shape = (BATCH, OUTPUTS)
+    values = float32_values(rng, x_shape, w_shape, b_shape, output_shape)
+
+    def build_graph() -> SymbolicGraph:
+        x = pt.matrix("logistic_x", dtype="float32", shape=x_shape)
+        w = pt.matrix("logistic_w", dtype="float32", shape=w_shape)
+        b = pt.vector("logistic_b", dtype="float32", shape=b_shape)
+        cotangent = pt.matrix("logistic_cotangent", dtype="float32", shape=output_shape)
+        activations = pt.sigmoid(pt.dot(x, w) + b)
+        cost = (activations * cotangent).sum()
+        grad_w = pt.grad(cost, w)
+        return SymbolicGraph((x, w, b, cotangent), (activations, grad_w))
+
+    return BenchmarkCase(
+        name="logistic_forward_vjp",
+        description=(
+            "outputs sigmoid(X @ W + b) and grad_W of "
+            "sum(sigmoid(X @ W + b) * cotangent)"
+        ),
+        shapes=(
+            f"X: {x_shape}; W: {w_shape}; b: {b_shape}; "
+            f"cotangent/activation: {output_shape}; grad_W: {w_shape}"
+        ),
+        values=values,
+        build_graph=build_graph,
+    )
+
+
+def materialize_outputs(result, backend: str) -> tuple[np.ndarray, ...]:
+    outputs = result if isinstance(result, (list, tuple)) else (result,)
+    if backend == "MLX":
+        mx.eval(*outputs)
+    return tuple(np.asarray(output) for output in outputs)
+
+
+def compile_function(graph: SymbolicGraph, backend: str):
+    return pytensor.function(list(graph.inputs), list(graph.outputs), mode=backend)
+
+
+def invoke(function, case: BenchmarkCase, backend: str) -> tuple[np.ndarray, ...]:
+    return materialize_outputs(function(*case.values), backend)
+
+
+def assert_correctness(case: BenchmarkCase, backend: str) -> None:
+    reference = compile_function(case.build_graph(), "FAST_COMPILE")
+    expected = invoke(reference, case, "FAST_COMPILE")
+    actual = invoke(compile_function(case.build_graph(), backend), case, backend)
+
+    if len(actual) != len(expected):
+        raise AssertionError(
+            f"{case.name} {backend} returned {len(actual)} outputs; expected {len(expected)}"
+        )
+    for output_index, (observed, wanted) in enumerate(
+        zip(actual, expected, strict=True)
+    ):
+        np.testing.assert_allclose(
+            observed,
+            wanted,
+            rtol=RTOL,
+            atol=ATOL,
+            err_msg=f"{case.name} {backend} output {output_index}",
+        )
+
+
+def time_cold_sample(case: BenchmarkCase, backend: str) -> tuple[float, float]:
+    graph = case.build_graph()
+    build_start = perf_counter()
+    function = compile_function(graph, backend)
+    build_seconds = perf_counter() - build_start
+
+    first_call_start = perf_counter()
+    invoke(function, case, backend)
+    first_call_seconds = perf_counter() - first_call_start
+    return build_seconds, first_call_seconds
+
+
+def time_steady_calls(case: BenchmarkCase, backend: str) -> tuple[float, ...]:
+    function = compile_function(case.build_graph(), backend)
+    invoke(function, case, backend)
+    for _ in range(STEADY_WARMUP_CALLS):
+        invoke(function, case, backend)
+
+    samples = []
+    for _ in range(STEADY_REPEATS):
+        start = perf_counter()
+        for _ in range(STEADY_CALLS_PER_REPEAT):
+            invoke(function, case, backend)
+        samples.append((perf_counter() - start) / STEADY_CALLS_PER_REPEAT)
+    return tuple(samples)
+
+
+def benchmark_case(case: BenchmarkCase, backend: str) -> TimingResult:
+    build_samples = []
+    first_call_samples = []
+    for _ in range(COLD_SAMPLES):
+        build_seconds, first_call_seconds = time_cold_sample(case, backend)
+        build_samples.append(build_seconds)
+        first_call_samples.append(first_call_seconds)
+
+    cold_totals = tuple(
+        build_seconds + first_call_seconds
+        for build_seconds, first_call_seconds in zip(
+            build_samples, first_call_samples, strict=True
+        )
+    )
+    return TimingResult(
+        case=case.name,
+        backend=backend,
+        build_samples=tuple(build_samples),
+        first_call_samples=tuple(first_call_samples),
+        cold_total_samples=cold_totals,
+        steady_call_samples=time_steady_calls(case, backend),
+    )
+
+
+def format_ms(samples: tuple[float, ...]) -> str:
+    values = tuple(sample * 1_000 for sample in samples)
+    return f"{median(values):.3f} [{min(values):.3f}, {max(values):.3f}]"
+
+
+def format_raw_ms(samples: tuple[float, ...]) -> str:
+    return ", ".join(f"{sample * 1_000:.3f}" for sample in samples)
+
+
+def package_version(distribution: str) -> str:
+    try:
+        return version(distribution)
+    except PackageNotFoundError:
+        return "not installed"
+
+
+def print_environment(cases: tuple[BenchmarkCase, ...]) -> None:
+    driver = iree.runtime.get_driver("metal")
+    devices = driver.query_available_devices()
+    if not devices:
+        raise RuntimeError("IREE Metal driver reported no available devices")
+
+    print("Environment")
+    print(f"  Python: {sys.version.split()[0]}; interpreter: {sys.executable}")
+    print(
+        f"  NumPy: {np.__version__}; PYTENSOR_FLAGS: {os.environ.get('PYTENSOR_FLAGS', '<unset>')}"
+    )
+    print(f"  PyTensor: {pytensor.__version__}")
+    print(f"  MLX: {mx.__version__}; default device: {mx.default_device()}")
+    print(
+        "  IREE: "
+        f"compiler={package_version('iree-base-compiler')}; "
+        f"runtime={package_version('iree-base-runtime')}; Metal driver=metal"
+    )
+    print(f"  IREE Metal devices: {devices}")
+    print(f"  NumPy seed: {SEED}; dtype: float32")
+    print("  Cases:")
+    for case in cases:
+        print(f"    {case.name}: {case.description}")
+        print(f"      {case.shapes}")
+    print()
+
+
+def print_methodology() -> None:
+    print("Methodology")
+    print(
+        "  Correctness gate: every MLX and MLIR_METAL output is compared with a "
+        f"FAST_COMPILE NumPy result using np.testing.assert_allclose(rtol={RTOL}, atol={ATOL}) "
+        "before timing."
+    )
+    print(
+        "  Each backend is compiled from the same static-shape expression for a case and "
+        "receives the same seeded NumPy float32 arrays."
+    )
+    print(
+        "  Timing scope: each call starts with the same host NumPy float32 inputs and ends "
+        "with host NumPy outputs. MLX outputs are synchronized with mx.eval and then "
+        "materialized with np.asarray; MLIR_METAL already returns owned NumPy outputs."
+    )
+    print(
+        f"  Cold samples: {COLD_SAMPLES} fresh symbolic graphs and pytensor.function calls "
+        "per backend and case; build and first fully synchronized call are timed separately."
+    )
+    print(
+        "  Cold samples do not clear process-level Python, MLX, IREE, or Metal driver/compiler "
+        "caches; imports and the correctness gate occur before timing."
+    )
+    print(
+        f"  Steady state: one first call plus {STEADY_WARMUP_CALLS} warm-up calls, then "
+        f"{STEADY_REPEATS} perf_counter timeit-style repeated batches of "
+        f"{STEADY_CALLS_PER_REPEAT} fully synchronized calls."
+    )
+    print("  Values are milliseconds; summaries are median [minimum, maximum].")
+    print()
+
+
+def print_results(results: tuple[TimingResult, ...]) -> None:
+    headers = (
+        "case",
+        "backend",
+        "correctness",
+        "build",
+        "first call",
+        "cold total",
+        "steady call",
+    )
+    rows = [
+        (
+            result.case,
+            result.backend,
+            "PASS",
+            format_ms(result.build_samples),
+            format_ms(result.first_call_samples),
+            format_ms(result.cold_total_samples),
+            format_ms(result.steady_call_samples),
+        )
+        for result in results
+    ]
+    widths = [
+        max(len(header), *(len(row[index]) for row in rows))
+        for index, header in enumerate(headers)
+    ]
+
+    print("Results (milliseconds; median [minimum, maximum])")
+    print(
+        "  "
+        + "  ".join(
+            header.ljust(width) for header, width in zip(headers, widths, strict=True)
+        )
+    )
+    print("  " + "  ".join("-" * width for width in widths))
+    for row in rows:
+        print(
+            "  "
+            + "  ".join(
+                value.ljust(width) for value, width in zip(row, widths, strict=True)
+            )
+        )
+
+    print("\nRaw samples (milliseconds)")
+    for result in results:
+        print(
+            f"  {result.case} / {result.backend}: "
+            f"build=[{format_raw_ms(result.build_samples)}]; "
+            f"first=[{format_raw_ms(result.first_call_samples)}]; "
+            f"cold_total=[{format_raw_ms(result.cold_total_samples)}]; "
+            f"steady_per_call=[{format_raw_ms(result.steady_call_samples)}]"
+        )
+    print("\nNo statistical-significance claims are made from these samples.")
+
+
+def main() -> None:
+    rng = np.random.default_rng(SEED)
+    cases = (
+        make_elementwise_case(rng),
+        make_matrix_case(rng),
+        make_logistic_vjp_case(rng),
+    )
+    print_environment(cases)
+    print_methodology()
+
+    for case in cases:
+        for backend in BACKENDS:
+            assert_correctness(case, backend)
+    print("Correctness gate: PASS for every backend and case.\n")
+
+    results = tuple(
+        benchmark_case(case, backend) for case in cases for backend in BACKENDS
+    )
+    print_results(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mlir_demo.py
+++ b/scripts/mlir_demo.py
@@ -1,0 +1,77 @@
+import numpy as np
+
+import pytensor
+import pytensor.tensor as pt
+
+
+def compare(output, inputs, values):
+    reference = pytensor.function(inputs, output, mode="FAST_COMPILE")
+    mlir = pytensor.function(inputs, output, mode="MLIR")
+    expected = reference(*values)
+    actual = mlir(*values)
+    np.testing.assert_allclose(actual, expected)
+    return actual
+
+
+if __name__ == "__main__":
+    x = pt.vector("x")
+    y = pt.vector("y")
+    vector = compare(
+        x + y * 2,
+        [x, y],
+        [np.array([1.0, 2.0, 3.0]), np.array([4.0, 5.0, 6.0])],
+    )
+    multiply = compare(
+        x * y,
+        [x, y],
+        [np.array([1.0, 2.0, 3.0]), np.array([4.0, 5.0, 6.0])],
+    )
+    assert vector.dtype == np.dtype("float64")
+
+    x32 = pt.vector("x32", dtype="float32")
+    y32 = pt.vector("y32", dtype="float32")
+    vector32 = compare(
+        x32 + y32 * np.float32(2),
+        [x32, y32],
+        [
+            np.array([1.0, 2.0, 3.0], dtype="float32"),
+            np.array([4.0, 5.0, 6.0], dtype="float32"),
+        ],
+    )
+    assert vector32.dtype == np.dtype("float32")
+
+    matrix = pt.matrix("matrix")
+    row = pt.vector("row")
+    matrix_value = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    broadcast = compare(
+        matrix + row,
+        [matrix, row],
+        [matrix_value, np.array([10.0, 20.0, 30.0])],
+    )
+    transpose = compare(matrix.T, [matrix], [matrix_value])
+    assert broadcast.dtype == np.dtype("float64")
+    assert transpose.dtype == np.dtype("float64")
+
+    lhs = pt.matrix("lhs")
+    rhs = pt.matrix("rhs")
+    lhs_value = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    rhs_value = np.array([[7.0, 8.0], [9.0, 10.0], [11.0, 12.0]])
+    dot = compare(pt.dot(lhs, rhs), [lhs, rhs], [lhs_value, rhs_value])
+    assert dot.dtype == np.dtype("float64")
+
+    lhs32 = pt.matrix("lhs32", dtype="float32")
+    rhs32 = pt.matrix("rhs32", dtype="float32")
+    dot32 = compare(
+        pt.dot(lhs32, rhs32),
+        [lhs32, rhs32],
+        [lhs_value.astype("float32"), rhs_value.astype("float32")],
+    )
+    assert dot32.dtype == np.dtype("float32")
+
+    print("vector_float64", vector)
+    print("multiply_float64", multiply)
+    print("vector_float32", vector32)
+    print("broadcast_float64", broadcast)
+    print("transpose_float64", transpose)
+    print("dot_float64", dot)
+    print("dot_float32", dot32)

--- a/scripts/mlir_demo.py
+++ b/scripts/mlir_demo.py
@@ -4,12 +4,12 @@ import pytensor
 import pytensor.tensor as pt
 
 
-def compare(output, inputs, values):
+def compare(output, inputs, values, *, mode="MLIR", rtol=1e-7, atol=0):
     reference = pytensor.function(inputs, output, mode="FAST_COMPILE")
-    mlir = pytensor.function(inputs, output, mode="MLIR")
+    mlir = pytensor.function(inputs, output, mode=mode)
     expected = reference(*values)
     actual = mlir(*values)
-    np.testing.assert_allclose(actual, expected)
+    np.testing.assert_allclose(actual, expected, rtol=rtol, atol=atol)
     return actual
 
 
@@ -67,6 +67,79 @@ if __name__ == "__main__":
         [lhs_value.astype("float32"), rhs_value.astype("float32")],
     )
     assert dot32.dtype == np.dtype("float32")
+    import iree.runtime
+
+    metal_devices = iree.runtime.get_driver("metal").query_available_devices()
+    assert metal_devices
+    try:
+        pytensor.function([x], x + 1, mode="MLIR_METAL")
+    except TypeError as error:
+        metal_f64_error = str(error)
+        assert metal_f64_error == "MLIR Metal only supports float32 graphs"
+    else:
+        raise AssertionError("MLIR_METAL must reject float64 graphs")
+
+
+    metal_vector32 = compare(
+        x32 + y32 * np.float32(2),
+        [x32, y32],
+        [
+            np.array([1.0, 2.0, 3.0], dtype="float32"),
+            np.array([4.0, 5.0, 6.0], dtype="float32"),
+        ],
+        mode="MLIR_METAL",
+        rtol=1e-6,
+        atol=1e-6,
+    )
+    metal_multiply32 = compare(
+        x32 * y32,
+        [x32, y32],
+        [
+            np.array([1.0, 2.0, 3.0], dtype="float32"),
+            np.array([4.0, 5.0, 6.0], dtype="float32"),
+        ],
+        mode="MLIR_METAL",
+        rtol=1e-6,
+        atol=1e-6,
+    )
+    matrix32 = pt.matrix("matrix32", dtype="float32")
+    row32 = pt.vector("row32", dtype="float32")
+    matrix32_value = matrix_value.astype("float32")
+    metal_broadcast32 = compare(
+        matrix32 + row32,
+        [matrix32, row32],
+        [matrix32_value, np.array([10.0, 20.0, 30.0], dtype="float32")],
+        mode="MLIR_METAL",
+        rtol=1e-6,
+        atol=1e-6,
+    )
+    metal_transpose32 = compare(
+        matrix32.T,
+        [matrix32],
+        [matrix32_value],
+        mode="MLIR_METAL",
+        rtol=1e-6,
+        atol=1e-6,
+    )
+    metal_dot32 = compare(
+        pt.dot(lhs32, rhs32),
+        [lhs32, rhs32],
+        [lhs_value.astype("float32"), rhs_value.astype("float32")],
+        mode="MLIR_METAL",
+        rtol=1e-6,
+        atol=1e-6,
+    )
+    assert all(
+        value.dtype == np.dtype("float32")
+        for value in (
+            metal_vector32,
+            metal_multiply32,
+            metal_broadcast32,
+            metal_transpose32,
+            metal_dot32,
+        )
+    )
+
 
     print("vector_float64", vector)
     print("multiply_float64", multiply)
@@ -75,3 +148,11 @@ if __name__ == "__main__":
     print("transpose_float64", transpose)
     print("dot_float64", dot)
     print("dot_float32", dot32)
+    print("metal_devices", metal_devices)
+    print("metal_float64_rejected", metal_f64_error)
+    print("metal_float32_tolerances", "rtol=1e-6", "atol=1e-6")
+    print("metal_vector_float32", metal_vector32)
+    print("metal_multiply_float32", metal_multiply32)
+    print("metal_broadcast_float32", metal_broadcast32)
+    print("metal_transpose_float32", metal_transpose32)
+    print("metal_dot_float32", metal_dot32)

--- a/scripts/mlir_toolchain_hello.py
+++ b/scripts/mlir_toolchain_hello.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+import iree.compiler.tools
+import iree.runtime
+
+
+MLIR_SOURCE = r'''
+module {
+  func.func @add(%lhs: tensor<?xf64>, %rhs: tensor<?xf64>) -> tensor<?xf64> {
+    %c0 = arith.constant 0 : index
+    %size = tensor.dim %lhs, %c0 : tensor<?xf64>
+    %init = tensor.empty(%size) : tensor<?xf64>
+    %result = linalg.generic {
+      indexing_maps = [
+        affine_map<(d0) -> (d0)>,
+        affine_map<(d0) -> (d0)>,
+        affine_map<(d0) -> (d0)>
+      ],
+      iterator_types = ["parallel"]
+    } ins(%lhs, %rhs : tensor<?xf64>, tensor<?xf64>) outs(%init : tensor<?xf64>) {
+    ^bb0(%lhs_value: f64, %rhs_value: f64, %out: f64):
+      %sum = arith.addf %lhs_value, %rhs_value : f64
+      linalg.yield %sum : f64
+    } -> tensor<?xf64>
+    return %result : tensor<?xf64>
+  }
+}
+'''
+
+
+if __name__ == "__main__":
+    vmfb = iree.compiler.tools.compile_str(
+        MLIR_SOURCE,
+        target_backends=["llvm-cpu"],
+        extra_args=["--iree-input-demote-f64-to-f32=false"],
+    )
+    module = iree.runtime.load_vm_flatbuffer(vmfb, backend="llvm-cpu")
+    lhs = np.array([1.0, 2.0, 3.0], dtype="float64")
+    rhs = np.array([4.0, 5.0, 6.0], dtype="float64")
+    result = np.asarray(module.add(lhs, rhs))
+    np.testing.assert_allclose(result, lhs + rhs)
+    assert result.dtype == np.dtype("float64")
+    print(result)


### PR DESCRIPTION
## Summary

Feasibility spike: can PyTensor grow an MLIR backend? This PR adds an **experimental** `pytensor/link/mlir/` that lowers a `FunctionGraph` to textual MLIR (`linalg` + `arith` on dynamic `tensor<?x...>`), compiles it with IREE's `llvm-cpu` target, and executes it through the IREE runtime — end to end, with correct results on simple CPU graphs.

This is **not** a backend proposal. It is evidence for a discussion: the working slice, the exact blockers found, and where they live.

## The simple graph

```python
import numpy as np, pytensor, pytensor.tensor as pt

x = pt.vector("x", dtype="float64")
y = pt.vector("y", dtype="float64")
f = pytensor.function([x, y], x + y * 2, mode="MLIR")
f(np.array([1.0, 2.0, 3.0]), np.array([4.0, 5.0, 6.0]))
# array([ 9., 12., 15.])
```

`scripts/mlir_demo.py` runs the full matrix (every case checked with `np.testing.assert_allclose` against `FAST_COMPILE`):

```
vector_float64    [ 9. 12. 15.]
multiply_float64  [ 4. 10. 18.]
vector_float32    [ 9. 12. 15.]
broadcast_float64 [[11. 22. 33.] [14. 25. 36.]]
transpose_float64 [[1. 4.] [2. 5.] [3. 6.]]
dot_float64       [[ 58.  64.] [139. 154.]]
dot_float32       [[ 58.  64.] [139. 154.]]
```

Because the emitted tensor types use `?` dims, one compiled function runs at multiple input lengths without retracing (exercised at 3 and 5).

## Design

Follows the house backend pattern (mirrors `link/mlx` / `link/jax`):

- `MLIRLinker(JITLinker)` converts the whole `FunctionGraph` via a `singledispatch mlir_funcify`, emits one MLIR module, calls `iree.compiler.compile_str(target_backends=["llvm-cpu"])`, and invokes the loaded VM module. No Python-op fallback — unsupported Ops raise `NotImplementedError` loudly.
- Dispatch covers what the demo needs: `Elemwise` Add/Mul/Second → `linalg.generic` + `arith`, `DimShuffle`/`DeepCopyOp` → `linalg.generic` affine maps, `Dot`/`Dot22` → `linalg.fill` + `linalg.matmul`. float32/float64, rank ≤ 2.
- `Mode("MLIR")` registered in `compile/mode.py`; `config.mode` accepts `MLIR`.
- float64 preserved by passing `--iree-input-demote-f64-to-f32=false`.
- A runtime validator enforces PyTensor's static-size-1 broadcasting rule and `Dot` inner-dim equality before IREE (IREE does not implement our runtime-broadcast policy itself).

## Toolchain (macOS arm64)

- **Works:** pip `iree-base-compiler` / `iree-base-runtime` 3.11.0 — clean install, `compile_str` → VM flatbuffer → runtime invocation. Deps are only installed in the experiment env, intentionally not declared in `pyproject`.
- **Doesn't:** conda-forge `mlir-python-bindings` 22.1.8 — imports fine but any `mlir.ir.Context()` aborts the process (`LLVM ERROR: Attempting to attach an interface to an unregistered operation builtin.unrealized_conversion_cast`), which is why the IR is string-templated rather than built through the bindings.

## Blockers found (why this stays a spike)

1. **Subnormal flush-to-zero:** IREE `llvm-cpu` silently flushes subnormal results (`float32 tiny*0.5 → 0.0` instead of `5.877e-39`; same for float64). No exposed IEEE-denormal control in `iree-compile --help-hidden`. Principal semantic divergence from the C/Numba/JAX backends.
2. **Host-mapped buffer leak:** returning NumPy outputs requires IREE host mapping, which leaks `MappedMemory`/`HalBufferView` instances per call (~9.8 MB RSS growth over a 100-call probe; reproduced in raw IREE without PyTensor). Rules out iterative workloads until fixed upstream.
3. Textual-IR emission is workable but fragile long-term; proper bindings (or IREE's Python IR APIs) would be the real path.

## Test plan

- [x] `scripts/mlir_demo.py` — all cases green vs `FAST_COMPILE` (exit 0).
- [x] `scripts/mlir_toolchain_hello.py` — raw IREE hello-world (dynamic `tensor<?xf64>`, `linalg.generic`/`arith.addf`) prints `[5. 7. 9.]` and asserts float64 preservation.
- [x] Edge paths exercised during review: rank-0, empty vector, transpose/broadcast, non-contiguous input, duplicate/multi-output functions, scientific-notation literals, `x*0` rewrites.

🤖 Explored and implemented with AI assistance (Claude Code), including adversarial/correctness/edge-case review passes and an independent fact-check of the claims above.

## Metal/MPS results

**Verdict: yes, with a float32-only contract.** The same simple graphs now run on the M3 Max GPU through IREE's **Metal HAL**:

```text
textual linalg/arith MLIR
  -> IREE metal-spirv
  -> SPIR-V -> MSL -> .metallib
  -> IREE runtime driver="metal"
  -> Apple M3 Max GPU
```

`MLIR_METAL` selects `metal-spirv` and `driver="metal"`; it is deliberately distinct from the CPU `MLIR` mode. `scripts/mlir_demo.py` enumerates and prints the actual IREE device, rejects float64 graphs before compilation, and checks all GPU outputs against `FAST_COMPILE` with `rtol=atol=1e-6`.

Observed run (IREE 3.11.0):

```text
metal_devices [{'path': '0000000100000635', 'name': 'Apple M3 Max', ...}]
metal_float64_rejected MLIR Metal only supports float32 graphs
metal_float32_tolerances rtol=1e-6 atol=1e-6
metal_vector_float32 [ 9. 12. 15.]
metal_multiply_float32 [ 4. 10. 18.]
metal_broadcast_float32 [[11. 22. 33.]
 [14. 25. 36.]]
metal_transpose_float32 [[1. 4.]
 [2. 5.]
 [3. 6.]]
metal_dot_float32 [[ 58.  64.]
 [139. 154.]]
```

The raw IREE hello-world was also compiled outside PyTensor from the existing `linalg.generic` source after changing its element type to `f32`; `target_backends=["metal-spirv"]` plus `load_vm_flatbuffer(..., driver="metal")` printed `[5. 7. 9.]`. The original `f64` source fails at the intended compiler link with:

```text
failed to convert SPIR-V type: 'memref<?xf64, #spirv.storage_class<StorageBuffer>>'
failed to legalize operation 'hal.interface.binding.subspan'
```

The Metal mode rejects every live float64 graph value and passes `--iree-input-demote-f64-to-f32=false` as a compiler backstop, so it does not silently change PyTensor's dtype contract. The existing `MLIR` CPU mode still preserves float64.

### What “MPS dialect / Metal backend” actually means

This working path is **not MPSGraph**. It is IREE's actively maintained Metal HAL target, which lowers through SPIR-V and cross-compiles to Metal Shading Language; see IREE's [Metal HAL design](https://iree.dev/developers/design-docs/metal-hal-driver/) and [target implementation](https://github.com/iree-org/iree/blob/main/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp).

There was a real Apple proposal for an MLIR `MPS` dialect targeting MetalPerformanceShadersGraph, but it was an [RFC](https://discourse.llvm.org/t/rfc-mps-dialect-in-mlir/) rather than a merged upstream MLIR dialect. The corresponding generic public linalg/arith -> MPSGraph Python route is not available. On this host, `/usr/bin/mpsgraphtool --help` exposes `convert -coremlpackage`, not a generic MLIR/bytecode input. Apple's [jax-metal documentation](https://developer.apple.com/metal/jax/) describes a separate JAX/OpenXLA StableHLO -> MPSGraph/PJRT route; it is not an ingress for this spike and it likewise lists `np.float64` as unsupported.

### Caveats

- This is a local macOS/Apple-silicon experiment, not a portable backend proposal or a performance result. No GPU timing comparison was made.
- Metal execution needs the IREE `metal-spirv` compiler target, `metal` runtime driver, and Xcode's Metal toolchain. The local wheel has all of them; `iree-run-module --dump_devices=metal` identifies the M3 Max as Metal 3/unified-memory.
- The linker materializes each returned value as a NumPy copy. The demo also emits IREE/nanobind reference-leak warnings at interpreter shutdown; this needs upstream investigation before iterative workloads.
- Input/output `float32` is supported in this slice. Float64 is intentionally rejected; complex and broader Op/dtype coverage remain outside the spike.
