### PR TITLE
Add MLX dispatch for gamma

### DIFF
--- a/pytensor/link/mlx/dispatch/scalar/__init__.py
+++ b/pytensor/link/mlx/dispatch/scalar/__init__.py
@@ -1,1 +1,1 @@
-from pytensor.link.mlx.dispatch.scalar import basic, bessel, erf, erfcinv, math
+from pytensor.link.mlx.dispatch.scalar import basic, bessel, erf, erfcinv, gamma, math

--- a/pytensor/link/mlx/dispatch/scalar/gamma.py
+++ b/pytensor/link/mlx/dispatch/scalar/gamma.py
@@ -1,0 +1,56 @@
+import mlx.core as mx
+import numpy as np
+
+from pytensor.link.mlx.dispatch.basic import mlx_funcify
+from pytensor.link.mlx.dispatch.scalar.helpers import _exp, _working_precision
+from pytensor.link.mlx.dispatch.scalar.math import _lanczos_log_gamma
+from pytensor.scalar.math import Gamma
+
+
+def _gamma_positive(z, const):
+    """``Gamma(z)`` for ``z > 0``, as ``exp`` of the Lanczos series."""
+    # Below 1/2 the series is evaluated one unit up and divided back down, which keeps
+    # the argument inside the range the Lanczos coefficients were fitted for
+    half = const(0.5)
+    shift_up = z < half
+    y = mx.where(shift_up, z + const(1.0), z)
+    out = _exp(_lanczos_log_gamma(y - const(1.0), const), const)
+    return mx.where(shift_up, out / z, out)
+
+
+@mlx_funcify.register(Gamma)
+def mlx_funcify_Gamma(op, **kwargs):
+    def gamma(x):
+        z, const, out_dtype = _working_precision(x)
+        zero = const(0.0)
+
+        # Both branches are evaluated for every element, so the one that will be
+        # discarded is handed a safe argument rather than a clamped one: clamping the
+        # positive branch would cap Gamma near the origin, where it grows like 1 / z
+        positive = _gamma_positive(mx.where(z > zero, z, const(1.0)), const)
+
+        # Gamma(z) = pi / (sin(pi z) Gamma(1 - z)) below zero. sin is a float32 kernel
+        # whatever dtype it is handed and tan is not, so sin(t) is taken from the
+        # half-angle identity 2 tan(t/2) / (1 + tan(t/2)**2), which holds float64
+        negative = mx.where(z < zero, z, -const(1.0))
+        tan_half = mx.tan(const(0.5 * np.pi) * negative)
+        sin_pi_z = const(2.0) * tan_half / (const(1.0) + tan_half * tan_half)
+        reflected = const(np.pi) / (
+            sin_pi_z * _gamma_positive(const(1.0) - negative, const)
+        )
+
+        out = mx.where(z > zero, positive, reflected)
+
+        # The poles: Gamma is +/-inf at zero, taking the sign of the zero, and undefined
+        # at every negative integer, where the reflection divides by a sin that rounding
+        # leaves merely tiny rather than exactly zero
+        out = mx.where(z == zero, const(1.0) / z, out)
+        # the series is inf / inf at the positive end, where the limit is plain inf
+        out = mx.where(mx.isinf(z) & (z > zero), const(np.inf), out)
+        # neither branch is handed a NaN -- both substitute a safe argument for the
+        # elements the other will select -- so it has to be put back explicitly
+        out = mx.where(mx.isnan(z), z, out)
+        nan = zero / zero
+        return mx.where((z < zero) & (z == mx.round(z)), nan, out).astype(out_dtype)
+
+    return gamma

--- a/pytensor/link/mlx/dispatch/scalar/math.py
+++ b/pytensor/link/mlx/dispatch/scalar/math.py
@@ -42,6 +42,21 @@ _PSI_COEFFS_SINGLE = _PSI_COEFFS[:3]
 _PSI_SHIFTS_SINGLE = 6
 
 
+def _lanczos_log_gamma(w, const):
+    """``log Gamma(w + 1)`` by the Lanczos series, for ``w`` at or above ``-0.5``."""
+    series = const(_LANCZOS_COEFFS[0])
+    for i, coeff in enumerate(_LANCZOS_COEFFS[1:], start=1):
+        series = series + const(coeff) / (w + const(float(i)))
+
+    t = w + const(_LANCZOS_G + 0.5)
+    return (
+        const(0.5 * np.log(2.0 * np.pi))
+        + (w + const(0.5)) * mx.log(t)
+        - t
+        + mx.log(series)
+    )
+
+
 @mlx_funcify.register(Sigmoid)
 def mlx_funcify_Sigmoid(op, **kwargs):
     return mx.sigmoid
@@ -96,17 +111,7 @@ def mlx_funcify_GammaLn(op, **kwargs):
         # Evaluating the series on the reflected argument means one polynomial
         # covers both branches, and neither can produce a NaN the other must mask
         w = mx.where(reflect, one - y, y) - one
