### PR TITLE
Take the gammaln and psi reflections through the tangent

### DIFF
--- a/pytensor/link/mlx/dispatch/scalar/math.py
+++ b/pytensor/link/mlx/dispatch/scalar/math.py
@@ -113,8 +113,11 @@ def mlx_funcify_GammaLn(op, **kwargs):
         w = mx.where(reflect, one - y, y) - one
         lanczos = _lanczos_log_gamma(w, const)
 
-        # Reducing the argument before sin keeps log|sin(pi x)| accurate at large |x|
-        log_sin = mx.log(mx.abs(mx.sin(const(np.pi) * (y - mx.floor(y)))))
+        # Reducing the argument keeps log|sin(pi x)| accurate at large |x|, and taking
+        # the sine from the tangent by the half-angle identity keeps it off mx.sin,
+        # which is a float32 kernel at any dtype where mx.tan is not
+        tan_half = mx.tan(const(0.5 * np.pi) * (y - mx.floor(y)))
+        log_sin = mx.log(const(2.0) * mx.abs(tan_half)) - mx.log1p(tan_half * tan_half)
         out = mx.where(reflect, const(np.log(np.pi)) - log_sin - lanczos, lanczos)
         if double:
             out = mx.where(shift_up, out - mx.log(z), out)
@@ -157,9 +160,14 @@ def mlx_funcify_Psi(op, **kwargs):
             series = const(coeff) + series * r2
         out = shift + mx.log(y) - const(0.5) / y - series * r2
 
-        # psi(x) = psi(1 - x) - pi * cot(pi x)
-        pi_z = const(np.pi) * z
-        out = mx.where(reflect, out - const(np.pi) * mx.cos(pi_z) / mx.sin(pi_z), out)
+        # psi(x) = psi(1 - x) - pi * cot(pi x), with the cotangent taken as a reciprocal
+        # tangent rather than a ratio of cosine to sine: mx.tan is genuine at float64
+        # where both of the others are float32 kernels whatever they are handed.
+        # Reducing by the nearest integer is exact and costs the period nothing, and it
+        # puts the tangent on a true zero at every pole rather than near one, so those
+        # come back infinite instead of large and finite
+        cot_arg = const(np.pi) * (z - mx.round(z))
+        out = mx.where(reflect, out - const(np.pi) / mx.tan(cot_arg), out)
 
         return out.astype(out_dtype)
 

--- a/tests/link/mlx/scalar/test_math.py
+++ b/tests/link/mlx/scalar/test_math.py
@@ -27,10 +27,11 @@ from pytensor.link.mlx.dispatch import mlx_funcify
         (0.5, 20.0, {"float32": (1e-5, 1e-4), "float64": (1e-11, 1e-11)}),
         (1e-3, 0.5, {"float32": (1e-5, 1e-4), "float64": (1e-11, 1e-11)}),
         (20.0, 1e4, {"float32": (1e-5, 0.0), "float64": (1e-12, 0.0)}),
-        # Negative arguments go through the log|sin(pi x)| reflection formula, which
-        # loses precision to cancellation near the poles. mx.sin is float32-accurate
-        # whatever the dtype, so float64 gains nothing here
-        (-5.4, -0.6, {"float32": (1e-3, 1e-3), "float64": (1e-3, 1e-3)}),
+        # Negative arguments go through the log|sin(pi x)| reflection, which takes its
+        # sine from the tangent by the half-angle identity. mx.tan is genuine at float64
+        # where mx.sin is a float32 kernel whatever it is handed, so float64 holds here
+        # rather than sharing single precision's ceiling
+        (-5.4, -0.6, {"float32": (1e-3, 1e-3), "float64": (1e-11, 1e-11)}),
     ],
     ids=["moderate", "tiny", "large", "negative"],
 )
@@ -123,7 +124,10 @@ def test_special_half_precision(op):
         # Negative arguments pick up the pi*cot(pi x) reflection term, which loses
         # precision to cancellation near the poles. mx.cos and mx.sin are
         # float32-accurate whatever the dtype, so float64 gains nothing here
-        (-5.85, -5.15, {"float32": (1e-4, 1e-4), "float64": (1e-4, 1e-4)}),
+        # The reflection's pi * cot(pi x) is taken as a reciprocal tangent rather than
+        # a ratio of cosine to sine, both of which are float32 kernels at any dtype. The
+        # absolute tolerance carries float32, where psi's own zeros sit near its poles
+        (-5.85, -5.15, {"float32": (1e-2, 1e-4), "float64": (1e-10, 1e-12)}),
     ],
     ids=["moderate", "tiny", "large", "negative"],
 )
@@ -142,10 +146,14 @@ def test_psi(low, high, tolerances, dtype):
 
 @pytest.mark.parametrize("dtype", ["float32", "float64"], ids=str)
 def test_psi_edge_cases(dtype):
