### PR TITLE
Numba: speed up advanced indexing with non-scalar core dims

### DIFF
--- a/pytensor/gradient.py
+++ b/pytensor/gradient.py
@@ -1335,8 +1335,8 @@ def _populate_grad_dict(var_to_app_to_idx, grad_dict, wrt, cost_name=None):
                     raise ValueError(
                         f"{node.op} returned the wrong number of gradient terms."
                     )
-            # We can not enforce this, as AdvancedSubtensor1 has an option to
-            # return the sparse grad for optimization reason.
+            # We can not enforce this, as sparse Ops have an option to return a
+            # structured grad for optimization reason.
 
             #            for ig, i in zip(input_grads, inputs):
             #                if (not isinstance(ig.type, (DisconnectedType, NullType)) and

--- a/pytensor/link/numba/dispatch/subtensor.py
+++ b/pytensor/link/numba/dispatch/subtensor.py
@@ -333,7 +333,8 @@ def vector_integer_advanced_indexing(
 
             # Index over tuples of raveled advanced indices and write to output buffer
             for i, scalar_idxs in enumerate(zip(idx0.ravel(), idx2.ravel())):
-                out_buffer[i] = basic_indexed_x[scalar_idxs]
+                for j0 in range(out_buffer.shape[1]):
+                    out_buffer[(i, j0)] = basic_indexed_x[(*scalar_idxs, j0)]
 
             # Unravel out_buffer (if needed)
             out_buffer = out_buffer.reshape((*adv_idx_shape, *basic_idx_shape))
@@ -385,7 +386,8 @@ def vector_integer_advanced_indexing(
 
             # Index over tuples of raveled advanced indices and update buffer
             for i, scalar_idxs in enumerate(zip(idx0, idx2)):
-                basic_indexed_x[scalar_idxs] = y_bcast[i]
+                for j0 in range(y_bcast.shape[1]):
+                    basic_indexed_x[(*scalar_idxs, j0)] = y_bcast[(i, j0)]
 
             # Return the original x, with the entries updated
             return x
@@ -435,7 +437,8 @@ def vector_integer_advanced_indexing(
 
             # Index over tuples of raveled advanced indices and update buffer
             for i, scalar_idxs in enumerate(zip(idx1, idx2)):
-                basic_indexed_x[scalar_idxs] += y_bcast[i]
+                for j0 in range(y_bcast.shape[1]):
+                    basic_indexed_x[(*scalar_idxs, j0)] += y_bcast[(i, j0)]
 
             # Return the original x, with the entries updated
             return x
@@ -492,6 +495,26 @@ def vector_integer_advanced_indexing(
     basic_indices = [idxs[i] for i in basic_indices_pos]
 
     to_tuple = create_tuple_string  # alias to make code more readable below
+
+    # Number of trailing dimensions carried along by each scalar-index step.
+    # Basic indices are always slices here, so `basic_indexed_x` keeps x's rank and the
+    # advanced group consumes `len(adv_indices_pos)` of its dimensions.
+    n_basic_dims = x.type.ndim - len(adv_indices_pos)
+    trailing_idxs = [f"j{k}" for k in range(n_basic_dims)]
+    buffer_idx = to_tuple(["i", *trailing_idxs])
+    indexed_idx = to_tuple(["*scalar_idxs", *trailing_idxs])
+
+    def trailing_loop_nest(assignment: str, extents_from: str) -> str:
+        # An index step written on whole subarrays goes through Numba's generic array
+        # machinery, and the `+=` form materialises a temporary. Spell it out as a scalar
+        # loop nest instead. The trailing rank is known here, the extents only at run time.
+        # Returned with relative indentation -- the caller places it.
+        lines = [
+            f"{'    ' * k}for {j} in range({extents_from}.shape[{k + 1}]):"
+            for k, j in enumerate(trailing_idxs)
+        ]
+        lines.append(f"{'    ' * n_basic_dims}{assignment}")
+        return "\n".join(lines)
 
     # Compute number of dimensions in advanced indices (after broadcasting)
     if len(adv_indices_pos) == 1:
@@ -568,7 +591,7 @@ def vector_integer_advanced_indexing(
 
                 # Index over tuples of raveled advanced indices and write to output buffer
                 for i, scalar_idxs in enumerate(zip{to_tuple([f"{idx}.ravel()" for idx in adv_indices] if adv_idx_ndim != 1 else adv_indices)}):
-                    out_buffer[i] = basic_indexed_x[scalar_idxs]
+{indent(trailing_loop_nest(f"out_buffer[{buffer_idx}] = basic_indexed_x[{indexed_idx}]", "out_buffer"), " " * 20)}
 
                 # Unravel out_buffer (if needed)
                 out_buffer = {f"out_buffer.reshape((*{adv_indices[0]}.shape, *basic_idx_shape))" if adv_idx_ndim != 1 else "out_buffer"}
@@ -657,7 +680,7 @@ def vector_integer_advanced_indexing(
 
                 # Index over tuples of raveled advanced indices and update buffer
                 for i, scalar_idxs in enumerate(zip{to_tuple([f"{idx}.ravel()" for idx in adv_indices] if adv_idx_ndim != 1 else adv_indices)}):
-                    basic_indexed_x[scalar_idxs] {"=" if op.set_instead_of_inc else "+="} y_bcast[i]
+{indent(trailing_loop_nest(f"basic_indexed_x[{indexed_idx}] {'=' if op.set_instead_of_inc else '+='} y_bcast[{buffer_idx}]", "y_bcast"), " " * 20)}
 
                 # Return the original x, with the entries updated
                 return x

--- a/pytensor/tensor/subtensor.py
+++ b/pytensor/tensor/subtensor.py
@@ -2768,20 +2768,8 @@ def inc_subtensor(
         return the_op(real_x, y, *index_variables)
     elif isinstance(x.owner.op, DimShuffle):
         inner_x = x.owner.inputs[0]
-        # In the dimshuffle case, there are in fact two dimshuffles:
-        # one to make the indexed dimension the last one,
-        # and one to put it back where it was. So, in the case where we have
-        # inc_subtensor(x[:,i], y), the graph is actually
-        # inc_subtensor((x.T)[i].T, y).
-        # We could get all the way to x, and then get rid of the dimshuffles
-        # completely, but the problem is that advanced_inc_subtensor1 can only
-        # work on the first (outer-most, left-most) dimension of x,
-        # just like advanced_subtensor1.
-        # So we call advanced_inc_subtensor1(x.T, i, y.T) (as we also need to
-        # transpose y if it is not a scalar or a vector), but then we need to
-        # return something that has the same shape as x, not as x.T (inner_x).
-        # So re-apply the outer dimshuffle on the new inc_subtensor,
-        # and return advanced_inc_subtensor1(x.T, i, y.T).T.
+        # Push the increment through to inner_x and re-apply the dimshuffle on the
+        # result, so what we return has the shape of x rather than of inner_x.
 
         # Get the dimshuffle pattern to apply to y.
         x_order = x.owner.op.new_order


### PR DESCRIPTION
vector_integer_advanced_indexing emitted one whole-subarray operation per index step (out_buffer[i] = basic_indexed_x[scalar_idxs], and the += form for scatters). Numba routes a subarray assignment through generic array machinery, and the += form materialises a temporary per step.

Emit an explicit scalar loop nest over the trailing dimensions instead.

```python
import numpy as np
import pytensor
import pytensor.tensor as pt

rng = np.random.default_rng(0)
x_val = rng.normal(size=(1000, 5))
idx_val = rng.integers(0, 1000, 10_000)
y_val = rng.normal(size=(10_000, 5))

x, y = pt.matrix("x"), pt.matrix("y")
idx = pt.lvector("idx")

take = pytensor.function([x, idx], x[idx], mode="NUMBA", trust_input=True)
add_at = pytensor.function([x, y, idx], x[idx].inc(y), mode="NUMBA", trust_input=True)
take(x_val, idx_val), add_at(x_val, y_val, idx_val)  # warm up compilation

%timeit take(x_val, idx_val)
%timeit add_at(x_val, y_val, idx_val)
```
Before:
```
178 μs ± 1.52 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
319 μs ± 28.6 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```
After:
```
43.1 μs ± 1.66 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
69.6 μs ± 6.68 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

I was shocked that we were leaving so much on the floor tbh