### PR TITLE
Implement erfcx and erfcinv in JAX without tensorflow-probability

### DIFF
--- a/pytensor/link/jax/dispatch/scalar.py
+++ b/pytensor/link/jax/dispatch/scalar.py
@@ -263,12 +263,27 @@ def jax_funcify_Erfinv(op, **kwargs):
 
 
 @jax_funcify.register(BetaIncInv)
-@jax_funcify.register(Erfcx)
-@jax_funcify.register(Erfcinv)
 def jax_funcify_from_tfp(op, **kwargs):
     tfp_jax_op = try_import_tfp_jax_op(op)
 
     return tfp_jax_op
+
+
+@jax_funcify.register(Erfcx)
+def jax_funcify_Erfcx(op, **kwargs):
+    if hasattr(jax.scipy.special, "erfcx"):
+        return jax.scipy.special.erfcx
+    # jax < 0.11 has no native erfcx
+    return try_import_tfp_jax_op(op)
+
+
+@jax_funcify.register(Erfcinv)
+def jax_funcify_Erfcinv(op, **kwargs):
+    def erfcinv(x):
+        # erfc(z) = 2 ndtr(-z * sqrt(2)), so z = -ndtri(x / 2) / sqrt(2)
+        return -jax.scipy.special.ndtri(x / 2) / jnp.sqrt(2)
+
+    return erfcinv
 
 
 @jax_funcify.register(NdtriExp)

--- a/tests/link/jax/test_scalar.py
+++ b/tests/link/jax/test_scalar.py
@@ -154,14 +154,28 @@ def test_ndtri_exp():
 @pytest.mark.parametrize(
     "op, test_values",
     [
-        (erfcx, (0.7,)),
-        (erfcinv, (0.7,)),
         (iv, (0.3, 0.7)),
         (kve, (-2.5, 2.0)),
     ],
 )
 @pytest.mark.skipif(not TFP_INSTALLED, reason="Test requires tensorflow-probability")
 def test_tfp_ops(op, test_values):
+    inputs = [as_tensor(test_value).type() for test_value in test_values]
+    output = op(*inputs)
+
+    compare_jax_and_py(inputs, [output], test_values)
+
+
+@pytest.mark.parametrize(
+    "op, test_values",
+    [
+        (erfcx, (0.7,)),
+        (erfcinv, (0.7,)),
+    ],
+)
+def test_erfcx_erfcinv(op, test_values):
+    if op is erfcx and not (hasattr(jax.scipy.special, "erfcx") or TFP_INSTALLED):
+        pytest.skip("erfcx needs jax >= 0.11 or tensorflow-probability")
     inputs = [as_tensor(test_value).type() for test_value in test_values]
     output = op(*inputs)
 

--- a/tests/link/jax/test_scalar.py
+++ b/tests/link/jax/test_scalar.py
@@ -166,20 +166,22 @@ def test_tfp_ops(op, test_values):
     compare_jax_and_py(inputs, [output], test_values)
 
 
-@pytest.mark.parametrize(
-    "op, test_values",
-    [
-        (erfcx, (0.7,)),
-        (erfcinv, (0.7,)),
-    ],
+@pytest.mark.skipif(
+    not (hasattr(jax.scipy.special, "erfcx") or TFP_INSTALLED),
+    reason="erfcx needs jax >= 0.11 or tensorflow-probability",
 )
-def test_erfcx_erfcinv(op, test_values):
-    if op is erfcx and not (hasattr(jax.scipy.special, "erfcx") or TFP_INSTALLED):
-        pytest.skip("erfcx needs jax >= 0.11 or tensorflow-probability")
-    inputs = [as_tensor(test_value).type() for test_value in test_values]
-    output = op(*inputs)
+def test_erfcx():
+    x = scalar("x")
+    out = erfcx(x)
 
-    compare_jax_and_py(inputs, [output], test_values)
+    compare_jax_and_py([x], [out], [0.7])
+
+
+def test_erfcinv():
+    x = scalar("x")
+    out = erfcinv(x)
+
+    compare_jax_and_py([x], [out], [0.7])
 
 
 def test_betaincinv():


### PR DESCRIPTION
## Description
jax has shipped erfcx natively since 0.11, and erfcinv is a one-line ndtri
composition (available since jax 0.1.49), so neither needs the
tensorflow-probability import anymore. This fixes sampling a Truncated
Normal with the numpyro/blackjax samplers on an installation without
tensorflow-probability: the normal log-CDF lowers through these two ops.

- Erfcx dispatches to jax.scipy.special.erfcx when available and keeps the
  existing tfp fallback on older jax.
- Erfcinv is computed as -ndtri(x/2)/sqrt(2), valid on any installable jax,
  no fallback needed.
- The two ops move out of test_tfp_ops into their own test that runs
  without tensorflow-probability (erfcx skips only when neither native jax
  nor tfp can provide it).

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to pymc-devs/pymc#7980

## Checklist
- [x] Checked that the pre-commit linting/style checks pass
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a relevant logical change

## Type of change
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
