### PR TITLE
Numba: rework the vectorize intrinsic interface to fix wide-node compile blowup

### DIFF
--- a/pytensor/link/numba/dispatch/blockwise.py
+++ b/pytensor/link/numba/dispatch/blockwise.py
@@ -11,13 +11,9 @@ from pytensor.link.numba.dispatch.basic import (
     register_funcify_and_cache_key,
 )
 from pytensor.link.numba.dispatch.vectorize_codegen import (
-    NO_INDEXED_INPUTS,
-    NO_INDEXED_OUTPUTS,
-    NO_REDUCE_OUTPUTS,
     NO_SIZE,
     _jit_options,
-    _vectorized,
-    encode_literals,
+    make_vectorized,
     store_core_outputs,
 )
 from pytensor.tensor import TensorVariable, get_vector_length
@@ -46,15 +42,16 @@ def numba_funcify_Blockwise(op: BlockwiseWithCoreShape, node, **kwargs):
 
     batch_ndim = blockwise_op.batch_ndim(node)
 
-    # numba doesn't support nested literals right now...
-    input_bc_patterns = encode_literals(
-        tuple(inp.type.broadcastable[:batch_ndim] for inp in node.inputs[:nin])
+    input_bc_patterns = tuple(
+        inp.type.broadcastable[:batch_ndim] for inp in node.inputs[:nin]
     )
-    output_bc_patterns = encode_literals(
-        tuple(out.type.broadcastable[:batch_ndim] for out in node.outputs)
+    _vectorized = make_vectorized(
+        input_bc_patterns,
+        tuple(out.type.broadcastable[:batch_ndim] for out in node.outputs),
+        tuple(out.type.dtype for out in node.outputs),
+        (),  # inplace_pattern
+        False,  # allow_core_scalar
     )
-    output_dtypes = encode_literals(tuple(out.type.dtype for out in node.outputs))
-    inplace_pattern = encode_literals(())
 
     # Numba does not allow a tuple generator in the Jitted function so we have to compile a helper to convert core_shapes into tuples
     # Alternatively, add an Op that converts shape vectors into tuples, like we did for JAX
@@ -86,18 +83,10 @@ def numba_funcify_Blockwise(op: BlockwiseWithCoreShape, node, **kwargs):
             tuple_core_shapes = to_tuple(core_shapes)
             return _vectorized(
                 core_op_fn,
-                input_bc_patterns,
-                output_bc_patterns,
-                output_dtypes,
-                inplace_pattern,
-                False,  # allow_core_scalar
                 (),  # constant_inputs
-                inputs,
                 tuple_core_shapes,
                 NO_SIZE,
-                NO_INDEXED_INPUTS,
-                NO_INDEXED_OUTPUTS,
-                NO_REDUCE_OUTPUTS,
+                inputs,
             )
 
         return impl
@@ -106,7 +95,7 @@ def numba_funcify_Blockwise(op: BlockwiseWithCoreShape, node, **kwargs):
         # If the core op cannot be cached, the Blockwise wrapper cannot be cached either
         blockwise_key = None
     else:
-        blockwise_cache_version = 2
+        blockwise_cache_version = 3
         blockwise_key = "_".join(
             map(
                 str,

--- a/pytensor/link/numba/dispatch/elemwise.py
+++ b/pytensor/link/numba/dispatch/elemwise.py
@@ -28,13 +28,8 @@ from pytensor.link.numba.dispatch.string_codegen import (
     create_tuple_string,
 )
 from pytensor.link.numba.dispatch.vectorize_codegen import (
-    NO_INDEXED_INPUTS,
-    NO_INDEXED_OUTPUTS,
-    NO_REDUCE_OUTPUTS,
-    NO_SIZE,
     _jit_options,
-    _vectorized,
-    encode_literals,
+    make_vectorized,
     store_core_outputs,
 )
 from pytensor.scalar.basic import (
@@ -696,14 +691,8 @@ def numba_funcify_Elemwise(op, node, **kwargs):
     inplace_pattern = tuple(op.inplace_pattern.items())
     core_output_shapes = tuple(() for _ in range(nout))
 
-    # numba doesn't support nested literals right now...
-    input_bc_patterns_enc = encode_literals(input_bc_patterns)
-    output_bc_patterns_enc = encode_literals(output_bc_patterns)
-    output_dtypes_enc = encode_literals(output_dtypes)
-    inplace_pattern_enc = encode_literals(inplace_pattern)
-
     # Pure python implementation, that will be used in tests
-    def elemwise(*inputs):
+    def _elemwise_py(*inputs):
         Elemwise._check_runtime_broadcast(node, inputs)
         inputs_bc = np.broadcast_arrays(*inputs)
         shape = inputs_bc[0].shape
@@ -722,26 +711,41 @@ def numba_funcify_Elemwise(op, node, **kwargs):
                     out[idx] = out_val
             return outputs
 
-    @overload(elemwise)
-    def ov_elemwise(*inputs):
-        def impl(*inputs):
-            return _vectorized(
-                core_op_fn,
-                input_bc_patterns_enc,
-                output_bc_patterns_enc,
-                output_dtypes_enc,
-                inplace_pattern_enc,
-                True,  # allow_core_scalar
-                (),  # constant_inputs
-                inputs,
-                core_output_shapes,
-                NO_SIZE,
-                NO_INDEXED_INPUTS,
-                NO_INDEXED_OUTPUTS,
-                NO_REDUCE_OUTPUTS,
-            )
+    # Named parameters throughout, not *args: numba types every star-args
+    # boundary with one wide tuple, which lowers as O(n^2) LLVM IR
+    params = ", ".join(f"i{k}" for k in range(len(node.inputs)))
+    elemwise = compile_numba_function_src(
+        f"def elemwise({params}):\n    return _elemwise_py({params})\n",
+        "elemwise",
+        {"_elemwise_py": _elemwise_py},
+    )
+    impl_fn = compile_numba_function_src(
+        f"""
+def elemwise_impl({params}):
+    return _vectorized(core_op_fn, (), core_output_shapes, None, {params})
+""",
+        "elemwise_impl",
+        {
+            **globals(),
+            "_vectorized": make_vectorized(
+                input_bc_patterns,
+                output_bc_patterns,
+                output_dtypes,
+                inplace_pattern,
+                True,
+                n_outer=len(node.inputs),
+            ),
+            "core_op_fn": core_op_fn,
+            "core_output_shapes": core_output_shapes,
+        },
+    )
 
-        return impl
+    ov_fn = compile_numba_function_src(
+        f"def ov_elemwise({params}):\n    return impl_fn\n",
+        "ov_elemwise",
+        {"impl_fn": impl_fn},
+    )
+    overload(elemwise)(ov_fn)
 
     if scalar_cache_key is None:
         # If the scalar op cannot be cached, the Elemwise wrapper cannot be cached either
@@ -750,6 +754,7 @@ def numba_funcify_Elemwise(op, node, **kwargs):
         elemwise_key = str(
             (
                 type(op),
+                3,  # cache_version
                 tuple(op.inplace_pattern.items()),
                 input_bc_patterns,
                 scalar_cache_key,
@@ -775,7 +780,7 @@ def _reduce_identity(identity, acc_dtype):
     return acc_dtype.type(identity)
 
 
-def _build_reduce_impl_src(nout, post_specs):
+def _build_reduce_impl_src(params, nout, post_specs):
     """Build the ``@overload`` impl source for a fused op with reduction outputs.
 
     Calls ``_vectorized`` (which produces a keepdims, size-1-on-reduced-axes
@@ -784,23 +789,15 @@ def _build_reduce_impl_src(nout, post_specs):
     ``None`` for a passthrough output, else ``(kept_axes, out_dtype, cast_needed)``.
     """
     code: list[str | CODE_TOKEN] = [
-        "def fused_elemwise_impl(*outer_inputs):",
+        f"def fused_elemwise_impl({params}):",
         CODE_TOKEN.INDENT,
         "raw = _vectorized(",
         CODE_TOKEN.INDENT,
         "core_op_fn,",
-        "input_bc_patterns_enc,",
-        "output_bc_patterns_enc,",
-        "output_dtypes_enc,",
-        "inplace_pattern_enc,",
-        "True,",
         "(),",
-        "outer_inputs,",
         "core_output_shapes,",
-        "NO_SIZE,",
-        "indexed_inputs_enc,",
-        "indexed_outputs_enc,",
-        "reduce_outputs_enc,",
+        "None,",
+        f"{params},",
         CODE_TOKEN.DEDENT,
         ")",
     ]
@@ -931,15 +928,19 @@ def numba_funcify_FusedElemwise(op, node, **kwargs):
         node.inputs[nin_elemwise + k].type.broadcastable for k in range(n_indices)
     )
 
-    input_bc_patterns_enc = encode_literals(input_bc_patterns)
-    output_bc_patterns_enc = encode_literals(output_bc_patterns)
-    output_dtypes_enc = encode_literals(output_dtypes)
-    inplace_pattern_enc = encode_literals(inplace_pattern)
-    indexed_inputs_enc = encode_literals((indexed_inputs, idx_broadcastable))
-    indexed_outputs_enc = encode_literals(indexed_outputs)
-    reduce_outputs_enc = encode_literals(tuple(reduce_identities))
+    vectorized_intr = make_vectorized(
+        input_bc_patterns,
+        output_bc_patterns,
+        output_dtypes,
+        inplace_pattern,
+        True,
+        (indexed_inputs, idx_broadcastable),
+        indexed_outputs,
+        tuple(reduce_identities),
+        n_outer=len(node.inputs),
+    )
 
-    def fused_elemwise_fn(*outer_inputs):
+    def _fused_elemwise_py(*outer_inputs):
         # Python-mode fallback (e.g. Numba's ``eval_python_only`` path, which
         # runs the funcified function without JIT). Evaluate the inner fgraph
         # faithfully, exactly like ``OpFromGraph.perform`` — so the fused op
@@ -949,52 +950,42 @@ def numba_funcify_FusedElemwise(op, node, **kwargs):
         res = op.fn(*outer_inputs)
         return res[0] if len(res) == 1 else tuple(res)
 
+    # Named parameters throughout, not *args: numba types every star-args
+    # boundary with one wide tuple, which lowers as O(n^2) LLVM IR
+    params = ", ".join(f"i{k}" for k in range(len(node.inputs)))
+    fused_elemwise_fn = compile_numba_function_src(
+        f"def fused_elemwise_fn({params}):\n    return _fused_elemwise_py({params})\n",
+        "fused_elemwise_fn",
+        {"_fused_elemwise_py": _fused_elemwise_py},
+    )
+
     if not has_reductions:
-
-        @overload(fused_elemwise_fn, jit_options=_jit_options)
-        def ov_fused_elemwise_fn(*outer_inputs):
-            def impl(*outer_inputs):
-                return _vectorized(
-                    core_op_fn,
-                    input_bc_patterns_enc,
-                    output_bc_patterns_enc,
-                    output_dtypes_enc,
-                    inplace_pattern_enc,
-                    True,  # allow_core_scalar
-                    (),  # constant_inputs
-                    outer_inputs,
-                    core_output_shapes,
-                    NO_SIZE,
-                    indexed_inputs_enc,
-                    indexed_outputs_enc,
-                    reduce_outputs_enc,
-                )
-
-            return impl
+        impl_src = f"""
+def fused_elemwise_impl({params}):
+    return _vectorized(core_op_fn, (), core_output_shapes, None, {params})
+"""
     else:
-        impl_src = _build_reduce_impl_src(nout, post_specs)
-        impl_fn = compile_numba_function_src(
-            impl_src,
-            "fused_elemwise_impl",
-            {
-                **globals(),
-                "core_op_fn": core_op_fn,
-                "input_bc_patterns_enc": input_bc_patterns_enc,
-                "output_bc_patterns_enc": output_bc_patterns_enc,
-                "output_dtypes_enc": output_dtypes_enc,
-                "inplace_pattern_enc": inplace_pattern_enc,
-                "core_output_shapes": core_output_shapes,
-                "indexed_inputs_enc": indexed_inputs_enc,
-                "indexed_outputs_enc": indexed_outputs_enc,
-                "reduce_outputs_enc": reduce_outputs_enc,
-            },
-        )
+        impl_src = _build_reduce_impl_src(params, nout, post_specs)
 
-        @overload(fused_elemwise_fn, jit_options=_jit_options)
-        def ov_fused_elemwise_fn(*outer_inputs):
-            return impl_fn
+    impl_fn = compile_numba_function_src(
+        impl_src,
+        "fused_elemwise_impl",
+        {
+            **globals(),
+            "_vectorized": vectorized_intr,
+            "core_op_fn": core_op_fn,
+            "core_output_shapes": core_output_shapes,
+        },
+    )
 
-    cache_version = 4
+    ov_fn = compile_numba_function_src(
+        f"def ov_fused_elemwise_fn({params}):\n    return impl_fn\n",
+        "ov_fused_elemwise_fn",
+        {"impl_fn": impl_fn},
+    )
+    overload(fused_elemwise_fn, jit_options=_jit_options)(ov_fn)
+
+    cache_version = 6
     if scalar_cache_key is None:
         key = None
     else:

--- a/pytensor/link/numba/dispatch/random.py
+++ b/pytensor/link/numba/dispatch/random.py
@@ -21,13 +21,9 @@ from pytensor.link.numba.dispatch.basic import (
 )
 from pytensor.link.numba.dispatch.compile_ops import numba_deepcopy
 from pytensor.link.numba.dispatch.vectorize_codegen import (
-    NO_INDEXED_INPUTS,
-    NO_INDEXED_OUTPUTS,
-    NO_REDUCE_OUTPUTS,
     NO_SIZE,
     _jit_options,
-    _vectorized,
-    encode_literals,
+    make_vectorized,
     store_core_outputs,
 )
 from pytensor.link.utils import (
@@ -455,15 +451,17 @@ def numba_funcify_RandomVariable(op: RandomVariableWithCoreShape, node, **kwargs
 
     batch_ndim = rv_op.batch_ndim(rv_node)
 
-    # numba doesn't support nested literals right now...
-    input_bc_patterns = encode_literals(
-        tuple(input_var.type.broadcastable[:batch_ndim] for input_var in dist_params)
+    input_bc_patterns = tuple(
+        input_var.type.broadcastable[:batch_ndim] for input_var in dist_params
     )
-    output_bc_patterns = encode_literals(
-        (rv_node.outputs[1].type.broadcastable[:batch_ndim],)
+    output_bc_patterns = (rv_node.outputs[1].type.broadcastable[:batch_ndim],)
+    _vectorized = make_vectorized(
+        input_bc_patterns,
+        output_bc_patterns,
+        (rv_node.default_output().type.dtype,),
+        (),  # inplace_pattern
+        True,  # allow_core_scalar
     )
-    output_dtypes = encode_literals((rv_node.default_output().type.dtype,))
-    inplace_pattern = encode_literals(())
 
     def random(core_shape, rng, size, *dist_params):
         raise NotImplementedError(
@@ -478,20 +476,12 @@ def numba_funcify_RandomVariable(op: RandomVariableWithCoreShape, node, **kwargs
 
             draws = _vectorized(
                 core_op_fn,
-                input_bc_patterns,
-                output_bc_patterns,
-                output_dtypes,
-                inplace_pattern,
-                True,  # allow_core_scalar
                 (rng,),
-                dist_params,
                 (numba_ndarray.to_fixed_tuple(core_shape, core_shape_len),),
                 NO_SIZE
                 if size_len is None
                 else numba_ndarray.to_fixed_tuple(size, size_len),
-                NO_INDEXED_INPUTS,
-                NO_INDEXED_OUTPUTS,
-                NO_REDUCE_OUTPUTS,
+                dist_params,
             )
             return rng, draws
 
@@ -510,6 +500,7 @@ def numba_funcify_RandomVariable(op: RandomVariableWithCoreShape, node, **kwargs
             input_bc_patterns,
             output_bc_patterns,
             core_cache_key,
+            1,  # cache_version
         )
         random_rv_key = sha256(str(random_rv_key_contents).encode()).hexdigest()
     return random, random_rv_key

--- a/pytensor/link/numba/dispatch/vectorize_codegen.py
+++ b/pytensor/link/numba/dispatch/vectorize_codegen.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import base64
-import pickle
 from collections.abc import Callable, Sequence
 from typing import Any
 
@@ -24,10 +22,6 @@ from pytensor.link.numba.dispatch.string_codegen import CODE_TOKEN, build_source
 
 
 ensure_self_ref_metadata_support()
-
-
-def encode_literals(literals: Sequence) -> str:
-    return base64.encodebytes(pickle.dumps(literals)).decode()
 
 
 def store_core_outputs(
@@ -104,12 +98,6 @@ _jit_options = {
     "no_cpython_wrapper": True,
     "no_cfunc_wrapper": True,
 }
-
-
-def _decode_literal(val, name):
-    if not isinstance(val, types.Literal):
-        raise TypingError(f"{name} must be literal.")
-    return pickle.loads(base64.decodebytes(val.literal_value.encode()))
 
 
 def _compute_idx_load_axes(indexed_inputs, indexed_outputs, idx_ndims):
@@ -294,9 +282,6 @@ def _codegen_return_outputs(
     )
 
 
-NO_INDEXED_INPUTS = encode_literals(((), ()))
-NO_INDEXED_OUTPUTS = encode_literals(())
-NO_REDUCE_OUTPUTS = encode_literals(())
 NO_SIZE = None
 
 
@@ -827,24 +812,23 @@ def make_loop_call(
         loop.__exit__(None, None, None)
 
 
-@numba.extending.intrinsic(jit_options=_jit_options, prefer_literal=True)
-def _vectorized(
+def _vectorized_typer(
+    metadata,
     typingctx,
     core_func,
-    input_bc_patterns,
-    output_bc_patterns,
-    output_dtypes,
-    inplace_pattern,
-    allow_core_scalar,
     constant_inputs_types,
-    outer_input_types,
     output_core_shape_types,
     size_type,
-    indexed_inputs,
-    indexed_outputs,
-    reduce_outputs,
+    *outer_input_types,
 ):
     """Vectorized intrinsic with optional indirect indexing for reads and writes.
+
+    Per-node static information arrives via `metadata` (closed over by the
+    generated intrinsic — see `make_vectorized`), keeping it out of the typed
+    signature: literal-encoded arguments would be re-hashed and re-decoded on
+    every type-inference sweep. The outer inputs are passed as trailing
+    individual arguments, or as one trailing tuple — individual arguments
+    avoid a wide tuple, whose LLVM lowering is O(n^2) in the input count.
 
     For indexed operations, outer inputs are ordered as
     ``[core_inputs..., idx_0, idx_1, ..., write_target_0, ...]``.
@@ -865,35 +849,30 @@ def _vectorized(
 
     For non-indexed/non-reducing calls, these are ``()``.
     """
+    tuple_mode = len(outer_input_types) == 1 and isinstance(
+        outer_input_types[0], types.BaseTuple
+    )
     arg_types = [
         core_func,
+        constant_inputs_types,
+        output_core_shape_types,
+        size_type,
+        *outer_input_types,
+    ]
+    if tuple_mode:
+        outer_input_types = tuple(outer_input_types[0])
+
+    (
         input_bc_patterns,
         output_bc_patterns,
         output_dtypes,
         inplace_pattern,
         allow_core_scalar,
-        constant_inputs_types,
-        outer_input_types,
-        output_core_shape_types,
-        size_type,
-        indexed_inputs,
+        (indexed_inputs, idx_broadcastable),
         indexed_outputs,
         reduce_outputs,
-    ]
-
-    input_bc_patterns = _decode_literal(input_bc_patterns, "input_bc_patterns")
-    output_bc_patterns = _decode_literal(output_bc_patterns, "output_bc_patterns")
-    output_dtypes = _decode_literal(output_dtypes, "output_dtypes")
-    inplace_pattern = _decode_literal(inplace_pattern, "inplace_pattern")
-    reduce_identities = dict(_decode_literal(reduce_outputs, "reduce_outputs"))
-    indexed_inputs, idx_broadcastable = _decode_literal(
-        indexed_inputs, "indexed_inputs"
-    )
-    indexed_outputs = _decode_literal(indexed_outputs, "indexed_outputs")
-
-    if not isinstance(allow_core_scalar, types.Literal):
-        raise TypingError("allow_core_scalar must be literal.")
-    allow_core_scalar = allow_core_scalar.literal_value
+    ) = metadata
+    reduce_identities = dict(reduce_outputs)
 
     # Count write targets (one per unique output index)
     write_out_idxs = set()
@@ -1022,22 +1001,18 @@ def _vectorized(
     def codegen(ctx, builder, sig, args):
         [
             _,
-            _,
-            _,
-            _,
-            _,
-            _,
             constant_inputs,
-            outer_inputs,
             output_core_shapes,
             size,
-            _,
-            _,
-            _,
+            *outer_inputs,
         ] = args
 
         constant_inputs = cgutils.unpack_tuple(builder, constant_inputs)
-        all_outer = cgutils.unpack_tuple(builder, outer_inputs)
+        all_outer = (
+            cgutils.unpack_tuple(builder, outer_inputs[0])
+            if tuple_mode
+            else outer_inputs
+        )
         output_core_shapes = [
             cgutils.unpack_tuple(builder, shape)
             for shape in cgutils.unpack_tuple(builder, output_core_shapes)
@@ -1215,3 +1190,60 @@ def _vectorized(
         )
 
     return sig, codegen
+
+
+NO_INDEXED = ((), ())
+NO_REDUCE = ()
+
+_vectorized_cache: dict = {}
+
+
+def make_vectorized(
+    input_bc_patterns,
+    output_bc_patterns,
+    output_dtypes,
+    inplace_pattern,
+    allow_core_scalar,
+    indexed_inputs=NO_INDEXED,
+    indexed_outputs=NO_REDUCE,
+    reduce_outputs=NO_REDUCE,
+    n_outer=1,
+):
+    """A `_vectorized_typer` intrinsic instance closing over the per-node
+    metadata, with ``n_outer`` named trailing parameters.
+
+    The closure keeps the metadata out of the typed signature (encoded-literal
+    arguments are re-hashed and re-decoded on every type-inference sweep), and
+    named parameters keep wide inputs out of one wide tuple (a *args signature
+    would be repacked by numba's lowering, which is O(n^2) in the tuple width).
+    """
+    metadata = (
+        input_bc_patterns,
+        output_bc_patterns,
+        output_dtypes,
+        inplace_pattern,
+        allow_core_scalar,
+        indexed_inputs,
+        indexed_outputs,
+        reduce_outputs,
+    )
+    key = (metadata, n_outer)
+    try:
+        return _vectorized_cache[key]
+    except KeyError:
+        pass
+    outer = ", ".join(f"o{i}" for i in range(n_outer))
+    src = (
+        f"def _vectorized(typingctx, core_func, constant_inputs, "
+        f"output_core_shapes, size, {outer}):\n"
+        f"    return _vectorized_typer(metadata, typingctx, core_func, "
+        f"constant_inputs, output_core_shapes, size, {outer})\n"
+    )
+    fn = compile_numba_function_src(
+        src,
+        "_vectorized",
+        {"_vectorized_typer": _vectorized_typer, "metadata": metadata},
+    )
+    intr = numba.extending.intrinsic(jit_options=_jit_options)(fn)
+    _vectorized_cache[key] = intr
+    return intr

--- a/tests/link/numba/test_fused_elemwise.py
+++ b/tests/link/numba/test_fused_elemwise.py
@@ -1080,3 +1080,19 @@ class TestReductionPythonMode:
         np.testing.assert_allclose(
             perform_fn(xv, yv, idxv)[0], np.sum(xv[idxv] + yv, axis=1), rtol=1e-10
         )
+
+
+@pytest.mark.parametrize("n_terms", [35, 60])
+def test_wide_gathered_add(n_terms):
+    """>30-input fused kernels (sum of gathered tables) compile and match numpy."""
+    rng = np.random.default_rng(n_terms)
+    idx = pt.lvector("idx")
+    mats = [pt.matrix(f"m{i}") for i in range(n_terms)]
+    out = sum(m[idx] for m in mats)
+
+    fn = function([idx, *mats], out, mode=get_mode("NUMBA"))
+    idx_val = rng.integers(0, 8, 50)
+    vals = [rng.normal(size=(8, 20)) for _ in range(n_terms)]
+    np.testing.assert_allclose(
+        fn(idx_val, *vals), sum(v[idx_val] for v in vals), rtol=1e-12
+    )


### PR DESCRIPTION
## Problem

Nodes with more than ~30 inputs (wide fused kernels from additive models, wide scalar Composites from gradient fusion) compiled quadratically in numba, in both time and memory — a 62 GB / killed-by-OOM real-model report in pymc-devs/nutpie#339. Two dispatch-level mechanisms were responsible. Star-args boundaries type as one wide tuple, whose LLVM lowering is O(n²) in the arity: the `_vectorized` intrinsic's inputs tuple and the `Elemwise`/`FusedElemwise` overload targets and impls. And the per-node metadata (broadcast patterns, dtypes, index specs) was passed to the intrinsic as base64-pickled literal-string arguments, which numba's type inference re-hashes and re-decodes on every fixpoint sweep — profiling showed this dominating compile time outright on wide graphs.

## Changes

All boundaries now use named parameters, with the outer inputs as trailing individual arguments of a per-node intrinsic instance that closes over its decoded metadata — only runtime values remain in typed signatures. Graphs are untouched. Pairs with #2361 (or numba/numba#10782 once released) for the >30-argument call *sites* in generated fgraph functions; without it results are unchanged but wide calls still pay the bytecode-chain cost.

## Results

Interleaved with `main` in a single session on an otherwise-idle 8-core/16-thread box (Ryzen 7 PRO 4750U, BLAS/OMP threads pinned to 1), cold caches (absolute times on this box are load-sensitive, so only same-session interleaved comparisons are quoted; measured together with #2361 and #2362, since the wide-node bottlenecks compose and any single one left unfixed caps the win):

| | main | this stack |
|---|---|---|
| n=80 additive repro | 364.2 / 365.3 s, 2632 MB | 105.1 / 105.0 s, 935 / 929 MB |
| nutpie#339 sentinel, lognormal 18/24 | 196.5 s, 3.62 GB | 88.8 s, 0.76 GB |
| same, gamma 18/24 | 137.8 s, 1.17 GB | 89.4 s, 0.84 GB |

That is 3.5× compile and 2.8× peak RSS on the repro, and on the sentinel it removes the pathology the issue is actually about: the lognormal/gamma disparity goes from 1.4× time / 3.1× memory to 1.0× / 0.9×. logp/grad parity exact on the sentinel; full numba test battery green with cold caches.

