### PR TITLE
Fix MergeOptimizer's dead guard against merging destroyed variables

### DIFF
--- a/pytensor/graph/rewriting/basic.py
+++ b/pytensor/graph/rewriting/basic.py
@@ -43,7 +43,6 @@ from pytensor.graph.traversal import (
 )
 from pytensor.graph.utils import AssocList, InconsistencyError
 from pytensor.misc.ordered_set import OrderedSet
-from pytensor.utils import flatten
 
 
 _logger = logging.getLogger("pytensor.graph.rewriting.basic")
@@ -755,15 +754,13 @@ class MergeOptimizer(GraphRewriter):
                         continue
 
                     if hasattr(fgraph, "destroy_handler"):
-                        # If both nodes have clients that destroy them, we
-                        # can't merge them.
-                        clients = (
-                            fgraph.clients[pairs[0][0]] + fgraph.clients[pairs[0][1]]
-                        )
-                        if any(
-                            i in flatten(c.op.destroy_map.values())
-                            for c, i in clients
-                            if c.op.destroy_map
+                        # If both variables are destroyed (directly, or through
+                        # a view chain), merging them would give the survivor
+                        # two destroyers, which `DestroyHandler` validation
+                        # always rejects -- skip instead of paying a
+                        # checkpoint + failed validate + revert per pair.
+                        if fgraph.destroyers(pairs[0][0]) and fgraph.destroyers(
+                            pairs[0][1]
                         ):
                             continue
 

--- a/pytensor/graph/rewriting/basic.py
+++ b/pytensor/graph/rewriting/basic.py
@@ -684,6 +684,16 @@ class MergeFeature(Feature):
                 self.noinput_nodes.add(node)
 
 
+def _has_direct_destroyer(fgraph, var):
+    """Whether any direct client destroys `var` (view-chain destroyers not seen)."""
+    return any(
+        i in destroyed_idxs
+        for client, i in fgraph.clients[var]
+        if client.op.destroy_map
+        for destroyed_idxs in client.op.destroy_map.values()
+    )
+
+
 class MergeOptimizer(GraphRewriter):
     r"""Merges parts of the graph that are identical and redundant.
 
@@ -754,14 +764,18 @@ class MergeOptimizer(GraphRewriter):
                         continue
 
                     if hasattr(fgraph, "destroy_handler"):
-                        # If both variables are destroyed (directly, or through
-                        # a view chain), merging them would give the survivor
-                        # two destroyers, which `DestroyHandler` validation
-                        # always rejects -- skip instead of paying a
-                        # checkpoint + failed validate + revert per pair.
-                        if fgraph.destroyers(pairs[0][0]) and fgraph.destroyers(
-                            pairs[0][1]
-                        ):
+                        # Merging two variables that both have a destroyer is
+                        # always rejected by `DestroyHandler` validation
+                        # ("multiple destroyers") -- skip those outright
+                        # instead of paying a checkpoint + failed validate +
+                        # revert per scheduled pair. A single-destroyer merge
+                        # may still be feasible, and destroyers reachable only
+                        # through view chains are rare: both are left to
+                        # validation, keeping this check O(clients) with no
+                        # droot recomputation.
+                        if _has_direct_destroyer(
+                            fgraph, pairs[0][0]
+                        ) and _has_direct_destroyer(fgraph, pairs[0][1]):
                             continue
 
                 # Keep the variable with the most specific static type from the pairs

--- a/pytensor/graph/rewriting/basic.py
+++ b/pytensor/graph/rewriting/basic.py
@@ -684,16 +684,6 @@ class MergeFeature(Feature):
                 self.noinput_nodes.add(node)
 
 
-def _has_direct_destroyer(fgraph, var):
-    """Whether any direct client destroys `var` (view-chain destroyers not seen)."""
-    return any(
-        i in destroyed_idxs
-        for client, i in fgraph.clients[var]
-        if client.op.destroy_map
-        for destroyed_idxs in client.op.destroy_map.values()
-    )
-
-
 class MergeOptimizer(GraphRewriter):
     r"""Merges parts of the graph that are identical and redundant.
 
@@ -714,6 +704,15 @@ class MergeOptimizer(GraphRewriter):
             fgraph.attach_feature(MergeFeature())
 
     def apply(self, fgraph):
+        def has_direct_destroyer(var):
+            """Whether any direct client destroys `var` (view-chain destroyers not seen)."""
+            return any(
+                i in destroyed_idxs
+                for client, i in fgraph.clients[var]
+                if client.op.destroy_map
+                for destroyed_idxs in client.op.destroy_map.values()
+            )
+
         sched = fgraph.merge_feature.scheduled
         nb_fail = 0
         t0 = time.perf_counter()
@@ -773,9 +772,9 @@ class MergeOptimizer(GraphRewriter):
                         # through view chains are rare: both are left to
                         # validation, keeping this check O(clients) with no
                         # droot recomputation.
-                        if _has_direct_destroyer(
-                            fgraph, pairs[0][0]
-                        ) and _has_direct_destroyer(fgraph, pairs[0][1]):
+                        if has_direct_destroyer(pairs[0][0]) and has_direct_destroyer(
+                            pairs[0][1]
+                        ):
                             continue
 
                 # Keep the variable with the most specific static type from the pairs

--- a/tests/graph/rewriting/test_basic.py
+++ b/tests/graph/rewriting/test_basic.py
@@ -6,6 +6,7 @@ import pytest
 from pytensor.configdefaults import config
 from pytensor.graph import rewrite_graph
 from pytensor.graph.basic import Apply, Constant, equal_computations
+from pytensor.graph.destroyhandler import DestroyHandler
 from pytensor.graph.features import Feature
 from pytensor.graph.fg import FunctionGraph
 from pytensor.graph.op import Op
@@ -374,6 +375,25 @@ class TestMergeOptimizer:
         g = FunctionGraph([x, y, z], [e])
         g.attach_feature(AssertNoChanges())
         MergeOptimizer().rewrite(g)
+
+    def test_no_merge_attempt_on_destroyed_variables(self):
+        # The two `op2(x, y)` nodes are identical, but each output is
+        # destroyed by its own destructive client, so merging them would give
+        # the survivor two destroyers and `DestroyHandler` validation would
+        # reject it. The pair must be skipped outright: attempting the merge
+        # and reverting on the `InconsistencyError` -- once per scheduled pair,
+        # rescheduled after every graph change -- made rewriting quadratic on
+        # graphs with many identical destroyed nodes (e.g. the gradient of
+        # ``sum_i params_i[idx_i]``, one destroyed zeros-`Alloc` per term).
+        x, y = MyVariable("x"), MyVariable("y")
+        twin1, twin2 = op2(x, y), op2(x, y)
+        destroyer = MyOp("destroyer", dmap={0: [0]})
+        g = FunctionGraph([x, y], [destroyer(twin1), destroyer(twin2)], clone=False)
+        g.attach_feature(DestroyHandler())
+        prof = MergeOptimizer().rewrite(g)
+        nb_fail = prof[0]
+        assert nb_fail == 0
+        assert g.outputs[0].owner.inputs[0] is not g.outputs[1].owner.inputs[0]
 
     def test_merge_outputs(self):
         x, y, z = MyVariable("x"), MyVariable("y"), MyVariable("z")

--- a/tests/graph/rewriting/test_basic.py
+++ b/tests/graph/rewriting/test_basic.py
@@ -377,14 +377,6 @@ class TestMergeOptimizer:
         MergeOptimizer().rewrite(g)
 
     def test_no_merge_attempt_on_destroyed_variables(self):
-        # The two `op2(x, y)` nodes are identical, but each output is
-        # destroyed by its own destructive client, so merging them would give
-        # the survivor two destroyers and `DestroyHandler` validation would
-        # reject it. The pair must be skipped outright: attempting the merge
-        # and reverting on the `InconsistencyError` -- once per scheduled pair,
-        # rescheduled after every graph change -- made rewriting quadratic on
-        # graphs with many identical destroyed nodes (e.g. the gradient of
-        # ``sum_i params_i[idx_i]``, one destroyed zeros-`Alloc` per term).
         x, y = MyVariable("x"), MyVariable("y")
         twin1, twin2 = op2(x, y), op2(x, y)
         destroyer = MyOp("destroyer", dmap={0: [0]})

--- a/tests/graph/rewriting/test_basic.py
+++ b/tests/graph/rewriting/test_basic.py
@@ -387,6 +387,36 @@ class TestMergeOptimizer:
         assert nb_fail == 0
         assert g.outputs[0].owner.inputs[0] is not g.outputs[1].owner.inputs[0]
 
+    def test_merge_single_destroyer_feasible(self):
+        # Only one twin is destroyed: the merge goes through, with the reader
+        # ordered before the destroyer.
+        x, y = MyVariable("x"), MyVariable("y")
+        twin1, twin2 = op2(x, y), op2(x, y)
+        destroyer = MyOp("destroyer", dmap={0: [0]})
+        g = FunctionGraph([x, y], [destroyer(twin1), op1(twin2)], clone=False)
+        g.attach_feature(DestroyHandler())
+        prof = MergeOptimizer().rewrite(g)
+        nb_fail = prof[0]
+        assert nb_fail == 0
+        assert g.outputs[0].owner.inputs[0] is g.outputs[1].owner.inputs[0]
+
+    def test_merge_single_destroyer_infeasible(self):
+        # The reader needs both the undestroyed twin and the destroyer's
+        # result, so it cannot run before the destroyer: validation rejects
+        # the attempted merge and the twins stay distinct.
+        x, y = MyVariable("x"), MyVariable("y")
+        twin1, twin2 = op2(x, y), op2(x, y)
+        destroyer = MyOp("destroyer", dmap={0: [0]})
+        g = FunctionGraph([x, y], [op1(twin2, destroyer(twin1))], clone=False)
+        g.attach_feature(DestroyHandler())
+        prof = MergeOptimizer().rewrite(g)
+        nb_fail = prof[0]
+        # The attempt is made (and rejected) -- single-destroyer pairs are for
+        # validation to decide, not for the cheap guard to skip.
+        assert nb_fail >= 1
+        reader = g.outputs[0].owner
+        assert reader.inputs[0] is not reader.inputs[1].owner.inputs[0]
+
     def test_merge_outputs(self):
         x, y, z = MyVariable("x"), MyVariable("y"), MyVariable("z")
         e1 = op3(op2(x, y))


### PR DESCRIPTION
### The bug

`MergeOptimizer.apply` has a guard meant to skip merging identical nodes whose outputs
are destroyed by inplace clients:

```python
if any(
    i in flatten(c.op.destroy_map.values())
    for c, i in clients
    if c.op.destroy_map
):
    continue
```

`pytensor.utils.flatten` only recurses into `tuple | list | set`. `dict.values()` is a
`dict_values` view, so `flatten` returns it wrapped in a single-element list and the
membership test can never succeed:

```python
>>> flatten({0: [0]}.values())
[dict_values([[0]])]
>>> 0 in flatten({0: [0]}.values())
False
```

Under Python 2, `dict.values()` returned a list and the guard worked. **It has been dead
code since the Python 3 port.**

### Why it matters

With the guard dead, every merge of two destroyed variables runs the full
`replace_all_validate` cycle — checkpoint, `DestroyHandler` validation failure
(`InconsistencyError: Multiple destroyers`), revert — and `MergeFeature` re-schedules the
pair after every subsequent graph change, so the same doomed pair is retried across the
whole rewrite phase.

Graphs with many *identical destroyed* nodes hit this combinatorially. The canonical shape
is the gradient of `sum_i params_i[idx_i]` (any additive model over gathered parameter
blocks): each term contributes a zeros-`Alloc` gradient buffer, all identical, and after
the inplace pass each is destroyed by its own `AdvancedIncSubtensor{inplace}`. Failed
merge attempts then grow ~n³:

| n terms | failed merge attempts | `pytensor.function` (mode=NUMBA, main) | fixed |
|---:|---:|---:|---:|
| 10 | 210 | 0.6 s | — |
| 20 | 1,520 | 4.4 s | 1.3 s (0 failures) |
| 40 | 11,440 | **294.5 s** | **2.1 s** (0 failures) |

The blowup is backend-independent (FAST_RUN produces identical failure counts); numba
only makes the wall-clock more visible. A real 142-variable PyMC model spent 40+ minutes
and tens of GB in this storm without finishing.

<details><summary>Repro script</summary>

```python
import numpy as np, pytensor, pytensor.tensor as pt

n, N, L, K = 40, 5232, 8, 20
rng = np.random.default_rng(0)
x = pt.dvector("x")
mu = pt.zeros((N, K))
for i in range(n):
    block = x[i*L*K:(i+1)*L*K].reshape((L, K))
    mu = mu + block[pt.constant(rng.integers(0, L, N))]
loss = pt.special.log_softmax(mu, axis=-1)[
    pt.arange(N), pt.constant(rng.integers(0, K, N))].sum()
g = pytensor.grad(loss, x)
f = pytensor.function([x], [loss, g], mode="NUMBA")   # 294s before, 2.1s after
```
</details>

### The fix

Skip a scheduled pair when **both** variables have a direct destroyer:

```python
if _has_direct_destroyer(fgraph, pairs[0][0]) and _has_direct_destroyer(
    fgraph, pairs[0][1]
):
    continue
```

Merging two destroyed variables always fails validation ("multiple destroyers"), so
these pairs are pure waste. Everything else is left to `DestroyHandler` validation,
which is the only thing that can decide it: a *single*-destroyer merge may or may not be
feasible (reordering can be possible, or can be proven cyclic — there is no cheap local
rule), and destroyers reachable only through a view chain are rare enough that paying
the occasional validate+revert beats recomputing the transitive droot map per pair. The
check is O(direct clients) and touches no `DestroyHandler` state.

The now-unused `flatten` import is removed.

### Numerical impact

None by construction: the guard only skips replacements that `DestroyHandler` validation
would have rejected and reverted. Verified bit-identical logp and grad (max rel. diff
~1e-16, float noise) on a 60-RV hierarchical PyMC model compiled before/after.

### Test

`TestMergeOptimizer::test_no_merge_attempt_on_destroyed_variables`: two identical `op2`
nodes each destroyed by a `destroy_map={0: [0]}` client; asserts `nb_fail == 0` from the
`MergeOptimizer` profile and that the twins stay unmerged. Red on main (`nb_fail == 2`),
green with the fix.

