### PR TITLE
Add MLX i0 and i1, and retire the erf family's float64 exp ceiling

### DIFF
--- a/pytensor/link/mlx/dispatch/scalar/__init__.py
+++ b/pytensor/link/mlx/dispatch/scalar/__init__.py
@@ -1,1 +1,1 @@
-from pytensor.link.mlx.dispatch.scalar import basic, erf, erfcinv, math
+from pytensor.link.mlx.dispatch.scalar import basic, bessel, erf, erfcinv, math

--- a/pytensor/link/mlx/dispatch/scalar/bessel.py
+++ b/pytensor/link/mlx/dispatch/scalar/bessel.py
@@ -2,7 +2,7 @@ import mlx.core as mx
 
 from pytensor.link.mlx.dispatch.basic import mlx_funcify
 from pytensor.link.mlx.dispatch.scalar.helpers import _exp, _working_precision
-from pytensor.scalar.math import I0
+from pytensor.scalar.math import I0, I1
 
 
 # Chebyshev expansions of the exponentially scaled modified Bessel functions, from the
@@ -89,6 +89,70 @@ _I0E_B = (
 
 _I0E_B_SINGLE = _I0E_B[-_SINGLE_LARGE_TERMS:]
 
+_I1E_A = (
+    2.77791411276104639959e-18,
+    -2.11142121435816608115e-17,
+    1.55363195773620046921e-16,
+    -1.10559694773538630805e-15,
+    7.60068429473540693410e-15,
+    -5.04218550472791168711e-14,
+    3.22379336594557470981e-13,
+    -1.98397439776494371520e-12,
+    1.17361862988909016308e-11,
+    -6.66348972350202774223e-11,
+    3.62559028155211703701e-10,
+    -1.88724975172282928790e-9,
+    9.38153738649577178388e-9,
+    -4.44505912879632808065e-8,
+    2.00329475355213526229e-7,
+    -8.56872026469545474066e-7,
+    3.47025130813767847674e-6,
+    -1.32731636560394358279e-5,
+    4.78156510755005422638e-5,
+    -1.61760815825896745588e-4,
+    5.12285956168575772895e-4,
+    -1.51357245063125314899e-3,
+    4.15642294431288815669e-3,
+    -1.05640848946261981558e-2,
+    2.47264490306265168283e-2,
+    -5.29459812080949914269e-2,
+    1.02643658689847095384e-1,
+    -1.76416518357834055153e-1,
+    2.52587186443633654823e-1,
+)
+
+_I1E_A_SINGLE = _I1E_A[-_SINGLE_SMALL_TERMS:]
+
+_I1E_B = (
+    7.51729631084210481353e-18,
+    4.41434832307170791151e-18,
+    -4.65030536848935832153e-17,
+    -3.20952592199342395980e-17,
+    2.96262899764595013876e-16,
+    3.30820231092092828324e-16,
+    -1.88035477551078244854e-15,
+    -3.81440307243700780478e-15,
+    1.04202769841288027642e-14,
+    4.27244001671195135429e-14,
+    -2.10154184277266431302e-14,
+    -4.08355111109219731823e-13,
+    -7.19855177624590851209e-13,
+    2.03562854414708950722e-12,
+    1.41258074366137813316e-11,
+    3.25260358301548823856e-11,
+    -1.89749581235054123450e-11,
+    -5.58974346219658380687e-10,
+    -3.83538038596423702205e-9,
+    -2.63146884688951950684e-8,
+    -2.51223623787020892529e-7,
+    -3.88256480887769039346e-6,
+    -1.10588938762623716291e-4,
+    -9.76109749136146840777e-3,
+    7.78576235018280120474e-1,
+)
+
+_I1E_B_SINGLE = _I1E_B[-_SINGLE_LARGE_TERMS:]
+
 
 def _chbevl(coeffs, x, const):
     """Evaluate a Chebyshev series at ``x`` in [-2, 2], in Cephes' arrangement.
@@ -126,6 +190,22 @@ def _i0e_positive(y, const):
     return mx.where(y <= split, small, large)
 
 
+def _i1e_positive(y, const):
+    """``i1e`` for non-negative ``y``, as a series on whichever interval holds it."""
+    double = y.dtype == mx.float64
+    split = const(_SPLIT)
+
+    # i1e vanishes like y / 2 at the origin, so the small-interval series is in
+    # i1e(y) / y and is multiplied back. A series fitted to i1e itself holds absolute
+    # error and lets the relative error run away as y -> 0
+    small_y = mx.minimum(y, split)
+    small_t = small_y / const(2.0) - const(2.0)
+    small = _chbevl(_I1E_A if double else _I1E_A_SINGLE, small_t, const) * small_y
+
+    large = _large_series(y, _I1E_B if double else _I1E_B_SINGLE, const)
+    return mx.where(y <= split, small, large)
+
+
 @mlx_funcify.register(I0)
 def mlx_funcify_I0(op, **kwargs):
     def i0(x):
@@ -139,3 +219,16 @@ def mlx_funcify_I0(op, **kwargs):
         return out.astype(out_dtype)
 
     return i0
+
+
+@mlx_funcify.register(I1)
+def mlx_funcify_I1(op, **kwargs):
+    def i1(x):
+        z, const, out_dtype = _working_precision(x)
+
+        # i1 is odd, so the series runs on |x| and the sign is restored afterwards
+        y = mx.abs(z)
+        out = _i1e_positive(y, const) * _exp(y, const)
+        return mx.where(z < const(0.0), -out, out).astype(out_dtype)
+
+    return i1

--- a/pytensor/link/mlx/dispatch/scalar/bessel.py
+++ b/pytensor/link/mlx/dispatch/scalar/bessel.py
@@ -1,0 +1,141 @@
+import mlx.core as mx
+
+from pytensor.link.mlx.dispatch.basic import mlx_funcify
+from pytensor.link.mlx.dispatch.scalar.helpers import _exp, _working_precision
+from pytensor.scalar.math import I0
+
+
+# Chebyshev expansions of the exponentially scaled modified Bessel functions, from the
+# netlib Cephes ``i0.c`` and ``i1.c``, transcribed in their own arrangement: highest
+# degree first, with ``chbevl`` halving the trailing term, and the same interval split
+# and argument transformations the C source uses. Keeping Cephes' layout is what makes
+# the coefficients checkable -- they are unreviewable by eye, and the only practical
+# review is a diff against the source they came from.
+#
+# The scaled forms are the primitives because they are bounded on the whole line, where
+# i0 itself overflows past x = 713 at float64 and x = 88 at float32 -- a von Mises
+# concentration well inside what a user will write.
+#
+# A Chebyshev series is near-minimax at every truncation, so float32 takes a suffix of
+# the same coefficients rather than a second fitted set: the leading entries are the
+# high-order terms, each costs a pass over the array, and single precision cannot see
+# the ones dropped.
+_SPLIT = 8.0
+_SINGLE_SMALL_TERMS = 18
+_SINGLE_LARGE_TERMS = 10
+
+_I0E_A = (
+    -4.41534164647933937950e-18,
+    3.33079451882223809783e-17,
+    -2.43127984654795469359e-16,
+    1.71539128555513303061e-15,
+    -1.16853328779934516808e-14,
+    7.67618549860493561688e-14,
+    -4.85644678311192946090e-13,
+    2.95505266312963983461e-12,
+    -1.72682629144155570723e-11,
+    9.67580903537323691224e-11,
+    -5.18979560163526290666e-10,
+    2.65982372468238665035e-9,
+    -1.30002500998624804212e-8,
+    6.04699502254191894932e-8,
+    -2.67079385394061173391e-7,
+    1.11738753912010371815e-6,
+    -4.41673835845875056359e-6,
+    1.64484480707288970893e-5,
+    -5.75419501008210370398e-5,
+    1.88502885095841655729e-4,
+    -5.76375574538582365885e-4,
+    1.63947561694133579842e-3,
+    -4.32430999505057594430e-3,
+    1.05464603945949983183e-2,
+    -2.37374148058994688156e-2,
+    4.93052842396707084878e-2,
+    -9.49010970480476444210e-2,
+    1.71620901522208775349e-1,
+    -3.04682672343198398683e-1,
+    6.76795274409476084995e-1,
+)
+
+_I0E_A_SINGLE = _I0E_A[-_SINGLE_SMALL_TERMS:]
+
+_I0E_B = (
+    -7.23318048787475395456e-18,
+    -4.83050448594418207126e-18,
+    4.46562142029675999901e-17,
+    3.46122286769746109310e-17,
+    -2.82762398051658348494e-16,
+    -3.42548561967721913462e-16,
+    1.77256013305652638360e-15,
+    3.81168066935262242075e-15,
+    -9.55484669882830764870e-15,
+    -4.15056934728722208663e-14,
+    1.54008621752140982691e-14,
+    3.85277838274214270114e-13,
+    7.18012445138366623367e-13,
+    -1.79417853150680611778e-12,
+    -1.32158118404477131188e-11,
+    -3.14991652796324136454e-11,
+    1.18891471078464383424e-11,
+    4.94060238822496958910e-10,
+    3.39623202570838634515e-9,
+    2.26666899049817806459e-8,
+    2.04891858946906374183e-7,
+    2.89137052083475648297e-6,
+    6.88975834691682398426e-5,
+    3.36911647825569408990e-3,
+    8.04490411014108831608e-1,
+)
+
+_I0E_B_SINGLE = _I0E_B[-_SINGLE_LARGE_TERMS:]
+
+
+def _chbevl(coeffs, x, const):
+    """Evaluate a Chebyshev series at ``x`` in [-2, 2], in Cephes' arrangement.
+
+    ``coeffs`` runs from the highest degree down, and the constant term is halved on the
+    way out, so an array transcribed from Cephes is used exactly as it appears there.
+    """
+    b0, b1, b2 = const(coeffs[0]), const(0.0), const(0.0)
+    for coeff in coeffs[1:]:
+        b2, b1 = b1, b0
+        b0 = x * b1 - b2 + const(coeff)
+    return const(0.5) * (b0 - b2)
+
+
+def _large_series(y, coeffs, const):
+    """Evaluate the ``y > 8`` series, which carries an explicit ``sqrt(y)``.
+
+    Callers pass unclamped ``y``: both intervals are evaluated for every element and
+    selected afterwards, so this clamps its own argument rather than trusting one that
+    would otherwise run the series far outside where it was fitted.
+    """
+    y = mx.maximum(y, const(_SPLIT))
+    return _chbevl(coeffs, const(32.0) / y - const(2.0), const) / mx.sqrt(y)
+
+
+def _i0e_positive(y, const):
+    """``i0e`` for non-negative ``y``, as a series on whichever interval holds it."""
+    double = y.dtype == mx.float64
+    split = const(_SPLIT)
+
+    small_t = mx.minimum(y, split) / const(2.0) - const(2.0)
+    small = _chbevl(_I0E_A if double else _I0E_A_SINGLE, small_t, const)
+
+    large = _large_series(y, _I0E_B if double else _I0E_B_SINGLE, const)
+    return mx.where(y <= split, small, large)
+
+
+@mlx_funcify.register(I0)
+def mlx_funcify_I0(op, **kwargs):
+    def i0(x):
+        z, const, out_dtype = _working_precision(x)
+
+        # i0 is even, and the series computes the scaled form. Restoring the scale is
+        # what caps the accuracy: exp is the one operation here that MLX cannot do
+        # better than the exponent's own rounding.
+        y = mx.abs(z)
+        out = _i0e_positive(y, const) * _exp(y, const)
+        return out.astype(out_dtype)
+
+    return i0

--- a/pytensor/link/mlx/dispatch/scalar/erf.py
+++ b/pytensor/link/mlx/dispatch/scalar/erf.py
@@ -12,12 +12,13 @@ from pytensor.scalar.math import Erfc, Erfcx
 # a series for erf below 0.46875, and two rationals that yield erfcx directly above it.
 #
 # Deriving all three from one kernel, rather than composing them out of mx.erf, is what
-# makes them accurate. mx.erf is a float32 kernel whatever dtype it is handed, as are
-# mx.exp, mx.sin and mx.cos, while mx.log and mx.sqrt are genuine at float64. Both upper
-# intervals here are free of exp, so erfcx holds the full working precision across the
-# range where erfc has decayed far past anything 1 - erf could resolve. The subunit
-# interval and the negative-argument reflections still need exp, which is why erfcx
-# keeps its rational branches rather than being derived from a single form.
+# makes them accurate: mx.erf is a float32 kernel whatever dtype it is handed. The two
+# upper intervals are free of exp entirely, and where exp is unavoidable the family goes
+# through _exp rather than mx.exp, which is float32 in range as well as in precision.
+#
+# The intervals are a matter of conditioning rather than precision. erfcx is the bounded
+# quantity and is computed directly, because reaching it as exp(x**2) * erfc(x) overflows
+# while erfc has decayed far past anything 1 - erf could resolve.
 _ERF_A = (
     3.16112374387056560e00,
     1.13864154151050156e02,

--- a/pytensor/link/mlx/dispatch/scalar/erf.py
+++ b/pytensor/link/mlx/dispatch/scalar/erf.py
@@ -3,7 +3,7 @@ from collections.abc import Callable
 import mlx.core as mx
 
 from pytensor.link.mlx.dispatch.basic import mlx_funcify
-from pytensor.link.mlx.dispatch.scalar.helpers import _LN2, _working_precision
+from pytensor.link.mlx.dispatch.scalar.helpers import _exp, _working_precision
 from pytensor.scalar.math import Erfc, Erfcx
 
 
@@ -16,9 +16,8 @@ from pytensor.scalar.math import Erfc, Erfcx
 # mx.exp, mx.sin and mx.cos, while mx.log and mx.sqrt are genuine at float64. Both upper
 # intervals here are free of exp, so erfcx holds the full working precision across the
 # range where erfc has decayed far past anything 1 - erf could resolve. The subunit
-# interval and the negative-argument reflections still need exp and inherit its ceiling
-# of roughly 1e-7 relative, which is why erfcx keeps its rational branches rather than
-# being derived from a single form.
+# interval and the negative-argument reflections still need exp, which is why erfcx
+# keeps its rational branches rather than being derived from a single form.
 _ERF_A = (
     3.16112374387056560e00,
     1.13864154151050156e02,
@@ -71,8 +70,6 @@ _ERFCX_Q = (
 _SQRT_PI_INV = 5.6418958354775628695e-1
 _ERF_THRESH = 0.46875
 _ERFCX_SPLIT = 4.0
-
-_EXP_CLAMP = 1e4
 
 
 def _metal_constants(**arrays):
@@ -227,25 +224,6 @@ def _metal_erf_call(name, x):
     return out.reshape(x.shape)
 
 
-def _exp_wide(t, const):
-    r"""``exp(t)`` over the full exponent range of the working precision.
-
-    ``mx.exp`` is a float32 kernel in range as well as in precision, flushing to zero
-    below ``exp(-87)`` and overflowing above ``exp(88)`` whatever the dtype. This holds
-    to the range the dtype itself supports, at ``mx.exp``'s float32 precision.
-    """
-    # Splitting e^t into 2^k e^r, with k an integer and |r| <= ln(2)/2, keeps the
-    # exponential's argument small while mx.power supplies the scale over the full range.
-    #
-    # An infinite argument would leave r = -inf + inf = nan, so t is clamped first. The
-    # bound is far outside the representable range of either precision, where 2**k has
-    # already saturated to zero or infinity, so no finite result is altered
-    t = mx.minimum(mx.maximum(t, const(-_EXP_CLAMP)), const(_EXP_CLAMP))
-    k = mx.round(t / const(_LN2))
-    r = t - k * const(_LN2)
-    return mx.exp(r) * mx.power(const(2.0), k)
-
-
 def _erf_series(x, const):
     """erf on |x| <= 0.46875, where 1 - erfc would cancel. Free of exp."""
     z = x * x
@@ -296,7 +274,7 @@ def _erfc_tail(y, const):
     Multiplying by ``exp(-y**2)`` underflows to zero smoothly, where ``1 - erf(y)``
     cancels to it abruptly and loses every significant digit on the way.
     """
-    return _exp_wide(-(y * y), const) * _erfcx_upper(y, const)
+    return _exp(-(y * y), const) * _erfcx_upper(y, const)
 
 
 def _erfcx_positive(y, const):
@@ -304,7 +282,7 @@ def _erfcx_positive(y, const):
     thresh = const(_ERF_THRESH)
     # y < 0.46875 is the one branch that needs exp, and exp(y^2) <= 1.25 there
     small_y = mx.minimum(y, thresh)
-    small = mx.exp(small_y * small_y) * (const(1.0) - _erf_series(small_y, const))
+    small = _exp(small_y * small_y, const) * (const(1.0) - _erf_series(small_y, const))
     return mx.where(y <= thresh, small, _erfcx_upper(mx.maximum(y, thresh), const))
 
 
@@ -348,7 +326,7 @@ def mlx_funcify_Erfcx(op, **kwargs):
         pos = _erfcx_positive(y, const)
         # erfcx(-y) = 2 exp(y^2) - erfcx(y). The exponential is unavoidable here and
         # genuinely overflows past y ~ 26.6, which is the function's own behavior
-        reflected = const(2.0) * _exp_wide(y * y, const) - pos
+        reflected = const(2.0) * _exp(y * y, const) - pos
         return mx.where(z >= const(0.0), pos, reflected).astype(out_dtype)
 
     return erfcx

--- a/pytensor/link/mlx/dispatch/scalar/helpers.py
+++ b/pytensor/link/mlx/dispatch/scalar/helpers.py
@@ -6,11 +6,11 @@ def _exp(t, const):
     r"""``exp(t)`` at the working precision, over the full exponent range of the dtype.
 
     ``mx.exp`` is a float32 kernel in range as well as in precision: its float64 result
-    is bitwise equal to its float32 one, and it overflows past ``exp(88)`` whatever the
-    dtype. ``mx.power`` is genuine at float64, so double precision goes through it and
-    is left with only the :math:`x \epsilon` the exponent itself carries. Single
-    precision keeps ``mx.exp``, which is cheaper and, at float32, the more accurate of
-    the two.
+    is bitwise equal to its float32 one, it overflows past ``exp(88)`` whatever the
+    dtype, and it flushes the float32 subnormals to zero from ``exp(-90)``. ``mx.power``
+    carries none of those limits, is at least as accurate at both precisions, and costs
+    nothing measurable inside a compiled dispatch, leaving only the :math:`x \epsilon`
+    the exponent itself carries.
 
     Parameters
     ----------
@@ -24,9 +24,7 @@ def _exp(t, const):
     mx.array
         ``exp(t)`` at the dtype of ``t``.
     """
-    if t.dtype == mx.float64:
-        return mx.power(const(np.e), t)
-    return mx.exp(t)
+    return mx.power(const(np.e), t)
 
 
 _LN2 = 0.6931471805599453

--- a/pytensor/link/mlx/dispatch/scalar/helpers.py
+++ b/pytensor/link/mlx/dispatch/scalar/helpers.py
@@ -1,4 +1,32 @@
 import mlx.core as mx
+import numpy as np
+
+
+def _exp(t, const):
+    r"""``exp(t)`` at the working precision, over the full exponent range of the dtype.
+
+    ``mx.exp`` is a float32 kernel in range as well as in precision: its float64 result
+    is bitwise equal to its float32 one, and it overflows past ``exp(88)`` whatever the
+    dtype. ``mx.power`` is genuine at float64, so double precision goes through it and
+    is left with only the :math:`x \epsilon` the exponent itself carries. Single
+    precision keeps ``mx.exp``, which is cheaper and, at float32, the more accurate of
+    the two.
+
+    Parameters
+    ----------
+    t : mx.array
+        Exponent, at the working precision.
+    const : callable
+        Materializes a Python float at the working precision.
+
+    Returns
+    -------
+    mx.array
+        ``exp(t)`` at the dtype of ``t``.
+    """
+    if t.dtype == mx.float64:
+        return mx.power(const(np.e), t)
+    return mx.exp(t)
 
 
 _LN2 = 0.6931471805599453

--- a/pytensor/link/mlx/dispatch/scalar/helpers.py
+++ b/pytensor/link/mlx/dispatch/scalar/helpers.py
@@ -8,9 +8,10 @@ def _exp(t, const):
     ``mx.exp`` is a float32 kernel in range as well as in precision: its float64 result
     is bitwise equal to its float32 one, it overflows past ``exp(88)`` whatever the
     dtype, and it flushes the float32 subnormals to zero from ``exp(-90)``. ``mx.power``
-    carries none of those limits, is at least as accurate at both precisions, and costs
-    nothing measurable inside a compiled dispatch, leaving only the :math:`x \epsilon`
-    the exponent itself carries.
+    carries none of those limits and is at least as accurate at both precisions, leaving
+    only the :math:`x \epsilon` the exponent itself carries. It is free on the GPU at
+    float32 and costs around a fifth more on the CPU float64 path -- which is the path
+    that would otherwise be returning ``inf``.
 
     Parameters
     ----------

--- a/tests/link/mlx/scalar/test_bessel.py
+++ b/tests/link/mlx/scalar/test_bessel.py
@@ -3,6 +3,7 @@ from functools import partial
 import numpy as np
 import pytest
 import scipy.special
+import scipy.stats
 
 import pytensor.tensor as pt
 from pytensor.scalar.math import I0, I1
@@ -129,6 +130,44 @@ def test_i1_edge_cases():
     x_test_value = np.array([0.0, -0.0, -1.0, -30.0, 713.0, np.inf, -np.inf, np.nan])
 
     compare_mlx_and_py([x], [pt.i1(x)], [x_test_value])
+
+
+@pytest.mark.parametrize("dtype", ["float32", "float64"], ids=str)
+def test_i0_grad(dtype):
+    # d/dx i0(x) is i1(x), so a graph with i0 in it fails at gradient time unless both
+    # are dispatched -- which is why they ship together rather than i0 alone.
+    x = vector("x", dtype=dtype)
+    x_test_value = np.random.default_rng(61).uniform(-8.0, 8.0, 51).astype(dtype)
+
+    compare_mlx_and_py(
+        [x],
+        [pt.grad(pt.i0(x).sum(), x)],
+        [x_test_value],
+        assert_fn=partial(np.testing.assert_allclose, rtol=1e-5, atol=1e-6),
+    )
+
+
+@pytest.mark.parametrize("kappa_value", [0.5, 5.0, 50.0, 700.0], ids=str)
+def test_vonmises_logp(kappa_value):
+    # pymc's VonMises.logp (continuous.py:3178) reaches i0 from the logp itself, so the
+    # distribution is unusable on this backend without it. The tolerance is set by
+    # mx.cos, which is a float32 kernel whatever dtype it is handed -- see the float64
+    # op-support table -- not by i0, which holds 1e-13 over this range.
+    value, mu, kappa = pt.scalars("value", "mu", "kappa")
+    logp = kappa * pt.cos(mu - value) - np.log(2.0 * np.pi) - pt.log(pt.i0(kappa))
+    test_values = [0.3, 1.1, kappa_value]
+
+    _, res = compare_mlx_and_py(
+        [value, mu, kappa],
+        logp,
+        test_values,
+        assert_fn=partial(np.testing.assert_allclose, rtol=1e-6),
+    )
+    np.testing.assert_allclose(
+        np.asarray(res),
+        scipy.stats.vonmises.logpdf(0.3, kappa_value, loc=1.1),
+        rtol=1e-6,
+    )
 
 
 @pytest.mark.parametrize("op", [pt.i0, pt.i1], ids=["i0", "i1"])

--- a/tests/link/mlx/scalar/test_bessel.py
+++ b/tests/link/mlx/scalar/test_bessel.py
@@ -1,0 +1,77 @@
+from functools import partial
+
+import numpy as np
+import pytest
+import scipy.special
+
+import pytensor.tensor as pt
+from pytensor.scalar.math import I0
+from pytensor.tensor.type import vector
+from tests.link.mlx.test_basic import compare_mlx_and_py
+
+
+mlx = pytest.importorskip("mlx.core")
+from pytensor.link.mlx.dispatch import mlx_funcify
+
+
+# The series splits at x = 8, so the ranges straddle it rather than sampling across it.
+# float32 tolerances loosen with the argument because i0 is the scaled series times
+# exp(x), and at float32 the exponent's own rounding is x * eps -- 5e-6 by x = 80. That
+# is the dtype, not the approximation: the same ranges hold 1e-14 at float64, where the
+# exponential goes through mx.power instead.
+@pytest.mark.parametrize("dtype", ["float32", "float64"], ids=str)
+@pytest.mark.parametrize(
+    "low, high, tolerances",
+    [
+        (1e-8, 1.0, {"float32": 1e-6, "float64": 1e-13}),
+        (1.0, 8.0, {"float32": 1e-6, "float64": 1e-13}),
+        (8.0, 20.0, {"float32": 5e-6, "float64": 1e-13}),
+        (20.0, 80.0, {"float32": 2e-5, "float64": 1e-13}),
+    ],
+    ids=["small", "below-split", "above-split", "large"],
+)
+def test_i0(low, high, tolerances, dtype):
+    x = vector("x", dtype=dtype)
+    x_test_value = np.random.default_rng(53).uniform(low, high, 101).astype(dtype)
+
+    compare_mlx_and_py(
+        [x],
+        [pt.i0(x)],
+        [x_test_value],
+        assert_fn=partial(np.testing.assert_allclose, rtol=tolerances[dtype]),
+    )
+
+
+@pytest.mark.parametrize(
+    "low, high, rtol",
+    [
+        (1e-12, 1.0, 1e-14),
+        (1.0, 8.0, 1e-14),
+        (8.0, 100.0, 1e-13),
+        # the exponent carries x * eps of its own, which is 1.5e-13 by x = 700 and has
+        # nothing to do with the series
+        (100.0, 700.0, 1e-12),
+    ],
+    ids=["tiny", "below-split", "above-split", "near-overflow"],
+)
+def test_i0_float64_precision(low, high, rtol):
+    # The Chebyshev coefficients are only worth carrying if float64 survives to the end,
+    # and the exponential is what decides that: mx.exp is a float32 kernel whatever it is
+    # handed and overflows outright past exp(88), so this range would return inf through
+    # it. This is also the test that fails if the coefficients weak-type to float32.
+    x_test_value = np.exp(np.linspace(np.log(low), np.log(high), 401))
+
+    with mlx.stream(mlx.cpu):
+        res = np.asarray(mlx_funcify(I0())(mlx.array(x_test_value, dtype=mlx.float64)))
+
+    np.testing.assert_allclose(res, scipy.special.i0(x_test_value), rtol=rtol)
+
+
+def test_i0_edge_cases():
+    # i0 is even and equals 1 at the origin. 713 is where i0 overflows float64, which is
+    # not an exotic von Mises concentration, so the boundary is pinned rather than left
+    # to chance.
+    x = vector("x", dtype="float64")
+    x_test_value = np.array([0.0, -0.0, -1.0, -30.0, 713.0, np.inf, -np.inf, np.nan])
+
+    compare_mlx_and_py([x], [pt.i0(x)], [x_test_value])

--- a/tests/link/mlx/scalar/test_bessel.py
+++ b/tests/link/mlx/scalar/test_bessel.py
@@ -5,7 +5,7 @@ import pytest
 import scipy.special
 
 import pytensor.tensor as pt
-from pytensor.scalar.math import I0
+from pytensor.scalar.math import I0, I1
 from pytensor.tensor.type import vector
 from tests.link.mlx.test_basic import compare_mlx_and_py
 
@@ -75,3 +75,76 @@ def test_i0_edge_cases():
     x_test_value = np.array([0.0, -0.0, -1.0, -30.0, 713.0, np.inf, -np.inf, np.nan])
 
     compare_mlx_and_py([x], [pt.i0(x)], [x_test_value])
+
+
+# i1 splits at the same x = 8, and is odd rather than even
+@pytest.mark.parametrize("dtype", ["float32", "float64"], ids=str)
+@pytest.mark.parametrize(
+    "low, high, tolerances",
+    [
+        (1e-8, 1.0, {"float32": 1e-6, "float64": 1e-13}),
+        (1.0, 8.0, {"float32": 5e-6, "float64": 1e-12}),
+        (8.0, 20.0, {"float32": 5e-6, "float64": 1e-12}),
+        (20.0, 80.0, {"float32": 2e-5, "float64": 1e-13}),
+    ],
+    ids=["small", "below-split", "above-split", "large"],
+)
+def test_i1(low, high, tolerances, dtype):
+    x = vector("x", dtype=dtype)
+    x_test_value = np.random.default_rng(59).uniform(low, high, 101).astype(dtype)
+
+    compare_mlx_and_py(
+        [x],
+        [pt.i1(x)],
+        [x_test_value],
+        assert_fn=partial(np.testing.assert_allclose, rtol=tolerances[dtype]),
+    )
+
+
+@pytest.mark.parametrize(
+    "low, high, rtol",
+    [
+        (1e-12, 1.0, 1e-14),
+        (1.0, 8.0, 1e-14),
+        (8.0, 100.0, 1e-13),
+        (100.0, 700.0, 1e-12),
+    ],
+    ids=["tiny", "below-split", "above-split", "near-overflow"],
+)
+def test_i1_float64_precision(low, high, rtol):
+    # The small-interval series is fitted to i1e(x) / x, because i1 vanishes at the
+    # origin and a series fitted to i1e itself holds absolute error there rather than
+    # relative. This is the test that would catch dropping that division.
+    x_test_value = np.exp(np.linspace(np.log(low), np.log(high), 401))
+
+    with mlx.stream(mlx.cpu):
+        res = np.asarray(mlx_funcify(I1())(mlx.array(x_test_value, dtype=mlx.float64)))
+
+    np.testing.assert_allclose(res, scipy.special.i1(x_test_value), rtol=rtol)
+
+
+def test_i1_edge_cases():
+    # i1 is odd and zero at the origin, where i0 is even and one
+    x = vector("x", dtype="float64")
+    x_test_value = np.array([0.0, -0.0, -1.0, -30.0, 713.0, np.inf, -np.inf, np.nan])
+
+    compare_mlx_and_py([x], [pt.i1(x)], [x_test_value])
+
+
+@pytest.mark.parametrize("op", [pt.i0, pt.i1], ids=["i0", "i1"])
+def test_bessel_i_continuous_across_split(op):
+    # x = 8 is where the two Chebyshev intervals meet, and they are independent
+    # approximations that have to agree there. Every other range stops at the boundary
+    # rather than crossing it, and no uniform sample lands on it exactly, so a mismatched
+    # clamp or a < where <= belongs would go unnoticed.
+    x = vector("x", dtype="float64")
+    x_test_value = np.array(
+        [np.nextafter(8.0, 0.0), 8.0, np.nextafter(8.0, 9.0), 7.999999, 8.000001]
+    )
+
+    compare_mlx_and_py(
+        [x],
+        [op(x)],
+        [x_test_value],
+        assert_fn=partial(np.testing.assert_allclose, rtol=1e-14),
+    )

--- a/tests/link/mlx/scalar/test_erf.py
+++ b/tests/link/mlx/scalar/test_erf.py
@@ -45,20 +45,22 @@ def test_erf(low, high, rtol, atol, dtype):
     )
 
 
