### PR TITLE
Add MLX dispatch for ive at real order

### DIFF
--- a/pytensor/link/mlx/dispatch/scalar/bessel.py
+++ b/pytensor/link/mlx/dispatch/scalar/bessel.py
@@ -1,8 +1,12 @@
 import mlx.core as mx
+import numpy as np
+from scipy.special import gammaln as scipy_gammaln
 
+from pytensor.graph.basic import Constant
+from pytensor.graph.traversal import ancestors
 from pytensor.link.mlx.dispatch.basic import mlx_funcify
 from pytensor.link.mlx.dispatch.scalar.helpers import _exp, _working_precision
-from pytensor.scalar.math import I0, I1
+from pytensor.scalar.math import I0, I1, Ive
 
 
 # Chebyshev expansions of the exponentially scaled modified Bessel functions, from the
@@ -232,3 +236,179 @@ def mlx_funcify_I1(op, **kwargs):
         return mx.where(z < const(0.0), -out, out).astype(out_dtype)
 
     return i1
+
+
+# ive at real order is a different construction from i0 and i1: an ascending power series
+# below x = 20 and a Hankel asymptotic expansion above it, rather than a Chebyshev fit.
+# Both branches are polynomials once the order is known, which is why the order has to be
+# a constant -- see mlx_funcify_Ive.
+# The Hankel expansion needs x large against v**2, and the series needs a term for
+# roughly every x / 2, so both the split and the trip count follow the order. Validated
+# against scipy to 3e-14 over -20 <= v <= 20; past that the series grows faster than it
+# is worth and the order is refused rather than approximated
+_IVE_MAX_ORDER = 20.0
+_IVE_ASYMPTOTIC_TERMS = 20
+
+
+def _ive_split(order):
+    """Argument at which the ascending series gives way to the Hankel expansion."""
+    return np.maximum(20.0, 0.25 * order * order + 0.5 * np.abs(order) + 15.0)
+
+
+def _ive_series_terms(order):
+    """Trip count the ascending series needs to reach :func:`_ive_split`.
+
+    One count covers the whole order array, since the loop is unrolled into the graph
+    and cannot vary per element.
+    """
+    return int(0.75 * np.max(_ive_split(order)) + 30)
+
+
+def _ive_series_step(order, k):
+    """Ratio of consecutive ascending-series terms, ``t_k / t_{k-1}``, less ``x**2 / 4``."""
+    return 1.0 / (k * (order + k))
+
+
+def _ive_asymptotic_coeffs(order, n_terms):
+    """Hankel coefficients ``a_k`` in ``ive(v, x) ~ sum (-1)**k a_k / x**k / sqrt(2 pi x)``.
+
+    The expansion terminates for half-integer orders, where ``mu`` meets an odd square
+    exactly and every later coefficient is zero.
+    """
+    mu = 4.0 * order * order
+    term = np.ones_like(mu)
+    coeffs = [term]
+    for k in range(1, n_terms):
+        term = term * -(mu - (2 * k - 1) ** 2) / (8.0 * k)
+        coeffs.append(term)
+    return tuple(coeffs)
+
+
+def _ive_series(y, order, const):
+    """``ive(order, y)`` by the ascending series, for ``y`` at or below the split."""
+    quarter_sq = y * y * const(0.25)
+    total = const(1.0)
+    term = const(1.0)
+    for k in range(1, _ive_series_terms(order)):
+        term = term * quarter_sq * const(_ive_series_step(order, k))
+        total = total + term
+
+    # The (y/2)**v / Gamma(v+1) prefactor is taken in log space so that a large order
+    # does not overflow on its way to a small answer. Only y = 0 has to be kept out of
+    # the logarithm, and its limits are exact anyway: 1, 0 and a pole for a zero,
+    # positive and negative order. Clamping the argument instead of substituting for it
+    # would floor every y below the clamp along with it
+    safe_y = mx.where(y > const(0.0), y, const(1.0))
+    log_prefactor = (
+        -y
+        - const(scipy_gammaln(order + 1.0))
+        + const(order) * mx.log(safe_y * const(0.5))
+    )
+    out = total * _exp(log_prefactor, const)
+    return mx.where(y == const(0.0), const(np.where(order == 0.0, 1.0, 0.0)), out)
+
+
+def _ive_asymptotic(y, order, const):
+    """``ive(order, y)`` by the Hankel expansion, for ``y`` at or above the split.
+
+    A plain polynomial in ``1 / y`` once the order is fixed.
+    """
+    inv_y = const(1.0) / y
+    coeffs = _ive_asymptotic_coeffs(order, _IVE_ASYMPTOTIC_TERMS)
+    acc = const(coeffs[-1])
+    for c in reversed(coeffs[:-1]):
+        acc = acc * inv_y + const(c)
+    return acc * mx.rsqrt(const(2.0 * np.pi) * y)
+
+
+def _ive_positive(y, order, const):
+    """``ive(order, y)`` for non-negative ``y`` at a known constant ``order``.
+
+    ``order`` is a NumPy array broadcasting against ``y``, so a graph asking for a whole
+    vector of orders at once -- as the HSGP approximation of a periodic kernel does --
+    is one evaluation rather than one per order.
+    """
+    # Both branches run for every element and are selected afterwards, so each is
+    # clamped into its own interval first
+    split = const(_ive_split(order))
+    small = _ive_series(mx.minimum(y, split), order, const)
+    large = _ive_asymptotic(mx.maximum(y, split), order, const)
+    return mx.where(y <= split, small, large)
+
+
+def _constant_order(var):
+    """Return the order as a NumPy array, or None when it is not fixed by the graph.
+
+    The order is used with the shape it has in the graph, so it broadcasts against the
+    argument exactly as the op does -- a whole vector of orders is one evaluation.
+    """
+    if isinstance(var, Constant):
+        return np.asarray(var.data, dtype="float64")
+    if all(
+        root.owner is not None or isinstance(root, Constant)
+        for root in ancestors([var])
+    ):
+        return np.asarray(var.eval(), dtype="float64")
+    return None
+
+
+@mlx_funcify.register(Ive)
+def mlx_funcify_Ive(op, node=None, **kwargs):
+    order = None if node is None else _constant_order(node.inputs[0])
+    if order is None:
+        raise NotImplementedError(
+            "MLX ive requires a constant order. The series is unrolled into the graph, "
+            "so its trip count has to be known, and the coefficients of both branches "
+            "along with the negative-integer and negative-argument rules are all fixed "
+            "by the order. A symbolic order needs a different implementation rather "
+            "than a different constant. An array of orders is fine: it is used with the "
+            "shape it has in the graph, so a vector of them costs one evaluation."
+        )
+    order = np.asarray(order, dtype="float64")
+    if np.max(np.abs(order)) > _IVE_MAX_ORDER:
+        raise NotImplementedError(
+            f"MLX ive supports orders up to {_IVE_MAX_ORDER:g}, not "
+            f"{np.max(np.abs(order)):g}. The ascending series needs a term for roughly "
+            "every x / 2 up to where the Hankel expansion takes over, and that "
+            "crossover grows with the square of the order."
+        )
+
+    # I(-n, x) = I(n, x) for integer n. Reflecting here keeps the series ratio away from
+    # the pole of Gamma at a non-positive integer, which is where 1 / (k + v) divides by
+    # zero
+    is_integer = order == np.round(order)
+    reflected = np.where(is_integer & (order < 0.0), -order, order)
+
+    # Only integer orders continue to negative argument, with the parity of the order;
+    # everything else is outside the real domain there, as is zero for a negative
+    # non-integer order
+    negative_sign = np.where(is_integer & (np.round(reflected) % 2 == 1), -1.0, 1.0)
+    negative_is_nan = ~is_integer
+    zero_is_pole = negative_is_nan & (order < 0.0)
+
+    def ive(v, x):
+        z, const, out_dtype = _working_precision(x)
+        out = _ive_positive(mx.abs(z), reflected, const)
+
+        out = mx.where(z < const(0.0), out * const(negative_sign), out)
+
+        # NaN is computed rather than named: mx.compile inlines a size-1 constant into
+        # its generated source, where a bare `nan` is a literal neither backend has
+        nan = const(0.0) / const(0.0)
+        if negative_is_nan.any():
+            off_domain = (z < const(0.0)) & (
+                const(negative_is_nan.astype("float64")) != const(0.0)
+            )
+            out = mx.where(off_domain, nan, out)
+        if zero_is_pole.any():
+            at_pole = (z == const(0.0)) & (
+                const(zero_is_pole.astype("float64")) != const(0.0)
+            )
+            out = mx.where(at_pole, nan, out)
+
+        # The series tends to zero at either infinity, but scipy reports NaN there and
+        # the op has to agree with it across backends
+        out = mx.where(mx.isinf(z), nan, out)
+        return out.astype(out_dtype)
+
+    return ive