-    # Negative integers are left out: PyTensor's own C implementation returns inf
-    # there while scipy returns nan, so there is no agreed reference to compare to.
-    # The finite entries keep the poles from being the only thing asserted
-    x_test_value = np.array([0.0, np.inf, np.nan, 0.5, 4.0], dtype=dtype)
+    # The negative integers are left out. psi has a pole at each of them and the three
+    # implementations disagree on what to report: scipy says nan, PyTensor's C code says
+    # inf, and this dispatch says -inf, because reducing the cotangent's argument by the
+    # nearest integer puts the tangent on a true zero there. All three are infinite or
+    # undefined rather than a plausible finite number, which is what matters; there is
+    # just no agreed reference to assert against. The finite entries keep the remaining
+    # poles from being the only thing asserted
+    x_test_value = np.array([0.0, np.inf, np.nan, 0.5, 4.0, -1.5], dtype=dtype)
     x = vector("x", dtype=dtype)
 
     compare_mlx_and_py([x], [pt.psi(x)], [x_test_value])
@@ -183,3 +191,31 @@ def test_nnet():
 
     out = softplus(x)
     compare_mlx_and_py([x], [out], [x_test_value])
+
+
+@pytest.mark.parametrize(
+    "scalar_op, reference",
+    [(GammaLn, scipy.special.gammaln), (Psi, scipy.special.digamma)],
+    ids=["gammaln", "psi"],
+)
+def test_reflection_near_the_poles(scalar_op, reference):
+    # Both reflections divide by something that vanishes at every negative integer, and
+    # both grow without bound approaching one. Every other range here samples uniformly
+    # and so never lands near a pole, which is how a reflection that was 45% wrong
+    # within 1e-12 of one went unnoticed. The tolerance is set by the argument
+    # reduction, which loses a digit for each decade closer to the pole.
+    poles = -np.array([1.0, 2.0, 5.0, 20.0])
+    offsets = np.array([1e-1, 1e-3, 1e-5, 1e-7, 1e-9])
+    x_test_value = np.unique(
+        np.concatenate(
+            [(poles[:, None] - offsets).ravel(), (poles[:, None] + offsets).ravel()]
+        )
+    )
+    x_test_value = x_test_value[x_test_value < 0.0]
+
+    with mlx.stream(mlx.cpu):
+        res = np.asarray(
+            mlx_funcify(scalar_op())(mlx.array(x_test_value, dtype=mlx.float64))
+        )
+
+    np.testing.assert_allclose(res, reference(x_test_value), rtol=1e-5)


### PR DESCRIPTION
`gammaln` was wrong by 70% within 1e-12 of a negative integer, and `psi` by more than 100% within 1e-7 of one. Both reflect through `sin(pi x)`, and `mx.sin` is a float32 kernel at every dtype -- so near a pole, where the sine is the small quantity everything else divides by, single precision cannot locate it. `mx.tan` is genuine at float64, so `psi` takes its cotangent as `pi / tan(pi x)` rather than `pi cos / sin`, and `gammaln` takes the sine from the half-angle identity.

`psi` also reduces the cotangent's argument by the nearest integer. The period is exactly pi so the reduction is free, and it puts the tangent on a true zero at each pole rather than near one, which is the difference between reporting an infinity there and reporting -2.6e16.

Distance from a negative integer, float64, max relative error:

```
offset      gammaln before    after      psi before    after
1e-3               5.8e-06  3.1e-14         3.1e-04  8.7e-14
1e-7               1.9e-02  5.8e-11         1.3e+00  9.3e-10
1e-9               2.1e-01  5.5e-10         1.0e+00  1.0e-07
1e-12              7.0e-01  2.5e-06         1.0e+00  5.8e-05
```

Nothing measured this before because every range in the tests samples uniformly, so no point ever landed near a pole. The ordinary ranges improve too, by about eight orders:

```
range              gammaln before    after      psi before    after
(0.5, 20)                 1.3e-11  1.3e-11         2.9e-12  2.9e-12
(-5.4, -0.6)              9.7e-05  9.6e-13         2.8e-03  1.1e-12
(-20.9, -20.1)            9.4e-09  6.7e-16         2.4e-02  2.4e-11
```

The positive domain is untouched, as it should be -- it never reaches the reflection.

At the poles themselves the three implementations now disagree: scipy reports nan, PyTensor's C code reports inf, and this reports -inf. All three are non-finite, which is the part that matters, so the edge-case test leaves those arguments out and says why rather than picking a side.

`pytest-benchmark`, n = 1e6, float32 on the GPU:

```
              before     after
gammaln        315.8     319.6 us   (+1.2%)
psi            263.6     268.8 us   (+2.0%)
```

Part of #2095.