+# erfc is exp(-y**2) * erfcx(y), so the exponential sets the float32 tolerances and
+# squaring the argument amplifies its error in proportion to y**2. float64 goes through
+# mx.power instead, which is genuine, so it holds full precision across every range.
 @pytest.mark.parametrize("dtype", ["float32", "float64"], ids=str)
 @pytest.mark.parametrize(
-    "low, high, rtol",
+    "low, high, tolerances",
     [
-        (-3.0, 0.0, 3e-7),
-        (0.0, 1.0, 1e-6),
-        (1.0, 4.0, 1e-5),
-        # erfc is exp(-y**2) * erfcx(y) out here. The exponential is the accuracy floor,
-        # and squaring the argument amplifies its error in proportion to y**2
-        (4.0, 9.0, 1e-4),
+        (-3.0, 0.0, {"float32": 3e-7, "float64": 1e-14}),
+        (0.0, 1.0, {"float32": 1e-6, "float64": 1e-14}),
+        (1.0, 4.0, {"float32": 1e-5, "float64": 1e-14}),
+        (4.0, 9.0, {"float32": 1e-4, "float64": 1e-14}),
     ],
     ids=["negative", "small", "moderate", "tail"],
 )
-def test_erfc(low, high, rtol, dtype):
+def test_erfc(low, high, tolerances, dtype):
+    rtol = tolerances[dtype]
     x = vector("x", dtype=dtype)
     x_test_value = np.random.default_rng(19).uniform(low, high, 101).astype(dtype)
 