--- a/pytensor/link/mlx/dispatch/scalar/bessel.py
+++ b/pytensor/link/mlx/dispatch/scalar/bessel.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 import mlx.core as mx
 import numpy as np
 from scipy.special import gammaln as scipy_gammaln
@@ -284,6 +286,111 @@ def _ive_asymptotic_coeffs(order, n_terms):
     return tuple(coeffs)
 
 
+# The vectorized ive evaluates a fixed trip count for every element and both branches on
+# top of that -- 62x a single fused pass at n = 1e7, the worst ratio in this module. A
+# kernel takes the branch and stops the series when it has converged, which for most
+# arguments is long before the worst-case term count. The order is a constant, so its
+# split, trip count and 1 / Gamma(v + 1) are baked into the source and the kernel is
+# cached per order.
+_METAL_IVE_SOURCE = """
+    uint i = thread_position_in_grid.x;
+    float y = fabs((float)x[i]);
+    float res;
+    if (y <= IVE_SPLIT) {
+        float quarter = 0.25f * y * y;
+        float term = 1.0f;
+        float total = 1.0f;
+        for (int k = 1; k < IVE_TERMS; ++k) {
+            term *= quarter / (float)(k * (IVE_ORDER + k));
+            total += term;
+            // the terms alternate in sign for a negative non-integer order, so the
+            // convergence test has to be on the magnitude or it fires on the first one
+            if (fabs(term) <= 1e-9f * fabs(total)) break;
+        }
+        float scale = IVE_RGAMMA * exp(-y);
+        if (IVE_ORDER != 0.0f) scale *= pow(0.5f * y, IVE_ORDER);
+        res = total * scale;
+    } else {
+        float term = 1.0f;
+        float total = 1.0f;
+        for (int k = 1; k < IVE_ASYMPTOTIC_TERMS; ++k) {
+            term *= -(IVE_MU - (float)((2 * k - 1) * (2 * k - 1))) / (8.0f * y * (float)k);
+            total += term;
+        }
+        res = total * rsqrt(2.0f * 3.14159265358979323846f * y);
+    }
+    out[i] = (T)res;
+"""
+
+
+_METAL_IVE_KERNELS: dict[float, Callable | None] = {}
+
+
+def _metal_ive_kernel(order):
+    """Build and cache the Metal kernel for ``order``, or None if it cannot be built."""
+    # .item() rather than float(): a scalar order arrives with shape (1,) once the op
+    # has broadcast it, and NumPy is retiring the implicit conversion of those
+    order = np.asarray(order).item()
+    if order not in _METAL_IVE_KERNELS:
+        # the trailing newline matters: MLX appends its own template declaration straight
+        # after this header, and a #define running into it fails to compile
+        header = (
+            "\n".join(
+                f"#define {name} {value}"
+                for name, value in (
+                    ("IVE_SPLIT", f"{_ive_split(order):.8f}f"),
+                    ("IVE_TERMS", _ive_series_terms(order)),
+                    ("IVE_ORDER", f"{order:.8f}f"),
+                    ("IVE_MU", f"{4.0 * order * order:.8f}f"),
+                    ("IVE_RGAMMA", f"{np.exp(-scipy_gammaln(order + 1.0)):.10e}f"),
+                    ("IVE_ASYMPTOTIC_TERMS", _IVE_ASYMPTOTIC_TERMS),
+                )
+            )
+            + "\n"
+        )
+        try:
+            _METAL_IVE_KERNELS[order] = mx.fast.metal_kernel(
+                name=f"pytensor_ive_{str(order).replace('.', '_').replace('-', 'neg')}",
+                input_names=["x"],
+                output_names=["out"],
+                header=header,
+                source=_METAL_IVE_SOURCE,
+            )
+        except Exception:
+            _METAL_IVE_KERNELS[order] = None
+    return _METAL_IVE_KERNELS[order]
+
+
+def _metal_ive_call(order, y):
+    """Evaluate ``ive(order, y)`` through its Metal kernel, or None to fall back.
+
+    The kernel bakes the order into its source, so it serves a single order only; a
+    vector of orders takes the vectorized path, where they cost one evaluation between
+    them rather than one each. A scalar order reaches this with shape ``(1,)`` when the
+    argument is an array, since the op broadcasts it, so size rather than rank decides.
+    """
+    if (
+        np.size(order) != 1
+        or y.dtype != mx.float32
+        or not mx.metal.is_available()
+        or mx.default_device() != mx.gpu
+    ):
+        return None
+    kernel = _metal_ive_kernel(order)
+    if kernel is None:
+        return None
+    flat = y.reshape(-1)
+    (out,) = kernel(
+        inputs=[flat],
+        template=[("T", flat.dtype)],
+        grid=(flat.size, 1, 1),
+        threadgroup=(min(256, max(flat.size, 1)), 1, 1),
+        output_shapes=[flat.shape],
+        output_dtypes=[flat.dtype],
+    )
+    return out.reshape(y.shape)
+
+
 def _ive_series(y, order, const):
     """``ive(order, y)`` by the ascending series, for ``y`` at or below the split."""
     quarter_sq = y * y * const(0.25)
