### PR TITLE
Refactor and improve `Pad`

### DIFF
--- a/pytensor/tensor/pad.py
+++ b/pytensor/tensor/pad.py
@@ -1,27 +1,24 @@
 from collections.abc import Callable
-from functools import partial
 from typing import Literal, cast
 
+import numpy as np
+
 from pytensor.compile.builders import OpFromGraph
-from pytensor.ifelse import ifelse
-from pytensor.scan import scan
+from pytensor.graph.basic import Constant
 from pytensor.tensor import TensorLike
 from pytensor.tensor.basic import (
     TensorVariable,
+    arange,
     as_tensor,
-    concatenate,
-    expand_dims,
-    moveaxis,
     switch,
     zeros,
 )
 from pytensor.tensor.extra_ops import broadcast_to, linspace
-from pytensor.tensor.math import divmod as pt_divmod
-from pytensor.tensor.math import eq, gt, mean, minimum
 from pytensor.tensor.math import max as pt_max
+from pytensor.tensor.math import maximum, mean, minimum
 from pytensor.tensor.math import min as pt_min
 from pytensor.tensor.shape import specify_broadcastable
-from pytensor.tensor.subtensor import flip, set_subtensor, slice_at_axis
+from pytensor.tensor.subtensor import flip, set_subtensor, slice_at_axis, take
 
 
 PadMode = Literal[
@@ -277,139 +274,79 @@ def _linear_ramp_pad(
     return padded
 
 
-def _wrap_pad(x: TensorVariable, pad_width: TensorVariable) -> TensorVariable:
-    pad_width = broadcast_to(pad_width, as_tensor((x.ndim, 2)))
-
-    for axis in range(x.ndim):
-        size = x.shape[axis]
-
-        # Compute how many complete copies of the input will be padded on this dimension, along with the amount of
-        # overflow on the final copy
-        repeats, (left_remainder, right_remainder) = pt_divmod(pad_width[axis], size)
-
-        # In the next step we will generate extra copies of the input, and then trim them down to the correct size.
-        left_trim = size - left_remainder
-        right_trim = size - right_remainder
-
-        # The total number of copies needed is always the sum of the number of complete copies to add, plus the original
-        # input itself, plus the two edge copies that will be trimmed down.
-        total_repeats = repeats.sum() + 3
-
-        # Create a batch dimension and clone the input the required number of times
-        parts = expand_dims(x, (0,)).repeat(total_repeats, axis=0)
-
-        # Move the batch dimension to the active dimension
-        parts = moveaxis(parts, 0, axis)
-
-        # Ravel the active dimension while preserving the shapes of the inactive dimensions. This will expand the
-        # active dimension to have the correctly padded shape, plus excess to be trimmed
-        new_shape = [-1 if i == axis else x.shape[i] for i in range(x.ndim)]
-        x = parts.reshape(new_shape)
-
-        # Trim the excess on the active dimension
-        trim_slice = slice_at_axis(slice(left_trim, -right_trim), axis)
-        x = x[trim_slice]
-
-    return x
+def _static_pad_width(pad_width: TensorVariable, ndim: int) -> np.ndarray | None:
+    """``pad_width`` broadcast to ``(ndim, 2)`` Python ints, or None if not constant."""
+    if not isinstance(pad_width, Constant):
+        return None
+    widths = np.asarray(pad_width.data)
+    if not np.issubdtype(widths.dtype, np.integer):
+        raise TypeError("`pad_width` must be of integral type.")
+    return np.broadcast_to(widths.astype("int64"), (ndim, 2))
 
 
-def _build_padding_one_direction(array, array_flipped, repeats, *, inner_func, axis):
-    [_, parts] = scan(
-        inner_func,
-        non_sequences=[array, array_flipped],
-        outputs_info=[0, None],
-        n_steps=repeats,
-        return_updates=False,
-    )
+def _gather_indices(
+    mode: Literal["wrap", "symmetric", "reflect"],
+    size: int | TensorVariable,
+    before: int | TensorVariable,
+    after: int | TensorVariable,
+) -> TensorVariable:
+    """Map output positions along one axis back to the input positions they copy.
 
-    parts = moveaxis(parts, 0, axis)
-    new_shape = [-1 if i == axis else array.shape[i] for i in range(array.ndim)]
-    padding = parts.reshape(new_shape)
+    ``wrap``, ``symmetric`` and ``reflect`` never compute new values: every
+    padded element is some element of the input, selected by a periodic index
+    map. ``wrap`` has period ``size``, ``symmetric`` period ``2 * size`` (each
+    edge value repeated once at the turning point), and ``reflect`` period
+    ``2 * size - 2`` (turning points not repeated).
 
-    return padding
+    When ``size``, ``before`` and ``after`` are all Python ints the map is built
+    with NumPy, which keeps the padded output shape statically known.
+    """
+    if all(isinstance(value, int) for value in (size, before, after)):
+        offsets = np.arange(before + size + after) - before
+        where, clamp = np.where, max
+    else:
+        offsets = arange(before + size + after) - before
+        where, clamp = switch, maximum
 
+    if mode == "wrap":
+        indices = offsets % size
+    elif mode == "symmetric":
+        period = 2 * size
+        folded = offsets % period
+        indices = where(folded < size, folded, period - 1 - folded)
+    elif mode == "reflect":
+        # A size of 1 degenerates the period to 0. Clamping it to 1 maps every
+        # position onto the single element, which is what reflecting a length-1
+        # axis means.
+        period = clamp(2 * size - 2, 1)
+        folded = offsets % period
+        indices = where(folded < size, folded, period - folded)
+    else:
+        raise ValueError(f"Invalid gather pad mode: {mode}")
 
-def _symmetric_pad(x, pad_width):
-    def _symmetric_inner(i, x, x_flipped, padding_left):
-        return i + 1, ifelse(eq(i % 2, int(padding_left)), x_flipped, x)
-
-    pad_width = broadcast_to(pad_width, as_tensor((x.ndim, 2)))
-
-    for axis in range(x.ndim):
-        x_flipped = flip(x, axis=axis)
-        original_size = x.shape[axis]
-
-        repeats, remainders = pt_divmod(pad_width[axis], original_size)
-        has_remainder = gt(remainders, 0)
-        repeats = repeats + has_remainder
-
-        left_padding = _build_padding_one_direction(
-            x,
-            x_flipped,
-            repeats[0],
-            axis=axis,
-            inner_func=partial(_symmetric_inner, padding_left=True),
-        )
-        right_padding = _build_padding_one_direction(
-            x,
-            x_flipped,
-            repeats[1],
-            axis=axis,
-            inner_func=partial(_symmetric_inner, padding_left=False),
-        )
-
-        x = concatenate([flip(left_padding, axis), x, right_padding], axis=axis)
-
-        (left_trim, right_trim) = switch(
-            has_remainder, original_size - remainders, remainders
-        )
-        right_trim = x.shape[axis] - right_trim
-
-        trim_slice = slice_at_axis(slice(left_trim, right_trim), axis)
-        x = x[trim_slice]
-
-    return x
+    return as_tensor(indices)
 
 
-def _reflect_pad(x, pad_width):
-    def _reflect_inner(i, x, x_flipped, padding_left):
-        return i + 1, ifelse(eq(i % 2, int(padding_left)), x_flipped, x)
+def _gather_pad(
+    x: TensorVariable,
+    pad_width: TensorVariable,
+    mode: Literal["wrap", "symmetric", "reflect"],
+) -> TensorVariable:
+    """Pad by gathering input elements, one axis at a time."""
+    static_widths = _static_pad_width(pad_width, x.ndim)
+    if static_widths is None:
+        widths = broadcast_to(pad_width, as_tensor((x.ndim, 2)))
+        width_pairs = [(widths[axis, 0], widths[axis, 1]) for axis in range(x.ndim)]
+    else:
+        width_pairs = [(int(before), int(after)) for before, after in static_widths]
 
-    pad_width = broadcast_to(pad_width, as_tensor((x.ndim, 2)))
-    for axis in range(x.ndim):
-        trimmed_size = x.shape[axis] - 1
+    for axis, (before, after) in enumerate(width_pairs):
+        size = x.type.shape[axis]
+        if size is None:
+            size = x.shape[axis]
 
-        trim_slice = slice_at_axis(slice(None, -1), axis)
-        x_trimmed = x[trim_slice]
-        x_flipped = flip(x, axis=axis)[trim_slice]
+        x = take(x, _gather_indices(mode, size, before, after), axis=axis)
 
-        repeats, remainders = pt_divmod(pad_width[axis], trimmed_size)
-        repeats = repeats + 1
-
-        left_padding = _build_padding_one_direction(
-            x_trimmed,
-            x_flipped,
-            repeats[0],
-            axis=axis,
-            inner_func=partial(_reflect_inner, padding_left=True),
-        )
-        right_padding = _build_padding_one_direction(
-            x_trimmed,
-            x_flipped,
-            repeats[1],
-            axis=axis,
-            inner_func=partial(_reflect_inner, padding_left=False),
-        )
-
-        left_trim = slice_at_axis(slice(trimmed_size - remainders[0] - 1, -1), axis)
-        right_trim = slice_at_axis(
-            slice(1, right_padding.shape[axis] - trimmed_size + remainders[1] + 1), axis
-        )
-
-        x = concatenate(
-            [flip(left_padding, axis)[left_trim], x, right_padding[right_trim]],
-            axis=axis,
-        )
     return x
 
 
@@ -661,9 +598,9 @@ def pad(
         outputs = _linear_ramp_pad(x, pad_width, end_values)
 
     elif mode == "wrap":
-        outputs = _wrap_pad(x, pad_width)
+        outputs = _gather_pad(x, pad_width, "wrap")
 
-    elif mode == "symmetric":
+    elif mode == "symmetric" or mode == "reflect":
         reflect_type = kwargs.pop("reflect_type", "even")
         if reflect_type == "odd":
             raise NotImplementedError(
@@ -671,17 +608,7 @@ def pad(
                 "issue at https://github.com/pymc-devs/pytensor/issues"
             )
         attrs.update({"reflect_type": reflect_type})
-        outputs = _symmetric_pad(x, pad_width)
-
-    elif mode == "reflect":
-        reflect_type = kwargs.pop("reflect_type", "even")
-        if reflect_type == "odd":
-            raise NotImplementedError(
-                "Odd reflection not implemented. If you need this feature, please open an "
-                "issue at https://github.com/pymc-devs/pytensor/issues"
-            )
-        attrs.update({"reflect_type": reflect_type})
-        outputs = _reflect_pad(x, pad_width)
+        outputs = _gather_pad(x, pad_width, mode)
 
     else:
         raise ValueError(f"Invalid mode: {mode}")

--- a/pytensor/tensor/pad.py
+++ b/pytensor/tensor/pad.py
@@ -557,6 +557,8 @@ def pad(
         [4 5 1 2 3 4 5 1 2 3]
 
     """
+    if mode not in allowed_kwargs:
+        raise ValueError(f"Invalid mode: {mode}")
     if any(value not in allowed_kwargs[mode] for value in kwargs.keys()):
         raise ValueError(
             f"Invalid keyword arguments for mode '{mode}': {kwargs.keys()}"

--- a/pytensor/tensor/pad.py
+++ b/pytensor/tensor/pad.py
@@ -35,17 +35,17 @@ PadMode = Literal[
 ]
 stat_funcs = {"maximum": pt_max, "minimum": pt_min, "mean": mean}
 
-allowed_kwargs = {
-    "edge": [],
-    "wrap": [],
-    "constant": ["constant_values"],
-    "linear_ramp": ["end_values"],
-    "maximum": ["stat_length"],
-    "mean": ["stat_length"],
-    "median": ["stat_length"],
-    "minimum": ["stat_length"],
-    "reflect": ["reflect_type"],
-    "symmetric": ["reflect_type"],
+mode_options = {
+    "edge": set(),
+    "wrap": set(),
+    "constant": {"constant_values"},
+    "linear_ramp": {"end_values"},
+    "maximum": {"stat_length"},
+    "mean": {"stat_length"},
+    "median": {"stat_length"},
+    "minimum": {"stat_length"},
+    "reflect": {"reflect_type"},
+    "symmetric": {"reflect_type"},
 }
 
 
@@ -405,14 +405,21 @@ class Pad(TensorSymbolicOp):
 
 
 def pad(
-    x: TensorLike, pad_width: TensorLike, mode: PadMode = "constant", **kwargs
+    x: TensorLike,
+    pad_width: TensorLike,
+    mode: PadMode = "constant",
+    *,
+    constant_values: TensorLike | None = None,
+    end_values: TensorLike | None = None,
+    stat_length: TensorLike | None = None,
+    reflect_type: Literal["even", "odd"] | None = None,
 ) -> TensorVariable:
     """
     Pad an array.
 
     Parameters
     ----------
-    array : array_like of rank N
+    x : array_like of rank N
         The array to pad.
 
     pad_width : sequence, array_like, or int
@@ -424,10 +431,10 @@ def pad(
         ``(pad,)`` or ``int`` is a shortcut for before = after = pad width
         for all axes.
 
-    mode : str or function, optional
-        One of the following string values or a user supplied function.
+    mode : str, optional
+        One of the following string values. Default is 'constant'.
 
-        'constant' (default)
+        'constant'
             Pads with a constant value.
         'edge'
             Pads with the edge values of array.
@@ -455,24 +462,9 @@ def pad(
             The first values are used to pad the end and the
             end values are used to pad the beginning.
 
-    stat_length : sequence or int, optional
-        Used in 'maximum', 'mean', and 'minimum'.  Number of
-        values at edge of each axis used to calculate the statistic value.
-
-        ``((before_1, after_1), ... (before_N, after_N))`` unique statistic
-        lengths for each axis.
-
-        ``(before, after)`` or ``((before, after),)`` yields same before
-        and after statistic lengths for each axis.
-
-        ``(stat_length,)`` or ``int`` is a shortcut for
-        ``before = after = statistic`` length for all axes.
-
-        Default is ``None``, to use the entire axis.
-
     constant_values : sequence or scalar, optional
-        Used in 'constant'.  The values to set the padded values for each
-        axis.
+        Only valid for mode 'constant'. The values to set the padded values to
+        for each axis.
 
         ``((before_1, after_1), ... (before_N, after_N))`` unique pad constants
         for each axis.
@@ -486,8 +478,8 @@ def pad(
         Default is 0.
 
     end_values : sequence or scalar, optional
-        Used in 'linear_ramp'.  The values used for the ending value of the
-        linear_ramp and that will form the edge of the padded array.
+        Only valid for mode 'linear_ramp'. The values used for the ending value
+        of the linear ramp, which form the edge of the padded array.
 
         ``((before_1, after_1), ... (before_N, after_N))`` unique end values
         for each axis.
@@ -500,15 +492,41 @@ def pad(
 
         Default is 0.
 
+    stat_length : sequence or int, optional
+        Only valid for modes 'maximum', 'mean', and 'minimum'. Number of values
+        at the edge of each axis used to compute the statistic.
+
+        ``((before_1, after_1), ... (before_N, after_N))`` unique statistic
+        lengths for each axis.
+
+        ``(before, after)`` or ``((before, after),)`` yields same before
+        and after statistic lengths for each axis.
+
+        ``(stat_length,)`` or ``int`` is a shortcut for
+        ``before = after = statistic`` length for all axes.
+
+        Default is ``None``, to use the entire axis.
+
     reflect_type : str, optional
-        Only 'even' is currently accepted. Used in 'reflect', and 'symmetric'.  The 'even' style is the
-        default with an unaltered reflection around the edge value.
+        Only valid for modes 'reflect' and 'symmetric'. Only 'even' is currently
+        accepted, which reflects around the edge value without altering it.
+        Default is 'even'.
 
     Returns
     -------
-    pad : ndarray
-        Padded array of rank equal to `array` with shape increased
-        according to `pad_width`.
+    padded : TensorVariable
+        Padded array of rank equal to ``x`` with shape increased according to
+        ``pad_width``.
+
+    Raises
+    ------
+    ValueError
+        If ``mode`` is not a recognized padding mode, or a keyword argument is
+        given that ``mode`` does not accept.
+    TypeError
+        If ``pad_width`` is a constant of non-integral dtype.
+    NotImplementedError
+        If ``mode`` is 'median', or ``reflect_type`` is 'odd'.
 
     Examples
     --------
@@ -596,42 +614,61 @@ def pad(
         [4 5 1 2 3 4 5 1 2 3]
 
     """
-    if mode not in allowed_kwargs:
+    if mode not in mode_options:
         raise ValueError(f"Invalid mode: {mode}")
-    if any(value not in allowed_kwargs[mode] for value in kwargs.keys()):
-        raise ValueError(
-            f"Invalid keyword arguments for mode '{mode}': {kwargs.keys()}"
+
+    supplied = {
+        name
+        for name, value in (
+            ("constant_values", constant_values),
+            ("end_values", end_values),
+            ("stat_length", stat_length),
+            ("reflect_type", reflect_type),
         )
+        if value is not None
+    }
+    unsupported = supplied - mode_options[mode]
+    if unsupported:
+        raise ValueError(
+            f"Invalid keyword arguments for mode '{mode}': {sorted(unsupported)}. "
+            f"Mode '{mode}' accepts {sorted(mode_options[mode])}"
+        )
+
     x = as_tensor(x, name="x")
     pad_width = as_tensor(pad_width, name="pad_width")
     inputs = [x, pad_width]
-    reflect_type: str | None = None
     has_stat_length = False
 
     if mode == "constant":
-        inputs += [as_tensor(kwargs.pop("constant_values", 0), name="constant_values")]
+        if constant_values is None:
+            constant_values = 0
+        inputs += [as_tensor(constant_values, name="constant_values")]
 
     elif mode == "linear_ramp":
-        inputs += [as_tensor(kwargs.pop("end_values", 0))]
+        if end_values is None:
+            end_values = 0
+        inputs += [as_tensor(end_values, name="end_values")]
 
-    elif mode in ["maximum", "minimum", "mean", "median"]:
+    elif mode in ("maximum", "minimum", "mean", "median"):
         if mode == "median":
             # TODO: Revisit this after we implement a quantile function.
             #  See https://github.com/pymc-devs/pytensor/issues/53
             raise NotImplementedError("Median padding not implemented")
-        stat_length = kwargs.get("stat_length")
         if stat_length is not None:
             has_stat_length = True
             inputs += [as_tensor(stat_length, name="stat_length")]
 
-    elif mode == "symmetric" or mode == "reflect":
-        reflect_type = kwargs.pop("reflect_type", "even")
+    elif mode in ("symmetric", "reflect"):
+        if reflect_type is None:
+            reflect_type = "even"
         if reflect_type == "odd":
             raise NotImplementedError(
                 "Odd reflection not implemented. If you need this feature, please open an "
                 "issue at https://github.com/pymc-devs/pytensor/issues"
             )
 
+    # Every other mode is rejected above if it was given a `reflect_type`, so this stays
+    # None outside the reflecting modes.
     op = Pad(
         pad_mode=mode,
         reflect_type=reflect_type,

--- a/pytensor/tensor/pad.py
+++ b/pytensor/tensor/pad.py
@@ -1,9 +1,8 @@
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Literal, cast
 
 import numpy as np
 
-from pytensor.compile.builders import OpFromGraph
 from pytensor.graph.basic import Constant
 from pytensor.tensor import TensorLike
 from pytensor.tensor.basic import (
@@ -19,6 +18,7 @@ from pytensor.tensor.math import maximum, mean, minimum
 from pytensor.tensor.math import min as pt_min
 from pytensor.tensor.shape import specify_broadcastable
 from pytensor.tensor.subtensor import flip, set_subtensor, slice_at_axis, take
+from pytensor.tensor.symbolic import TensorSymbolicOp
 
 
 PadMode = Literal[
@@ -274,14 +274,19 @@ def _linear_ramp_pad(
     return padded
 
 
-def _static_pad_width(pad_width: TensorVariable, ndim: int) -> np.ndarray | None:
-    """``pad_width`` broadcast to ``(ndim, 2)`` Python ints, or None if not constant."""
+def _static_pad_width(
+    pad_width: TensorVariable, ndim: int
+) -> tuple[tuple[int, int], ...] | None:
+    """``pad_width`` broadcast to ``ndim`` (before, after) pairs, or None if not constant."""
     if not isinstance(pad_width, Constant):
         return None
     widths = np.asarray(pad_width.data)
     if not np.issubdtype(widths.dtype, np.integer):
         raise TypeError("`pad_width` must be of integral type.")
-    return np.broadcast_to(widths.astype("int64"), (ndim, 2))
+    return tuple(
+        (int(before), int(after))
+        for before, after in np.broadcast_to(widths, (ndim, 2))
+    )
 
 
 def _gather_indices(
@@ -333,12 +338,13 @@ def _gather_pad(
     mode: Literal["wrap", "symmetric", "reflect"],
 ) -> TensorVariable:
     """Pad by gathering input elements, one axis at a time."""
+    width_pairs: Sequence[tuple[int | TensorVariable, int | TensorVariable]]
     static_widths = _static_pad_width(pad_width, x.ndim)
     if static_widths is None:
         widths = broadcast_to(pad_width, as_tensor((x.ndim, 2)))
         width_pairs = [(widths[axis, 0], widths[axis, 1]) for axis in range(x.ndim)]
     else:
-        width_pairs = [(int(before), int(after)) for before, after in static_widths]
+        width_pairs = static_widths
 
     for axis, (before, after) in enumerate(width_pairs):
         size = x.type.shape[axis]
@@ -350,19 +356,46 @@ def _gather_pad(
     return x
 
 
-class Pad(OpFromGraph):
-    """
-    Wrapper Op for Pad graphs
-    """
+class Pad(TensorSymbolicOp):
+    """Pad an array, with the padding graph built from the input types."""
+
+    __props__ = ("pad_mode", "reflect_type", "has_stat_length", "static_pad_width")
 
     def __init__(
-        self, inputs, outputs, pad_mode, reflect_type=None, has_stat_length=False
+        self,
+        *,
+        pad_mode: PadMode,
+        reflect_type: str | None = None,
+        has_stat_length: bool = False,
+        static_pad_width: tuple[tuple[int, int], ...] | None = None,
+        **kwargs,
     ):
         self.pad_mode = pad_mode
         self.reflect_type = reflect_type
         self.has_stat_length = has_stat_length
+        # `pad_width` reaches build_inner_graph as a dummy with no value, so a
+        # constant one has to travel alongside it to stay visible inside the graph.
+        self.static_pad_width = static_pad_width
 
-        super().__init__(inputs=inputs, outputs=outputs)
+        super().__init__(**kwargs)
+
+    def build_inner_graph(self, x, pad_width, *extra_inputs):
+        if self.static_pad_width is not None:
+            pad_width = as_tensor(np.asarray(self.static_pad_width, dtype="int64"))
+
+        mode = self.pad_mode
+        if mode == "constant":
+            (constant_values,) = extra_inputs
+            return [_constant_pad(x, pad_width, constant_values)]
+        if mode == "edge":
+            return [_edge_pad(x, pad_width)]
+        if mode == "linear_ramp":
+            (end_values,) = extra_inputs
+            return [_linear_ramp_pad(x, pad_width, end_values)]
+        if mode in ("maximum", "minimum", "mean"):
+            stat_length = extra_inputs[0] if self.has_stat_length else None
+            return [_stat_pad(x, pad_width, stat_funcs[mode], stat_length)]
+        return [_gather_pad(x, pad_width, mode)]
 
 
 def pad(
@@ -566,41 +599,24 @@ def pad(
     x = as_tensor(x, name="x")
     pad_width = as_tensor(pad_width, name="pad_width")
     inputs = [x, pad_width]
-    attrs = {}
+    reflect_type: str | None = None
+    has_stat_length = False
 
     if mode == "constant":
-        constant_values = as_tensor(
-            kwargs.pop("constant_values", 0), name="constant_values"
-        )
-        inputs += [constant_values]
-        outputs = _constant_pad(x, pad_width, constant_values)
+        inputs += [as_tensor(kwargs.pop("constant_values", 0), name="constant_values")]
 
-    elif mode == "edge":
-        outputs = _edge_pad(x, pad_width)
+    elif mode == "linear_ramp":
+        inputs += [as_tensor(kwargs.pop("end_values", 0))]
 
     elif mode in ["maximum", "minimum", "mean", "median"]:
         if mode == "median":
             # TODO: Revisit this after we implement a quantile function.
             #  See https://github.com/pymc-devs/pytensor/issues/53
             raise NotImplementedError("Median padding not implemented")
-        stat_func = cast(Callable, stat_funcs[mode])
         stat_length = kwargs.get("stat_length")
         if stat_length is not None:
-            attrs.update({"has_stat_length": True})
-            stat_length = as_tensor(stat_length, name="stat_length")
-            inputs += [stat_length]
-
-        outputs = _stat_pad(x, pad_width, stat_func, stat_length)
-
-    elif mode == "linear_ramp":
-        end_values = kwargs.pop("end_values", 0)
-        end_values = as_tensor(end_values)
-
-        inputs += [end_values]
-        outputs = _linear_ramp_pad(x, pad_width, end_values)
-
-    elif mode == "wrap":
-        outputs = _gather_pad(x, pad_width, "wrap")
+            has_stat_length = True
+            inputs += [as_tensor(stat_length, name="stat_length")]
 
     elif mode == "symmetric" or mode == "reflect":
         reflect_type = kwargs.pop("reflect_type", "even")
@@ -609,14 +625,14 @@ def pad(
                 "Odd reflection not implemented. If you need this feature, please open an "
                 "issue at https://github.com/pymc-devs/pytensor/issues"
             )
-        attrs.update({"reflect_type": reflect_type})
-        outputs = _gather_pad(x, pad_width, mode)
 
-    else:
-        raise ValueError(f"Invalid mode: {mode}")
-
-    op = Pad(inputs=inputs, outputs=[outputs], pad_mode=mode, **attrs)(*inputs)
-    return cast(TensorVariable, op)
+    op = Pad(
+        pad_mode=mode,
+        reflect_type=reflect_type,
+        has_stat_length=has_stat_length,
+        static_pad_width=_static_pad_width(pad_width, x.ndim),
+    )
+    return cast(TensorVariable, op(*inputs))
 
 
 __all__ = ["flip", "pad"]

--- a/pytensor/tensor/pad.py
+++ b/pytensor/tensor/pad.py
@@ -83,7 +83,13 @@ def _get_edges(
     right_slice = slice_at_axis(slice(right_index - 1, right_index), axis)
     right_edge = padded[right_slice]
 
-    return left_edge, right_edge
+    # The slices are symbolic, so `axis` comes back with an unknown length. Callers
+    # broadcast these edges across the pad area, and the gradient of that
+    # broadcast is only summed when the length is known to be 1.
+    return (
+        specify_broadcastable(left_edge, axis),
+        specify_broadcastable(right_edge, axis),
+    )
 
 
 def _symbolic_pad(

--- a/tests/link/jax/test_pad.py
+++ b/tests/link/jax/test_pad.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-from packaging import version
 
 import pytensor.tensor as pt
 from pytensor import config
@@ -18,14 +17,7 @@ RTOL = ATOL = 1e-6 if floatX.endswith("64") else 1e-3
     "mode, kwargs",
     [
         ("constant", {"constant_values": 0}),
-        pytest.param(
-            "constant",
-            {"constant_values": (1, 2)},
-            marks=pytest.mark.skipif(
-                version.parse(jax.__version__) > version.parse("0.4.35"),
-                reason="Bug in JAX: https://github.com/jax-ml/jax/issues/26888",
-            ),
-        ),
+        ("constant", {"constant_values": (1, 2)}),
         ("edge", {}),
         ("linear_ramp", {"end_values": 0}),
         ("linear_ramp", {"end_values": (1, 2)}),

--- a/tests/link/jax/test_pad.py
+++ b/tests/link/jax/test_pad.py
@@ -4,6 +4,7 @@ from packaging import version
 
 import pytensor.tensor as pt
 from pytensor import config
+from pytensor.gradient import grad
 from pytensor.tensor.pad import PadMode
 from tests.link.jax.test_basic import compare_jax_and_py
 
@@ -66,5 +67,39 @@ def test_jax_pad(mode: PadMode, kwargs):
         [res],
         [x],
         assert_fn=lambda x, y: np.testing.assert_allclose(x, y, rtol=RTOL, atol=ATOL),
+        py_mode="FAST_RUN",
+    )
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "constant",
+        "edge",
+        "linear_ramp",
+        "mean",
+        "maximum",
+        "minimum",
+        "wrap",
+        "symmetric",
+        "reflect",
+    ],
+)
+def test_jax_pad_grad(mode: PadMode):
+    x_pt = pt.tensor("x", shape=(8, 8))
+    x = np.random.normal(size=(8, 8))
+
+    res = pt.pad(x_pt, mode=mode, pad_width=[[1, 1], [2, 2]])
+    grad_x = grad(res.sum(), x_pt)
+
+    # The gradient allocates its zero buffer from the padded shape, which jax can
+    # only trace once constant folding has resolved that shape to literals, so the
+    # module's thinner `jax_mode` is not enough here.
+    compare_jax_and_py(
+        [x_pt],
+        [grad_x],
+        [x],
+        assert_fn=lambda x, y: np.testing.assert_allclose(x, y, rtol=RTOL, atol=ATOL),
+        jax_mode="JAX",
         py_mode="FAST_RUN",
     )

--- a/tests/link/jax/test_pad.py
+++ b/tests/link/jax/test_pad.py
@@ -101,5 +101,4 @@ def test_jax_pad_grad(mode: PadMode):
         [x],
         assert_fn=lambda x, y: np.testing.assert_allclose(x, y, rtol=RTOL, atol=ATOL),
         jax_mode="JAX",
-        py_mode="FAST_RUN",
     )

--- a/tests/tensor/test_pad.py
+++ b/tests/tensor/test_pad.py
@@ -316,24 +316,6 @@ def test_pad_grad_has_static_slice_bounds(mode):
     assert _dynamic_subtensors([x], grad_x) == []
 
 
-@pytest.mark.parametrize("mode", ALL_MODES)
-def test_pad_grad_jax(mode):
-    """The gradient of every pad mode should compile and run under jax.jit."""
-    pytest.importorskip("jax")
-
-    x = pt.tensor("x", shape=(8, 8))
-    z = pad(x, [[1, 1], [2, 2]], mode=mode, **MODE_KWARGS.get(mode, {}))
-    grad_x = grad(z.sum(), x)
-
-    test_x = np.random.default_rng(7).normal(size=(8, 8)).astype(floatX)
-    expected = pytensor.function(
-        [x], grad_x, mode=Mode(linker="py", optimizer="fast_run")
-    )(test_x)
-    got = pytensor.function([x], grad_x, mode="JAX")(test_x)
-
-    np.testing.assert_allclose(got, expected, atol=ATOL, rtol=RTOL)
-
-
 @pytest.mark.xfail(reason="pad does not constant-fold a symbolic pad_width")
 @pytest.mark.parametrize("mode", ["constant", "edge"])
 def test_pad_static_shape_from_foldable_pad_width(mode):

--- a/tests/tensor/test_pad.py
+++ b/tests/tensor/test_pad.py
@@ -267,11 +267,7 @@ GATHER_BASED_MODES = ["wrap", "symmetric", "reflect"]
 
 
 def _pad_width_as_symbolic_expression(ndim, width):
-    """Build a pad_width that is symbolic but constant-foldable.
-
-    This is the shape ``convolve2d`` used to construct, and it is the reason
-    static shapes were lost downstream.
-    """
+    """Build a uniform pad_width of ``width`` that is symbolic but constant-foldable."""
     pad_width = pt.zeros((ndim, 2), dtype="int64")
     for axis in range(ndim):
         pad_width = pad_width[axis, 0].set(width)
@@ -280,10 +276,10 @@ def _pad_width_as_symbolic_expression(ndim, width):
 
 
 def _dynamic_subtensors(inputs, outputs):
-    """Subtensor idx_lists whose index inputs are not all constants.
+    """Collect the ``idx_list`` of every Subtensor whose indices are not all constants.
 
-    Descends into ``OpFromGraph`` inner graphs, which is where ``Pad`` hides the
-    interior slice it takes in its gradient.
+    Descends into ``OpFromGraph`` inner graphs, where ``Pad`` keeps the interior
+    slice it takes in its gradient.
     """
     fn = pytensor.function(
         inputs, outputs, mode=Mode(linker="py", optimizer="fast_run")
@@ -316,9 +312,8 @@ def test_pad_static_shape(mode):
 def test_pad_grad_has_static_slice_bounds(mode):
     """The gradient must not index the padded interior with runtime values.
 
-    A statically known ``pad_width`` travels as an Op property, so the inner
-    graph indexes with literals and the gradient's slice bounds stay constant.
-    Backends that require static slice bounds could not compile them otherwise.
+    Backends that require static slice bounds cannot compile a gradient whose
+    interior slice is bounded by a runtime value.
     """
     x = pt.tensor("x", shape=(8, 8))
     z = pad(x, [[1, 1], [2, 2]], mode=mode)
@@ -330,11 +325,7 @@ def test_pad_grad_has_static_slice_bounds(mode):
 @pytest.mark.xfail(reason="pad does not constant-fold a symbolic pad_width")
 @pytest.mark.parametrize("mode", ["constant", "edge"])
 def test_pad_static_shape_from_foldable_pad_width(mode):
-    """A constant-foldable pad_width expression should still give static shapes.
-
-    Without this, callers are forced to build ``pad_width`` as a literal nested
-    list to keep static shapes, which is what ``convolve2d`` had to work around.
-    """
+    """A constant-foldable pad_width expression should still give static shapes."""
     x = pt.tensor("x", shape=(8, 8))
     pad_width = _pad_width_as_symbolic_expression(2, 1)
     z = pad(x, pad_width, mode=mode)
@@ -350,11 +341,7 @@ def test_pad_static_shape_from_foldable_pad_width(mode):
 )
 @pytest.mark.parametrize("size", [(1,), (2,), (5,), (3, 4)], ids=str)
 def test_gather_pad_wider_than_axis(mode, pad_width, size):
-    """Padding wider than the axis wraps/reflects repeatedly.
-
-    This is the case the previous replicate-and-trim implementation needed its
-    repeat/remainder bookkeeping for; the index map handles it directly.
-    """
+    """Padding wider than the axis wraps/reflects repeatedly."""
     x = np.arange(np.prod(size), dtype=floatX).reshape(size)
     expected = np.pad(x, pad_width, mode=mode)
 

--- a/tests/tensor/test_pad.py
+++ b/tests/tensor/test_pad.py
@@ -5,7 +5,12 @@ import pytest
 
 import pytensor
 import pytensor.tensor as pt
+from pytensor.compile.builders import OpFromGraph
+from pytensor.compile.mode import Mode
+from pytensor.gradient import grad
+from pytensor.graph.basic import Constant
 from pytensor.tensor.pad import PadMode, pad
+from pytensor.tensor.subtensor import Subtensor
 
 
 floatX = pytensor.config.floatX
@@ -243,6 +248,43 @@ MODE_KWARGS = {
 }
 
 
+def _pad_width_as_symbolic_expression(ndim, width):
+    """Build a pad_width that is symbolic but constant-foldable.
+
+    This is the shape ``convolve2d`` used to construct, and it is the reason
+    static shapes were lost downstream.
+    """
+    pad_width = pt.zeros((ndim, 2), dtype="int64")
+    for axis in range(ndim):
+        pad_width = pad_width[axis, 0].set(width)
+        pad_width = pad_width[axis, 1].set(width)
+    return pad_width
+
+
+def _dynamic_subtensors(inputs, outputs):
+    """Subtensor idx_lists whose index inputs are not all constants.
+
+    Descends into ``OpFromGraph`` inner graphs, which is where ``Pad`` hides the
+    interior slice it takes in its gradient.
+    """
+    fn = pytensor.function(
+        inputs, outputs, mode=Mode(linker="py", optimizer="fast_run")
+    )
+    found = []
+
+    def walk(nodes):
+        for node in nodes:
+            if isinstance(node.op, Subtensor) and any(
+                not isinstance(i, Constant) for i in node.inputs[1:]
+            ):
+                found.append(node.op.idx_list)
+            if isinstance(node.op, OpFromGraph):
+                walk(node.op.fgraph.apply_nodes)
+
+    walk(fn.maker.fgraph.apply_nodes)
+    return found
+
+
 @pytest.mark.parametrize("mode", ALL_MODES)
 def test_pad_static_shape(mode):
     """A statically known pad_width should give a statically known output shape."""
@@ -256,6 +298,85 @@ def test_pad_static_shape(mode):
 # constants. The slice-based modes still read pad_width at runtime.
 SLICE_BASED_MODES = ["constant", "edge", "linear_ramp", "mean", "maximum", "minimum"]
 GATHER_BASED_MODES = ["wrap", "symmetric", "reflect"]
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        *[
+            pytest.param(
+                m,
+                marks=pytest.mark.xfail(
+                    reason="pad_width is an opaque OpFromGraph input, so constant "
+                    "folding cannot reach the interior slice bounds in the gradient"
+                ),
+            )
+            for m in SLICE_BASED_MODES
+        ],
+        *GATHER_BASED_MODES,
+    ],
+)
+def test_pad_grad_has_static_slice_bounds(mode):
+    """The gradient must not index the padded interior with runtime values.
+
+    ``Pad`` takes ``pad_width`` as a graph input, so inside the inner graph its
+    value is opaque even when the caller passed a literal. The gradient then
+    slices the interior with widths read out of a tensor at runtime, which
+    backends requiring static slice bounds cannot compile.
+    """
+    x = pt.tensor("x", shape=(8, 8))
+    z = pad(x, [[1, 1], [2, 2]], mode=mode, **MODE_KWARGS.get(mode, {}))
+    grad_x = grad(z.sum(), x)
+
+    assert _dynamic_subtensors([x], grad_x) == []
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        *[
+            pytest.param(
+                m,
+                marks=pytest.mark.xfail(
+                    reason="slice-based pad gradients index with runtime pad_width, "
+                    "which jax.jit cannot compile"
+                ),
+            )
+            for m in SLICE_BASED_MODES
+        ],
+        *GATHER_BASED_MODES,
+    ],
+)
+def test_pad_grad_jax(mode):
+    """The gradient of every pad mode should compile and run under jax.jit."""
+    pytest.importorskip("jax")
+
+    x = pt.tensor("x", shape=(8, 8))
+    z = pad(x, [[1, 1], [2, 2]], mode=mode, **MODE_KWARGS.get(mode, {}))
+    grad_x = grad(z.sum(), x)
+
+    test_x = np.random.default_rng(7).normal(size=(8, 8)).astype(floatX)
+    expected = pytensor.function(
+        [x], grad_x, mode=Mode(linker="py", optimizer="fast_run")
+    )(test_x)
+    got = pytensor.function([x], grad_x, mode="JAX")(test_x)
+
+    np.testing.assert_allclose(got, expected, atol=ATOL, rtol=RTOL)
+
+
+@pytest.mark.xfail(reason="pad does not constant-fold a symbolic pad_width")
+@pytest.mark.parametrize("mode", ["constant", "edge"])
+def test_pad_static_shape_from_foldable_pad_width(mode):
+    """A constant-foldable pad_width expression should still give static shapes.
+
+    Without this, callers are forced to build ``pad_width`` as a literal nested
+    list to keep static shapes, which is what ``convolve2d`` had to work around.
+    """
+    x = pt.tensor("x", shape=(8, 8))
+    pad_width = _pad_width_as_symbolic_expression(2, 1)
+    z = pad(x, pad_width, mode=mode, **MODE_KWARGS.get(mode, {}))
+
+    assert z.type.shape == (10, 10)
 
 
 @pytest.mark.parametrize("mode", GATHER_BASED_MODES)

--- a/tests/tensor/test_pad.py
+++ b/tests/tensor/test_pad.py
@@ -298,35 +298,16 @@ def test_pad_static_shape(mode):
     assert z.type.shape == (10, 12)
 
 
-# The gather-based modes index the input directly, so their slice bounds are
-# constants. The slice-based modes still read pad_width at runtime.
-SLICE_BASED_MODES = ["constant", "edge", "linear_ramp", "mean", "maximum", "minimum"]
 GATHER_BASED_MODES = ["wrap", "symmetric", "reflect"]
 
 
-@pytest.mark.parametrize(
-    "mode",
-    [
-        *[
-            pytest.param(
-                m,
-                marks=pytest.mark.xfail(
-                    reason="pad_width is an opaque OpFromGraph input, so constant "
-                    "folding cannot reach the interior slice bounds in the gradient"
-                ),
-            )
-            for m in SLICE_BASED_MODES
-        ],
-        *GATHER_BASED_MODES,
-    ],
-)
+@pytest.mark.parametrize("mode", ALL_MODES)
 def test_pad_grad_has_static_slice_bounds(mode):
     """The gradient must not index the padded interior with runtime values.
 
-    ``Pad`` takes ``pad_width`` as a graph input, so inside the inner graph its
-    value is opaque even when the caller passed a literal. The gradient then
-    slices the interior with widths read out of a tensor at runtime, which
-    backends requiring static slice bounds cannot compile.
+    A statically known ``pad_width`` travels as an Op property, so the inner
+    graph indexes with literals and the gradient's slice bounds stay constant.
+    Backends that require static slice bounds could not compile them otherwise.
     """
     x = pt.tensor("x", shape=(8, 8))
     z = pad(x, [[1, 1], [2, 2]], mode=mode, **MODE_KWARGS.get(mode, {}))
@@ -338,17 +319,18 @@ def test_pad_grad_has_static_slice_bounds(mode):
 @pytest.mark.parametrize(
     "mode",
     [
-        *[
-            pytest.param(
-                m,
-                marks=pytest.mark.xfail(
-                    reason="slice-based pad gradients index with runtime pad_width, "
-                    "which jax.jit cannot compile"
-                ),
-            )
-            for m in SLICE_BASED_MODES
-        ],
-        *GATHER_BASED_MODES,
+        pytest.param(
+            m,
+            marks=(
+                pytest.mark.xfail(
+                    reason="edge gradient broadcasts the border slice against the "
+                    "wrong width, so it fails on every backend"
+                )
+                if m == "edge"
+                else ()
+            ),
+        )
+        for m in ALL_MODES
     ],
 )
 def test_pad_grad_jax(mode):

--- a/tests/tensor/test_pad.py
+++ b/tests/tensor/test_pad.py
@@ -425,3 +425,35 @@ def test_pad_rejects_non_integral_pad_width(mode):
 
     with pytest.raises(TypeError):
         pad(x, (1.5, 1.5), mode=mode, **MODE_KWARGS.get(mode, {}))
+
+
+@pytest.mark.xfail(
+    reason="edge gradient broadcasts the border slice against the wrong width"
+)
+@pytest.mark.parametrize(
+    "pad_width",
+    [((1, 1), (2, 2)), ((0, 3), (2, 1)), 2],
+    ids=["axes", "sides", "scalar"],
+)
+def test_edge_pad_grad(pad_width):
+    """``edge`` gradients fail for any pad width other than 1 on every side.
+
+    Each input element is copied a fixed number of times into the output, so
+    ``d(sum(pad(x)))/dx`` is exactly that copy count.
+    """
+    x = pt.tensor("x", shape=(8, 8))
+    grad_x = grad(pad(x, pad_width, mode="edge").sum(), x)
+
+    x_val = np.arange(64, dtype=floatX).reshape(8, 8)
+    got = pytensor.function([x], grad_x, mode=Mode(linker="py", optimizer="fast_run"))(
+        x_val
+    )
+
+    width = pad_width if not isinstance(pad_width, int) else ((pad_width,) * 2,) * 2
+    expected = np.zeros_like(x_val)
+    for i in range(8):
+        for j in range(8):
+            probe = np.zeros_like(x_val)
+            probe[i, j] = 1.0
+            expected[i, j] = np.pad(probe, width, mode="edge").sum()
+    np.testing.assert_allclose(got, expected, atol=ATOL, rtol=RTOL)

--- a/tests/tensor/test_pad.py
+++ b/tests/tensor/test_pad.py
@@ -17,10 +17,14 @@ floatX = pytensor.config.floatX
 RTOL = ATOL = 1e-8 if floatX.endswith("64") else 1e-4
 
 
-def test_unknown_mode_raises():
+@pytest.mark.parametrize(
+    "kwargs", [{}, {"foo": 1}, {"constant_values": 0}], ids=["none", "unknown", "valid"]
+)
+def test_unknown_mode_raises(kwargs):
+    """An unknown mode is reported as such whatever keyword arguments come with it."""
     x = np.random.normal(size=(3, 3)).astype(floatX)
     with pytest.raises(ValueError, match="Invalid mode: unknown"):
-        pad(x, 1, mode="unknown")
+        pad(x, 1, mode="unknown", **kwargs)
 
 
 @pytest.mark.parametrize(

--- a/tests/tensor/test_pad.py
+++ b/tests/tensor/test_pad.py
@@ -316,23 +316,7 @@ def test_pad_grad_has_static_slice_bounds(mode):
     assert _dynamic_subtensors([x], grad_x) == []
 
 
-@pytest.mark.parametrize(
-    "mode",
-    [
-        pytest.param(
-            m,
-            marks=(
-                pytest.mark.xfail(
-                    reason="edge gradient broadcasts the border slice against the "
-                    "wrong width, so it fails on every backend"
-                )
-                if m == "edge"
-                else ()
-            ),
-        )
-        for m in ALL_MODES
-    ],
-)
+@pytest.mark.parametrize("mode", ALL_MODES)
 def test_pad_grad_jax(mode):
     """The gradient of every pad mode should compile and run under jax.jit."""
     pytest.importorskip("jax")
@@ -413,18 +397,13 @@ def test_pad_rejects_non_integral_pad_width(mode):
         pad(x, (1.5, 1.5), mode=mode, **MODE_KWARGS.get(mode, {}))
 
 
-@pytest.mark.xfail(
-    reason="edge gradient broadcasts the border slice against the wrong width"
-)
 @pytest.mark.parametrize(
     "pad_width",
-    [((1, 1), (2, 2)), ((0, 3), (2, 1)), 2],
-    ids=["axes", "sides", "scalar"],
+    [((1, 1), (1, 1)), ((1, 1), (2, 2)), ((0, 3), (2, 1)), 2, ((5, 5), (5, 5))],
+    ids=["all_ones", "axes", "sides", "scalar", "wider_than_axis"],
 )
 def test_edge_pad_grad(pad_width):
-    """``edge`` gradients fail for any pad width other than 1 on every side.
-
-    Each input element is copied a fixed number of times into the output, so
+    """Each input element is copied a fixed number of times into the output, so
     ``d(sum(pad(x)))/dx`` is exactly that copy count.
     """
     x = pt.tensor("x", shape=(8, 8))

--- a/tests/tensor/test_pad.py
+++ b/tests/tensor/test_pad.py
@@ -11,6 +11,7 @@ from pytensor.gradient import grad
 from pytensor.graph.basic import Constant
 from pytensor.tensor.pad import PadMode, pad
 from pytensor.tensor.subtensor import Subtensor
+from tests import unittest_tools as utt
 
 
 floatX = pytensor.config.floatX
@@ -352,20 +353,28 @@ def test_gather_pad_wider_than_axis(mode, pad_width, size):
 
 
 @pytest.mark.parametrize("mode", GATHER_BASED_MODES)
-def test_gather_pad_symbolic_pad_width(mode):
-    """A symbolic pad_width still works, without static shapes."""
-    x = pt.tensor("x", shape=(5,))
+@pytest.mark.parametrize(
+    "width", [(1, 1), (7, 2)], ids=["within_axis", "wider_than_axis"]
+)
+@pytest.mark.parametrize("size", [5, 1], ids=["size_5", "size_1"])
+def test_gather_pad_symbolic_pad_width(mode, width, size):
+    """A symbolic pad_width still works, without static shapes.
+
+    A size-1 axis degenerates the reflect period, which the symbolic branch of the
+    index map has to clamp separately from the static one.
+    """
+    x = pt.tensor("x", shape=(size,))
     pad_width = pt.vector("pad_width", shape=(2,), dtype="int64")
     z = pad(x, pad_width, mode=mode)
+    assert z.type.shape == (None,)
 
-    x_val = np.arange(5, dtype=floatX)
-    for width in [(1, 1), (7, 2)]:
-        np.testing.assert_allclose(
-            z.eval({x: x_val, pad_width: np.array(width, dtype="int64")}),
-            np.pad(x_val, width, mode=mode),
-            atol=ATOL,
-            rtol=RTOL,
-        )
+    x_val = np.arange(size, dtype=floatX)
+    np.testing.assert_allclose(
+        z.eval({x: x_val, pad_width: np.array(width, dtype="int64")}),
+        np.pad(x_val, width, mode=mode),
+        atol=ATOL,
+        rtol=RTOL,
+    )
 
 
 @pytest.mark.parametrize("mode", ALL_MODES)
@@ -373,8 +382,21 @@ def test_pad_rejects_non_integral_pad_width(mode):
     """A float pad_width must be rejected, not silently truncated."""
     x = pt.tensor("x", shape=(5,))
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="must be of integral type"):
         pad(x, (1.5, 1.5), mode=mode)
+
+
+@pytest.mark.parametrize("mode", ALL_MODES)
+def test_pad_grad_matches_numeric(mode):
+    """Every mode's gradient must match finite differences."""
+    rng = np.random.default_rng(11)
+    x_val = rng.normal(size=(4, 4))
+
+    utt.verify_grad(
+        lambda x: pad(x, ((1, 2), (2, 1)), mode=mode),
+        [x_val],
+        rng=np.random.default_rng(11),
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/tensor/test_pad.py
+++ b/tests/tensor/test_pad.py
@@ -17,14 +17,31 @@ floatX = pytensor.config.floatX
 RTOL = ATOL = 1e-8 if floatX.endswith("64") else 1e-4
 
 
-@pytest.mark.parametrize(
-    "kwargs", [{}, {"foo": 1}, {"constant_values": 0}], ids=["none", "unknown", "valid"]
-)
+@pytest.mark.parametrize("kwargs", [{}, {"constant_values": 0}], ids=["none", "valid"])
 def test_unknown_mode_raises(kwargs):
-    """An unknown mode is reported as such whatever keyword arguments come with it."""
+    """An unknown mode is reported as such, before its options are looked up."""
     x = np.random.normal(size=(3, 3)).astype(floatX)
     with pytest.raises(ValueError, match="Invalid mode: unknown"):
         pad(x, 1, mode="unknown", **kwargs)
+
+
+@pytest.mark.parametrize(
+    "mode, kwargs",
+    [
+        ("edge", {"constant_values": 1}),
+        ("constant", {"end_values": 1}),
+        ("wrap", {"stat_length": 2}),
+        ("mean", {"reflect_type": "even"}),
+    ],
+    ids=str,
+)
+def test_option_not_valid_for_mode_raises(mode, kwargs):
+    """An option a mode does not accept is rejected rather than silently ignored."""
+    x = np.random.normal(size=(3, 3)).astype(floatX)
+    with pytest.raises(
+        ValueError, match=f"Invalid keyword arguments for mode '{mode}'"
+    ):
+        pad(x, 1, mode=mode, **kwargs)
 
 
 @pytest.mark.parametrize(
@@ -246,10 +263,7 @@ ALL_MODES = [
     "reflect",
 ]
 
-MODE_KWARGS = {
-    "constant": {"constant_values": 0},
-    "linear_ramp": {"end_values": 0},
-}
+GATHER_BASED_MODES = ["wrap", "symmetric", "reflect"]
 
 
 def _pad_width_as_symbolic_expression(ndim, width):
@@ -293,12 +307,9 @@ def _dynamic_subtensors(inputs, outputs):
 def test_pad_static_shape(mode):
     """A statically known pad_width should give a statically known output shape."""
     x = pt.tensor("x", shape=(8, 8))
-    z = pad(x, [[1, 1], [2, 2]], mode=mode, **MODE_KWARGS.get(mode, {}))
+    z = pad(x, [[1, 1], [2, 2]], mode=mode)
 
     assert z.type.shape == (10, 12)
-
-
-GATHER_BASED_MODES = ["wrap", "symmetric", "reflect"]
 
 
 @pytest.mark.parametrize("mode", ALL_MODES)
@@ -310,7 +321,7 @@ def test_pad_grad_has_static_slice_bounds(mode):
     Backends that require static slice bounds could not compile them otherwise.
     """
     x = pt.tensor("x", shape=(8, 8))
-    z = pad(x, [[1, 1], [2, 2]], mode=mode, **MODE_KWARGS.get(mode, {}))
+    z = pad(x, [[1, 1], [2, 2]], mode=mode)
     grad_x = grad(z.sum(), x)
 
     assert _dynamic_subtensors([x], grad_x) == []
@@ -326,7 +337,7 @@ def test_pad_static_shape_from_foldable_pad_width(mode):
     """
     x = pt.tensor("x", shape=(8, 8))
     pad_width = _pad_width_as_symbolic_expression(2, 1)
-    z = pad(x, pad_width, mode=mode, **MODE_KWARGS.get(mode, {}))
+    z = pad(x, pad_width, mode=mode)
 
     assert z.type.shape == (10, 10)
 
@@ -376,7 +387,7 @@ def test_pad_rejects_non_integral_pad_width(mode):
     x = pt.tensor("x", shape=(5,))
 
     with pytest.raises(TypeError):
-        pad(x, (1.5, 1.5), mode=mode, **MODE_KWARGS.get(mode, {}))
+        pad(x, (1.5, 1.5), mode=mode)
 
 
 @pytest.mark.parametrize(

--- a/tests/tensor/test_pad.py
+++ b/tests/tensor/test_pad.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import pytensor
+import pytensor.tensor as pt
 from pytensor.tensor.pad import PadMode, pad
 
 
@@ -222,3 +223,84 @@ def test_nd_padding(mode, padding):
     f = pytensor.function([], z, mode="FAST_COMPILE")
 
     np.testing.assert_allclose(expected, f(), atol=ATOL, rtol=RTOL)
+
+
+ALL_MODES = [
+    "constant",
+    "edge",
+    "linear_ramp",
+    "mean",
+    "maximum",
+    "minimum",
+    "wrap",
+    "symmetric",
+    "reflect",
+]
+
+MODE_KWARGS = {
+    "constant": {"constant_values": 0},
+    "linear_ramp": {"end_values": 0},
+}
+
+
+@pytest.mark.parametrize("mode", ALL_MODES)
+def test_pad_static_shape(mode):
+    """A statically known pad_width should give a statically known output shape."""
+    x = pt.tensor("x", shape=(8, 8))
+    z = pad(x, [[1, 1], [2, 2]], mode=mode, **MODE_KWARGS.get(mode, {}))
+
+    assert z.type.shape == (10, 12)
+
+
+# The gather-based modes index the input directly, so their slice bounds are
+# constants. The slice-based modes still read pad_width at runtime.
+SLICE_BASED_MODES = ["constant", "edge", "linear_ramp", "mean", "maximum", "minimum"]
+GATHER_BASED_MODES = ["wrap", "symmetric", "reflect"]
+
+
+@pytest.mark.parametrize("mode", GATHER_BASED_MODES)
+@pytest.mark.parametrize(
+    "pad_width",
+    [(1, 1), (7, 7), (13, 4), (0, 9)],
+    ids=["within_axis", "wider_than_axis", "asymmetric_wide", "one_sided_wide"],
+)
+@pytest.mark.parametrize("size", [(1,), (2,), (5,), (3, 4)], ids=str)
+def test_gather_pad_wider_than_axis(mode, pad_width, size):
+    """Padding wider than the axis wraps/reflects repeatedly.
+
+    This is the case the previous replicate-and-trim implementation needed its
+    repeat/remainder bookkeeping for; the index map handles it directly.
+    """
+    x = np.arange(np.prod(size), dtype=floatX).reshape(size)
+    expected = np.pad(x, pad_width, mode=mode)
+
+    z = pad(pt.as_tensor(x), pad_width, mode=mode)
+    assert z.type.shape == expected.shape
+
+    np.testing.assert_allclose(z.eval(), expected, atol=ATOL, rtol=RTOL)
+
+
+@pytest.mark.parametrize("mode", GATHER_BASED_MODES)
+def test_gather_pad_symbolic_pad_width(mode):
+    """A symbolic pad_width still works, without static shapes."""
+    x = pt.tensor("x", shape=(5,))
+    pad_width = pt.vector("pad_width", shape=(2,), dtype="int64")
+    z = pad(x, pad_width, mode=mode)
+
+    x_val = np.arange(5, dtype=floatX)
+    for width in [(1, 1), (7, 2)]:
+        np.testing.assert_allclose(
+            z.eval({x: x_val, pad_width: np.array(width, dtype="int64")}),
+            np.pad(x_val, width, mode=mode),
+            atol=ATOL,
+            rtol=RTOL,
+        )
+
+
+@pytest.mark.parametrize("mode", ALL_MODES)
+def test_pad_rejects_non_integral_pad_width(mode):
+    """A float pad_width must be rejected, not silently truncated."""
+    x = pt.tensor("x", shape=(5,))
+
+    with pytest.raises(TypeError):
+        pad(x, (1.5, 1.5), mode=mode, **MODE_KWARGS.get(mode, {}))


### PR DESCRIPTION
This PR refactors THE MOST IMPORTANT OP IN PYTENSOR that is definitely used widely by everyone: `Pad`

- Talking with a robot, it pointed out that pad is just an advanced indexing Op, and all the calculation we were doing with scan/etc was super wasteful. It proposed a much cleaner implementation with better benchmarks.
- I was hitting scan static shape errors in the gradient of `Pad` due to `n_steps` not constant folding, so removing the scan has the benefit of unlocking the pullbacks for jax/mlx
- Change `OpFromGraph` to `TensorSymbolicOp`

There's a bit of ugliness with specify_broadcastable, im curious if there's a better way to do that.

Benchmark before/after the patch:

## BEFORE — `main` @ `7a730b57d`

```
------------------------------------------------------------------------------------------------------- benchmark: 14 tests --------------------------------------------------------------------------------------------------------
Name (time in us)                                       Min                   Max                  Mean              StdDev                Median                 IQR            Outliers          OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_pad_benchmark[cvm-constant-forward]            17.3748 (1.06)       317.3337 (2.80)        19.8914 (1.0)        3.2486 (1.06)        20.0002 (1.0)        0.4997 (1.0)     1109;9989  50,273.0082 (1.0)       35295           1
test_pad_benchmark[cvm-constant-grad]               47.3750 (2.90)       369.4580 (3.26)        62.6333 (3.15)      17.2934 (5.65)        55.1250 (2.76)      13.9583 (27.94)    2065;745  15,965.9358 (0.32)      15405           1
test_pad_benchmark[cvm-symmetric-forward]          297.9999 (18.24)    1,317.6249 (11.62)      458.8499 (23.07)     98.8555 (32.32)      436.7288 (21.84)     82.2290 (164.57)    274;138   2,179.3618 (0.04)       2152           1
test_pad_benchmark[cvm-symmetric-grad]           1,684.7909 (103.15)   3,478.9159 (30.69)    2,173.9340 (109.29)   295.7918 (96.72)    2,104.6256 (105.23)   310.8340 (622.10)     110;29     459.9956 (0.01)        470           1
test_pad_benchmark[jax-constant-forward]            16.3340 (1.0)        296.2081 (2.61)        23.7090 (1.19)       6.8037 (2.22)        23.4172 (1.17)       1.6238 (3.25)     365;1101  42,178.0643 (0.84)       8979           1
test_pad_benchmark[jax-symmetric-forward]           56.7078 (3.47)       532.8334 (4.70)        96.8118 (4.87)      28.9289 (9.46)        90.5418 (4.53)      35.4163 (70.88)     643;135  10,329.3247 (0.21)       9930           1
test_pad_benchmark[mlx-constant-forward]           121.4156 (7.43)       513.7501 (4.53)       177.5512 (8.93)      83.7873 (27.40)      149.2919 (7.46)      45.2092 (90.48)       19;20   5,632.1771 (0.11)        170           1
test_pad_benchmark[mlx-constant-grad]            3,568.0840 (218.45)   6,876.1660 (60.65)    6,023.7106 (302.83)   329.4565 (107.73)   6,074.8751 (303.74)   304.6874 (609.80)      40;10     166.0106 (0.00)        217           1
test_pad_benchmark[numba-constant-forward]          24.2079 (1.48)       113.3750 (1.0)         27.0414 (1.36)       3.0583 (1.0)         27.2919 (1.36)       2.7083 (5.42)      806;480  36,980.3371 (0.74)      11076           1
test_pad_benchmark[numba-constant-grad]             47.7084 (2.92)       231.5831 (2.04)        55.0675 (2.77)       6.9418 (2.27)        53.9171 (2.70)       1.8333 (3.67)    1519;3993  18,159.5334 (0.36)      14102           1
test_pad_benchmark[numba-symmetric-forward]        260.0839 (15.92)      793.4999 (7.00)       340.0455 (17.10)     58.0973 (19.00)      330.6875 (16.53)     49.9170 (99.90)     350;122   2,940.7831 (0.06)       2542           1
test_pad_benchmark[numba-symmetric-grad]         1,557.0000 (95.32)    2,727.4578 (24.06)    1,864.3581 (93.73)    195.6389 (63.97)    1,821.2497 (91.06)    177.3232 (354.89)      98;42     536.3776 (0.01)        533           1
test_pad_benchmark[pytorch-constant-forward]       304.5001 (18.64)    1,368.9999 (12.07)      474.5742 (23.86)     93.4736 (30.56)      451.7077 (22.59)     81.1142 (162.34)     214;77   2,107.1521 (0.04)       1153           1
test_pad_benchmark[pytorch-constant-grad]          555.2089 (33.99)    1,930.1670 (17.02)      801.6095 (40.30)    130.5579 (42.69)      775.6669 (38.78)    136.5097 (273.21)     137;21   1,247.4901 (0.02)        609           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

`14 passed, 6 skipped, 17 warnings in 22.83s`

Skipped:

- `jax/constant/grad unsupported: IndexError`
- `jax/symmetric/grad unsupported: TypeError`
- `mlx/symmetric/forward unsupported: NotImplementedError`
- `mlx/symmetric/grad unsupported: NotImplementedError`
- `pytorch/symmetric/forward unsupported: AttributeError`
- `pytorch/symmetric/grad unsupported: NotImplementedError`

## AFTER — `symbolic-pad` @ `756da0844`

```
------------------------------------------------------------------------------------------------------- benchmark: 16 tests --------------------------------------------------------------------------------------------------------
Name (time in us)                                       Min                   Max                  Mean              StdDev                Median                 IQR            Outliers          OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_pad_benchmark[cvm-constant-forward]            14.2921 (1.0)        142.4998 (1.88)        16.4509 (1.0)        2.1386 (1.0)         16.7498 (1.0)        1.6671 (1.21)    1650;1306  60,786.9409 (1.0)       46153           1
test_pad_benchmark[cvm-constant-grad]               41.7079 (2.92)       221.8341 (2.92)        47.0885 (2.86)       3.7586 (1.76)        47.1668 (2.82)       1.3751 (1.0)     1983;2563  21,236.6082 (0.35)       9784           1
test_pad_benchmark[cvm-symmetric-forward]          118.6249 (8.30)       408.5000 (5.38)       138.3497 (8.41)      12.2368 (5.72)       134.5421 (8.03)       9.7915 (7.12)     1678;914   7,228.0595 (0.12)       7269           1
test_pad_benchmark[cvm-symmetric-grad]             796.8331 (55.75)    1,229.1670 (16.20)      900.7076 (54.75)     39.3259 (18.39)      891.2496 (53.21)     24.1568 (17.57)     171;122   1,110.2382 (0.02)       1115           1
test_pad_benchmark[jax-constant-forward]            16.2083 (1.13)       232.7501 (3.07)        23.4265 (1.42)       7.4820 (3.50)        23.2081 (1.39)       1.9162 (1.39)       98;706  42,686.6245 (0.70)       5322           1
test_pad_benchmark[jax-constant-grad]              751.8753 (52.61)      991.7081 (13.07)      902.1917 (54.84)     94.1413 (44.02)      911.9590 (54.45)    122.2085 (88.87)         1;0   1,108.4118 (0.02)          5           1
test_pad_benchmark[jax-symmetric-forward]           65.7919 (4.60)       424.5420 (5.60)        78.3073 (4.76)      15.2750 (7.14)        72.8332 (4.35)      13.7080 (9.97)       229;84  12,770.2083 (0.21)       5119           1
test_pad_benchmark[jax-symmetric-grad]             523.7088 (36.64)    1,390.5410 (18.33)      705.7758 (42.90)    130.7219 (61.13)      678.3330 (40.50)    207.7091 (151.05)      371;5   1,416.8805 (0.02)       1061           1
test_pad_benchmark[mlx-constant-forward]           142.3750 (9.96)       578.0002 (7.62)       182.9280 (11.12)    105.6624 (49.41)      148.3127 (8.85)       3.7909 (2.76)          2;4   5,466.6320 (0.09)         22           1
test_pad_benchmark[mlx-constant-grad]            3,993.7906 (279.44)   7,555.3330 (99.58)    6,057.1595 (368.20)   389.6345 (182.19)   6,043.4169 (360.80)   245.9692 (178.87)       13;8     165.0939 (0.00)        105           1
test_pad_benchmark[numba-constant-forward]          23.9583 (1.68)        75.8749 (1.0)         26.3611 (1.60)       2.2363 (1.05)        26.0831 (1.56)       2.8326 (2.06)      971;241  37,934.6793 (0.62)       9375           1
test_pad_benchmark[numba-constant-grad]             47.0420 (3.29)       169.9161 (2.24)        52.8126 (3.21)       5.2841 (2.47)        52.9159 (3.16)       4.5830 (3.33)     2335;937  18,934.8619 (0.31)      14546           1
test_pad_benchmark[numba-symmetric-forward]         62.9998 (4.41)       199.6248 (2.63)        68.6041 (4.17)       5.4997 (2.57)        65.7924 (3.93)       7.3332 (5.33)     1489;250  14,576.3956 (0.24)      14572           1
test_pad_benchmark[numba-symmetric-grad]           513.5420 (35.93)      908.5829 (11.97)      551.5471 (33.53)     41.2321 (19.28)      537.3750 (32.08)     30.6772 (22.31)     203;164   1,813.0818 (0.03)       1793           1
test_pad_benchmark[pytorch-constant-forward]       234.6248 (16.42)    1,269.7922 (16.74)      301.8768 (18.35)     57.9823 (27.11)      290.3338 (17.33)     32.5008 (23.64)     135;130   3,312.6100 (0.05)       1818           1
test_pad_benchmark[pytorch-constant-grad]          364.9583 (25.54)    1,475.9582 (19.45)      534.9712 (32.52)     85.9054 (40.17)      517.7495 (30.91)     75.2495 (54.72)      189;64   1,869.2594 (0.03)       1458           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

`16 passed, 4 skipped, 15 warnings in 20.30s`

Skipped:

- `mlx/symmetric/forward unsupported: NotImplementedError`
- `mlx/symmetric/grad unsupported: NotImplementedError`
- `pytorch/symmetric/forward unsupported: InternalTorchDynamoError`
- `pytorch/symmetric/grad unsupported: NotImplementedError`
