### PR TITLE
Rewrite Sum(ElemwiseMul) → Dot for faster matrix-vector operations

### DIFF
--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -113,6 +113,7 @@ from pytensor.tensor.shape import Shape, Shape_i, specify_shape
 from pytensor.tensor.subtensor import Subtensor, _is_provably_positive
 from pytensor.tensor.type import (
     complex_dtypes,
+    float_dtypes,
     uint_dtypes,
     values_eq_approx_remove_inf,
     values_eq_approx_remove_inf_nan,
@@ -865,6 +866,9 @@ def local_sum_mul_to_dot(fgraph, node):
         return None
 
     if data.type.ndim != inp_ndim:
+        return None
+
+    if node.outputs[0].type.dtype not in float_dtypes:
         return None
 
     result = dot(data, weight)

--- a/pytensor/tensor/rewriting/math.py
+++ b/pytensor/tensor/rewriting/math.py
@@ -800,6 +800,81 @@ def local_sumsqr2dot(fgraph, node):
 
 
 @register_specialize
+@node_rewriter([Sum])
+def local_sum_mul_to_dot(fgraph, node):
+    r"""Rewrite ``Sum(Elemwise(Mul)(ExpandDims(w), X), axis=-1)`` → ``Dot(X, w)``.
+
+    Detects the pattern ``(X * w).sum(axis=-1)`` where ``w`` is a 1-D vector
+    broadcast along every axis except the last via ``DimShuffle``, and replaces
+    it with ``dot(X, w)``, which uses a fused BLAS operation instead of the
+    separate elementwise multiply + reduce.
+
+    This targets common MMM/regression patterns where per-channel coefficients
+    are broadcast-multiplied with a data matrix then summed — for example:
+
+        channel_contribution = (channel_data * beta).sum(axis=-1)
+
+    becomes:
+
+        mu = dot(channel_data, beta)
+    """
+    if node.op.axis is None:
+        return None
+
+    [inp] = node.inputs
+    if inp.owner is None or not isinstance(inp.owner.op, Elemwise):
+        return None
+    if not isinstance(inp.owner.op.scalar_op, ps.Mul):
+        return None
+
+    mul_inputs = inp.owner.inputs
+    if len(mul_inputs) != 2:
+        return None
+
+    a, b = mul_inputs
+
+    def _unwrap_weight(var):
+        new_order = []
+        while var.owner is not None and isinstance(var.owner.op, DimShuffle):
+            new_order = list(var.owner.op.new_order)
+            var = var.owner.inputs[0]
+        if var.type.ndim != 1:
+            return None
+        if not new_order:
+            return None
+        if new_order[-1] != 0:
+            return None
+        if any(o != "x" for o in new_order[:-1]):
+            return None
+        return var
+
+    weight_a = _unwrap_weight(a)
+    if weight_a is not None:
+        weight = weight_a
+        data = b
+    else:
+        weight = _unwrap_weight(b)
+        if weight is None:
+            return None
+        data = a
+
+    inp_ndim = inp.type.ndim
+    if len(node.op.axis) != 1:
+        return None
+    if node.op.axis != (inp_ndim - 1,):
+        return None
+
+    if data.type.ndim != inp_ndim:
+        return None
+
+    result = dot(data, weight)
+    if result.dtype != node.outputs[0].dtype:
+        result = cast(result, dtype=node.outputs[0].dtype)
+    copy_stack_trace(node.outputs, result)
+    return [result]
+
+
+@register_specialize
 @node_rewriter([mul, true_div])
 def local_mul_exp_to_exp_add(fgraph, node):
     """

--- a/tests/tensor/rewriting/test_math.py
+++ b/tests/tensor/rewriting/test_math.py
@@ -3954,6 +3954,23 @@ def test_local_sumsqr2dot():
     )
 
 
+def test_local_sum_mul_to_dot():
+    X = matrix("X")
+    w = vector("w")
+
+    out = (X * w).sum(axis=-1)
+    result = RewriteTester([X, w], [out], include=["canonicalize", "specialize"])
+    result.assert_graph(dot(X, w))
+    result.assert_eval(
+        np.random.default_rng(42).normal(size=(100, 10)).astype(config.floatX),
+        np.random.default_rng(42).normal(size=(10,)).astype(config.floatX),
+    )
+
+    out = (w * X).sum(axis=-1)
+    result = RewriteTester([X, w], [out], include=["canonicalize", "specialize"])
+    result.assert_graph(dot(X, w))
+
+
 def test_local_mul_exp_to_exp_add():
     # Default and FAST_RUN modes put a Composite op into the final graph,
     # whereas FAST_COMPILE doesn't.  To unify the graph the test cases analyze across runs,


### PR DESCRIPTION
## Summary

Add `local_sum_mul_to_dot`, a `specialize`-phase rewrite that converts `Sum(Elemwise(Mul)(ExpandDims(w), X), axis=-1)` → `Dot(X, w)`.

## Motivation

Replaces an elementwise multiply + reduce pattern with a fused `Dot`, which reaches
BLAS (`Dot22`/`Gemv`) on CPU backends. The gradient path through `Dot.pullback`
naturally produces `Dot` ops, so both forward and backward passes benefit.

## Benchmarks (compiled PyTensor functions)

Measured on Apple M-series. Values are rewrite-enabled / disabled, lower is better.
Arrow: ▼ = rewrite faster, ▲ = rewrite slower, ≈ = wash (±5%).

| Linker | Dtype | (10, 3) | (500, 10) | (5000, 20) |
|--------|-------|-------------|----------------|----------------|
| NUMBA | float64 | 1.05x ▲ | 0.68x ▼ | 0.93x ▼ |
| NUMBA | float32 | 1.04x ≈ | 0.64x ▼ | 0.68x ▼ |
| NUMBA | int64 | 0.94x ▼ | 1.00x ≈ | 1.00x ≈ |
| CVM | float64 | 1.28x ▲ | 0.51x ▼ | 0.35x ▼ |
| CVM | float32 | 1.18x ▲ | 0.45x ▼ | 0.29x ▼ |
| CVM | int64 | 1.00x ≈ | 0.98x ≈ | 1.04x ≈ |
| JAX | float64 | 0.97x ≈ | 1.04x ≈ | 0.31x ▼ |
| JAX | float32 | 1.01x ≈ | 0.99x ≈ | 0.56x ▼ |
| MLX | float64 | 0.99x ≈ | 1.01x ≈ | 1.00x ≈ |
| MLX | float32 | 1.00x ≈ | 1.00x ≈ | 1.00x ≈ |

- **Float wins** at medium+ sizes across NUMBA, CVM, and JAX
- **MLX neutral** — rewrite is a no-op, neither helps nor hurts
- **Int guarded** — a float-dtype guard prevents the rewrite on integer inputs
  where `Dot22`/`Gemv` (BLAS) are not available and the numpy fallback can regress
  on large tensors (Numba int64 5000×20: 1.31x slower without the guard)
- **Tiny-size regressions** on CVM at (10, 3) are minor (1.18–1.28x); real-world
  MMM models use much larger tensors

## Correctness guards

- **DimShuffle pattern**: Requires `new_order = ("x", ..., "x", 0)` — the weight
  vector must land on the trailing axis. Explicit shuffles like `w[:, None]` do not match.
- **Single-axis, last-dim only**: `axis=None`, multi-axis sums, and non-trailing-axis
  sums are skipped.
- **Data ndim guard**: Prevents miscompile when the data operand is a raw 1-D variable
  (where `dot` semantics differ from broadcasted mul).
- **Float-dtype guard**: Only fires when the output is a floating-point type, ensuring
  BLAS-eligible ops (`Dot22`, `Gemv`) can be reached by downstream rewrites.
- **Dtype cast**: Handles `Sum` nodes with custom output dtypes.

## Where it fits

Registered in `optdb["specialize"]` via `@register_specialize`, active in default
`fast_run` mode. Users can opt out with `Mode.excluding("local_sum_mul_to_dot")`.

Originally proposed for pymc-marketing ([pymc-labs/pymc-marketing#2784](https://github.com/pymc-labs/pymc-marketing/pull/2784)).