### PR TITLE
Make minimun/maximum gradient more robust to numerical precision

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,18 +191,18 @@ jobs:
           # python-freethreading constrains the solve to the free-threaded CPython build
           if [[ $FREE_THREADING == "1" ]]; then FT_PKG="python-freethreading"; else FT_PKG=""; fi
           if [[ $OS == "macos-15" ]]; then
-            micromamba install --yes -q "python~=${PYTHON_VERSION}" $FT_PKG numpy "scipy<1.17.0" "numba==${NUMBA_VERSION}" pip graphviz cython pytest coverage pytest-cov pytest-benchmark pytest-mock pytest-sphinx libblas=*=*accelerate rich;
+            micromamba install --yes -q "python=${PYTHON_VERSION}" $FT_PKG numpy "scipy<1.17.0" "numba==${NUMBA_VERSION}" pip graphviz cython pytest coverage pytest-cov pytest-benchmark pytest-mock pytest-sphinx libblas=*=*accelerate rich;
           elif [[ $FREE_THREADING == "1" ]]; then
             # mkl/mkl-service have no free-threaded (cp*t) builds, so rely on the default (openblas) BLAS.
-            micromamba install --yes -q "python~=${PYTHON_VERSION}" $FT_PKG numpy "scipy<1.17.0" "numba==${NUMBA_VERSION}" pip graphviz cython pytest coverage pytest-cov pytest-benchmark pytest-mock pytest-sphinx rich;
+            micromamba install --yes -q "python=${PYTHON_VERSION}" $FT_PKG numpy "scipy<1.17.0" "numba==${NUMBA_VERSION}" pip graphviz cython pytest coverage pytest-cov pytest-benchmark pytest-mock pytest-sphinx rich;
           else
-            micromamba install --yes -q "python~=${PYTHON_VERSION}" $FT_PKG numpy "scipy<1.17.0" "numba==${NUMBA_VERSION}" pip graphviz cython pytest coverage pytest-cov pytest-benchmark pytest-mock pytest-sphinx mkl mkl-service rich;
+            micromamba install --yes -q "python=${PYTHON_VERSION}" $FT_PKG numpy "scipy<1.17.0" "numba==${NUMBA_VERSION}" pip graphviz cython pytest coverage pytest-cov pytest-benchmark pytest-mock pytest-sphinx mkl mkl-service rich;
           fi
           if [[ $FREE_THREADING == "1" ]]; then python -c 'import sysconfig; assert sysconfig.get_config_var("Py_GIL_DISABLED") == 1, "Expected a free-threaded interpreter"'; fi
-          if [[ $INSTALL_JAX == "1" ]]; then micromamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}" && pip install "jax>=0.8,<0.9.1" jaxlib numpyro equinox tfp-nightly; fi
-          if [[ $INSTALL_TORCH == "1" ]]; then micromamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}" pytorch pytorch-cuda=12.1 "mkl<=2024.0" -c pytorch -c nvidia; fi
-          if [[ $INSTALL_MLX == "1" ]]; then micromamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}" "mlx>=0.30,<0.32"; fi
-          if [[ $INSTALL_XARRAY == "1" ]]; then micromamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}" xarray xarray-einstats; fi
+          if [[ $INSTALL_JAX == "1" ]]; then micromamba install --yes -q -c conda-forge "python=${PYTHON_VERSION}" && pip install "jax>=0.8,<0.9.1" jaxlib numpyro equinox tfp-nightly; fi
+          if [[ $INSTALL_TORCH == "1" ]]; then micromamba install --yes -q -c conda-forge "python=${PYTHON_VERSION}" pytorch pytorch-cuda=12.1 "mkl<=2024.0" -c pytorch -c nvidia; fi
+          if [[ $INSTALL_MLX == "1" ]]; then micromamba install --yes -q -c conda-forge "python=${PYTHON_VERSION}" "mlx>=0.30,<0.32"; fi
+          if [[ $INSTALL_XARRAY == "1" ]]; then micromamba install --yes -q -c conda-forge "python=${PYTHON_VERSION}" xarray xarray-einstats; fi
 
           pip install -e ./
           micromamba list && pip freeze
@@ -278,7 +278,7 @@ jobs:
         run: |
           NUMBA_VERSION=$(sed -n 's/.*"numba>=[0-9.]*,<=\([0-9.]*\)".*/\1/p' pyproject.toml | head -1)
           echo "Installing numba==${NUMBA_VERSION}"
-          micromamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}" mkl numpy scipy pip mkl-service cython pytest "numba==${NUMBA_VERSION}" jax jaxlib pytest-benchmark
+          micromamba install --yes -q -c conda-forge "python=${PYTHON_VERSION}" mkl numpy scipy pip mkl-service cython pytest "numba==${NUMBA_VERSION}" jax jaxlib pytest-benchmark
           pip install -e ./
           micromamba list && pip freeze
           python -c 'import pytensor; print(pytensor.config.__str__(print_doc=False))'

--- a/pytensor/scalar/basic.py
+++ b/pytensor/scalar/basic.py
@@ -1772,9 +1772,9 @@ class Maximum(BinaryScalarOp):
                 x.zeros_like(dtype=config.floatX),
                 y.zeros_like(dtype=config.floatX),
             ]
-        # This form handle the case when both value are the same.
-        # In that case, gx will be gz, gy will be 0.
-        e = eq(outputs[0], x)
+        # maximum returns x when x >= y, ties included; testing eq(outputs[0], x)
+        # would need x recomputed bit-for-bit, which fastmath reassoc can break.
+        e = ge(x, y)
         gx = e * gz
         gy = (constant(1, dtype=gz.dtype) - e) * gz
         return (gx, gy)
