### PR TITLE
Use target-sized indices in Numba vectorized codegen

### DIFF
--- a/pytensor/link/numba/dispatch/vectorize_codegen.py
+++ b/pytensor/link/numba/dispatch/vectorize_codegen.py
@@ -307,7 +307,7 @@ def compute_itershape(
     broadcast_pattern: tuple[tuple[bool, ...], ...],
     size: list[ir.Instruction] | None,
 ):
-    one = ir.IntType(64)(1)
+    one = ctx.get_constant(types.intp, 1)
     batch_ndim = len(broadcast_pattern[0])
     shape = [None] * batch_ndim
     if size is not None:
@@ -417,7 +417,7 @@ def make_outputs(
     """
     output_arrays = []
     output_arry_types = []
-    one = ir.IntType(64)(1)
+    one = ctx.get_constant(types.intp, 1)
     inplace_dict = dict(inplace)
     for i, (core_shape, bc, dtype) in enumerate(
         zip(output_core_shapes, out_bc, dtypes, strict=True)
@@ -448,7 +448,7 @@ def make_outputs(
             # reduction identity.  A flat scan over every element is valid
             # regardless of which axes are reduced, and seeds each kept-axis
             # accumulator cell (size-1 reduced axes included).
-            nitems = ir.IntType(64)(1)
+            nitems = ctx.get_constant(types.intp, 1)
             for dim_len in shape:
                 nitems = builder.mul(nitems, dim_len)
             ident = ctx.get_constant(dtype, reduce_identities[i])
@@ -522,7 +522,7 @@ def make_loop_call(
     ]
     destroyed_inputs = {in_idx: out_idx for out_idx, in_idx in inplace}
 
-    zero = ir.Constant(ir.IntType(64), 0)
+    zero = context.get_constant(types.intp, 0)
 
     def _wrap_negative_index(idx_val, dim_size, signed):
         """Wrap a negative index by adding the dimension size: idx + size if idx < 0.
@@ -580,12 +580,7 @@ def make_loop_call(
             val = builder.load(ptr)
             val.set_metadata("alias.scope", input_scope_set)
             val.set_metadata("noalias", output_scope_set)
-            i64 = ir.IntType(64)
-            if val.type != i64:
-                if idx_arr_type.dtype.signed:
-                    val = builder.sext(val, i64)
-                else:
-                    val = builder.zext(val, i64)
+            val = context.cast(builder, val, idx_arr_type.dtype, types.intp)
             indirect_idxs.append(val)
 
     # Load values from input arrays
@@ -1076,7 +1071,7 @@ def _vectorized(
             cgutils.unpack_tuple(builder, idx_arrs[k].shape) for k in range(n_indices)
         ]
 
-        one = ir.IntType(64)(1)
+        one = ctx.get_constant(types.intp, 1)
         iter_shapes = list(in_shapes)
         iter_bc = list(input_bc_patterns)
 

--- a/tests/link/numba/test_vectorize_codegen.py
+++ b/tests/link/numba/test_vectorize_codegen.py
@@ -1,0 +1,40 @@
+from llvmlite import ir
+from numba import types
+
+from pytensor.link.numba.dispatch.vectorize_codegen import compute_itershape
+
+
+class Mock32BitContext:
+    """Minimal Numba context whose ``intp`` LLVM representation is i32."""
+
+    class CallConv:
+        @staticmethod
+        def return_user_exc(builder, exc, args):
+            pass
+
+    call_conv = CallConv()
+
+    @staticmethod
+    def get_constant(typ, value):
+        assert typ is types.intp
+        return ir.Constant(ir.IntType(32), value)
+
+
+def test_compute_itershape_uses_target_intp_width():
+    module = ir.Module()
+    function_type = ir.FunctionType(ir.VoidType(), ())
+    function = ir.Function(module, function_type, "compute_itershape")
+    builder = ir.IRBuilder(function.append_basic_block("entry"))
+
+    one_i32 = ir.Constant(ir.IntType(32), 1)
+    shape = compute_itershape(
+        Mock32BitContext(),
+        builder,
+        in_shapes=[[one_i32]],
+        broadcast_pattern=((True,),),
+        size=None,
+    )
+    builder.ret_void()
+
+    assert shape == [one_i32]
+    assert "icmp ne i32" in str(module)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pytensor/releases -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
