### PR TITLE
Numba: faster Alloc implementation

### DIFF
--- a/pytensor/link/numba/dispatch/tensor_basic.py
+++ b/pytensor/link/numba/dispatch/tensor_basic.py
@@ -9,7 +9,11 @@ from pytensor.link.numba.dispatch.basic import (
     register_funcify_and_cache_key,
     register_funcify_default_op_cache_key,
 )
-from pytensor.link.numba.dispatch.string_codegen import create_tuple_string
+from pytensor.link.numba.dispatch.string_codegen import (
+    CODE_TOKEN,
+    build_source_code,
+    create_tuple_string,
+)
 from pytensor.tensor.basic import (
     Alloc,
     AllocEmpty,
@@ -55,47 +59,146 @@ def allocempty({", ".join(shape_var_names)}):
 
 @register_funcify_and_cache_key(Alloc)
 def numba_funcify_Alloc(op, node, **kwargs):
-    shape_var_names = [f"sh{i}" for i in range(len(node.inputs) - 1)]
+    r"""Generate one of three fills, chosen by the static shape of the value.
+
+    Examples
+    --------
+
+    A 0d value is filled directly, as in ``alloc(scalar, m, n)``:
+
+    .. code-block:: python
+
+        def alloc(val, sh0, sh1):
+            sh0_item = sh0.item()
+            sh1_item = sh1.item()
+            scalar_shape = (sh0_item, sh1_item)
+            res = np.empty(scalar_shape, dtype=np.float64)
+            res[...] = val
+            return res
+
+    A value that broadcasts in every dimension is filled by its only element, as in
+    ``alloc(tensor(shape=(1, 1)), m, n)``:
+
+    .. code-block:: python
+
+        def alloc(val, sh0, sh1):
+            sh0_item = sh0.item()
+            sh1_item = sh1.item()
+            scalar_shape = (sh0_item, sh1_item)
+            res = np.empty(scalar_shape, dtype=np.float64)
+            res[...] = val[0, 0]
+            return res
+
+    Any other value is copied by a loop nest that indexes broadcast dimensions with a
+    literal 0, as in ``alloc(tensor(shape=(None, 1)), m, n)``. Dimensions that do not
+    broadcast are checked first, so that every index in the loop is in bounds:
+
+    .. code-block:: python
+
+        def alloc(val, sh0, sh1):
+            sh0_item = sh0.item()
+            sh1_item = sh1.item()
+            scalar_shape = (sh0_item, sh1_item)
+            if val.shape[-2] != scalar_shape[-2]:
+                if val.shape[-2] == 1:
+                    raise ValueError(...)  # Runtime broadcasting not allowed
+                raise ValueError(...)  # Could not broadcast into the requested shape
+            res = np.empty(scalar_shape, dtype=np.float64)
+            for i0 in range(sh0_item):
+                for i1 in range(sh1_item):
+                    res[i0, i1] = val[i0, 0]
+            return res
+
+    """
+    val, *shape_vars = node.inputs
+    out_ndim = len(shape_vars)
+    # The dimensions of `val` align with the trailing dimensions of the output
+    offset = out_ndim - val.type.ndim
+
+    shape_var_names = [f"sh{i}" for i in range(out_ndim)]
     shape_var_item_names = [f"{name}_item" for name in shape_var_names]
-    shapes_to_items_src = indent(
-        "\n".join(
+
+    code: list[str | CODE_TOKEN] = [
+        f"def alloc(val, {', '.join(shape_var_names)}):",
+        CODE_TOKEN.INDENT,
+        *(
             f"{item_name} = {shape_name}.item()"
             for item_name, shape_name in zip(
                 shape_var_item_names, shape_var_names, strict=True
             )
         ),
-        " " * 4,
-    )
+        f"scalar_shape = {create_tuple_string(shape_var_item_names)}",
+    ]
 
-    check_runtime_broadcast = []
-    for i, val_static_dim in enumerate(node.inputs[0].type.shape[::-1]):
-        if val_static_dim is None:
-            check_runtime_broadcast.append(
-                f'if val.shape[{-i - 1}] == 1 and scalar_shape[{-i - 1}] != 1: raise ValueError("{Alloc._runtime_broadcast_error_msg}")'
+    mismatch_error_msg = (
+        "could not broadcast input array into the shape requested by Alloc"
+    )
+    for i, val_static_dim in enumerate(val.type.shape[::-1]):
+        if val_static_dim == 1:
+            # Broadcasts against any output dimension
+            continue
+        code.extend(
+            (
+                f"if val.shape[{-i - 1}] != scalar_shape[{-i - 1}]:",
+                CODE_TOKEN.INDENT,
             )
-    check_runtime_broadcast_src = indent("\n".join(check_runtime_broadcast), " " * 4)
-    dtype = node.inputs[0].type.dtype
-    alloc_def_src = f"""
-def alloc(val, {", ".join(shape_var_names)}):
-{shapes_to_items_src}
-    scalar_shape = {create_tuple_string(shape_var_item_names)}
-{check_runtime_broadcast_src}
-    res = np.empty(scalar_shape, dtype=np.{dtype})
-    res[...] = val
-    return res
-    """
+        )
+        if val_static_dim is None:
+            code.append(
+                f'if val.shape[{-i - 1}] == 1: raise ValueError("{Alloc._runtime_broadcast_error_msg}")'
+            )
+        code.extend((f'raise ValueError("{mismatch_error_msg}")', CODE_TOKEN.DEDENT))
+
+    code.append(f"res = np.empty(scalar_shape, dtype=np.{val.type.dtype})")
+
+    # A dimension of `val` is either statically size 1, and so broadcasts, or it
+    # matches the output dimension (the checks above reject every other case), so
+    # the whole broadcasting pattern is known here. Filling `res` with an explicit
+    # loop nest instead of `res[...] = val` matters: Numba lowers array-to-array
+    # assignment to a dtype-generic byte-wise copy helper, while the loop nest
+    # vectorizes.
+    val_idxs = [
+        "0" if val.type.shape[d - offset] == 1 else f"i{d}"
+        for d in range(offset, out_ndim)
+    ]
+    if all(idx == "0" for idx in val_idxs):
+        # Every dimension broadcasts, so this is a fill by a scalar, which Numba
+        # already lowers well. This is also the only branch valid for a 0d output.
+        # A 0d value is filled directly, without indexing it into a scalar first,
+        # because Numba is not consistent about the distinction and may hand us a
+        # scalar that cannot be indexed.
+        val_item = f"val[{', '.join(val_idxs)}]" if val_idxs else "val"
+        code.append(f"res[...] = {val_item}")
+    else:
+        for d in range(out_ndim):
+            code.extend(
+                (f"for i{d} in range({shape_var_item_names[d]}):", CODE_TOKEN.INDENT)
+            )
+        out_idxs = [f"i{d}" for d in range(out_ndim)]
+        code.append(f"res[{', '.join(out_idxs)}] = val[{', '.join(val_idxs)}]")
+        code.extend([CODE_TOKEN.DEDENT] * out_ndim)
+
+    code.extend(("return res", CODE_TOKEN.DEDENT))
+
     alloc_fn = compile_numba_function_src(
-        alloc_def_src,
+        build_source_code(code),
         "alloc",
         globals() | {"np": np},
         write_to_disk=True,
     )
 
-    cache_version = -1
+    cache_version = 1
+    # The code branches on whether a dimension of the value is statically 1 (it
+    # broadcasts), of unknown size (it needs a runtime broadcast check) or of known
+    # size, but never on the concrete sizes.
+    static_shape_key = tuple(
+        dim if dim in (1, None) else "known" for dim in val.type.shape
+    )
     cache_key = sha256(
-        str((type(op), node.inputs[0].type.broadcastable, cache_version)).encode()
+        str((type(op), static_shape_key, cache_version)).encode()
     ).hexdigest()
-    return numba_basic.numba_njit(alloc_fn), cache_key
+    # The shape checks above make every index in the fill loop in-bounds by construction
+    return numba_basic.numba_njit(alloc_fn, boundscheck=False), cache_key
 
 
 @register_funcify_default_op_cache_key(ARange)

--- a/tests/benchmarks/test_alloc.py
+++ b/tests/benchmarks/test_alloc.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+
+from pytensor import In, Out, function
+from pytensor.tensor import alloc, tensor
+
+
+# Each case broadcasts a different subset of dimensions, which is what decides
+# the fill loop Alloc generates.
+# name: (static shape of value, runtime shape of value, output shape)
+ALLOC_CASES = {
+    "scalar": ((), (), (1000, 1000)),
+    "outer": ((1, None), (1, 1000), (1000, 1000)),
+    "inner": ((None, 1), (1000, 1), (1000, 1000)),
+}
+
+
+@pytest.mark.parametrize("case", ALLOC_CASES)
+def test_alloc_benchmark_numba(case, benchmark):
+    static_shape, val_shape, out_shape = ALLOC_CASES[case]
+    x = tensor("x", shape=static_shape)
+    x_val = np.random.random(val_shape).astype(x.type.dtype)
+    y = alloc(x, *out_shape)
+    # Borrow to avoid deepcopy overhead
+    fn = function(
+        [In(x, borrow=True)],
+        Out(y, borrow=True),
+        mode="NUMBA",
+        trust_input=True,
+    )
+    fn(x_val)  # JIT compile
+    benchmark(fn, x_val)

--- a/tests/link/numba/test_tensor_basic.py
+++ b/tests/link/numba/test_tensor_basic.py
@@ -28,6 +28,37 @@ rng = np.random.default_rng(42849)
         (1.1, (2, 3)),
         ((pt.scalar("a"), np.array(10.0, dtype=config.floatX)), (20,)),
         ((pt.vector("a"), np.ones(10, dtype=config.floatX)), (20, 10)),
+        # Cover each broadcasting pattern of the generated fill loop
+        (
+            (pt.tensor("a", shape=(1, None)), np.arange(10, dtype=config.floatX)[None]),
+            (20, 10),
+        ),
+        (
+            (
+                pt.tensor("a", shape=(None, 1)),
+                np.arange(20, dtype=config.floatX)[:, None],
+            ),
+            (20, 10),
+        ),
+        (
+            (
+                pt.tensor("a", shape=(None, 1, None)),
+                np.arange(20 * 10, dtype=config.floatX).reshape(20, 1, 10),
+            ),
+            (20, 5, 10),
+        ),
+        (
+            (pt.matrix("a"), np.arange(20 * 10, dtype=config.floatX).reshape(20, 10)),
+            (20, 10),
+        ),
+        # Non-contiguous value
+        (
+            (
+                pt.matrix("a"),
+                np.arange(40 * 10, dtype=config.floatX).reshape(40, 10)[::2],
+            ),
+            (20, 10),
+        ),
     ],
 )
 def test_Alloc(v, shape):
@@ -45,6 +76,18 @@ def test_Alloc(v, shape):
 
 def test_alloc_runtime_broadcast():
     check_alloc_runtime_broadcast(get_mode("NUMBA"))
+
+
+def test_alloc_shape_mismatch():
+    # A value that neither broadcasts nor matches the requested shape must be rejected,
+    # instead of running past the end of the value in the fill loop
+    mode = get_mode("NUMBA").excluding("shape_unsafe")
+    x_test = np.zeros((3, 7), dtype=config.floatX)
+    for static_shape in ((None, 7), (None, None)):
+        x = pt.tensor("x", shape=static_shape)
+        fn = function([x], pt.alloc(x, 6, 7), mode=mode)
+        with pytest.raises(ValueError, match="could not broadcast input array"):
+            fn(x_test)
 
 
 def test_AllocEmpty():

--- a/tests/tensor/rewriting/test_basic.py
+++ b/tests/tensor/rewriting/test_basic.py
@@ -306,16 +306,9 @@ class TestLocalCanonicalizeAlloc:
                 f()
         else:
             assert has_alloc
-            # Error raised by Alloc Op. Numba swapped the two shapes in its message in
-            # 0.66 (numba/numba#10499), so accept them in either order.
-            with pytest.raises(
-                ValueError,
-                match=(
-                    r"(could not broadcast input array from shape \(3,7\) into shape \(6,7\)"
-                    r"|cannot assign slice of shape \((3, 7|6, 7)\) "
-                    r"from input of shape \((3, 7|6, 7)\))"
-                ),
-            ):
+            # Error raised by Alloc Op. Backends differ on how they report the offending
+            # shapes, so only the common prefix of the message is checked.
+            with pytest.raises(ValueError, match="could not broadcast input array"):
                 f()
 
         good_x_val = self.rng.standard_normal((6, 7))


### PR DESCRIPTION
Before
```
Name (time in us)                           Min                Mean             StdDev              Median            Rounds
----------------------------------------------------------------------------------------------------------------------------
test_alloc_benchmark_numba[scalar]      63.7000 (1.0)       67.3365 (1.0)       9.5839 (1.0)       64.8110 (1.0)       15791
test_alloc_benchmark_numba[outer]      215.2940 (3.38)     223.2032 (3.31)     18.6194 (1.94)     219.6620 (3.39)       4749
test_alloc_benchmark_numba[inner]      216.2260 (3.39)     232.2599 (3.45)     52.9809 (5.53)     224.9920 (3.47)       4661
```

After
```
Name (time in us)                          Min               Mean             StdDev             Median            Rounds
-------------------------------------------------------------------------------------------------------------------------
test_alloc_benchmark_numba[scalar]     65.2430 (1.0)      72.5559 (1.0)      24.4287 (1.34)     67.7070 (1.0)       15234
test_alloc_benchmark_numba[inner]      66.8160 (1.02)     77.5265 (1.07)     26.5970 (1.45)     70.6130 (1.04)      15218
test_alloc_benchmark_numba[outer]      71.5940 (1.10)     82.2667 (1.13)     18.2818 (1.0)      77.2250 (1.14)      13920
-------------------------------------------------------------------------------------------------------------------------
```