@@ -88,21 +90,22 @@ def test_erfinv(low, high, rtol, dtype):
     )
 
 
+# erfcx decays like 1 / (y sqrt(pi)) rather than vanishing, so the far tail is no harder
+# than the near one once the asymptotic rational takes over
 @pytest.mark.parametrize("dtype", ["float32", "float64"], ids=str)
 @pytest.mark.parametrize(
-    "low, high, rtol",
+    "low, high, tolerances",
     [
-        (-3.0, 0.0, 3e-6),
-        (0.0, 0.47, 1e-6),
-        (0.47, 4.0, 3e-6),
-        (4.0, 27.0, 1e-6),
-        # erfcx decays like 1 / (y sqrt(pi)) rather than vanishing, so the far tail is
-        # no harder than the near one once the asymptotic rational takes over
-        (27.0, 1e3, 1e-6),
+        (-3.0, 0.0, {"float32": 3e-6, "float64": 1e-14}),
+        (0.0, 0.47, {"float32": 1e-6, "float64": 1e-14}),
+        (0.47, 4.0, {"float32": 3e-6, "float64": 1e-14}),
+        (4.0, 27.0, {"float32": 1e-6, "float64": 1e-14}),
+        (27.0, 1e3, {"float32": 1e-6, "float64": 1e-14}),
     ],
     ids=["negative", "small", "moderate", "large", "far-tail"],
 )
