### PR TITLE
Numba: don't materialize index broadcast

### DIFF
--- a/pytensor/link/numba/dispatch/subtensor.py
+++ b/pytensor/link/numba/dispatch/subtensor.py
@@ -326,18 +326,18 @@ def vector_integer_advanced_indexing(
                 np.broadcast_to(idx2, adv_idx_shape),
             )
 
-            # Create output buffer
-            adv_idx_size = idx0.size
+            # Create output buffer, shaped like the advanced group
+            adv_idx_shape = idx0.shape
             basic_idx_shape = basic_indexed_x.shape[2:]
-            out_buffer = np.empty((adv_idx_size, *basic_idx_shape), dtype=x.dtype)
+            out_buffer = np.empty((*adv_idx_shape, *basic_idx_shape), dtype=x.dtype)
 
-            # Index over tuples of raveled advanced indices and write to output buffer
-            for i, scalar_idxs in enumerate(zip(idx0.ravel(), idx2.ravel())):
-                for j0 in range(out_buffer.shape[1]):
-                    out_buffer[(i, j0)] = basic_indexed_x[(*scalar_idxs, j0)]
-
-            # Unravel out_buffer (if needed)
-            out_buffer = out_buffer.reshape((*adv_idx_shape, *basic_idx_shape))
+            # Walk the broadcast advanced shape, reading each index view by position
+            for a0 in range(adv_idx_shape[0]):
+                for a1 in range(adv_idx_shape[1]):
+                    s0 = idx0[(a0, a1)]
+                    s1 = idx2[(a0, a1)]
+                    for j0 in range(out_buffer.shape[2]):
+                        out_buffer[(a0, a1, j0)] = basic_indexed_x[(s0, s1, j0)]
 
             # Move advanced output indexing group to its final position (if needed) and return
             return out_buffer
