### PR TITLE
Fix `AdvancedIncSubtensor` runtime-broadcast check crashing on a scalar update

### DIFF
--- a/pytensor/link/jax/dispatch/subtensor.py
+++ b/pytensor/link/jax/dispatch/subtensor.py
@@ -1,3 +1,5 @@
+import jax.numpy as jnp
+
 from pytensor.link.jax.dispatch.basic import jax_funcify
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
@@ -60,7 +62,11 @@ def jax_funcify_IncSubtensor(op, node, **kwargs):
             indices = indices[0]
 
         if isinstance(op, AdvancedIncSubtensor):
-            op._check_runtime_broadcast_of_vector_index(node, x, y, indices)
+            # jax_typify downgrades 0d arrays to Python scalars, which have no .shape,
+            # so re-arrayify y for a check that is written against array values.
+            op._check_runtime_broadcast_of_vector_index(
+                node, x, jnp.asarray(y), indices
+            )
 
         return jax_fn(x, indices, y)
 

--- a/tests/link/jax/test_subtensor.py
+++ b/tests/link/jax/test_subtensor.py
@@ -228,6 +228,26 @@ def test_jax_IncSubtensor():
 @pytest.mark.parametrize(
     "func", (pt_subtensor.advanced_inc_subtensor1, pt_subtensor.advanced_set_subtensor1)
 )
+def test_jax_AdvancedIncSubtensor1_scalar_y(func):
+    """A 0d update must not trip the runtime-broadcast check.
+
+    The check is written against array values, but ``jax_typify`` turns a 0d array into a
+    Python scalar, which has no ``.shape``.
+    """
+    from pytensor import function
+
+    x = pt.zeros((5,))
+    out = func(x, 1.0, np.array([1, 3]))
+
+    res = function([], out, mode="JAX")()
+    expected = np.zeros(5)
+    expected[[1, 3]] = 1.0
+    np.testing.assert_allclose(res, expected)
+
+
+@pytest.mark.parametrize(
+    "func", (pt_subtensor.advanced_inc_subtensor1, pt_subtensor.advanced_set_subtensor1)
+)
 def test_jax_AdvancedIncSubtensor1_runtime_broadcast(func):
     """Test that JAX backend checks for runtime broadcasting in AdvancedIncSubtensor1.
 


### PR DESCRIPTION
## What / why

`set_subtensor(x[idx_vector], scalar)` works on the Python and numba backends and raises on JAX:

```python
import numpy as np, pytensor, pytensor.tensor as pt

x = pt.vector("x")
out = pt.set_subtensor(x[pt.constant([1, 3])], 1.0)   # 0d update

pytensor.function([x], out, mode="JAX")(np.zeros(5))
# AttributeError: 'float' object has no attribute 'shape'
#   pytensor/link/jax/dispatch/subtensor.py:63  in incsubtensor
#   pytensor/tensor/subtensor.py:2468           in _check_runtime_broadcast_of_vector_index
```

The update input is a 0d `TensorType`, so `_check_runtime_broadcast_of_vector_index` is entitled to
a value with a `.shape`. It doesn't get one because `jax_typify` downgrades 0d arrays to Python
scalars:

```python
@jax_typify.register(np.ndarray)
def jax_typify_ndarray(data, dtype=None, **kwargs):
    if len(data.shape) == 0:
        return data.item()          # 0d array -> Python scalar
    return jnp.array(data, dtype=dtype)
```

## The change

Coerce at the dispatch call site — the layer that knows it is handing linker values to a check
written against arrays:

```python
-op._check_runtime_broadcast_of_vector_index(node, x, y, indices)
+op._check_runtime_broadcast_of_vector_index(node, x, jnp.asarray(y), indices)
```

This is a bandaid over the typify behaviour, by @ricardoV94's call in the thread below. Removing the
`.item()` branch instead does fix the crash on its own, but it takes `tests/link/jax/` from **2
failures to 27** (25 new, verified against the same suite on clean `main`) — 10 in `test_scan.py`,
4 in `test_sort.py` (`ValueError: Non-hashable static arguments`), 3 in `test_shape.py`, plus
`linalg`/`pad`/`conv`, mostly `TracerBoolConversionError` and non-hashable static args. The
`.item()` is load-bearing for dispatches that want a static Python value for an axis, shape or loop
bound, so doing it properly means having those pull their scalar from the constant node instead —
a much wider change than this PR.

## Testing

- New `test_jax_AdvancedIncSubtensor1_scalar_y`, parametrised over
  `advanced_inc_subtensor1` / `advanced_set_subtensor1` to match the neighbouring
  `test_jax_AdvancedIncSubtensor1_runtime_broadcast`. **Verified it fails without the fix**
  (`AttributeError`) and passes with it.
- The existing `test_jax_AdvancedIncSubtensor1_runtime_broadcast` still passes: a length-1 `y`
  written into 2 indices continues to raise `ValueError: Runtime broadcasting not allowed…`, so the
  guard still fires where it should.
- `tests/link/jax/test_subtensor.py` passes (11 passed, 1 xfailed). `tests/tensor/test_subtensor.py`
  has one failure, `TestSubtensor::test_boolean`, which fails identically on the base commit.
- Found via real models: PyMC ranking models (`Multinomial` over best/worst choice sets) whose
  expansion function builds its rank structure with a scalar `set_subtensor`. Under
  `nuts_sampler="nutpie"` with the JAX backend this surfaced only as an opaque
  `Error during point expansion` panic from nuts-rs mid-sampling, with the Python exception
  swallowed. Three multi-step MRP models (~5k respondents) that could not be fitted under the JAX
  backend at all now complete; the numba backend fit all three identically before and after.

Versions: pytensor `main` @ `a85bc78`, jax 0.6.2, numpy 2.3.5, Python 3.12, Linux.

Related: #2241 extended this check to the MLX backend and #2303 fixed a different false positive in
it; neither covers the 0d-`y` case. The MLX and PyTorch dispatches call the same method, so they are
presumably reachable the same way if their typify does the same thing — not touched here, since I
have not reproduced it on either.
