### PR TITLE
Add an AS241 rational kernel for MLX erfcinv

### DIFF
--- a/pytensor/link/mlx/dispatch/scalar/__init__.py
+++ b/pytensor/link/mlx/dispatch/scalar/__init__.py
@@ -1,1 +1,1 @@
-from pytensor.link.mlx.dispatch.scalar import basic, erf, math
+from pytensor.link.mlx.dispatch.scalar import basic, erf, erfcinv, math

--- a/pytensor/link/mlx/dispatch/scalar/erf.py
+++ b/pytensor/link/mlx/dispatch/scalar/erf.py
@@ -3,7 +3,7 @@ from collections.abc import Callable
 import mlx.core as mx
 
 from pytensor.link.mlx.dispatch.basic import mlx_funcify
-from pytensor.link.mlx.dispatch.scalar.helpers import _working_precision
+from pytensor.link.mlx.dispatch.scalar.helpers import _LN2, _working_precision
 from pytensor.scalar.math import Erfc, Erfcx
 
 
@@ -72,7 +72,6 @@ _SQRT_PI_INV = 5.6418958354775628695e-1
 _ERF_THRESH = 0.46875
 _ERFCX_SPLIT = 4.0
 
-_LN2 = 0.6931471805599453
 _EXP_CLAMP = 1e4
 
 