@@ -381,10 +381,7 @@ def vector_integer_advanced_indexing(
             basic_idx_shape = basic_indexed_x.shape[2:]
             y_bcast = np.broadcast_to(y_adv_dims_front, (*adv_idx_shape, *basic_idx_shape))
 
-            # Ravel the advanced dims (if needed)
-            y_bcast = y_bcast
-
-            # Index over tuples of raveled advanced indices and update buffer
+            # Index over tuples of advanced indices and update buffer
             for i, scalar_idxs in enumerate(zip(idx0, idx2)):
                 for j0 in range(y_bcast.shape[1]):
                     basic_indexed_x[(*scalar_idxs, j0)] = y_bcast[(i, j0)]
@@ -431,11 +428,7 @@ def vector_integer_advanced_indexing(
             basic_idx_shape = basic_indexed_x.shape[2:]
             y_bcast = np.broadcast_to(y_adv_dims_front, (*adv_idx_shape, *basic_idx_shape))
 
-            # Ravel the advanced dims (if needed)
-            # Note that numba reshape only supports C-arrays, so we ravel before reshape
-            y_bcast = y_bcast
-
-            # Index over tuples of raveled advanced indices and update buffer
+            # Index over tuples of advanced indices and update buffer
             for i, scalar_idxs in enumerate(zip(idx1, idx2)):
                 for j0 in range(y_bcast.shape[1]):
                     basic_indexed_x[(*scalar_idxs, j0)] += y_bcast[(i, j0)]
@@ -524,6 +517,36 @@ def vector_integer_advanced_indexing(
         # Multiple advanced indices - use max ndim (broadcast result ndim)
         adv_idx_ndim = max(reconstructed_indices[i].ndim for i in adv_indices_pos)  # type: ignore[union-attr]
 
+    adv_loop_idxs = [f"a{k}" for k in range(adv_idx_ndim)]
+    adv_pos = to_tuple(adv_loop_idxs)
+    adv_scalar_names = [f"s{k}" for k in range(len(adv_indices))]
+    nd_buffer_idx = to_tuple([*adv_loop_idxs, *trailing_idxs])
+    nd_indexed_idx = to_tuple([*adv_scalar_names, *trailing_idxs])
+
+    def advanced_loop_nest(assignment: str, extents_from: str) -> str:
+        """Nest over the broadcast advanced-index shape, then the trailing dims.
+
+        Each index view is read into a scalar at the advanced-position level, so the
+        trailing loop has a loop-invariant base address and vectorizes. LLVM cannot hoist
+        such a read on its own: Numba emits no TBAA, so it must assume the store aliases
+        the index buffer.
+        """
+        lines = [
+            f"{'    ' * k}for {a} in range(adv_idx_shape[{k}]):"
+            for k, a in enumerate(adv_loop_idxs)
+        ]
+        pad = "    " * adv_idx_ndim
+        lines += [
+            f"{pad}{s} = {idx}[{adv_pos}]"
+            for s, idx in zip(adv_scalar_names, adv_indices)
+        ]
+        lines += [
+            f"{'    ' * (adv_idx_ndim + k)}for {j} in range({extents_from}.shape[{adv_idx_ndim + k}]):"
+            for k, j in enumerate(trailing_idxs)
+        ]
+        lines.append(f"{'    ' * (adv_idx_ndim + n_basic_dims)}{assignment}")
+        return "\n".join(lines)
+
     # Determine output position of advanced indexed dimensions
     # If advanced indices are consecutive, they go in the first advanced index position
     # Otherwise they go at the beginning
@@ -581,21 +604,31 @@ def vector_integer_advanced_indexing(
                 ),
                 " " * 4,
             )
-        codegen += indent(
-            dedent(
-                f"""
+        if adv_idx_ndim == 1:
+            gather_body = f"""
                 # Create output buffer
                 adv_idx_size = {adv_indices[0]}.size
                 basic_idx_shape = basic_indexed_x.shape[{len(adv_indices)}:]
                 out_buffer = np.empty((adv_idx_size, *basic_idx_shape), dtype=x.dtype)
 
-                # Index over tuples of raveled advanced indices and write to output buffer
-                for i, scalar_idxs in enumerate(zip{to_tuple([f"{idx}.ravel()" for idx in adv_indices] if adv_idx_ndim != 1 else adv_indices)}):
+                # Index over tuples of advanced indices and write to output buffer
+                for i, scalar_idxs in enumerate(zip{to_tuple(adv_indices)}):
 {indent(trailing_loop_nest(f"out_buffer[{buffer_idx}] = basic_indexed_x[{indexed_idx}]", "out_buffer"), " " * 20)}
+"""
+        else:
+            gather_body = f"""
+                # Create output buffer, shaped like the advanced group
+                adv_idx_shape = {adv_indices[0]}.shape
+                basic_idx_shape = basic_indexed_x.shape[{len(adv_indices)}:]
+                out_buffer = np.empty((*adv_idx_shape, *basic_idx_shape), dtype=x.dtype)
 
-                # Unravel out_buffer (if needed)
-                out_buffer = {f"out_buffer.reshape((*{adv_indices[0]}.shape, *basic_idx_shape))" if adv_idx_ndim != 1 else "out_buffer"}
-
+                # Walk the broadcast advanced shape, reading each index view by position
+{indent(advanced_loop_nest(f"out_buffer[{nd_buffer_idx}] = basic_indexed_x[{nd_indexed_idx}]", "out_buffer"), " " * 16)}
+"""
+        codegen += indent(
+            dedent(
+                gather_body
+                + f"""
                 # Move advanced output indexing group to its final position (if needed) and return
                 return {f"out_buffer.transpose({final_axis_order})" if final_axis_transpose_needed else "out_buffer"}
                 """
@@ -663,6 +696,18 @@ def vector_integer_advanced_indexing(
                 ),
                 " " * 4,
             )
+        update = "=" if op.set_instead_of_inc else "+="
+        if adv_idx_ndim == 1:
+            scatter_body = f"""
+                # Index over tuples of advanced indices and update buffer
+                for i, scalar_idxs in enumerate(zip{to_tuple(adv_indices)}):
+{indent(trailing_loop_nest(f"basic_indexed_x[{indexed_idx}] {update} y_bcast[{buffer_idx}]", "y_bcast"), " " * 20)}
+"""
+        else:
+            scatter_body = f"""
+                # Walk the broadcast advanced shape, reading each index view by position
+{indent(advanced_loop_nest(f"basic_indexed_x[{nd_indexed_idx}] {update} y_bcast[{nd_buffer_idx}]", "y_bcast"), " " * 16)}
+"""
         codegen += indent(
             dedent(
                 f"""
@@ -673,15 +718,9 @@ def vector_integer_advanced_indexing(
                 adv_idx_shape = {adv_indices[0]}.shape
                 basic_idx_shape = basic_indexed_x.shape[{len(adv_indices)}:]
                 y_bcast = np.broadcast_to(y_adv_dims_front, (*adv_idx_shape, *basic_idx_shape))
-
-                # Ravel the advanced dims (if needed)
-                # Note that numba reshape only supports C-arrays, so we ravel before reshape
-                y_bcast = {"y_bcast.ravel().reshape((-1, *basic_idx_shape))" if adv_idx_ndim != 1 else "y_bcast"}
-
-                # Index over tuples of raveled advanced indices and update buffer
-                for i, scalar_idxs in enumerate(zip{to_tuple([f"{idx}.ravel()" for idx in adv_indices] if adv_idx_ndim != 1 else adv_indices)}):
-{indent(trailing_loop_nest(f"basic_indexed_x[{indexed_idx}] {'=' if op.set_instead_of_inc else '+='} y_bcast[{buffer_idx}]", "y_bcast"), " " * 20)}
-
+"""
+                + scatter_body
+                + """
                 # Return the original x, with the entries updated
                 return x
                 """


### PR DESCRIPTION
Follow up to #2345 that I missed

```python
import numpy as np
import pytensor
import pytensor.tensor as pt

rng = np.random.default_rng(0)
x_val = rng.normal(size=(1000, 8, 5))
i_val = rng.integers(0, 1000, (2500, 1))
j_val = rng.integers(0, 8, (1, 8))
y_val = rng.normal(size=(2500, 8, 5))

x, y = pt.tensor3("x"), pt.tensor3("y")
i, j = pt.lmatrix("i"), pt.lmatrix("j")

take = pytensor.function([x, i, j], x[i, j], mode="NUMBA", trust_input=True)
add_at = pytensor.function([x, y, i, j], x[i, j].inc(y), mode="NUMBA", trust_input=True)
take(x_val, i_val, j_val), add_at(x_val, y_val, i_val, j_val)  # warm up compilation

%timeit take(x_val, i_val, j_val)
%timeit add_at(x_val, y_val, i_val, j_val)
```

Before:
```
140 μs ± 8.96 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
230 μs ± 6.28 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```
After:
```
112 μs ± 10.3 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
143 μs ± 3.54 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```