-        series = const(_LANCZOS_COEFFS[0])
-        for i, coeff in enumerate(_LANCZOS_COEFFS[1:], start=1):
-            series = series + const(coeff) / (w + const(float(i)))
-
-        t = w + const(_LANCZOS_G + 0.5)
-        lanczos = (
-            const(0.5 * np.log(2.0 * np.pi))
-            + (w + half) * mx.log(t)
-            - t
-            + mx.log(series)
-        )
+        lanczos = _lanczos_log_gamma(w, const)
 
         # Reducing the argument before sin keeps log|sin(pi x)| accurate at large |x|
         log_sin = mx.log(mx.abs(mx.sin(const(np.pi) * (y - mx.floor(y)))))

--- a/tests/link/mlx/scalar/test_gamma.py
+++ b/tests/link/mlx/scalar/test_gamma.py
@@ -1,0 +1,109 @@
+from functools import partial
+
+import numpy as np
+import pytest
+import scipy.special
+
+import pytensor.tensor as pt
+from pytensor.scalar.math import Gamma
+from pytensor.tensor.type import vector
+from tests.link.mlx.test_basic import compare_mlx_and_py
+
+
+mlx = pytest.importorskip("mlx.core")
+from pytensor.link.mlx.dispatch import mlx_funcify
+
+
+# float32 loosens with the argument because gamma grows like a factorial and the
+# exponential carries x * eps of its own; it overflows float32 outright past x = 35,
+# which is why the ranges stop short of that.
+@pytest.mark.parametrize("dtype", ["float32", "float64"], ids=str)
+@pytest.mark.parametrize(
+    "low, high, tolerances",
+    [
+        (1e-3, 1.0, {"float32": 1e-5, "float64": 1e-13}),
+        (1.0, 10.0, {"float32": 1e-5, "float64": 1e-13}),
+        (10.0, 34.0, {"float32": 1e-4, "float64": 1e-12}),
+        (-0.9, -0.1, {"float32": 1e-5, "float64": 1e-13}),
+        (-5.9, -5.1, {"float32": 1e-4, "float64": 1e-13}),
+    ],
+    ids=["tiny", "moderate", "large", "negative", "negative-deep"],
+)
+def test_gamma(low, high, tolerances, dtype):
+    x = vector("x", dtype=dtype)
+    x_test_value = np.random.default_rng(83).uniform(low, high, 101).astype(dtype)
+
+    compare_mlx_and_py(
+        [x],
+        [pt.gamma(x)],
+        [x_test_value],
+        assert_fn=partial(np.testing.assert_allclose, rtol=tolerances[dtype]),
+    )
+
+
+@pytest.mark.parametrize(
+    "low, high",
+    [(1e-3, 1.0), (1.0, 34.0), (34.0, 170.0), (-0.9, -0.1), (-20.9, -20.1)],
+    ids=["tiny", "moderate", "near-overflow", "negative", "negative-deep"],
+)
+def test_gamma_float64_precision(low, high):
+    # The negative ranges are the point. Below zero gamma goes through the reflection
+    # formula, whose sin(pi z) is taken from tan by the half-angle identity: tan is
+    # genuine at float64 where sin is a float32 kernel whatever it is handed, and going
+    # through sin directly caps these ranges near 1e-6.
+    x_test_value = np.linspace(low, high, 401)
+
+    with mlx.stream(mlx.cpu):
+        res = np.asarray(
+            mlx_funcify(Gamma())(mlx.array(x_test_value, dtype=mlx.float64))
+        )
+
+    np.testing.assert_allclose(res, scipy.special.gamma(x_test_value), rtol=1e-12)
+
+
+def test_gamma_edge_cases():
+    # gamma is +/-inf at zero by the sign of the zero, undefined at every negative
+    # integer -- where the reflection divides by a sin that rounding leaves tiny rather
+    # than exactly zero -- and 171 is the last argument float64 can hold.
+    x = vector("x", dtype="float64")
+    x_test_value = np.array(
+        [0.0, -0.0, -1.0, -3.0, 1.0, 171.0, np.inf, -np.inf, np.nan]
+    )
+
+    compare_mlx_and_py([x], [pt.gamma(x)], [x_test_value])
+
+
+@pytest.mark.parametrize(
+    "dtype, rtol", [("float32", 1e-4), ("float64", 1e-13)], ids=["float32", "float64"]
+)
+def test_gamma_grad(dtype, rtol):
+    # d/dx gamma(x) is gamma(x) * psi(x), so this needs both dispatches
+    x = vector("x", dtype=dtype)
+    x_test_value = np.random.default_rng(89).uniform(0.5, 8.0, 51).astype(dtype)
+
+    compare_mlx_and_py(
+        [x],
+        [pt.grad(pt.gamma(x).sum(), x)],
+        [x_test_value],
+        assert_fn=partial(np.testing.assert_allclose, rtol=rtol),
+    )
+
+
+@pytest.mark.parametrize(
+    "low, high",
+    [(1e-300, 1e-100), (1e-100, 1e-38), (1e-38, 1e-3)],
+    ids=["subnormal-scale", "below-float32", "small"],
+)
+def test_gamma_small_positive(low, high):
+    # Gamma grows like 1 / z toward the origin, so anything that floors the argument
+    # floors the whole region with it: clamping at float32's smallest normal returned
+    # 8.5e37 for every argument below 1.2e-38, where the answers run out to 1e300. The
+    # ranges are log-spaced because a linear sample here is all upper endpoint.
+    x_test_value = np.exp(np.linspace(np.log(low), np.log(high), 201))
+
+    with mlx.stream(mlx.cpu):
+        res = np.asarray(
+            mlx_funcify(Gamma())(mlx.array(x_test_value, dtype=mlx.float64))
+        )
+
+    np.testing.assert_allclose(res, scipy.special.gamma(x_test_value), rtol=1e-12)