-def test_erfcx(low, high, rtol, dtype):
+def test_erfcx(low, high, tolerances, dtype):
+    rtol = tolerances[dtype]
     x = vector("x", dtype=dtype)
     x_test_value = np.random.default_rng(29).uniform(low, high, 101).astype(dtype)
 
@@ -120,10 +123,8 @@ def test_erfcx(low, high, rtol, dtype):
     ids=["mid-rational", "asymptotic", "far-tail"],
 )
 def test_erfcx_float64_precision(low, high):
-    # The two upper Cody intervals are free of exp, which is what lets erfcx hold full
-    # float64 accuracy where every other member of the family is capped near 1e-7. This
-    # is also the test that fails if the coefficients are weak-typed to float32, since
-    # MLX weak-types Python floats. float64 lives on the CPU stream, so the dispatch is
+    # The test that fails if the coefficients are weak-typed to float32, since MLX
+    # weak-types Python floats. float64 lives on the CPU stream, so the dispatch is
     # exercised directly rather than through a compiled function.
     x_test_value = np.linspace(low, high, 201)
 
@@ -136,8 +137,8 @@ def test_erfcx_float64_precision(low, high):
 
 def test_erfc_tail_is_not_truncated():
     # erfc reaches 1e-309 before it stops being representable. Deriving it from
