### PR TITLE
Stable logsumexp softmax gradients without rewrites

### DIFF
--- a/pytensor/compile/rewriting.py
+++ b/pytensor/compile/rewriting.py
@@ -7,7 +7,7 @@ from pytensor.compile.aliasing import (
     add_supervisor_to_fgraph,
     insert_deepcopy,
 )
-from pytensor.compile.builders import OpFromGraph
+from pytensor.compile.builders import OpFromGraph, SymbolicOp
 from pytensor.compile.io import In, Out
 from pytensor.compile.mode import optdb
 from pytensor.graph.basic import Apply, Variable
@@ -134,12 +134,12 @@ def rewrite_ofg_inner_graph(linker, op, node, inner, *, mode):
     )
 
 
-def _ofg_inner_optimizer(mode):
-    # Recognition rewrites fold a pattern into an inner-graph op (e.g.
-    # ``exp(x) / sum(exp(x))`` -> ``Softmax``, itself an ``OpFromGraph``). Running
-    # them on an ``OpFromGraph`` inner graph -- which may *be* that pattern --
-    # would re-create the op inside itself and recurse without end.
-    return mode.excluding("symbolic_op_recognition").optimizer
+def _ofg_inner_optimizer(mode, op):
+    # Recognition would re-create a `SymbolicOp` inside its own inner graph and never
+    # terminate. Any other `OpFromGraph` must keep it, or wrapping destabilizes the body.
+    if isinstance(op, SymbolicOp):
+        return mode.excluding("symbolic_op_recognition").optimizer
+    return mode.optimizer
 
 
 @rewrite_ofg_inner_graph.register(VMLinker)
@@ -152,7 +152,7 @@ def destructive_rewrite_ofg_inner_graph(linker, op, node, inner, *, mode):
     # still be baked between purely internal buffers.
     input_specs = [In(x, borrow=True, mutable=False) for x in inner.inputs]
     add_supervisor_to_fgraph(fgraph=inner, input_specs=input_specs, accept_inplace=True)
-    _ofg_inner_optimizer(mode).rewrite(inner)
+    _ofg_inner_optimizer(mode, op).rewrite(inner)
     # The op's outputs must not alias its inputs or each other (it declares no
     # view_map, so the outer graph cannot see such aliases); deepcopies break any
     # boundary alias the optimized graph ends up with.
@@ -165,7 +165,7 @@ def destructive_rewrite_ofg_inner_graph(linker, op, node, inner, *, mode):
 @rewrite_ofg_inner_graph.register(MLXLinker)
 def functional_rewrite_ofg_inner_graph(linker, op, node, inner, *, mode):
     """Structurally optimize the inner graph for the functional JIT backends."""
-    _ofg_inner_optimizer(mode).rewrite(inner)
+    _ofg_inner_optimizer(mode, op).rewrite(inner)
 
 
 @graph_rewriter

--- a/pytensor/graph/features.py
+++ b/pytensor/graph/features.py
@@ -546,10 +546,10 @@ class FullHistory(Feature):
                      └─ ···
         >> local_softmax_stabilize
         Log [id A] 1
-         └─ Softmax{axis=None} [id B] 0
+         └─ Softmax{axis=(0,)} [id B] 0
             └─ x [id C]
         >> local_logsoftmax
-        LogSoftmax{axis=None} [id A] 0
+        LogSoftmax{axis=(0,)} [id A] 0
          └─ x [id B]
 
 
@@ -563,7 +563,7 @@ class FullHistory(Feature):
     .. testoutput::
         >> local_logsoftmax
         Log [id A] 1
-         └─ Softmax{axis=None} [id B] 0
+         └─ Softmax{axis=(0,)} [id B] 0
             └─ x [id C]
         >> local_softmax_stabilize
         Log [id A] 4
@@ -591,7 +591,7 @@ class FullHistory(Feature):
 
     .. testoutput::
         Log [id A] 1
-         └─ Softmax{axis=None} [id B] 0
+         └─ Softmax{axis=(0,)} [id B] 0
             └─ x [id C]
 
 

--- a/pytensor/graph/rewriting/unify.py
+++ b/pytensor/graph/rewriting/unify.py
@@ -572,7 +572,8 @@ def reify_pattern(pattern, subs: Mapping[PatternVar | Asterisk, Any]):
                 inputs.extend(captured)
             else:
                 inputs.append(reify_pattern(p, subs))
-        return op.make_node(*inputs).default_output()
+        # Call the Op, so those that build state lazily (SymbolicOp) are constructed
+        return op(*inputs)
 
     if isinstance(pattern, OpPattern):
         op_type = pattern.op_type

--- a/pytensor/tensor/__init__.py
+++ b/pytensor/tensor/__init__.py
@@ -126,6 +126,10 @@ from pytensor.tensor.interpolate import interp, interpolate1d
 from pytensor.tensor.math import *
 from pytensor.tensor.pad import pad
 
+# Kept in the top-level namespace for backwards compatibility; the rest of
+# `pytensor.tensor.special` is only reachable as `pt.special.*`
+from pytensor.tensor.special import logaddexp, logsumexp
+
 
 # isort: off
 # reshape needs to be imported before shape.reshape, otherwise the tensor.reshape imports fail

--- a/pytensor/tensor/math.py
+++ b/pytensor/tensor/math.py
@@ -3891,53 +3891,6 @@ def power(x, y):
     return x**y
 
 
-def logaddexp(*xs):
-    """Logarithm of the sum of exponentiations of the inputs.
-
-    See ``numpy.logaddexp``.
-
-    Parameters
-    ----------
-    xs : symbolic tensors
-        Input
-
-    Returns
-    -------
-    TensorVariable
-
-    """
-
-    return log(add(*[exp(x) for x in xs]))
-
-
-def logsumexp(x, axis=None, keepdims=False):
-    """Compute the log of the sum of exponentials of input elements.
-
-    See ``scipy.special.logsumexp``.
-
-    Parameters
-    ----------
-    x : symbolic tensor
-        Input
-
-    axis : None or int or tuple of ints, optional
-        Axis or axes over which the sum is taken. By default axis is None,
-        and all elements are summed.
-
-    keepdims : bool, optional
-        If this is set to True, the axes which are reduced are left in the
-        result as dimensions with size one. With this option, the result will
-        broadcast correctly against the original array.
-
-    Returns
-    -------
-    TensorVariable
-
-    """
-
-    return log(sum(exp(x), axis=axis, keepdims=keepdims))
-
-
 _matmul = Blockwise(_dot, name="Matmul")
 
 