--- a/pytensor/link/mlx/dispatch/scalar/erfcinv.py
+++ b/pytensor/link/mlx/dispatch/scalar/erfcinv.py
@@ -1,0 +1,150 @@
+import mlx.core as mx
+
+from pytensor.link.mlx.dispatch.basic import mlx_funcify
+from pytensor.link.mlx.dispatch.scalar.helpers import _LN2, _working_precision
+from pytensor.scalar.math import Erfcinv
+
+
+# Wichura, "Algorithm AS 241: The Percentage Points of the Normal Distribution" (Applied
+# Statistics 37, 1988), the PPND16 variant. Three intervals again, but the two outer
+# ones are rational in sqrt(-log(tail)) rather than in the probability itself, which is
+# what holds them together where the probability underflows -- erfcinv(1e-300) is an
+# ordinary 26.1. Nothing here needs exp, sin or cos, only log, sqrt and arithmetic, all
+# of which MLX computes at the full working precision, so this carries no ceiling.
+_NDTRI_A = (
+    3.3871328727963666080e0,
+    1.3314166789178437745e2,
+    1.9715909503065514427e3,
+    1.3731693765509461125e4,
+    4.5921953931549871457e4,
+    6.7265770927008700853e4,
+    3.3430575583588128105e4,
+    2.5090809287301226727e3,
+)
+_NDTRI_B = (
+    4.2313330701600911252e1,
+    6.8718700749205790830e2,
+    5.3941960214247511077e3,
+    2.1213794301586595867e4,
+    3.9307895800092710610e4,
+    2.8729085735721942674e4,
+    5.2264952788528545610e3,
+)
+_NDTRI_C = (
+    1.42343711074968357734e0,
+    4.63033784615654529590e0,
+    5.76949722146069140550e0,
+    3.64784832476320460504e0,
+    1.27045825245236838258e0,
+    2.41780725177450611770e-1,
+    2.27238449892691845833e-2,
+    7.74545014278341407640e-4,
+)
+_NDTRI_D = (
+    2.05319162663775882187e0,
+    1.67638483018380384940e0,
+    6.89767334985100004550e-1,
+    1.48103976427480074590e-1,
+    1.51986665636164571966e-2,
+    5.47593808499534494600e-4,
+    1.05075007164441684324e-9,
+)
+_NDTRI_E = (
+    6.65790464350110377720e0,
+    5.46378491116411436990e0,
+    1.78482653991729133580e0,
+    2.96560571828504891230e-1,
+    2.65321895265761230930e-2,
+    1.24266094738807843860e-3,
+    2.71155556874348757815e-5,
+    2.01033439929228813265e-7,
+)
+_NDTRI_F = (
+    5.99832206555887937690e-1,
+    1.36929880922735805310e-1,
+    1.48753612908506148525e-2,
+    7.86869131145613259100e-4,
+    1.84631831751005468180e-5,
+    1.42151175831644588870e-7,
+    2.04426310338993978564e-15,
+)
+_NDTRI_CENTRAL_HALF_WIDTH = 0.425
+# The central branch clamps q**2 at the point |q| is compared against, so the two must
+# agree exactly or the unselected branch stops being finite
+_NDTRI_CENTRAL_OFFSET = _NDTRI_CENTRAL_HALF_WIDTH**2
+_NDTRI_MID_SHIFT = 1.6
+_NDTRI_TAIL_SPLIT = 5.0
+# The tail variable saturates rather than running to infinity at the poles, which keeps
+# the unselected far branch from turning an inf into a nan. Far outside either
+# precision: r = 30 corresponds to a tail probability of exp(-900)
+_NDTRI_MAX_R = 30.0
+
+_SQRT_2 = 1.4142135623730951
+
+
+def _horner(coeffs, t, const):
+    """Evaluate a polynomial listed lowest-order first, as AS241 tabulates them."""
+    out = const(coeffs[-1])
+    for c in reversed(coeffs[:-1]):
+        out = out * t + const(c)
+    return out
+
+
+def _ndtri_ratio(num_coeffs, den_coeffs, t, const):
+    # AS241's denominators are monic with the trailing 1 left implicit
+    return _horner(num_coeffs, t, const) / (
+        _horner(den_coeffs, t, const) * t + const(1.0)
+    )
+
+
+def _ndtri_of_half(x, const):
+    """``ndtri(x / 2)`` for ``0 <= x <= 2``, taken on ``x`` rather than on ``x / 2``."""
+    # Both reductions the algorithm needs are exact taken on x directly: for
+    # 0.5 <= x <= 2 neither x - 1 nor 2 - x loses a bit, where the same quantities
+    # reached as x / 2 - 0.5 and 1 - x / 2 cancel as x approaches 1
+    half = const(0.5)
+    q = (x - const(1.0)) * half
+    half_width = const(_NDTRI_CENTRAL_HALF_WIDTH)
+    offset = const(_NDTRI_CENTRAL_OFFSET)
+    split = const(_NDTRI_TAIL_SPLIT)
+
+    central_r = offset - mx.minimum(q * q, offset)
+    central = q * _ndtri_ratio(_NDTRI_A, _NDTRI_B, central_r, const)
+
+    # Outside the central band the branch is taken on whichever tail is the small one,
+    # so the argument keeps its significant digits instead of cancelling against 1.
+    # The halving is folded into the logarithm as -log(t / 2) == ln2 - log(t): forming
+    # the product instead would flush the smallest float32 subnormals to zero, and this
+    # way the sqrt argument is non-negative by construction, since t never exceeds 1
+    tail_x = mx.where(q < const(0.0), x, const(2.0) - x)
+    r = mx.minimum(mx.sqrt(const(_LN2) - mx.log(tail_x)), const(_NDTRI_MAX_R))
+
+    mid = _ndtri_ratio(
+        _NDTRI_C, _NDTRI_D, mx.minimum(r, split) - const(_NDTRI_MID_SHIFT), const
+    )
+    far = _ndtri_ratio(_NDTRI_E, _NDTRI_F, mx.maximum(r, split) - split, const)
+    tail = mx.where(r <= split, mid, far)
+    tail = mx.where(q < const(0.0), -tail, tail)
+
+    return mx.where(mx.abs(q) <= half_width, central, tail)
+
+
+@mlx_funcify.register(Erfcinv)
+def mlx_funcify_Erfcinv(op, **kwargs):
+    def erfcinv(x):
+        z, const, out_dtype = _working_precision(x)
+
+        # erfc(y) = 2 ndtr(-y sqrt(2)), so y = -ndtri(x / 2) / sqrt(2)
+        out = -_ndtri_of_half(z, const) / const(_SQRT_2)
+
+        # The poles are exact, and ndtri cannot reach them itself once r saturates. NaN
+        # is computed rather than named: mx.compile inlines size-1 constants into its
+        # generated source, where a bare `nan` is invalid in both backends -- Metal has
+        # no such literal, and C++ resolves it to `nan(const char *)`. `inf` is fine.
+        nan = const(0.0) / const(0.0)
+        out = mx.where(z == const(0.0), const(float("inf")), out)
+        out = mx.where(z == const(2.0), const(float("-inf")), out)
+        out = mx.where((z < const(0.0)) | (z > const(2.0)), nan, out)
+        return out.astype(out_dtype)
+
+    return erfcinv

