### PR TITLE
Add MLX dispatches for gammaln and psi

### DIFF
--- a/pytensor/link/mlx/dispatch/basic.py
+++ b/pytensor/link/mlx/dispatch/basic.py
@@ -15,25 +15,36 @@ from pytensor.link.utils import fgraph_to_python
 from pytensor.raise_op import Assert, CheckAndRaise
 
 
+def float64_supported():
+    """Return whether the current default device can operate on float64.
+
+    MLX implements float64 on the CPU only; the Metal backend rejects it outright.
+    """
+    return mx.default_device() == mx.cpu
+
+
 def convert_dtype_to_mlx(dtype_str, auto_cast_unsupported=True):
     """Convert PyTensor dtype strings to MLX dtype objects.
 
     MLX expects dtype objects rather than string literals for type conversion.
     This function maps common dtype strings to their MLX equivalents.
 
+    float64 survives when the default device supports it and is narrowed to float32
+    otherwise. complex128 is always narrowed, MLX having no wider complex type.
+
     Parameters
     ----------
     dtype_str : str or MLX dtype
         The dtype to convert
-    auto_cast_unsupported : bool
-        If True, automatically cast unsupported dtypes to supported ones with warnings
+    auto_cast_unsupported : bool, optional
+        If True, narrow dtypes the current device cannot handle, warning as it does so.
+        If False, return the requested dtype and let any later failure surface. Default
+        True.
 
     Returns
     -------
     MLX dtype object
     """
-    import warnings
-
     if isinstance(dtype_str, str):
         if dtype_str == "bool":
             return mx.bool_
@@ -58,11 +69,12 @@ def convert_dtype_to_mlx(dtype_str, auto_cast_unsupported=True):
         elif dtype_str == "float32":
             return mx.float32
         elif dtype_str == "float64":
-            if auto_cast_unsupported:
+            if auto_cast_unsupported and not float64_supported():
                 warnings.warn(
                     "MLX does not support float64 on GPU. Automatically casting to float32. "
-                    "This may result in reduced precision. To avoid this warning, "
-                    "explicitly use float32 in your code or set floatX='float32' in PyTensor config.",
+                    "This may result in reduced precision. To keep float64, run on the CPU "
+                    "device with mx.set_default_device(mx.cpu); to avoid this warning, use "
+                    "float32 or set floatX='float32' in PyTensor config.",
                     UserWarning,
                     stacklevel=3,
                 )
@@ -116,6 +128,10 @@ def mlx_typify(data, **kwargs):
 
 @mlx_typify.register(np.ndarray)
 def mlx_typify_tensor(data, dtype=None, **kwargs):
+    # mx.array narrows float64 input to float32 unless the dtype is named explicitly,
+    # and it does so on the CPU too, where float64 is perfectly usable
+    if dtype is None and data.dtype == np.float64 and float64_supported():
+        dtype = mx.float64
     return _nan_safe_constant(data, dtype=dtype)
 
 

--- a/pytensor/link/mlx/dispatch/scalar.py
+++ b/pytensor/link/mlx/dispatch/scalar.py
@@ -18,6 +18,7 @@ from pytensor.scalar.math import (
     Erfcx,
     GammaLn,
     Log1mexp,
+    Psi,
     Sigmoid,
     Softplus,
 )
@@ -41,6 +42,22 @@ _LANCZOS_COEFFS = (
     9.9843695780195716e-6,
     1.5056327351493116e-7,
 )
+
+# Asymptotic expansion of psi, with terms B_2n / 2n, applied after the recurrence has
+# carried the argument up by _PSI_SHIFTS. Single precision reaches its own limit with a
+# shorter recurrence and fewer terms, and every one of them costs a pass over the array.
+_PSI_COEFFS = (
+    1 / 12,
+    -1 / 120,
+    1 / 252,
+    -1 / 240,
+    1 / 132,
+    -691 / 32760,
+    1 / 12,
+)
+_PSI_SHIFTS = 10
+_PSI_COEFFS_SINGLE = _PSI_COEFFS[:3]
+_PSI_SHIFTS_SINGLE = 6
 
 
 def _working_precision(x):