@@ -4321,8 +4274,6 @@ __all__ = [
     "log1pexp",
     "log2",
     "log10",
-    "logaddexp",
-    "logsumexp",
     "lt",
     "matmul",
     "matvec",

--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -71,7 +71,6 @@ from pytensor.tensor.math import (
     expm1,
     ge,
     int_div,
-    isinf,
     ive,
     kve,
     le,
@@ -79,8 +78,6 @@ from pytensor.tensor.math import (
     log1mexp,
     log1p,
     log1pexp,
-    makeKeepDims,
-    maximum,
     mul,
     neg,
     polygamma,
@@ -100,9 +97,7 @@ from pytensor.tensor.math import (
     variadic_mul,
 )
 from pytensor.tensor.math import abs as pt_abs
-from pytensor.tensor.math import max as pt_max
 from pytensor.tensor.math import pow as pt_pow
-from pytensor.tensor.math import sum as pt_sum
 from pytensor.tensor.rewriting.basic import (
     broadcast_like_elemwise,
     local_second_sink,
@@ -2811,87 +2806,6 @@ def local_log1p(fgraph, node):
 
         new_out = log1p(neg(other))
         return [broadcast_like_elemwise(new_out, node, fgraph=fgraph, stack_trace=True)]
-
-
-@register_stabilize("fast_compile")
-@register_specialize
-@node_rewriter([log])
-def local_log_add_exp(fgraph, node):
-    """
-    ``log(exp(x)+exp(y)+exp(z)) = max + log(x-max, y-max, z-max)``
-
-    TODO: in canonicalize, change log10 and log2 -> log
-    """
-
-    z = node.inputs[0]
-    if z.owner and z.owner.op == add:
-        zi = z.owner.inputs
-        pre_exp = [x.owner.inputs[0] for x in zi if x.owner and x.owner.op == exp]
-        # all arguments to add are exp(<something>)
-        if len(pre_exp) == len(zi):
-            # Do not offset when max_pre = -np.inf, to avoid nan in the output
-            # Switch statement is placed directly inside add to break the self-symmetry
-            # of the returned output (otherwise the rewrite would not stabilize)
-            max_pre = reduce(maximum, pre_exp)
-            ret = max_pre + log(
-                add(
-                    *[
-                        switch(isinf(max_pre), exp(max_pre), exp(p - max_pre))
-                        for p in pre_exp
-                    ]
-                )
-            )
-            return [ret]
-
-
-@register_stabilize("fast_compile")
-@register_specialize
-@node_rewriter([log])
-def local_log_sum_exp(fgraph, node):
-    # log(sum_i(exp(x_i))) = x_max + log(sum_i(exp(x_i - x_max)))
-
-    sum_node = node.inputs[0].owner
-    # If the sum has keepdims=True, there might be a dimshuffle
-    if sum_node and isinstance(sum_node.op, DimShuffle):
-        dimshuffle_op = sum_node.op
-        sum_node = sum_node.inputs[0].owner
-    else:
-        dimshuffle_op = None
-
-    if not (sum_node and isinstance(sum_node.op, Sum)):
-        return
-
-    exp_node, axis = sum_node.inputs[0].owner, sum_node.op.axis
-    if not (
-        exp_node
-        and isinstance(exp_node.op, Elemwise)
-        and isinstance(exp_node.op.scalar_op, ps.Exp)
-    ):
-        return
-
-    pre_exp = exp_node.inputs[0]
-    max_pre_exp = pt_max(pre_exp, axis=axis)
-    max_pre_exp_keepdims = makeKeepDims(pre_exp, max_pre_exp, axis)
-
-    # Do not offset when max_pre = -np.inf, to avoid nan in the output
-    # Switch statement is placed directly inside sum to break the self-symmetry
-    # of the returned output (otherwise the rewrite would not stabilize)
-    ret = max_pre_exp + log(
-        pt_sum(
-            switch(
-                isinf(max_pre_exp_keepdims),
-                exp(max_pre_exp_keepdims),
-                exp(pre_exp - max_pre_exp_keepdims),
-            ),
-            axis=axis,
-        ),
-    )
-
-    # Restore the dimshuffle op, if any.
-    if dimshuffle_op:
-        ret = dimshuffle_op(ret)
-
-    return [ret]
 
 
 def add_calculate(num, denum, aslist=False, out_type=None):

--- a/pytensor/tensor/rewriting/ofg.py
+++ b/pytensor/tensor/rewriting/ofg.py
@@ -2,11 +2,11 @@ from pytensor.compile.rewriting import inline_ofg_node
 from pytensor.graph import node_rewriter
 from pytensor.tensor.basic import AllocDiag
 from pytensor.tensor.rewriting.basic import register_specialize
-from pytensor.tensor.special import XLog1PY, XLogY
+from pytensor.tensor.special import LogAddExp, LogSumExp, XLog1PY, XLogY
 
 
 @register_specialize("inline_ofg")
-@node_rewriter([AllocDiag, XLogY, XLog1PY])
+@node_rewriter([AllocDiag, XLogY, XLog1PY, LogSumExp, LogAddExp])
 def late_inline_OpFromGraph(fgraph, node):
     """
     Inline `OpFromGraph` nodes.

--- a/pytensor/tensor/rewriting/special.py
+++ b/pytensor/tensor/rewriting/special.py
@@ -1,9 +1,9 @@
 from pytensor.graph.rewriting.basic import copy_stack_trace, node_rewriter
 from pytensor.scalar.basic import Exp
 from pytensor.tensor.elemwise import DimShuffle, Elemwise
-from pytensor.tensor.math import Sum, log, true_div
+from pytensor.tensor.math import Sum, add, exp, log, true_div
 from pytensor.tensor.rewriting.basic import register_stabilize
-from pytensor.tensor.special import Softmax, log_softmax
+from pytensor.tensor.special import Softmax, log_softmax, logaddexp, logsumexp
 from pytensor.tensor.subtensor import (
     AdvancedSubtensor,
     Subtensor,
@@ -94,4 +94,52 @@ def local_softmax_stabilize(fgraph, node):
 
     ret = Softmax(axis=axis)(x)
     copy_stack_trace(node.outputs, ret)
+    return [ret]
+
+
+@register_stabilize("symbolic_op_recognition", "fast_compile")
+@node_rewriter([log])
+def local_log_add_exp(fgraph, node):
+    """``log(exp(x) + exp(y) + exp(z)) -> logaddexp(x, y, z)``.
+
+    TODO: in canonicalize, change log10 and log2 -> log
+    """
+    z = node.inputs[0]
+    if z.owner and z.owner.op == add:
+        zi = z.owner.inputs
+        pre_exp = [x.owner.inputs[0] for x in zi if x.owner and x.owner.op == exp]
+        # all arguments to add are exp(<something>)
+        if len(pre_exp) == len(zi):
+            return [logaddexp(*pre_exp)]
+
+
+@register_stabilize("symbolic_op_recognition", "fast_compile")
+@node_rewriter([log])
+def local_log_sum_exp(fgraph, node):
+    """``log(sum_i(exp(x_i))) -> logsumexp(x)``."""
+    sum_node = node.inputs[0].owner
+    # If the sum has keepdims=True, there might be a dimshuffle
+    if sum_node and isinstance(sum_node.op, DimShuffle):
+        dimshuffle_op = sum_node.op
+        sum_node = sum_node.inputs[0].owner
+    else:
+        dimshuffle_op = None
+
+    if not (sum_node and isinstance(sum_node.op, Sum)):
+        return
+
+    exp_node, axis = sum_node.inputs[0].owner, sum_node.op.axis
+    if not (
+        exp_node
+        and isinstance(exp_node.op, Elemwise)
+        and isinstance(exp_node.op.scalar_op, Exp)
+    ):
+        return
+
+    ret = logsumexp(exp_node.inputs[0], axis=axis)
+
+    # Restore the dimshuffle op, if any.
+    if dimshuffle_op:
+        ret = dimshuffle_op(ret)
+
     return [ret]

--- a/pytensor/tensor/rewriting/special.py
+++ b/pytensor/tensor/rewriting/special.py
@@ -1,14 +1,27 @@
-from pytensor.graph.rewriting.basic import copy_stack_trace, node_rewriter
+from pytensor.graph.rewriting.basic import (
+    PatternNodeRewriter,
+    copy_stack_trace,
+    node_rewriter,
+)
+from pytensor.graph.rewriting.unify import OpPattern
 from pytensor.scalar.basic import Exp
 from pytensor.tensor.elemwise import DimShuffle, Elemwise
-from pytensor.tensor.math import Sum, add, exp, log, true_div
+from pytensor.tensor.math import Sum, add, exp, log, sub, true_div
 from pytensor.tensor.rewriting.basic import register_stabilize
-from pytensor.tensor.special import Softmax, log_softmax, logaddexp, logsumexp
+from pytensor.tensor.special import (
+    LogSoftmax,
+    LogSumExp,
+    Softmax,
+    log_softmax,
+    logaddexp,
+    logsumexp,
+)
 from pytensor.tensor.subtensor import (
     AdvancedSubtensor,
     Subtensor,
 )
 from pytensor.tensor.type import values_eq_approx_remove_inf
+from pytensor.tensor.utils import normalize_reduce_axis
 
 
 subtensor_ops = (
@@ -64,6 +77,32 @@ def local_logsoftmax(fgraph, node):
     return [ret]
 
 
+# Exp(LogSoftmax(x)) -> Softmax(x)
+local_exp_log_softmax = PatternNodeRewriter(
+    (exp, (OpPattern(LogSoftmax, axis="axis"), "x")),
+    (OpPattern(Softmax, axis="axis"), "x"),
+    name="local_exp_log_softmax",
+)
+register_stabilize(local_exp_log_softmax)
+
+
+# x - logsumexp(x, axis, keepdims=True) -> LogSoftmax(x)
+# The shared "axis" makes the DimShuffle match only when it re-expands the reduced axes
+local_log_softmax_from_logsumexp = PatternNodeRewriter(
+    (
+        sub,
+        "x",
+        (
+            OpPattern(DimShuffle, is_expand_dims=True, augment="axis"),
+            (OpPattern(LogSumExp, axis="axis"), "x"),
+        ),
+    ),
+    (OpPattern(LogSoftmax, axis="axis"), "x"),
+    name="local_log_softmax_from_logsumexp",
+)
+register_stabilize(local_log_softmax_from_logsumexp)
+
+
 @register_stabilize("symbolic_op_recognition", "fast_compile")
 @node_rewriter([true_div])
 def local_softmax_stabilize(fgraph, node):
@@ -92,7 +131,7 @@ def local_softmax_stabilize(fgraph, node):
         case _:
             return None
 
-    ret = Softmax(axis=axis)(x)
+    ret = Softmax(axis=normalize_reduce_axis(axis, x.type.ndim, normalize_none=True))(x)
     copy_stack_trace(node.outputs, ret)
     return [ret]
 

--- a/pytensor/tensor/special.py
+++ b/pytensor/tensor/special.py
@@ -1,7 +1,5 @@
 from functools import reduce
 
-from numpy.lib.array_utils import normalize_axis_tuple
-
 from pytensor.gradient import DisconnectedType, disconnected_type
 from pytensor.graph.replace import _vectorize_node
 from pytensor.tensor import as_tensor_variable
@@ -22,6 +20,7 @@ from pytensor.tensor.math import (
     switch,
 )
 from pytensor.tensor.symbolic import TensorSymbolicOp
+from pytensor.tensor.utils import normalize_reduce_axis
 
 
 class Softmax(TensorSymbolicOp):
@@ -61,8 +60,7 @@ class Softmax(TensorSymbolicOp):
 
 def softmax(c, axis=None):
     c = as_tensor_variable(c)
-    if axis is not None:
-        axis = normalize_axis_tuple(axis, c.type.ndim)
+    axis = normalize_reduce_axis(axis, c.type.ndim, normalize_none=True)
     return Softmax(axis=axis)(c)
 
 
@@ -97,8 +95,7 @@ class LogSoftmax(TensorSymbolicOp):
 
 def log_softmax(c, axis=None):
     c = as_tensor_variable(c)
-    if axis is not None:
-        axis = normalize_axis_tuple(axis, c.type.ndim)
+    axis = normalize_reduce_axis(axis, c.type.ndim, normalize_none=True)
     return LogSoftmax(axis=axis)(c)
 
 
@@ -153,11 +150,7 @@ def logsumexp(x, axis=None, keepdims=False):
 
     """
     x = as_tensor_variable(x)
-    axis = (
-        tuple(range(x.type.ndim))
-        if axis is None
-        else normalize_axis_tuple(axis, x.type.ndim)
-    )
+    axis = normalize_reduce_axis(axis, x.type.ndim, normalize_none=True)
     out = LogSumExp(axis=axis)(x)
     return expand_dims(out, axis) if keepdims else out
 

--- a/pytensor/tensor/special.py
+++ b/pytensor/tensor/special.py
@@ -1,16 +1,22 @@
+from functools import reduce
+
 from numpy.lib.array_utils import normalize_axis_tuple
 
 from pytensor.gradient import DisconnectedType, disconnected_type
 from pytensor.graph.replace import _vectorize_node
 from pytensor.tensor import as_tensor_variable
+from pytensor.tensor.basic import expand_dims
 from pytensor.tensor.elemwise import get_normalized_batch_axes
 from pytensor.tensor.math import (
+    add,
     eq,
     exp,
     gamma,
     gammaln,
+    isinf,
     log,
     log1p,
+    maximum,
     mul,
     sum,
     switch,
@@ -94,6 +100,103 @@ def log_softmax(c, axis=None):
     if axis is not None:
         axis = normalize_axis_tuple(axis, c.type.ndim)
     return LogSoftmax(axis=axis)(c)
+
+
+class LogSumExp(TensorSymbolicOp):
+    r"""Log of the sum of exponentials.
+
+    :math:`\log \sum_k e^{x_k}`
+
+    Includes the numerical stabilization trick (subtracting the maximum), so unlike a
+    bare ``log(sum(exp(x)))`` the gradient taken from it is stable too.
+    """
+
+    __props__ = ("axis",)
+
+    # See the note on `XLogY.inline`.
+    inline = False
+
+    def __init__(self, *, axis, **kwargs):
+        self.axis = tuple(axis)
+        super().__init__(**kwargs)
+
+    def build_inner_graph(self, x):
+        x_max = x.max(axis=self.axis, keepdims=True)
+        # Do not offset when x_max = -inf, to avoid nan in the output
+        x_max = switch(isinf(x_max), 0.0, x_max)
+        out = log(exp(x - x_max).sum(axis=self.axis, keepdims=True)) + x_max
+        return [out.squeeze(axis=self.axis)]
+
+
+def logsumexp(x, axis=None, keepdims=False):
+    """Compute the log of the sum of exponentials of input elements.
+
+    See ``scipy.special.logsumexp``.
+
+    Parameters
+    ----------
+    x : symbolic tensor
+        Input
+
+    axis : None or int or tuple of ints, optional
+        Axis or axes over which the sum is taken. By default axis is None,
+        and all elements are summed.
+
+    keepdims : bool, optional
+        If this is set to True, the axes which are reduced are left in the
+        result as dimensions with size one. With this option, the result will
+        broadcast correctly against the original array.
+
+    Returns
+    -------
+    TensorVariable
+
+    """
+    x = as_tensor_variable(x)
+    axis = (
+        tuple(range(x.type.ndim))
+        if axis is None
+        else normalize_axis_tuple(axis, x.type.ndim)
+    )
+    out = LogSumExp(axis=axis)(x)
+    return expand_dims(out, axis) if keepdims else out
+
+
+class LogAddExp(TensorSymbolicOp):
+    r"""Log of the sum of exponentials of separate (broadcastable) inputs.
+
+    :math:`\log \sum_k e^{x_k}`, where the :math:`x_k` are the variadic inputs.
+
+    Includes the numerical stabilization trick (subtracting the maximum), so unlike a
+    bare ``log(exp(x) + exp(y))`` the gradient taken from it is stable too.
+    """
+
+    # See the note on `XLogY.inline`.
+    inline = False
+
+    def build_inner_graph(self, *xs):
+        x_max = reduce(maximum, xs)
+        # Do not offset when x_max = -inf, to avoid nan in the output
+        x_max = switch(isinf(x_max), 0.0, x_max)
+        return [log(add(*(exp(x - x_max) for x in xs))) + x_max]
+
+
+def logaddexp(*xs):
+    """Logarithm of the sum of exponentiations of the inputs.
+
+    See ``numpy.logaddexp``.
+
+    Parameters
+    ----------
+    xs : symbolic tensors
+        Input
+
+    Returns
+    -------
+    TensorVariable
+
+    """
+    return LogAddExp()(*xs)
 
 
 @_vectorize_node.register(Softmax)
@@ -230,7 +333,9 @@ __all__ = [
     "betaln",
     "factorial",
     "log_softmax",
+    "logaddexp",
     "logit",
+    "logsumexp",
     "poch",
     "softmax",
     "xlog1py",

--- a/pytensor/tensor/utils.py
+++ b/pytensor/tensor/utils.py
@@ -229,10 +229,16 @@ def safe_signature(
     return f"{inputs_sig}->{outputs_sig}"
 
 
-def normalize_reduce_axis(axis, ndim: int) -> tuple[int, ...] | None:
-    """Normalize the axis parameter for reduce operations."""
+def normalize_reduce_axis(
+    axis, ndim: int, normalize_none: bool = False
+) -> tuple[int, ...] | None:
+    """Normalize the axis parameter for reduce operations.
+
+    With ``normalize_none`` a ``None`` axis becomes every axis, for Ops that need them
+    spelled out so that ``None`` and the explicit axes give Ops that compare equal.
+    """
     if axis is None:
-        return None
+        return tuple(range(ndim)) if normalize_none else None
 
     # scalar inputs are treated as 1D regarding axis in reduce operations
     if axis is not None:

--- a/tests/compile/test_builders.py
+++ b/tests/compile/test_builders.py
@@ -2,6 +2,7 @@ from functools import partial
 
 import numpy as np
 import pytest
+import scipy.special
 
 import pytensor.tensor as pt
 from pytensor import Mode
@@ -841,3 +842,17 @@ def test_perform_with_inner_scan_rvs():
     out = op(shared(np.random.default_rng(0)))
     fn = function([], out, mode=Mode(linker="py", optimizer=None))
     assert fn().shape == (2,)
+
+
+def test_inner_graph_keeps_symbolic_op_recognition():
+    # Wrapping an expression in an OpFromGraph must not destabilize it: the inner graph
+    # still needs the rewrite recognizing exp(x) / sum(exp(x)) as the stable Softmax.
+    x = pt.vector("x")
+    inner = pt.vector("inner")
+    e = exp(inner)
+    op = OpFromGraph([inner], [e / e.sum()])
+
+    test_val = np.array([1000.0, 1001.0])
+    np.testing.assert_allclose(
+        function([x], op(x))(test_val), scipy.special.softmax(test_val)
+    )

--- a/tests/tensor/rewriting/test_math.py
+++ b/tests/tensor/rewriting/test_math.py
@@ -5,7 +5,6 @@ from io import StringIO
 
 import numpy as np
 import pytest
-from scipy.special import logsumexp as scipy_logsumexp
 
 import pytensor
 import pytensor.scalar as ps
@@ -1213,41 +1212,6 @@ def test_log1p():
     z = imatrix()
     f = function([z], log(1 + (z)), mode=m)
     assert [node.op for node in f.maker.fgraph.toposort()] == [log1p]
-
-
-@pytest.mark.parametrize("mode", ["FAST_COMPILE", "FAST_RUN"])
-def test_local_log_add_exp(mode):
-    m = get_mode(mode).excluding("fusion")
-    m = copy.copy(m)
-    # No need to put them back as we have a new object
-    m.check_isfinite = False
-
-    # check some basic cases
-    x = dvector()
-    y = dvector()
-    f = function([x, y], log(exp(x) + exp(y)), mode=m)
-
-    # test that it gives the correct result when it doesn't overflow
-    f([10], [10])  # doesn't causes overflow
-    utt.assert_allclose(f([10], [10]), 10 + np.log1p(1))
-
-    assert np.isfinite(f([10000], [10000]))  # causes overflow if handled incorrectly
-    utt.assert_allclose(f([10000], [10000]), 10000 + np.log1p(1))
-
-    # test that when max = +-inf, rewritten output still works correctly
-    assert f([-np.inf], [-np.inf]) == -np.inf
-    assert f([np.inf], [np.inf]) == np.inf
-    assert f([np.inf], [-np.inf]) == np.inf
-
-    # test that it also works with more than two args
-    x = dvector()
-    y = dvector()
-    f = function([x, y], log(exp(x) + exp(y) + exp(x - y) + exp(x + y)), mode=m)
-
-    assert np.isfinite(f([10000], [10000]))  # causes overflow if handled incorrectly
-    utt.assert_allclose(f([10000], [10000]), 20000)
-
-    # TODO: test that the rewrite works in the presence of broadcasting.
 
 
 def test_local_elemwise_sub_zeros():
@@ -4200,94 +4164,6 @@ def test_local_expm1():
         isinstance(n.op, Elemwise) and isinstance(n.op.scalar_op, ps.basic.Expm1)
         for n in r.maker.fgraph.toposort()
     )
-
-
-def compile_graph_log_sum_exp(x, axis, dimshuffle_op=None, mode="FAST_RUN"):
-    sum_exp = pt_sum(exp(x), axis=axis)
-    if dimshuffle_op:
-        sum_exp = dimshuffle_op(sum_exp)
-    y = log(sum_exp)
-    return function([x], y, mode=mode)
-
-
-def check_max_log_sum_exp(x, axis, dimshuffle_op=None):
-    f = compile_graph_log_sum_exp(x, axis, dimshuffle_op)
-
-    fgraph = f.maker.fgraph.toposort()
-    for node in fgraph:
-        if hasattr(node.op, "scalar_op") and node.op.scalar_op == ps.basic.maximum:
-            return
-
-        if isinstance(node.op, Max):
-            return
-
-    # TODO FIXME: Refactor this test so that it makes a direct assertion and
-    # nothing more.
-    raise AssertionError("No maximum detected after log_sum_exp rewrite")
-
-
-def test_local_log_sum_exp_maximum():
-    """Test that the rewrite is applied by checking the presence of the maximum."""
-    x = tensor3("x")
-    check_max_log_sum_exp(x, axis=(0,), dimshuffle_op=None)
-    check_max_log_sum_exp(x, axis=(1,), dimshuffle_op=None)
-    check_max_log_sum_exp(x, axis=(2,), dimshuffle_op=None)
-    check_max_log_sum_exp(x, axis=(0, 1), dimshuffle_op=None)
-    check_max_log_sum_exp(x, axis=(0, 1, 2), dimshuffle_op=None)
-
-    # If a transpose is applied to the sum
-    transpose_op = DimShuffle(input_ndim=2, new_order=(1, 0))
-    check_max_log_sum_exp(x, axis=2, dimshuffle_op=transpose_op)
-
-    # If the sum is performed with keepdims=True
-    x = TensorType(dtype="floatX", shape=(None, 1, None))("x")
-    sum_keepdims_op = x.sum(axis=(0, 1), keepdims=True).owner.op
-    check_max_log_sum_exp(x, axis=(0, 1), dimshuffle_op=sum_keepdims_op)
-
-
-def test_local_log_sum_exp_near_one():
-    """Test that the rewritten result is correct around 1.0."""
-
-    x = tensor3("x")
-    x_val = 1.0 + np.random.random((4, 3, 2)).astype(config.floatX) / 10.0
-
-    f = compile_graph_log_sum_exp(x, axis=(1,))
-    naive_ret = np.log(np.sum(np.exp(x_val), axis=1))
-    rewritten_ret = f(x_val)
-    assert np.allclose(naive_ret, rewritten_ret)
-
-    # If a transpose is applied
-    transpose_op = DimShuffle(input_ndim=2, new_order=(1, 0))
-    f = compile_graph_log_sum_exp(x, axis=(1,), dimshuffle_op=transpose_op)
-    naive_ret = np.log(np.sum(np.exp(x_val), axis=1).T)
-    rewritten_ret = f(x_val)
-    assert np.allclose(naive_ret, rewritten_ret)
-
-
-@pytest.mark.parametrize("mode", ["FAST_COMPILE", "FAST_RUN"])
-@pytest.mark.parametrize(
-    "x_val", ([-800.0, 800.0], [-800.0, -805.0]), ids=["overflow", "underflow"]
-)
-def test_local_log_sum_exp_large(x_val, mode):
-    """Test that the rewrite result is correct for values the naive graph can't represent."""
-    x = vector("x")
-    f = compile_graph_log_sum_exp(x, axis=0, mode=mode)
-
-    x_val = np.array(x_val, dtype=config.floatX)
-
-    rewritten_ret = f(x_val)
-    np.testing.assert_allclose(rewritten_ret, scipy_logsumexp(x_val), rtol=1e-5)
-
-
-@pytest.mark.parametrize("mode", ["FAST_COMPILE", "FAST_RUN"])
-def test_local_log_sum_exp_inf(mode):
-    """Test that when max = +-inf, the rewritten output still works correctly."""
-    x = vector("x")
-    f = compile_graph_log_sum_exp(x, axis=0, mode=mode)
-
-    assert f([-np.inf, -np.inf]) == -np.inf
-    assert f([np.inf, np.inf]) == np.inf
-    assert f([-np.inf, np.inf]) == np.inf
 
 
 def test_local_reciprocal_1_plus_exp():

--- a/tests/tensor/rewriting/test_special.py
+++ b/tests/tensor/rewriting/test_special.py
@@ -16,9 +16,14 @@ from pytensor.graph.rewriting.db import RewriteDatabaseQuery
 from pytensor.tensor.elemwise import DimShuffle
 from pytensor.tensor.math import Max, exp, log
 from pytensor.tensor.math import sum as pt_sum
-from pytensor.tensor.special import LogSoftmax, Softmax, softmax
+from pytensor.tensor.rewriting.special import (
+    local_exp_log_softmax,
+    local_log_softmax_from_logsumexp,
+)
+from pytensor.tensor.special import LogSoftmax, Softmax, log_softmax, logsumexp, softmax
 from pytensor.tensor.type import TensorType, dvector, matrix, tensor3, vector
 from tests import unittest_tools as utt
+from tests.unittest_tools import RewriteTester
 
 
 _fast_run_rewrites = RewriteDatabaseQuery(include=["fast_run"])
@@ -42,6 +47,46 @@ class TestLogSoftmaxRewrites:
         assert isinstance(fgraph.outputs[0].owner.op, LogSoftmax)
         assert check_stack_trace(fgraph, ops_to_check=LogSoftmax)
         assert check_stack_trace(fgraph, ops_to_check="all")
+
+    @pytest.mark.parametrize("axis", [None, 0, -1])
+    def test_local_exp_log_softmax_rewrite(self, axis):
+        """Check that ``Exp(LogSoftmax(x)) -> Softmax(x)``."""
+        x = matrix("x")
+        test_val = np.array([[1000.0, 1001.0], [1.0, 2.0]])
+
+        result = RewriteTester(
+            [x], [exp(log_softmax(x, axis=axis))], custom_rewrite=local_exp_log_softmax
+        )
+        result.assert_graph(softmax(x, axis=axis))
+        result.assert_eval(test_val)
+
+        # When the LogSoftmax is needed anyway, reusing it beats repeating the reduction
+        log_sm = log_softmax(x, axis=axis)
+        result = RewriteTester(
+            [x], [log_sm, exp(log_sm)], custom_rewrite=local_exp_log_softmax
+        )
+        result.assert_graph(log_sm, exp(log_sm))
+
+    @pytest.mark.parametrize("axis", [None, 0, -1])
+    def test_local_log_softmax_from_logsumexp(self, axis):
+        """Check that ``x - logsumexp(x, axis, keepdims=True) -> LogSoftmax(x)``."""
+        x = matrix("x")
+        test_val = np.array([[1000.0, 1001.0], [1.0, 2.0]])
+
+        result = RewriteTester(
+            [x],
+            [x - logsumexp(x, axis=axis, keepdims=True)],
+            custom_rewrite=local_log_softmax_from_logsumexp,
+        )
+        result.assert_graph(log_softmax(x, axis=axis))
+        result.assert_eval(test_val)
+
+        # When the logsumexp is needed anyway, reusing it beats repeating the reduction
+        lse = logsumexp(x, axis=axis, keepdims=True)
+        result = RewriteTester(
+            [x], [x - lse, lse], custom_rewrite=local_log_softmax_from_logsumexp
+        )
+        result.assert_graph(x - lse, lse)
 
     @pytest.mark.parametrize("axis", [None, 0, -1])
     @pytest.mark.parametrize("idx0", [0, slice(1, None), slice(None)])

--- a/tests/tensor/rewriting/test_special.py
+++ b/tests/tensor/rewriting/test_special.py
@@ -1,8 +1,11 @@
+import copy
+
 import numpy as np
 import pytest
 import scipy.special
 
 import pytensor
+import pytensor.scalar as ps
 from pytensor import shared
 from pytensor.compile import optdb
 from pytensor.compile.mode import get_mode
@@ -10,9 +13,11 @@ from pytensor.configdefaults import config
 from pytensor.graph.fg import FunctionGraph
 from pytensor.graph.rewriting.basic import check_stack_trace
 from pytensor.graph.rewriting.db import RewriteDatabaseQuery
-from pytensor.tensor.math import exp, log
+from pytensor.tensor.elemwise import DimShuffle
+from pytensor.tensor.math import Max, exp, log
+from pytensor.tensor.math import sum as pt_sum
 from pytensor.tensor.special import LogSoftmax, Softmax, softmax
-from pytensor.tensor.type import matrix
+from pytensor.tensor.type import TensorType, dvector, matrix, tensor3, vector
 from tests import unittest_tools as utt
 
 
@@ -114,3 +119,128 @@ def test_softmax_graph():
         return pytensor.grad(None, x, known_grads={y: inputs})
 
     utt.verify_grad(f, [rng.random((3, 4))])
+
+
+@pytest.mark.parametrize("mode", ["FAST_COMPILE", "FAST_RUN"])
+def test_local_log_add_exp(mode):
+    m = get_mode(mode).excluding("fusion")
+    m = copy.copy(m)
+    # No need to put them back as we have a new object
+    m.check_isfinite = False
+
+    # check some basic cases
+    x = dvector()
+    y = dvector()
+    f = pytensor.function([x, y], log(exp(x) + exp(y)), mode=m)
+
+    # test that it gives the correct result when it doesn't overflow
+    f([10], [10])  # doesn't causes overflow
+    utt.assert_allclose(f([10], [10]), 10 + np.log1p(1))
+
+    assert np.isfinite(f([10000], [10000]))  # causes overflow if handled incorrectly
+    utt.assert_allclose(f([10000], [10000]), 10000 + np.log1p(1))
+
+    # test that when max = +-inf, rewritten output still works correctly
+    assert f([-np.inf], [-np.inf]) == -np.inf
+    assert f([np.inf], [np.inf]) == np.inf
+    assert f([np.inf], [-np.inf]) == np.inf
+
+    # test that it also works with more than two args
+    x = dvector()
+    y = dvector()
+    f = pytensor.function(
+        [x, y], log(exp(x) + exp(y) + exp(x - y) + exp(x + y)), mode=m
+    )
+
+    assert np.isfinite(f([10000], [10000]))  # causes overflow if handled incorrectly
+    utt.assert_allclose(f([10000], [10000]), 20000)
+
+    # TODO: test that the rewrite works in the presence of broadcasting.
+
+
+def compile_graph_log_sum_exp(x, axis, dimshuffle_op=None, mode="FAST_RUN"):
+    sum_exp = pt_sum(exp(x), axis=axis)
+    if dimshuffle_op:
+        sum_exp = dimshuffle_op(sum_exp)
+    y = log(sum_exp)
+    return pytensor.function([x], y, mode=mode)
+
+
+def check_max_log_sum_exp(x, axis, dimshuffle_op=None):
+    f = compile_graph_log_sum_exp(x, axis, dimshuffle_op)
+
+    fgraph = f.maker.fgraph.toposort()
+    for node in fgraph:
+        if hasattr(node.op, "scalar_op") and node.op.scalar_op == ps.basic.maximum:
+            return
+
+        if isinstance(node.op, Max):
+            return
+
+    # TODO FIXME: Refactor this test so that it makes a direct assertion and
+    # nothing more.
+    raise AssertionError("No maximum detected after log_sum_exp rewrite")
+
+
+def test_local_log_sum_exp_maximum():
+    """Test that the rewrite is applied by checking the presence of the maximum."""
+    x = tensor3("x")
+    check_max_log_sum_exp(x, axis=(0,), dimshuffle_op=None)
+    check_max_log_sum_exp(x, axis=(1,), dimshuffle_op=None)
+    check_max_log_sum_exp(x, axis=(2,), dimshuffle_op=None)
+    check_max_log_sum_exp(x, axis=(0, 1), dimshuffle_op=None)
+    check_max_log_sum_exp(x, axis=(0, 1, 2), dimshuffle_op=None)
+
+    # If a transpose is applied to the sum
+    transpose_op = DimShuffle(input_ndim=2, new_order=(1, 0))
+    check_max_log_sum_exp(x, axis=2, dimshuffle_op=transpose_op)
+
+    # If the sum is performed with keepdims=True
+    x = TensorType(dtype="floatX", shape=(None, 1, None))("x")
+    sum_keepdims_op = x.sum(axis=(0, 1), keepdims=True).owner.op
+    check_max_log_sum_exp(x, axis=(0, 1), dimshuffle_op=sum_keepdims_op)
+
+
+def test_local_log_sum_exp_near_one():
+    """Test that the rewritten result is correct around 1.0."""
+
+    x = tensor3("x")
+    x_val = 1.0 + np.random.random((4, 3, 2)).astype(config.floatX) / 10.0
+
+    f = compile_graph_log_sum_exp(x, axis=(1,))
+    naive_ret = np.log(np.sum(np.exp(x_val), axis=1))
+    rewritten_ret = f(x_val)
+    assert np.allclose(naive_ret, rewritten_ret)
+
+    # If a transpose is applied
+    transpose_op = DimShuffle(input_ndim=2, new_order=(1, 0))
+    f = compile_graph_log_sum_exp(x, axis=(1,), dimshuffle_op=transpose_op)
+    naive_ret = np.log(np.sum(np.exp(x_val), axis=1).T)
+    rewritten_ret = f(x_val)
+    assert np.allclose(naive_ret, rewritten_ret)
+
+
+@pytest.mark.parametrize("mode", ["FAST_COMPILE", "FAST_RUN"])
+@pytest.mark.parametrize(
+    "x_val", ([-800.0, 800.0], [-800.0, -805.0]), ids=["overflow", "underflow"]
+)
+def test_local_log_sum_exp_large(x_val, mode):
+    """Test that the rewrite result is correct for values the naive graph can't represent."""
+    x = vector("x")
+    f = compile_graph_log_sum_exp(x, axis=0, mode=mode)
+
+    x_val = np.array(x_val, dtype=config.floatX)
+
+    rewritten_ret = f(x_val)
+    np.testing.assert_allclose(rewritten_ret, scipy.special.logsumexp(x_val), rtol=1e-5)
+
+
+@pytest.mark.parametrize("mode", ["FAST_COMPILE", "FAST_RUN"])
+def test_local_log_sum_exp_inf(mode):
+    """Test that when max = +-inf, the rewritten output still works correctly."""
+    x = vector("x")
+    f = compile_graph_log_sum_exp(x, axis=0, mode=mode)
+
+    assert f([-np.inf, -np.inf]) == -np.inf
+    assert f([np.inf, np.inf]) == np.inf
+    assert f([-np.inf, np.inf]) == np.inf

--- a/tests/tensor/test_math.py
+++ b/tests/tensor/test_math.py
@@ -9,7 +9,6 @@ import numpy as np
 import pytest
 import scipy.special
 from numpy.testing import assert_array_equal
-from scipy.special import logsumexp as scipy_logsumexp
 
 import pytensor
 import pytensor.scalar as ps
@@ -89,8 +88,6 @@ from pytensor.tensor.math import (
     log1p,
     log2,
     log10,
-    logaddexp,
-    logsumexp,
     matmul,
     matvec,
     max,
@@ -151,7 +148,6 @@ from pytensor.tensor.type import (
     matrices,
     matrix,
     scalar,
-    scalars,
     tensor,
     tensor3,
     tensor4,
@@ -3699,76 +3695,6 @@ def test_tanh_grad_broadcast():
     grad(tanh(x + y).sum(), y)
     # TODO FIXME: This is a bad test
     grad(tanh(x + y).sum(), [x, y])
-
-
-def test_logaddexp():
-    # Test more than two multidimensional inputs
-    x, y, z = matrices("x", "y", "z")
-    out = logaddexp(x, y, z)
-    f = function([x, y, z], out)
-
-    inp = np.zeros((3, 3), dtype=config.floatX)
-    np.testing.assert_allclose(
-        f(inp, inp, inp),
-        np.full((3, 3), np.log(3)),
-    )
-
-    # Test scalar inputs
-    x, y = scalars("x", "y")
-    out = logaddexp(x, y)
-    f = function([x, y], out)
-
-    res = f(0, 0)
-    assert np.ndim(res) == 0
-    assert np.isclose(res, np.log(2))
-
-    # Test scalar and matrix inputs
-    x = scalar("x")
-    y = matrix("y")
-    out = logaddexp(x, y)
-    f = function([x, y], out)
-
-    res = f(
-        np.array(0, dtype=config.floatX),
-        np.zeros((3, 3), dtype=config.floatX),
-    )
-    assert np.shape(res) == (3, 3)
-    np.testing.assert_allclose(
-        res,
-        np.full((3, 3), np.log(2)),
-    )
-
-
-@pytest.mark.parametrize(
-    ["shape", "axis"],
-    [
-        ((1,), 0),
-        ((3,), 0),
-        ((3, 4), None),
-        ((3, 4), 0),
-        ((3, 4), 1),
-        ((3, 4, 5), None),
-        ((3, 3, 5), 0),
-        ((3, 4, 5), 1),
-        ((3, 4, 5), 2),
-    ],
-)
-@pytest.mark.parametrize(
-    "keepdims",
-    [True, False],
-)
-def test_logsumexp(shape, axis, keepdims):
-    scipy_inp = np.zeros(shape)
-    scipy_out = scipy_logsumexp(scipy_inp, axis=axis, keepdims=keepdims)
-
-    pytensor_inp = as_tensor_variable(scipy_inp)
-    f = function([], logsumexp(pytensor_inp, axis=axis, keepdims=keepdims))
-    pytensor_out = f()
-
-    np.testing.assert_array_almost_equal(
-        pytensor_out,
-        scipy_out,
-    )
 
 
 def test_pprint():

--- a/tests/tensor/test_special.py
+++ b/tests/tensor/test_special.py
@@ -4,6 +4,7 @@ from scipy.special import beta as scipy_beta
 from scipy.special import factorial as scipy_factorial
 from scipy.special import log_softmax as scipy_log_softmax
 from scipy.special import logit as scipy_logit
+from scipy.special import logsumexp as scipy_logsumexp
 from scipy.special import poch as scipy_poch
 from scipy.special import softmax as scipy_softmax
 from scipy.special import xlog1py as scipy_xlog1py
@@ -13,6 +14,7 @@ from pytensor import grad
 from pytensor.compile.maker import function
 from pytensor.configdefaults import config
 from pytensor.graph.replace import vectorize_graph
+from pytensor.tensor.basic import as_tensor_variable
 from pytensor.tensor.special import (
     LogSoftmax,
     Softmax,
@@ -20,13 +22,25 @@ from pytensor.tensor.special import (
     betaln,
     factorial,
     log_softmax,
+    logaddexp,
     logit,
+    logsumexp,
     poch,
     softmax,
     xlog1py,
     xlogy,
 )
-from pytensor.tensor.type import matrix, tensor, tensor3, tensor4, vector, vectors
+from pytensor.tensor.type import (
+    matrices,
+    matrix,
+    scalar,
+    scalars,
+    tensor,
+    tensor3,
+    tensor4,
+    vector,
+    vectors,
+)
 from tests import unittest_tools as utt
 from tests.tensor.utils import random_ranged
 
@@ -173,6 +187,94 @@ def test_softmax_stability(constructor, scipy_fn, mode):
     f = function([x], constructor(x, axis=-1), mode=mode)
 
     np.testing.assert_allclose(f(x_val), scipy_fn(x_val, axis=-1), rtol=1e-6)
+
+
+def test_logaddexp():
+    # Test more than two multidimensional inputs
+    x, y, z = matrices("x", "y", "z")
+    out = logaddexp(x, y, z)
+    f = function([x, y, z], out)
+
+    inp = np.zeros((3, 3), dtype=config.floatX)
+    np.testing.assert_allclose(
+        f(inp, inp, inp),
+        np.full((3, 3), np.log(3)),
+    )
+
+    # Test scalar inputs
+    x, y = scalars("x", "y")
+    out = logaddexp(x, y)
+    f = function([x, y], out)
+
+    res = f(0, 0)
+    assert np.ndim(res) == 0
+    assert np.isclose(res, np.log(2))
+
+    # Test scalar and matrix inputs
+    x = scalar("x")
+    y = matrix("y")
+    out = logaddexp(x, y)
+    f = function([x, y], out)
+
+    res = f(
+        np.array(0, dtype=config.floatX),
+        np.zeros((3, 3), dtype=config.floatX),
+    )
+    assert np.shape(res) == (3, 3)
+    np.testing.assert_allclose(
+        res,
+        np.full((3, 3), np.log(2)),
+    )
+
+
+@pytest.mark.parametrize(
+    ["shape", "axis"],
+    [
+        ((1,), 0),
+        ((3,), 0),
+        ((3, 4), None),
+        ((3, 4), 0),
+        ((3, 4), 1),
+        ((3, 4, 5), None),
+        ((3, 3, 5), 0),
+        ((3, 4, 5), 1),
+        ((3, 4, 5), 2),
+    ],
+)
+@pytest.mark.parametrize(
+    "keepdims",
+    [True, False],
+)
+def test_logsumexp(shape, axis, keepdims):
+    scipy_inp = np.zeros(shape)
+    scipy_out = scipy_logsumexp(scipy_inp, axis=axis, keepdims=keepdims)
+
+    pytensor_inp = as_tensor_variable(scipy_inp)
+    f = function([], logsumexp(pytensor_inp, axis=axis, keepdims=keepdims))
+    pytensor_out = f()
+
+    np.testing.assert_array_almost_equal(
+        pytensor_out,
+        scipy_out,
+    )
+
+
+@pytest.mark.parametrize("mode", ["FAST_RUN", "FAST_COMPILE"])
+def test_logsumexp_logaddexp_stable_grad(mode):
+    """Both helpers promise a stable forward, so their gradient must be stable too.
+
+    A naive ``log(sum(exp(x)))`` is only stabilized by `local_log_sum_exp`, which runs
+    too late to help `grad`: the gradient built from the raw form is
+    ``exp(x) / sum(exp(x))``, which overflows for large ``x`` and is 0/0 for very
+    negative ``x``. Multiplying by ``w`` keeps the output gradient from folding to 1,
+    which is what would otherwise let `local_softmax_stabilize` repair the pattern.
+    """
+    x, w = vector("x"), scalar("w")
+
+    for out in (logsumexp(x), logaddexp(x[0], x[1])):
+        f = function([x, w], grad(out * w, x), mode=mode)
+        for inp in (np.array([1000.0, 1001.0]), np.array([-800.0, -805.0])):
+            np.testing.assert_allclose(f(inp, 2.0), 2.0 * scipy_softmax(inp))
 
 
 def test_poch():


### PR DESCRIPTION
- **Make logsumexp and logaddexp stable by construction**
- **Only exclude symbolic_op_recognition inside SymbolicOp inner graphs**
- **Recognize log_softmax and rewrite exp(log_softmax) -> softmax**

Related to https://github.com/pymc-devs/pymc-extras/issues/720
Related to #2289 

Gotta bite the bullet and make logsumexp/logaddexp eager SymbolicRVOp so their gradients are stable.
Also figure out a more clean way to avoid recursion in rewrites but still handle OFG(naive_graph)