--- a/pytensor/link/mlx/dispatch/scalar/helpers.py
+++ b/pytensor/link/mlx/dispatch/scalar/helpers.py
@@ -1,6 +1,9 @@
 import mlx.core as mx
 
 
+_LN2 = 0.6931471805599453
+
+
 def _working_precision(x):
     """Set up a series approximation over ``x``.
 

--- a/tests/link/mlx/scalar/test_erfcinv.py
+++ b/tests/link/mlx/scalar/test_erfcinv.py
@@ -1,0 +1,128 @@
+from functools import partial
+
+import numpy as np
+import pytest
+import scipy.special
+
+import pytensor.tensor as pt
+from pytensor.scalar.math import Erfcinv
+from pytensor.tensor.type import vector
+from tests.link.mlx.test_basic import compare_mlx_and_py
+
+
+mlx = pytest.importorskip("mlx.core")
+from pytensor.link.mlx.dispatch import mlx_funcify
+
+
+# erfcinv is sampled log-spaced rather than uniformly on purpose. The whole difficulty
+# is at small argument, where erfinv(1 - x) cancels; a uniform draw over (0, 2) would
+# put almost no points below 1e-3 and would pass against the implementation this
+# replaces.
+#
+# The tolerances are per-dtype because erfcinv, alone in this family, has no float32
+# ceiling to inherit: AS241 needs only log, sqrt and arithmetic, all of which MLX
+# computes at the full working precision. One shared float32-sized tolerance would let a
+# regression to mx.erfinv accuracy pass unnoticed, which is the failure this op exists
+# to avoid. An absolute tolerance carries the upper range, where erfcinv crosses zero at
+# x = 1.
+@pytest.mark.parametrize("dtype", ["float32", "float64"], ids=str)
+@pytest.mark.parametrize(
+    "low, high",
+    [
+        (1e-12, 1e-6),
+        (1e-6, 1e-3),
+        (1e-3, 0.5),
+        (1.0, 2.0 - 1e-9),
+    ],
+    ids=["tiny", "small", "moderate", "upper"],
+)
+def test_erfcinv(low, high, dtype):
+    rtol, atol = {"float32": (3e-6, 3e-6), "float64": (3e-15, 1e-14)}[dtype]
+    rng = np.random.default_rng(43)
+    x = vector("x", dtype=dtype)
+    x_test_value = np.exp(rng.uniform(np.log(low), np.log(high), 101)).astype(dtype)
+
+    compare_mlx_and_py(
+        [x],
+        [pt.erfcinv(x)],
+        [x_test_value],
+        assert_fn=partial(np.testing.assert_allclose, rtol=rtol, atol=atol),
+    )
+
+
+@pytest.mark.parametrize(
+    "low, high",
+    [(1e-300, 1e-12), (1e-12, 1e-3), (1e-3, 1.0), (1.0, 2.0 - 1e-12)],
+    ids=["far-tail", "tail", "lower", "upper"],
+)
+def test_erfcinv_float64_precision(low, high):
+    # Nothing in this kernel needs exp, sin or cos -- only log, sqrt and arithmetic, all
+    # of which MLX computes at the full working precision -- so unlike the rest of the
+    # family it carries no float32 ceiling and is held to 1 ulp. This is also the test
+    # that fails if the coefficients weak-type to float32, or if anyone reintroduces
+    # mx.erfinv, which is float32 whatever it is handed.
+    x_test_value = np.exp(np.linspace(np.log(low), np.log(high), 401))
+
+    with mlx.stream(mlx.cpu):
+        res = np.asarray(
+            mlx_funcify(Erfcinv())(mlx.array(x_test_value, dtype=mlx.float64))
+        )
+
+    np.testing.assert_allclose(res, scipy.special.erfcinv(x_test_value), rtol=1e-14)
+
+
+def test_erfcinv_edge_cases():
+    # The poles at 0 and 2, the exact zero at 1, and both out-of-domain sides. The
+    # out-of-domain entries also cover the compiled path, which aborts outright if the
+    # NaN they select is written as a literal rather than computed.
+    x = vector("x", dtype="float64")
+    x_test_value = np.array([0.0, 1.0, 2.0, -0.5, 2.5, np.nan])
+
+    compare_mlx_and_py([x], [pt.erfcinv(x)], [x_test_value])
+
+
+def test_erfcinv_float32_subnormal():
+    # AS241 needs -log(x / 2). Forming that product flushes the smallest float32
+    # subnormals to exactly zero, which sends the tail variable to its saturation point
+    # and returned 29.9 for an argument whose answer is 10.0. Folding the halving into
+    # the logarithm as ln2 - log(x) keeps it exact.
+    x_test_value = np.array([1.4e-45, 2.8e-45, 1e-44, 1e-40], dtype="float32")
+
+    with mlx.stream(mlx.cpu):
+        res = np.asarray(mlx_funcify(Erfcinv())(mlx.array(x_test_value)))
+
+    np.testing.assert_allclose(
+        res, scipy.special.erfcinv(x_test_value.astype("float64")), rtol=1e-6
+    )
+
+
+def test_erfcinv_upper_pole():
+    # The other pole. Every range above samples log-spaced in x, which cannot approach 2
+    # densely, so nothing else exercises the tail_x = 2 - x branch where the subtraction
+    # is the whole computation -- the mirror of the small-x case this op exists for, and
+    # where erfinv(1 - x) also fails.
+    x_test_value = 2.0 - np.exp(np.linspace(np.log(1e-15), np.log(1e-3), 401))
+
+    with mlx.stream(mlx.cpu):
+        res = np.asarray(
+            mlx_funcify(Erfcinv())(mlx.array(x_test_value, dtype=mlx.float64))
+        )
+
+    np.testing.assert_allclose(res, scipy.special.erfcinv(x_test_value), rtol=1e-14)
+
+
+def test_erfcinv_half_precision():
+    # float16 has too few mantissa bits for the AS241 coefficients, so the dispatch
+    # widens to float32 internally and casts back. 1.0 is left out because erfcinv is
+    # exactly zero there and a relative tolerance says nothing.
+    x = vector("x", dtype="float16")
+    x_test_value = np.array([1e-4, 0.01, 0.5, 1.5, 1.99], dtype="float16")
+
+    _, [res] = compare_mlx_and_py(
+        [x],
+        [pt.erfcinv(x)],
+        [x_test_value],
+        assert_fn=partial(np.testing.assert_allclose, rtol=1e-3, atol=1e-3),
+    )
+    # the widening is internal; the result comes back at the dtype it went in as
+    assert np.asarray(res).dtype == "float16"

--- a/tests/link/mlx/scalar/test_erfcinv.py
+++ b/tests/link/mlx/scalar/test_erfcinv.py
@@ -145,3 +145,16 @@ def test_normal_icdf():
     np.testing.assert_allclose(
         np.asarray(res), scipy.stats.norm.ppf(q_test_value), rtol=1e-10
     )
+
+
+@pytest.mark.parametrize("dtype", ["float32", "float64"], ids=str)
+def test_erfcinv_grad(dtype):
+    x = vector("x", dtype=dtype)
+    x_test_value = np.random.default_rng(47).uniform(0.05, 1.95, 51).astype(dtype)
+
+    compare_mlx_and_py(
+        [x],
+        [pt.grad(pt.erfcinv(x).sum(), x)],
+        [x_test_value],
+        assert_fn=partial(np.testing.assert_allclose, rtol=1e-5, atol=1e-6),
+    )

--- a/tests/link/mlx/scalar/test_erfcinv.py
+++ b/tests/link/mlx/scalar/test_erfcinv.py
@@ -3,6 +3,7 @@ from functools import partial
 import numpy as np
 import pytest
 import scipy.special
+import scipy.stats
 
 import pytensor.tensor as pt
 from pytensor.scalar.math import Erfcinv
@@ -126,3 +127,21 @@ def test_erfcinv_half_precision():
     )
     # the widening is internal; the result comes back at the dtype it went in as
     assert np.asarray(res).dtype == "float16"
+
+
+def test_normal_icdf():
+    # mu + sigma * -sqrt(2) * erfcinv(2 * q) is Normal.icdf, and pymc's ErfcTransform
+    # inverts through the same op, so any model applying erfc to a variable needs it
+    q = vector("q", dtype="float64")
+    icdf = -np.sqrt(2.0) * pt.erfcinv(2.0 * q)
+    q_test_value = np.array([1e-12, 1e-6, 1e-3, 0.025, 0.5, 0.975, 1.0 - 1e-9])
+
+    _, [res] = compare_mlx_and_py(
+        [q],
+        [icdf],
+        [q_test_value],
+        assert_fn=partial(np.testing.assert_allclose, rtol=1e-10, atol=1e-10),
+    )
+    np.testing.assert_allclose(
+        np.asarray(res), scipy.stats.norm.ppf(q_test_value), rtol=1e-10
+    )


### PR DESCRIPTION
`Erfcinv` has no MLX dispatch, so `Normal.icdf` raises. It's also `ErfcTransform.backward` in pymc's logprob machinery, so any model applying `pt.erfc` to a random variable derives its logprob through it.

The obvious `erfinv(1 - x)` doesn't work  -  `1 - x` throws away exactly the information `erfinv` needs at small argument, and `mx.erfinv` is a float32 kernel whatever dtype it's handed. Wichura AS241 (PPND16) instead, whose outer intervals are rational in `sqrt(-log(tail))` rather than in the probability, so they hold together where the probability underflows: `erfcinv(1e-300)` is an ordinary 26.1. Nothing in it needs `exp`, `sin` or `cos`  -  only `log`, `sqrt` and arithmetic, all of which MLX computes at the full working precision  -  so alone in the erf family it carries no float32 ceiling.

Max relative error vs scipy, log-spaced over each region:

```
region              erfinv(1-x)         new         new
                        float64     float64     float32
(1e-300, 1e-12)             inf    9.00e-16    2.40e-07
(1e-12, 1e-6)               inf    8.71e-16    3.67e-07
(1e-6, 1e-3)           1.13e-03    1.06e-15    3.19e-07
(1e-3, 0.5)            2.38e-06    9.73e-16    3.08e-07
(0.5, 1.5)             1.91e-07    9.33e-16    3.49e-07
(1.5, 2)               1.59e-05    9.64e-16    2.73e-07
```

float64 is 1 ulp across the whole domain, both poles included.

Warm `mx.compile`, best of 20, materialized inside the timed call. `passes` is against one fused elementwise pass over the same buffer.

```
GPU stream, float32
           n    MLX (ms)  scipy (ms)   passes  vs scipy
       1,000       0.207       0.008     1.4x      0.0x
      10,000       0.234       0.076     2.0x      0.3x
     100,000       0.290       0.738     2.2x      2.5x
   1,000,000       0.511       7.596     2.8x     14.9x
  10,000,000       5.257      77.998    14.5x     14.8x

CPU stream, float64
           n    MLX (ms)  scipy (ms)   passes  vs scipy
       1,000       0.048       0.006     3.2x      0.1x
      10,000       0.150       0.072    10.7x      0.5x
     100,000       1.299       0.725    50.1x      0.6x
   1,000,000      12.985       7.607    88.9x      0.6x
  10,000,000     131.915      77.728    96.2x      0.6x
```

No Metal kernel. Below 10^5  -  where an icdf actually runs, serving prior predictive draws, initialization and `pm.icdf` rather than a per-leapfrog evaluation  -  it's 1.4-2.2x the floor and dispatch-bound, so a kernel would buy nothing; the branch-free selection only shows at 10^7, where it still beats scipy 15x. Metal is float32-only in any case, and the float64 path is what makes this op worth having.

float32 runs the full PPND16 coefficient set rather than a shortened one, for the same reason: at the sizes an icdf runs at, the extra terms are free.

Part of #2095.