@@ -270,6 +287,45 @@ def mlx_funcify_GammaLn(op, **kwargs):
         return out.astype(out_dtype)
 
     return gammaln
+
+
+@mlx_funcify.register(Psi)
+def mlx_funcify_Psi(op, **kwargs):
+    def psi(x):
+        z, const, out_dtype = _working_precision(x)
+
+        double = z.dtype == mx.float64
+        n_shifts = _PSI_SHIFTS if double else _PSI_SHIFTS_SINGLE
+        coeffs = _PSI_COEFFS if double else _PSI_COEFFS_SINGLE
+
+        # Only negative arguments need reflecting; the recurrence below walks a
+        # small positive argument up to the asymptotic regime on its own, and it
+        # keeps full precision where cot(pi x) would not
+        reflect = z < const(0.0)
+        y = mx.where(reflect, const(1.0) - z, z)
+
+        # psi(y) = psi(y + n) - sum 1/(y + i), which holds for every y, so the shift
+        # is applied unconditionally. Testing whether each element still needs it
+        # would cost a comparison and a select per iteration and buy nothing
+        one = const(1.0)
+        shift = -one / y
+        for i in range(1, n_shifts):
+            shift = shift - one / (y + const(float(i)))
+        y = y + const(float(n_shifts))
+
+        r2 = one / (y * y)
+        series = const(coeffs[-1])
+        for coeff in reversed(coeffs[:-1]):
+            series = const(coeff) + series * r2
+        out = shift + mx.log(y) - const(0.5) / y - series * r2
+
+        # psi(x) = psi(1 - x) - pi * cot(pi x)
+        pi_z = const(np.pi) * z
+        out = mx.where(reflect, out - const(np.pi) * mx.cos(pi_z) / mx.sin(pi_z), out)
+
+        return out.astype(out_dtype)
+
+    return psi
 
 
 @mlx_funcify.register(Composite)

--- a/pytensor/link/mlx/dispatch/scalar.py
+++ b/pytensor/link/mlx/dispatch/scalar.py
@@ -1,6 +1,7 @@
 from functools import reduce
 
 import mlx.core as mx