@@ -1817,9 +1817,9 @@ class Minimum(BinaryScalarOp):
                 x.zeros_like(dtype=config.floatX),
                 y.zeros_like(dtype=config.floatX),
             ]
-        # This form handle the case when both value are the same.
-        # In that case, gx will be gz, gy will be 0.
-        e = eq(outputs[0], x)
+        # minimum returns x when x <= y, ties included; testing eq(outputs[0], x)
+        # would need x recomputed bit-for-bit, which fastmath reassoc can break.
+        e = le(x, y)
         gx = e * gz
         gy = (constant(1, dtype=gz.dtype) - e) * gz
         return (gx, gy)

--- a/tests/link/numba/test_elemwise.py
+++ b/tests/link/numba/test_elemwise.py
@@ -8,10 +8,12 @@ import pytensor.tensor as pt
 import pytensor.tensor.math as ptm
 from pytensor import config, function
 from pytensor.compile import get_mode
+from pytensor.compile.mode import Mode
 from pytensor.compile.ops import deep_copy_op
 from pytensor.gradient import grad
 from pytensor.scalar import Composite, and_, float64, or_, xor
 from pytensor.scalar import add as scalar_add
+from pytensor.scalar import mul as scalar_mul
 from pytensor.tensor import blas, matrix, tensor3
 from pytensor.tensor.elemwise import CAReduce, DimShuffle, Elemwise
 from pytensor.tensor.math import All, Any, Max, Min, Prod, ProdWithoutZeros, Sum
@@ -608,6 +610,75 @@ def test_elemwise_multiple_inplace_outs():
     assert out2 is y_test
     np.testing.assert_allclose(out1, [2, 3, 4])
     np.testing.assert_allclose(out2, [5, 6, 7])
+
+
+@pytest.mark.parametrize(
+    "op, x_range, y_range",
+    [
+        # x*y < 1, so the product is the smaller operand and `minimum` picks it
+        (pt.minimum, (0.02, 0.06), (0.2, 0.9)),
+        # x*y > 1, so the product is the larger operand and `maximum` picks it
+        (pt.maximum, (1.5, 3.0), (2.0, 4.0)),
+    ],
+    ids=["minimum", "maximum"],
+)
+def test_minimum_maximum_grad_ignores_operand_rounding(op, x_range, y_range):
+    # The mask must be decided by the inputs: an `eq(outputs[0], x)` mask needs x
+    # recomputed bit-for-bit, which fastmath reassoc breaks. `z * x * y` and
+    # `x * y * z` are the same product, but the operand order makes LLVM group
+    # them differently, so the forward value stops matching the rebuilt operand.
+    # `L_op` is called the way scan's gradient calls it: forward value from the
+    # loop, operand rebuilt outside it.
+    x = pt.vector("x")
+    y = pt.vector("y")
+    z = pt.vector("z")
+    out = op(z * x * y, z)
+    gx, gy = op.L_op([x * y * z, z], [out], [pt.ones_like(out)])
+
+    n = 10_000
+    x_test = rng.uniform(*x_range, n)
+    y_test = rng.uniform(*y_range, n)
+    z_test = rng.uniform(1e7, 4e7, n)
+
+    # the product wins by 20-250x, so the gradient belongs entirely to it
+    fn = function([x, y, z], [gx, gy], mode=Mode(linker="numba", optimizer=None))
+    gx_val, gy_val = fn(x_test, y_test, z_test)
+    np.testing.assert_array_equal(gx_val, np.ones(n))
+    np.testing.assert_array_equal(gy_val, np.zeros(n))
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="fastmath reassoc groups a Composite's products by argument "
+    "position, so two Composites over one expression disagree "
+    "(pymc-devs/pytensor#2187)",
+)
+def test_composite_product_independent_of_argument_order():
+    # LLVM ranks values by argument position and left-associates commutative
+    # chains, so signature (z, x, y) evaluates x*y*z as (x*z)*y while (x, y, z)
+    # gives (x*y)*z. Fusion assigns those signatures per Composite, so any two
+    # Composites over a shared subexpression can silently disagree.
+    x_ = float64("x")
+    y_ = float64("y")
+    z_ = float64("z")
+    prod = scalar_mul(x_, y_, z_)
+    op_zxy = Elemwise(Composite([z_, x_, y_], [prod]))
+    op_xyz = Elemwise(Composite([x_, y_, z_], [prod]))
+
+    x = pt.vector("x")
+    y = pt.vector("y")
+    z = pt.vector("z")
+    fn = function(
+        [x, y, z],
+        [op_zxy(z, x, y), op_xyz(x, y, z)],
+        mode=Mode(linker="numba", optimizer=None),
+    )
+
+    n = 10_000
+    x_test = rng.uniform(0.02, 0.06, n)
+    y_test = rng.uniform(0.2, 0.9, n)
+    z_test = rng.uniform(1e7, 4e7, n)
+    np.testing.assert_array_equal(*fn(x_test, y_test, z_test))
 
 
 def test_scalar_loop():


### PR DESCRIPTION
Related to #2187 

I found issues in a scan model, unlike #2187 it was not when branches are exactly equal, aka ties (where it is still kinda undefined), but where there were still relatively large differences. Re-associativity led `eq` to not match, where minimum would still be unambiguous, using `le` or `ge` (which matches the forward semantics) makes the problem I was seeing go away.

Added a regression test for #2187 which is NOT fixed by this PR