### PR DESCRIPTION
`pt.gamma` has no MLX dispatch, so it raises. It has more call sites in pymc than the rest of this family put together: `Matern32` and `Matern52` power spectral densities, `RationalQuadratic`'s, and the `Rice` / `Weibull` moments (gp/cov.py:707,760,653 ,  moments/means.py:395,450 ,  continuous.py:2751).

It's `exp` of the Lanczos series `gammaln` already carries, so the series is extracted rather than copied. Two things make it more than a one-liner.

`mx.exp` is a float32 kernel at every dtype and overflows past `exp(88)`, so `exp(gammaln(x))` returns `inf` from x around 35, where float64 holds out to 171. Through `mx.power` it does not  -  that helper is the first commit, and it is the same one in #2332, byte for byte, so whichever lands first the other resolves.

Below zero the reflection needs `sin(pi z)`, and `mx.sin` is float32-only whatever it is handed. `tan` is not, so `sin` comes from the half-angle identity instead:

```
region              via mx.sin    via tan
(-0.9, -0.1)          2.8e-07    2.2e-15
(-2.9, -2.1)          1.3e-06    4.7e-15
(-5.9, -5.1)          2.7e-06    1.2e-14
(-20.9, -20.1)        9.5e-06    3.2e-14
```

The same substitution should work for `gammaln` and `psi`, whose negative domains go through the same `mx.sin` and are pinned near 1e-6 for it. Follow-up, not this PR.

Accuracy against scipy:

```
region              float64      float32
(1e-300, 1e-38)     1.1e-15  out of range
(1e-38, 1e-3)       1.7e-15  out of range
(1e-3, 1)           1.9e-15      1.0e-06
(1, 10)             7.8e-15      3.2e-06
(10, 34)            4.7e-14      1.4e-05
(34, 171)           3.1e-13  out of range
(-0.9, -0.1)        2.2e-15      1.2e-06
(-5.9, -5.1)        1.2e-14      5.3e-06
(-20.9, -20.1)      3.2e-14      2.4e-05
```

float32 overflows at x = 35 and cannot represent the small-argument rows at all, so those are left out rather than asserted against `inf`. Both signed zeros, the negative-integer poles, 171 and both infinities match scipy exactly.

Warm `mx.compile`, best of 40, materialized inside the timed call. `passes` is against one fused elementwise pass over the same buffer, in the same configuration. Note the accuracy table above is float64, which only runs on the CPU stream, so both configurations are given:

```
GPU stream, float32
           n   gamma (ms)   scipy (ms)   passes   vs scipy
     100,000        0.313         1.70     3.0x       5.4x
   1,000,000        0.722        17.72     5.3x      24.5x
  10,000,000        4.927       176.79    13.8x      35.9x

CPU stream, float64 -- where the accuracy above is measured
           n   gamma (ms)   scipy (ms)   passes   vs scipy
     100,000        3.204         1.56   123.4x       0.5x
   1,000,000       31.918        16.83   271.4x       0.5x
  10,000,000      322.446       168.93   252.8x       0.5x
```

So float64 is about half scipy's speed, not a win -- MLX has no float64 on the GPU at all, and the CPU stream does not fuse the way Metal does. The float32 GPU numbers are the ones that beat scipy, and they are a different configuration from the accuracy table.

No Metal kernel. The 15x at 10^7 is the Lanczos series being evaluated twice, once per branch, but the spectral densities that call this run over hundreds of elements where it's 1.9x the floor and dispatch-bound. Metal is float32-only in any case, which is the half that doesn't need help, and it has no `lgamma`  -  a kernel would mean a second hand-transcribed copy of the coefficients.

Part of #2095.
