### PR TITLE
Fix SparseDenseMultiply gradient when the dense input is a scalar

### DIFF
--- a/pytensor/sparse/math.py
+++ b/pytensor/sparse/math.py
@@ -786,11 +786,13 @@ class SparseDenseMultiply(Op):
         (gz,) = gout
         assert psb._is_sparse_variable(x) and psb._is_dense_variable(y)
         assert psb._is_sparse_variable(gz)
-        gy = psb.dense_from_sparse(x * gz)
         if y.type.ndim == 0:
             # y was broadcast against every entry of x, so its gradient is the
-            # sum of the contributions of all entries.
-            gy = gy.sum()
+            # sum of the contributions of all entries. Reduce on the sparse
+            # product directly instead of densifying it first.
+            gy = sp_sum(x * gz, sparse_grad=True)
+        else:
+            gy = psb.dense_from_sparse(x * gz)
         return y * gz, gy
 
     def infer_shape(self, node, shapes):

--- a/pytensor/sparse/math.py
+++ b/pytensor/sparse/math.py
@@ -786,7 +786,12 @@ class SparseDenseMultiply(Op):
         (gz,) = gout
         assert psb._is_sparse_variable(x) and psb._is_dense_variable(y)
         assert psb._is_sparse_variable(gz)
-        return y * gz, psb.dense_from_sparse(x * gz)
+        gy = psb.dense_from_sparse(x * gz)
+        if y.type.ndim == 0:
+            # y was broadcast against every entry of x, so its gradient is the
+            # sum of the contributions of all entries.
+            gy = gy.sum()
+        return y * gz, gy
 
     def infer_shape(self, node, shapes):
         return [shapes[0]]

--- a/tests/sparse/test_math.py
+++ b/tests/sparse/test_math.py
@@ -100,6 +100,20 @@ class TestAddMul:
             np.array([[1.0, 2], [3, 0], [0, 6]]),
         )
 
+    @pytest.mark.parametrize("format", ["csc", "csr"])
+    def test_MulSD_scalar_grad(self, format):
+        # Multiplying a sparse matrix by a scalar broadcasts the scalar over
+        # every entry, so the gradient wrt the scalar must be a scalar too.
+        array = np.array([[1.0, 0], [3, 0], [0, 6]])
+        x = as_sparse_variable(as_sparse_format(array, format))
+        y = scalar("y", dtype="float64")
+
+        gy = pytensor.grad(psm.sp_sum(multiply(x, y)), y)
+        assert gy.type.ndim == 0
+
+        f = pytensor.function([y], gy)
+        utt.assert_allclose(array.sum(), f(2.0))
+
     def _testSS(self, op, array1=None, array2=None):
         if array1 is None:
             array1 = np.array([[1.0, 0], [3, 0], [0, 6]])


### PR DESCRIPTION
## Description
`SparseDenseMultiply.pullback` returned the full dense gradient for its second input, but when that input is a scalar it was broadcast over every entry of the sparse matrix, so its gradient must be a scalar. `pt.grad` rejected the 2-d term with `ValueError: SparseDenseMultiply.grad returned a term with 2 dimensions, but 0 are required.` The gradient is now summed when the dense input is 0-d; the 2-d case is unchanged.

## Related Issue
- [x] Closes #1338
- [ ] Related to #

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):

`test_MulSD_scalar_grad` (csc and csr) fails on `main` with the reported ValueError and passes with the fix. This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