@@ -328,6 +435,10 @@ def _ive_positive(y, order, const):
     vector of orders at once -- as the HSGP approximation of a periodic kernel does --
     is one evaluation rather than one per order.
     """
+    fast = _metal_ive_call(order, y)
+    if fast is not None:
+        return fast
+
     # Both branches run for every element and are selected afterwards, so each is
     # clamped into its own interval first
     split = const(_ive_split(order))

--- a/tests/link/mlx/scalar/test_bessel.py
+++ b/tests/link/mlx/scalar/test_bessel.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import numpy as np
@@ -14,6 +15,12 @@ from tests.link.mlx.test_basic import compare_mlx_and_py
 
 mlx = pytest.importorskip("mlx.core")
 from pytensor.link.mlx.dispatch import mlx_funcify
+from pytensor.link.mlx.dispatch.scalar.bessel import (
+    _constant_order as constant_order,
+)
+from pytensor.link.mlx.dispatch.scalar.bessel import (
+    _metal_ive_call as metal_ive_call,
+)
 
 
 # The series splits at x = 8, so the ranges straddle it rather than sampling across it.
@@ -259,6 +266,45 @@ def test_ive_large_order_raises():
 
     with pytest.raises(NotImplementedError, match="orders up to 20"):
         pytensor.function([x], pt.ive(25.0, x), mode="MLX")
+
+
+@pytest.mark.skipif(
+    not mlx.metal.is_available() or os.environ.get("PYTENSOR_MLX_SKIP_GPU") == "1",
+    reason="needs a GPU that can run kernels; set PYTENSOR_MLX_SKIP_GPU=1 where it cannot",
+)
+@pytest.mark.parametrize("order", [0.0, 0.5, 1.0, 2.5, 5.0, -0.5, -1.0, -2.5], ids=str)
+def test_ive_paths_agree(order):
+    # ive is implemented twice: a Metal kernel, taken for float32 on the GPU stream, and
+    # the vectorized fallback taken everywhere else -- which is every float64 graph,
+    # since Metal has no float64 at all. Only the fallback runs on CI, so this is the
+    # only thing standing between the kernel and a silent drift.
+    #
+    # The negative non-integer orders are the ones that matter. Their series terms
+    # alternate in sign, and a convergence test written on the term rather than its
+    # magnitude stops at the first one, which is wrong by a factor of two rather than by
+    # an ulp. Every order with strictly positive terms passes such a test happily.
+    x_test_value = np.exp(
+        np.random.default_rng(71).uniform(np.log(1e-4), np.log(500.0), 1001)
+    ).astype("float32")
+    x = vector("x", dtype="float32")
+    node = pt.ive(order, x).owner
+
+    with mlx.stream(mlx.gpu):
+        # Without this the test compares the fallback against itself and passes whatever
+        # the kernel does. A scalar order reaches the dispatch with shape (1,) once it
+        # has been broadcast against the argument, which is enough to disqualify it from
+        # the kernel if the guard checks rank rather than size.
+        graph_order = constant_order(node.inputs[0])
+        assert metal_ive_call(graph_order, mlx.array(x_test_value)) is not None, (
+            "the Metal kernel did not engage, so this comparison proves nothing"
+        )
+        metal = np.asarray(mlx_funcify(Ive(), node=node)(None, mlx.array(x_test_value)))
+    with mlx.stream(mlx.cpu):
+        vectorized = np.asarray(
+            mlx_funcify(Ive(), node=node)(None, mlx.array(x_test_value))
+        )
+
+    np.testing.assert_allclose(metal, vectorized, rtol=1e-4, atol=0.0)
 
 
 def test_ive_vector_order():

--- a/tests/link/mlx/scalar/test_bessel.py
+++ b/tests/link/mlx/scalar/test_bessel.py
@@ -5,9 +5,10 @@ import pytest
 import scipy.special
 import scipy.stats
 
+import pytensor
 import pytensor.tensor as pt
-from pytensor.scalar.math import I0, I1
-from pytensor.tensor.type import vector
+from pytensor.scalar.math import I0, I1, Ive
+from pytensor.tensor.type import scalar, vector
 from tests.link.mlx.test_basic import compare_mlx_and_py
 
 
@@ -187,3 +188,126 @@ def test_bessel_i_continuous_across_split(op):
         [x_test_value],
         assert_fn=partial(np.testing.assert_allclose, rtol=1e-14),
     )
+
+
+# The order is sampled across the shapes that behave differently: integer (where the
+# function continues to negative argument), half-integer (where the Hankel expansion
+# terminates early), non-integer, and negative. One log-spaced range covers the series,
+# the crossover and the asymptotic branch together, because the tolerance the dispatch
+# holds does not vary across them -- only with the dtype.
+@pytest.mark.parametrize("dtype", ["float32", "float64"], ids=str)
+@pytest.mark.parametrize("order", [0.0, 0.5, 2.5, -0.5], ids=str)
+def test_ive(order, dtype):
+    rtol = {"float32": 1e-5, "float64": 1e-13}[dtype]
+    x = vector("x", dtype=dtype)
+    x_test_value = np.exp(
+        np.random.default_rng(67).uniform(np.log(1e-6), np.log(2000.0), 201)
+    ).astype(dtype)
+
+    compare_mlx_and_py(
+        [x],
+        [pt.ive(order, x)],
+        [x_test_value],
+        assert_fn=partial(np.testing.assert_allclose, rtol=rtol),
+    )
+
+
+@pytest.mark.parametrize("order", [0.0, 0.5, 2.5, -0.5, 10.0, 20.0], ids=str)
+def test_ive_float64_precision(order):
+    # The split between the series and the Hankel expansion moves with the order, and so
+    # does the trip count the series needs to reach it. This is the test that catches a
+    # split left behind when the order grows: the expansion needs x large against v**2,
+    # and applying it too early is wrong by whole percent rather than by an ulp.
+    x_test_value = np.exp(np.linspace(np.log(1e-6), np.log(2000.0), 601))
+
+    with mlx.stream(mlx.cpu):
+        res = np.asarray(
+            mlx_funcify(Ive(), node=pt.ive(order, vector("x", dtype="float64")).owner)(
+                None, mlx.array(x_test_value, dtype=mlx.float64)
+            )
+        )
+
+    np.testing.assert_allclose(res, scipy.special.ive(order, x_test_value), rtol=1e-12)
+
+
+@pytest.mark.parametrize("order", [0.0, 1.0, 2.0, 0.5, -0.5], ids=str)
+def test_ive_domain(order):
+    # Only integer orders continue to negative argument, carrying the parity of the
+    # order; a negative non-integer order also has a pole at zero. scipy is the contract
+    # here, nan for nan.
+    x = vector("x", dtype="float64")
+    # ive decays to zero at either infinity, but scipy reports nan there and the op has
+    # to agree with it across backends
+    x_test_value = np.array([-2.0, -1.0, 0.0, 1.0, np.inf, -np.inf, np.nan])
+
+    compare_mlx_and_py([x], [pt.ive(order, x)], [x_test_value])
+
+
+def test_ive_symbolic_order_raises():
+    # Both branches are polynomials whose coefficients come from the order, and the
+    # domain rules above branch on whether it is an integer, so a symbolic order needs a
+    # different implementation rather than a different constant.
+    x = vector("x", dtype="float64")
+    v = scalar("v", dtype="float64")
+
+    with pytest.raises(NotImplementedError, match="constant order"):
+        pytensor.function([v, x], pt.ive(v, x), mode="MLX")
+
+
+def test_ive_large_order_raises():
+    x = vector("x", dtype="float64")
+
+    with pytest.raises(NotImplementedError, match="orders up to 20"):
+        pytensor.function([x], pt.ive(25.0, x), mode="MLX")
+
+
+def test_ive_vector_order():
+    # pymc's Periodic kernel asks for a whole vector of orders at once in its HSGP
+    # approximation (gp/cov.py, power_spectral_density_approx): ive(J, a) with
+    # J = arange(m). The order is constant there, just not a scalar, and the graph gets
+    # one evaluation for all of them rather than one per order.
+    a = scalar("a", dtype="float64")
+    orders = np.arange(6)
+
+    _, res = compare_mlx_and_py(
+        [a],
+        pt.ive(orders, a),
+        [0.7],
+        assert_fn=partial(np.testing.assert_allclose, rtol=1e-13),
+    )
+    np.testing.assert_allclose(
+        np.asarray(res), scipy.special.ive(orders, 0.7), rtol=1e-13
+    )
+
+
+def test_ive_mixed_vector_order():
+    # The domain rules are per-element once the order is a vector: the integer orders
+    # continue to negative argument with their parity, the non-integer ones do not, and
+    # a negative non-integer order has a pole at zero.
+    x = vector("x", dtype="float64")
+    orders = np.array([0.0, 1.0, -2.5, 2.0])
+    x_test_value = np.array([-1.5, -1.5, -1.5, 0.0])
+
+    compare_mlx_and_py([x], [pt.ive(orders, x)], [x_test_value])
+
+
+@pytest.mark.parametrize("order", [0.0, 0.5, 1.0, 2.5, -0.5], ids=str)
+def test_ive_small_argument(order):
+    # The series takes its prefactor in log space, and the logarithm has to be kept away
+    # from zero without being floored: clamping its argument at float32's smallest normal
+    # left every x below 1.2e-38 sharing one value, which for ive(1, 1e-300) meant 5.9e-39
+    # against a true 5.0e-301. Log-spaced because a linear sample here is all endpoint.
+    x_test_value = np.exp(np.linspace(np.log(1e-300), np.log(1e-3), 301))
+
+    with mlx.stream(mlx.cpu):
+        res = np.asarray(
+            mlx_funcify(Ive(), node=pt.ive(order, vector("x", dtype="float64")).owner)(
+                None, mlx.array(x_test_value, dtype=mlx.float64)
+            )
+        )
+
+    reference = scipy.special.ive(order, x_test_value)
+    # scipy flushes the deepest subnormals to zero where the series still resolves them,
+    # so the comparison runs where the reference is a normal number
+    representable = reference > np.finfo(np.float64).tiny
+    np.testing.assert_allclose(res[representable], reference[representable], rtol=1e-12)


### PR DESCRIPTION
`Ive` is the last unimplemented member of the Bessel-I family. Its one pymc call site is `Periodic.power_spectral_density_approx` (gp/cov.py:874), which asks for a whole vector of orders at once as `ive(arange(m), a)`, so the order is constant but not a scalar.

An ascending power series below a crossover, a Hankel asymptotic expansion above it. No recurrence in the order, so the usual hazard of forward recurrence being unstable for `I` does not arise. What does follow the order is the crossover and the series trip count: the expansion needs x large against v**2, so a fixed split is fine to about v = 10 and 300% wrong at v = 20. Both are computed from the constant order, and past |v| = 20 the series outgrows its worth and the dispatch refuses rather than approximating. A symbolic order also refuses -- both branches are polynomials in the order and the integer/parity domain rules branch on it.

Accuracy against scipy, on the path and dtype the accuracy claim is about:

```
vectorized path, CPU stream, float64
region                     v=0     v=0.5       v=1     v=2.5       v=5
(1e-300, 1e-38)        0.0e+00   4.3e-14   8.6e-14   1.5e-13   1.5e-13
(1e-38, 1)             2.2e-16   9.5e-15   1.9e-14   6.9e-14   1.4e-13
(1, 50)                2.2e-15   2.5e-14   2.4e-15   2.5e-14   2.9e-15
(50, 2000)             6.7e-16   3.3e-16   4.4e-16   4.4e-16   6.7e-16
```

The Metal kernel is float32 on the GPU stream only, so it is timed against the same dispatch with the kernel disabled -- same device, same dtype, same data. `passes` is against one fused elementwise pass over that same buffer.

```
GPU stream, float32, order 2.5
           n    kernel  vectorized     scipy  speedup   passes
     100,000      0.26        0.38      23.3     1.5x     2.2x
   1,000,000      0.49        1.69     238.0     3.4x     2.8x
  10,000,000      2.87       23.58    2339.7     8.2x     8.7x
```

The kernel is worth having because the series is a loop, and the vectorized form has to unroll it into the graph -- up to 123 terms at high order, all of them evaluated for every element on top of the usual branch-free selection. The kernel writes an ordinary `for` with an early exit. It is faster at every size, not only at 10^7.

float64 has no kernel at all, since Metal has no float64, and it is slower than scipy rather than faster:

```
CPU stream, float64, order 2.5
           n    ive (ms)     scipy   passes  vs scipy
     100,000         3.6      23.4   134.7x     6.58x
   1,000,000        34.6     234.0   316.2x     6.76x
  10,000,000       357.1    2349.7   256.6x     6.58x
```

Two kernel-only hazards are worth a reviewer's attention, both caught by comparing the kernel against the fallback rather than by any single-path test. The series terms alternate in sign for a negative non-integer order, so a convergence test written on the term rather than its magnitude stops at the first one -- wrong by a factor of two, and invisible for every order whose terms are positive. And a scalar order arrives with shape `(1,)` once the op has broadcast it against the argument, so a kernel guard written on rank rather than size silently disables the kernel for every scalar-order graph and leaves the comparison test measuring the fallback against itself. CI cannot run Metal at all, so that test only ever executes on a developer machine.

Part of #2095.