+import numpy as np
 
 from pytensor.link.mlx.dispatch.basic import convert_dtype_to_mlx, mlx_funcify
 from pytensor.scalar.basic import (
@@ -12,7 +13,14 @@ from pytensor.scalar.basic import (
     ScalarOp,
     Second,
 )
-from pytensor.scalar.math import Erfc, Erfcx, Log1mexp, Sigmoid, Softplus
+from pytensor.scalar.math import (
+    Erfc,
+    Erfcx,
+    GammaLn,
+    Log1mexp,
+    Sigmoid,
+    Softplus,
+)
 
 
 # MLX name overrides for nfunc_spec names that don't match mlx.core
@@ -20,6 +28,50 @@ MLX_NFUNC_OVERRIDES = {
     "true_divide": "divide",
     "invert": "bitwise_invert",
 }
+
+_LANCZOS_G = 7.0
+_LANCZOS_COEFFS = (
+    0.99999999999980993,
+    676.5203681218851,
+    -1259.1392167224028,
+    771.32342877765313,
+    -176.61502916214059,
+    12.507343278686905,
+    -0.13857109526572012,
+    9.9843695780195716e-6,
+    1.5056327351493116e-7,
+)
+
+
+def _working_precision(x):
+    """Set up a series approximation over ``x``.
+
+    Half precision is widened to float32, having too few mantissa bits for series
+    coefficients to mean anything.
+
+    Parameters
+    ----------
+    x : mx.array
+        Input to the approximation.
+
+    Returns
+    -------
+    z : mx.array
+        ``x`` at the working precision.
+    const : callable
+        Materialize a Python float as an ``mx.array`` of the working precision. MLX
+        weak-types Python floats to float32, which would otherwise silently pin a
+        float64 approximation to float32 accuracy.
+    out_dtype : MLX dtype
+        The dtype the result should be cast back to.
+    """
+    x = mx.array(x)
+    working_dtype = mx.float32 if x.dtype in (mx.float16, mx.bfloat16) else x.dtype
+
+    def const(value):
+        return mx.array(value, dtype=working_dtype)
+
+    return x.astype(working_dtype), const, x.dtype
 
 
 @mlx_funcify.register(ScalarOp)
@@ -171,6 +223,53 @@ def mlx_funcify_Log1mexp(op, node, **kwargs):
         return mx.where(x < mx.log(0.5), mx.log1p(-mx.exp(x)), mx.log(-mx.expm1(x)))
 
     return log1mexp
+
+
+@mlx_funcify.register(GammaLn)
+def mlx_funcify_GammaLn(op, **kwargs):
+    def gammaln(x):
+        z, const, out_dtype = _working_precision(x)
+
+        double = z.dtype == mx.float64
+        half = const(0.5)
+        one = const(1.0)
+
+        # In double precision, small positive arguments go up by one via
+        # lgamma(x) = lgamma(x + 1) - log(x) rather than through the reflection formula
+        # below. Both are exact as mathematics, but reflection would route them through
+        # mx.sin, which is only float32-accurate whatever the input dtype. Single
+        # precision has nothing to protect, and the extra log costs a pass
+        shift_up = (z > const(0.0)) & (z < half) if double else None
+        y = mx.where(shift_up, z + one, z) if double else z
+        reflect = y < half
+
+        # Evaluating the series on the reflected argument means one polynomial
+        # covers both branches, and neither can produce a NaN the other must mask
+        w = mx.where(reflect, one - y, y) - one
+        series = const(_LANCZOS_COEFFS[0])
+        for i, coeff in enumerate(_LANCZOS_COEFFS[1:], start=1):
+            series = series + const(coeff) / (w + const(float(i)))
+
+        t = w + const(_LANCZOS_G + 0.5)
+        lanczos = (
+            const(0.5 * np.log(2.0 * np.pi))
+            + (w + half) * mx.log(t)
+            - t
+            + mx.log(series)
+        )
+
+        # Reducing the argument before sin keeps log|sin(pi x)| accurate at large |x|
+        log_sin = mx.log(mx.abs(mx.sin(const(np.pi) * (y - mx.floor(y)))))
+        out = mx.where(reflect, const(np.log(np.pi)) - log_sin - lanczos, lanczos)
+        if double:
+            out = mx.where(shift_up, out - mx.log(z), out)
+
+        # The series returns NaN at +/-inf, where both limits are +inf
+        out = mx.where(mx.isinf(z), const(np.inf), out)
+
+        return out.astype(out_dtype)
+
+    return gammaln
 
 
 @mlx_funcify.register(Composite)

--- a/tests/link/mlx/test_basic.py
+++ b/tests/link/mlx/test_basic.py
@@ -2,6 +2,7 @@
 Basic tests for the MLX backend.
 """
 
+import warnings
 from collections.abc import Callable, Iterable
 from functools import partial
 
@@ -21,6 +22,8 @@ from pytensor.raise_op import assert_op
 
 
 mx = pytest.importorskip("mlx.core")
+from pytensor.link.mlx.dispatch.basic import convert_dtype_to_mlx
+
 
 optimizer = RewriteDatabaseQuery(include=["mlx"], exclude=MLX._optimizer.exclude)
 mlx_mode = Mode(linker=MLXLinker(), optimizer=optimizer)
@@ -189,62 +192,40 @@ def test_scalar_from_tensor_pytensor_integration():
     assert isinstance(result, mx.array)
 
 
-def test_mlx_float64_auto_casting():
-    """Test MLX automatic casting of float64 to float32 with warnings."""
-    import warnings
-
-    # Test 1: Direct Cast operation with warning
-    x = pt.scalar("x", dtype="float32")
-    y = pt.cast(x, "float64")
-
-    # Capture warnings
-    with warnings.catch_warnings(record=True) as warning_list:
+def test_mlx_float64_downcast_on_gpu_warns():
+    # Only the dtype resolution is exercised, not a kernel: the suite pins the CPU
+    # device (see conftest) because Metal aborts on some runners
+    with mx.stream(mx.gpu), warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always")
+        dtype = convert_dtype_to_mlx("float64")
 
-        f = pytensor.function([x], y, mode=mlx_mode, allow_input_downcast=True)
-        result = f(3.14)
-
-        # Check that the operation succeeded
-        assert result.dtype == mx.float32  # Should be auto-cast to float32
-        assert abs(float(result) - 3.14) < 1e-6
-
-        # Check that a warning was issued
-        warning_messages = [str(w.message) for w in warning_list]
-        dtype_warnings = [
-            msg for msg in warning_messages if "float64" in msg and "float32" in msg
-        ]
-        assert len(dtype_warnings) > 0, (
-            f"Expected dtype warning, got warnings: {warning_messages}"
-        )
+    assert dtype == mx.float32
+    assert any(
+        "float64" in str(w.message) and "float32" in str(w.message)
+        for w in warning_list
+    )
 
 
-def test_mlx_float64_complex_operations():
-    """Test float64 casting in more complex operations."""
-    import warnings
+def test_mlx_float64_preserved_on_cpu():
+    x = pt.vector("x", dtype="float64")
+    # log and arithmetic are genuinely float64 in MLX; exp, sin, and cos are computed
+    # to float32 accuracy whatever the input dtype, and would mask the thing under test
+    out = pt.log(x) * 2.0 + x
 
-    # Test with vector operations
-    x = pt.vector("x", dtype="float32")
-    y = pt.cast(x, "float64")
-    z = pt.exp(y) + pt.sin(y)  # Multiple operations on float64
+    x_test_value = np.array([1.0, 2.0, 3.0], dtype="float64")
 
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always")
+        with mx.stream(mx.cpu):
+            f = function([x], out, mode=mlx_mode)
+            res = f(x_test_value)
 
-        f = pytensor.function([x], z, mode=mlx_mode, allow_input_downcast=True)
-        result = f([1.0, 2.0, 3.0])
-
-        # Should work and return float32 results
-        assert result.dtype == mx.float32
-        assert result.shape == (3,)
-
-        # Should have issued warnings
-        warning_messages = [str(w.message) for w in warning_list]
-        dtype_warnings = [
-            msg
-            for msg in warning_messages
-            if "float64" in msg or "MLX GPU limitation" in msg
-        ]
-        assert len(dtype_warnings) > 0
+    assert res.dtype == mx.float64
+    # Narrowing would cost about seven digits here, so this is a precision check too
+    np.testing.assert_allclose(
+        np.asarray(res), np.log(x_test_value) * 2.0 + x_test_value, rtol=1e-15
+    )
+    assert not any("float64" in str(w.message) for w in warning_list)
 
 
 def test_mlx_float64_no_warning_when_disabled():

--- a/tests/link/mlx/test_scalar.py
+++ b/tests/link/mlx/test_scalar.py
@@ -1,11 +1,15 @@
+from functools import partial
+
 import numpy as np
 import pytest
+import scipy.special
 
 import pytensor.scalar.basic as ps
 import pytensor.tensor as pt
 from pytensor.configdefaults import config
 from pytensor.graph.fg import FunctionGraph
 from pytensor.scalar.basic import Composite
+from pytensor.scalar.math import GammaLn
 from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.math import all as pt_all
 from pytensor.tensor.math import (
@@ -150,6 +154,75 @@ def test_clip(min_val, max_val):
             np.array(min_val, dtype=config.floatX),
             np.array(max_val, dtype=config.floatX),
         ],
+    )
+
+
+# float32 and float64 take deliberately different paths through both dispatches, so
+# every range is checked at both precisions with tolerances the path actually supports
+@pytest.mark.parametrize("dtype", ["float32", "float64"], ids=str)
+@pytest.mark.parametrize(
+    "low, high, tolerances",
+    [
+        # gammaln has zeros at 1 and 2 and a minimum of -0.12 in between, so the
+        # moderate and tiny ranges need an absolute tolerance to stay meaningful
+        (0.5, 20.0, {"float32": (1e-5, 1e-4), "float64": (1e-11, 1e-11)}),
+        (1e-3, 0.5, {"float32": (1e-5, 1e-4), "float64": (1e-11, 1e-11)}),
+        (20.0, 1e4, {"float32": (1e-5, 0.0), "float64": (1e-12, 0.0)}),
+        # Negative arguments go through the log|sin(pi x)| reflection formula, which
+        # loses precision to cancellation near the poles. mx.sin is float32-accurate
+        # whatever the dtype, so float64 gains nothing here
+        (-5.4, -0.6, {"float32": (1e-3, 1e-3), "float64": (1e-3, 1e-3)}),
+    ],
+    ids=["moderate", "tiny", "large", "negative"],
+)
+def test_gammaln(low, high, tolerances, dtype):
+    rtol, atol = tolerances[dtype]
+    x = vector("x", dtype=dtype)
+    x_test_value = np.random.default_rng(11).uniform(low, high, 101).astype(dtype)
+
+    compare_mlx_and_py(
+        [x],
+        [pt.gammaln(x)],
+        [x_test_value],
+        assert_fn=partial(np.testing.assert_allclose, rtol=rtol, atol=atol),
+    )
+
+
+@pytest.mark.parametrize("dtype", ["float32", "float64"], ids=str)
+def test_gammaln_edge_cases(dtype):
+    x = vector("x", dtype=dtype)
+    # Poles at the non-positive integers, plus inf and nan propagation. The finite
+    # entries keep the test from passing on an implementation that returns inf for
+    # everything
+    x_test_value = np.array([0.0, -1.0, -2.0, np.inf, np.nan, 0.5, 4.0], dtype=dtype)
+
+    compare_mlx_and_py([x], [pt.gammaln(x)], [x_test_value])
+
+
+@pytest.mark.parametrize(
+    "low, high",
+    [
+        (0.5, 20.0),
+        # Below 0.5 the argument must be shifted up by the recurrence rather than
+        # reflected: reflection would route it through mx.sin, which is float32-accurate
+        # whatever the input dtype, and that alone costs seven orders of magnitude
+        (1e-3, 0.5),
+    ],
+    ids=["above-half", "below-half"],
+)
+def test_gammaln_float64_precision(low, high):
+    # MLX weak-types Python floats to float32, which would silently pin the Lanczos
+    # coefficients (and so the whole result) to float32 accuracy. float64 lives on
+    # the CPU stream, so the dispatch is exercised directly rather than through a
+    # compiled function.
+    x_test_value = np.linspace(low, high, 201)
+
+    with mlx.stream(mlx.cpu):
+        gammaln = mlx_funcify(GammaLn())
+        res = np.asarray(gammaln(mlx.array(x_test_value, dtype=mlx.float64)))
+
+    np.testing.assert_allclose(
+        res, scipy.special.gammaln(x_test_value), rtol=1e-13, atol=1e-14
     )
 
 

--- a/tests/link/mlx/test_scalar.py
+++ b/tests/link/mlx/test_scalar.py
@@ -9,7 +9,7 @@ import pytensor.tensor as pt
 from pytensor.configdefaults import config
 from pytensor.graph.fg import FunctionGraph
 from pytensor.scalar.basic import Composite
-from pytensor.scalar.math import GammaLn
+from pytensor.scalar.math import GammaLn, Psi
 from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.math import all as pt_all
 from pytensor.tensor.math import (
@@ -223,6 +223,89 @@ def test_gammaln_float64_precision(low, high):
 
     np.testing.assert_allclose(
         res, scipy.special.gammaln(x_test_value), rtol=1e-13, atol=1e-14
+    )
+
+
+@pytest.mark.parametrize("dtype", ["float32", "float64"], ids=str)
+def test_gammaln_grad(dtype):
+    # d/dx gammaln is psi, which is why the two dispatches ship together: this is the
+    # graph PyMC builds for the Gamma, Beta, Poisson and NegativeBinomial logps
+    x = vector("x", dtype=dtype)
+    x_test_value = np.random.default_rng(13).uniform(0.1, 20.0, 51).astype(dtype)
+
+    compare_mlx_and_py([x], [pt.grad(pt.gammaln(x).sum(), x)], [x_test_value])
+
+
+@pytest.mark.parametrize("op", [pt.gammaln, pt.psi], ids=["gammaln", "psi"])
+def test_special_half_precision(op):
+    # float16 has too few mantissa bits for the series coefficients, so the dispatch
+    # widens to float32 internally. Evaluating the series in float16 throughout is
+    # about a hundred times less accurate, which this tolerance rules out
+    x = vector("x", dtype="float16")
+    x_test_value = np.array([0.2, 0.5, 1.5, 3.0, 7.0, 12.0], dtype="float16")
+
+    _, [res] = compare_mlx_and_py(
+        [x],
+        [op(x)],
+        [x_test_value],
+        assert_fn=partial(np.testing.assert_allclose, rtol=1e-3, atol=1e-3),
+    )
+    # the widening is internal; the result comes back at the dtype it went in as
+    assert np.asarray(res).dtype == "float16"
+
+
+@pytest.mark.parametrize("dtype", ["float32", "float64"], ids=str)
+@pytest.mark.parametrize(
+    "low, high, tolerances",
+    [
+        # psi crosses zero at 1.4616, so this range needs an absolute tolerance
+        (0.5, 20.0, {"float32": (1e-5, 1e-4), "float64": (1e-12, 1e-12)}),
+        (1e-3, 0.5, {"float32": (1e-5, 0.0), "float64": (1e-12, 0.0)}),
+        (20.0, 1e4, {"float32": (1e-5, 0.0), "float64": (1e-12, 0.0)}),
+        # Negative arguments pick up the pi*cot(pi x) reflection term, which loses
+        # precision to cancellation near the poles. mx.cos and mx.sin are
+        # float32-accurate whatever the dtype, so float64 gains nothing here
+        (-5.85, -5.15, {"float32": (1e-4, 1e-4), "float64": (1e-4, 1e-4)}),
+    ],
+    ids=["moderate", "tiny", "large", "negative"],
+)
+def test_psi(low, high, tolerances, dtype):
+    rtol, atol = tolerances[dtype]
+    x = vector("x", dtype=dtype)
+    x_test_value = np.random.default_rng(12).uniform(low, high, 101).astype(dtype)
+
+    compare_mlx_and_py(
+        [x],
+        [pt.psi(x)],
+        [x_test_value],
+        assert_fn=partial(np.testing.assert_allclose, rtol=rtol, atol=atol),
+    )
+
+
+@pytest.mark.parametrize("dtype", ["float32", "float64"], ids=str)
+def test_psi_edge_cases(dtype):
+    # Negative integers are left out: PyTensor's own C implementation returns inf
+    # there while scipy returns nan, so there is no agreed reference to compare to.
+    # The finite entries keep the poles from being the only thing asserted
+    x_test_value = np.array([0.0, np.inf, np.nan, 0.5, 4.0], dtype=dtype)
+    x = vector("x", dtype=dtype)
+
+    compare_mlx_and_py([x], [pt.psi(x)], [x_test_value])
+
+
+@pytest.mark.parametrize(
+    "low, high", [(0.5, 20.0), (1e-3, 0.5)], ids=["above-half", "below-half"]
+)
+def test_psi_float64_precision(low, high):
+    # Guards the same weak-typing trap as test_gammaln_float64_precision
+    x_test_value = np.linspace(low, high, 201)
+
+    with mlx.stream(mlx.cpu):
+        psi = mlx_funcify(Psi())
+        res = np.asarray(psi(mlx.array(x_test_value, dtype=mlx.float64)))
+
+    np.testing.assert_allclose(
+        res, scipy.special.psi(x_test_value), rtol=1e-12, atol=1e-14
     )
 
 


### PR DESCRIPTION
MLX has no scipy special functions and upstream isn't adding them (ml-explore/mlx#3330, ml-explore/mlx#3181, ml-explore/mlx#3927), so these are hand-written. Unblocks the Gamma, Beta, Poisson, NegativeBinomial and StudentT logps and their gradients, which is most of #2095.

float64 was also being narrowed to float32 unconditionally, including on the CPU device where MLX supports it fine.

ulp against 50-digit mpmath. Negative arguments need `sin`/`cos`, which MLX computes at float32 accuracy whatever the dtype — that's the bad column and it isn't fixable from here. `near-zeros` is a metric artifact where the functions cross zero, scipy on the same points for scale.

Accuracy:
```
gammaln
| region     | f32 median | f32 p99 | f32 max | f64 median | f64 p99 | f64 max | scipy f64 max |
|------------|------------|---------|---------|------------|---------|---------|---------------|
| negative   | 3.4        | 564.8   | 6.0e+04 | 6.1e+07    | 1.9e+10 | 7.8e+12 | 264.0         |
| subunit    | 0.9        | 8.0     | 18.4    | 1.0        | 9.0     | 13.0    | 2.0           |
| near-zeros | 43.4       | 1,463.9 | 1.2e+04 | 33.0       | 1,127.9 | 2.4e+04 | 1,746.0       |
| moderate   | 1.3        | 90.1    | 2,896.1 | 1.0        | 68.0    | 2,303.0 | 2.0           |
| large      | 0.7        | 2.5     | 3.9     | 1.0        | 3.0     | 5.0     | 1.0           |
| huge       | 0.6        | 2.5     | 3.5     | 1.0        | 2.0     | 3.0     | 1.0           |

psi
| region     | f32 median | f32 p99 | f32 max | f64 median | f64 p99 | f64 max | scipy f64 max |
|------------|------------|---------|---------|------------|---------|---------|---------------|
| negative   | 44.9       | 5,292.5 | 5.9e+05 | 4.4e+09    | 3.9e+11 | 6.9e+13 | 2,024.0       |
| subunit    | 0.6        | 2.5     | 3.7     | 1.0        | 3.0     | 6.0     | 1.0           |
| near-zeros | 3.2        | 180.1   | 1,662.0 | 4.0        | 197.1   | 2,182.0 | 2.0           |
| moderate   | 0.7        | 4.0     | 12.9    | 1.0        | 4.0     | 10.0    | 2.0           |
| large      | 0.6        | 2.0     | 2.5     | 0.0        | 2.0     | 3.0     | 1.0           |
| huge       | 0.4        | 1.8     | 2.3     | 0.0        | 2.0     | 2.0     | 1.0           |

regions: negative (-10, -0.05) | subunit (1e-3, 0.5) | near-zeros (0.5, 2)
         moderate (2, 20) | large (20, 1e4) | huge (1e4, 1e8)
```

Warm JIT, materialized inside the timed call so the lazy backends aren't credited with dispatch-only numbers. MLX on GPU, JAX on CPU here, numba single-threaded. Harness isn't in this PR.

Timings:
```
------------------------ benchmark 'func_name=gammaln': 16 tests -------------------------
Name (time in ms)                                      Min    Median           OPS  Rounds
------------------------------------------------------------------------------------------
test_special_benchmark_jax[gammaln-n=1000]          0.0107    0.0223   50,342.5310    3907
test_special_benchmark_numba[gammaln-n=1000]        0.0060    0.0071  138,456.9020   46512
test_special_benchmark_mlx[gammaln-n=1000]          0.1003    0.1226    7,433.8278    2383
test_special_benchmark_scipy[gammaln-n=1000]        0.0058    0.0066  148,035.3326   48001

test_special_benchmark_jax[gammaln-n=100000]        0.1075    0.1490    6,591.4439    4854
test_special_benchmark_numba[gammaln-n=100000]      0.8417    0.8799    1,126.4479    1117
test_special_benchmark_mlx[gammaln-n=100000]        0.1173    0.1414    6,691.3718    3826
test_special_benchmark_scipy[gammaln-n=100000]      1.4453    1.5130      653.6127     563

test_special_benchmark_jax[gammaln-n=1000000]       1.0373    1.2490      814.8769     844
test_special_benchmark_numba[gammaln-n=1000000]     9.1983    9.4693      105.2662     104
test_special_benchmark_mlx[gammaln-n=1000000]       0.2656    0.2914    3,271.0888     907
test_special_benchmark_scipy[gammaln-n=1000000]    15.5197   16.1085       61.9842      63

test_special_benchmark_jax[gammaln-n=10000000]     10.5475   12.3096       79.2586      84
test_special_benchmark_numba[gammaln-n=10000000]   94.2866   95.4473       10.4605      11
test_special_benchmark_mlx[gammaln-n=10000000]      2.3863    2.5214      372.2069     185
test_special_benchmark_scipy[gammaln-n=10000000]  161.4135  161.9291        6.1675       7
------------------------------------------------------------------------------------------

------------------------ benchmark 'func_name=psi': 16 tests -------------------------
Name (time in ms)                                  Min    Median           OPS  Rounds
--------------------------------------------------------------------------------------
test_special_benchmark_jax[psi-n=1000]          0.0102    0.0123   71,737.0575   30535
test_special_benchmark_numba[psi-n=1000]        0.0085    0.0098   98,956.8233   41741
test_special_benchmark_mlx[psi-n=1000]          0.0973    0.1209    7,508.8258    5252
test_special_benchmark_scipy[psi-n=1000]        0.0072    0.0082  119,759.6234   52863

test_special_benchmark_jax[psi-n=100000]        0.1132    0.1478    6,488.8400    4329
test_special_benchmark_numba[psi-n=100000]      1.3450    1.4066      705.9134     716
test_special_benchmark_mlx[psi-n=100000]        0.1137    0.1321    7,327.6337    3104
test_special_benchmark_scipy[psi-n=100000]      1.3976    1.4597      678.2851     653

test_special_benchmark_jax[psi-n=1000000]       1.1119    1.4437      687.6364     501
test_special_benchmark_numba[psi-n=1000000]    14.2093   14.7437       67.7740      68
test_special_benchmark_mlx[psi-n=1000000]       0.2184    0.2403    3,907.1578    1483
test_special_benchmark_scipy[psi-n=1000000]    15.1117   15.4188       64.8537      66

test_special_benchmark_jax[psi-n=10000000]     11.4180   13.9620       72.3374      86
test_special_benchmark_numba[psi-n=10000000]  146.6234  146.9638        6.8006       7
test_special_benchmark_mlx[psi-n=10000000]      1.7145    1.8032      540.0605     219
test_special_benchmark_scipy[psi-n=10000000]  153.8917  154.5676        6.4395       7
--------------------------------------------------------------------------------------

--------------------------- benchmark 'float64, n = 1,000,000': 6 tests ---------------------------
Name (time in ms)                                                    Min   Median       OPS  Rounds
---------------------------------------------------------------------------------------------------
test_special_benchmark_float64[backend=JAX-gammaln-n=1000000]     2.1787   2.6047  361.5279     372
test_special_benchmark_float64[backend=NUMBA-gammaln-n=1000000]   8.9504   9.2940  107.4537     106
test_special_benchmark_float64[backend=MLX-gammaln-n=1000000]    28.0955  28.4060   35.1534      36

test_special_benchmark_float64[backend=JAX-psi-n=1000000]         1.8832   2.3707  419.7058     461
test_special_benchmark_float64[backend=NUMBA-psi-n=1000000]      14.1154  14.5211   68.8784      70
test_special_benchmark_float64[backend=MLX-psi-n=1000000]         9.6103   9.8595  101.1387     102
---------------------------------------------------------------------------------------------------
```