-    # 1 - erf(x) collapses it to exactly zero from x = 4, and a plain mx.exp scale
-    # factor stops at x = 9.5, mx.exp having float32 range as well as float32 precision.
+    # 1 - erf(x) collapses it to exactly zero from x = 4, and a plain mx.exp scale factor
+    # stops at x = 9.5, mx.exp having float32 range as well as float32 precision.
     x_test_value = np.array([4.0, 6.0, 9.0, 12.0, 20.0, 26.0])
 
     with mlx.stream(mlx.cpu):
@@ -145,7 +146,7 @@ def test_erfc_tail_is_not_truncated():
         res = np.asarray(erfc_fn(mlx.array(x_test_value, dtype=mlx.float64)))
 
     assert (res > 0).all()
-    np.testing.assert_allclose(res, scipy.special.erfc(x_test_value), rtol=1e-5)
+    np.testing.assert_allclose(res, scipy.special.erfc(x_test_value), rtol=1e-13)
 
 
 @pytest.mark.skipif(

--- a/tests/link/mlx/scalar/test_erf.py
+++ b/tests/link/mlx/scalar/test_erf.py
@@ -149,6 +149,27 @@ def test_erfc_tail_is_not_truncated():
     np.testing.assert_allclose(res, scipy.special.erfc(x_test_value), rtol=1e-13)
 
 
+def test_erfc_float32_subnormal_tail():
+    # erfc is still representable as a float32 subnormal past x = 9.5, where mx.exp
+    # flushes to zero and would send log(erfc) to -inf against a true value near -93.
+    x_test_value = np.array([9.3, 9.5], dtype="float32")
+
+    with mlx.stream(mlx.cpu):
+        res = np.asarray(mlx_funcify(Erfc())(mlx.array(x_test_value)))
+        # x = 10 sits on the smallest float32 subnormal, carrying a bit or two, and by
+        # x = 10.5 erfc is 7e-50 and genuinely underflows -- zero is the right answer
+        bottom = np.asarray(
+            mlx_funcify(Erfc())(mlx.array(np.array([10.0, 10.5], dtype="float32")))
+        )
+
+    assert (res > 0).all()
+    np.testing.assert_allclose(
+        res, scipy.special.erfc(x_test_value.astype("float64")), rtol=1e-5
+    )
+    assert bottom[0] > 0.0
+    assert bottom[1] == 0.0
+
+
 @pytest.mark.skipif(
     not mlx.metal.is_available() or os.environ.get("PYTENSOR_MLX_SKIP_GPU") == "1",
     reason="needs a GPU that can run kernels; set PYTENSOR_MLX_SKIP_GPU=1 where it cannot",


### PR DESCRIPTION
`VonMises.logp` reaches `pt.i0` from the logp itself (`continuous.py:3178`), so the distribution doesn't work on MLX at all. `i1` ships with it because it's the derivative of `i0`  -  dispatching `i0` alone buys NUTS nothing.

Cephes `i0.c`/`i1.c`, transcribed in Cephes' own arrangement  -  highest degree first, `chbevl` halving the trailing term, the same interval split and transformations  -  so the coefficients diff against netlib rather than having to be taken on trust. A Chebyshev series is near-minimax at every truncation, so float32 takes a prefix of the same array instead of a second fitted set.

The larger find is in the shared helper, and it reaches back into already-merged code. **`mx.exp` is a float32 kernel at every dtype**  -  its float64 result is bitwise equal to its float32 one  -  and it also overflows past `exp(88)` and flushes the float32 subnormals from `exp(-90)`. `mx.power` carries none of those limits and costs nothing measurable in a compiled dispatch. That was capping `i0` at 7e-06 whatever the series in front of it did, and it was capping the merged `erfc`/`erfcx` at roughly 8e-08 on every branch that needs an exponential, so the erf family moves to the same helper here.

Accuracy, max relative error vs scipy:

```
region          i0 f64    i0 f32    i1 f64    i1 f32
(1e-8, 1)      8.9e-16   4.1e-07   1.1e-15   5.4e-07
(1, 8)         8.9e-16   4.8e-07   2.1e-15   1.1e-06
(8, 20)        1.4e-15   1.6e-06   1.4e-15   1.6e-06
(20, 80)       4.4e-15   6.1e-06   4.4e-15   6.2e-06
(80, 700)      3.7e-14  overflow   3.7e-14  overflow
```

float32 grows with x because the exponent's own rounding is x*eps; float64 holds ~1 ulp until the same term takes over near x = 700.

The erf family at float64, before and after the helper:

```
                        before      after
erfc  (0, 1)          8.1e-08    1.7e-15
erfc  (1, 4)          8.2e-08    1.8e-15
erfc  (4, 9)          7.8e-08    4.7e-15
erfcx (0, 0.47)       7.3e-08    1.0e-15
erfcx (-4, -0.47)     9.6e-08    1.1e-15
erfcx (0.47, 4)       8.9e-16    unchanged, already exp-free
```

float32 `erfc` also stops truncating: it returned exactly 0.0 from x = 9.5, where the true value is a representable subnormal and `log(erfc)` should be about -93 rather than `-inf`.

Warm `mx.compile`, best of 60, materialized inside the timed call. `passes` is against one fused elementwise pass over the same buffer.

```
GPU stream, float32
           n   i0 (ms)   i1 (ms)   scipy i0   passes  vs scipy
       1,000     0.256     0.274      0.013     2.7x      0.1x
      10,000     0.291     0.312      0.130     3.2x      0.4x
     100,000     0.386     0.403      1.378     3.7x      3.6x
   1,000,000     0.835     0.926     14.332     5.3x     17.2x
  10,000,000    11.011    12.571    142.413    30.2x     12.9x

CPU stream, float64 -- where the accuracy above is measured
           n   i0 (ms)   i1 (ms)   scipy i0   passes  vs scipy
     100,000      2.11      2.26       1.29    85.1x     0.61x
   1,000,000     20.48     21.81      13.60   191.7x     0.66x
  10,000,000    206.33    225.28     137.83   149.0x     0.67x
```

float64 is about two thirds of scipy's speed rather than a win: MLX has no float64 on the GPU, so it falls to the CPU stream, which does not fuse the way Metal does. The float32 GPU rows and the float64 accuracy rows are different configurations and should not be read together.

No Metal kernel. The 30x at 10^7 is the usual branch-free-selection cost  -  both intervals evaluated for every element  -  but a von Mises concentration is a scalar or a small vector, not 10^7, and below 10^5 this is 2.7-3.7x the floor and dispatch-bound. Metal is float32-only in any case, and float64 is where the accuracy lives.

Part of #2095.
