### PR TITLE
Numba: solve triangular C-contiguous B without copy

### DIFF
--- a/pytensor/link/numba/dispatch/linalg/_BLAS.py
+++ b/pytensor/link/numba/dispatch/linalg/_BLAS.py
@@ -1,0 +1,74 @@
+import numba
+from numba.core import types
+from numba.core.extending import get_cython_function_address
+from numba.core.registry import CPUDispatcher
+from numba.np.linalg import ensure_blas, get_blas_kind
+
+from pytensor.link.numba.cache import _call_cached_ptr
+from pytensor.link.numba.dispatch import basic as numba_basic
+from pytensor.link.numba.dispatch.linalg._LAPACK import (
+    _get_nb_float_from_dtype,
+    nb_i32p,
+)
+
+
+def get_blas_ptr(dtype, name):
+    d = get_blas_kind(dtype)
+    func_name = f"{d}{name}"
+    blas_ptr = get_cython_function_address("scipy.linalg.cython_blas", func_name)
+    return blas_ptr
+
+
+class _BLAS:
+    """
+    Functions to return type signatures for wrapped BLAS functions.
+
+    Patterned after https://github.com/numba/numba/blob/bd7ebcfd4b850208b627a3f75d4706000be36275/numba/np/linalg.py#L74
+    """
+
+    def __init__(self):
+        ensure_blas()
+
+    @classmethod
+    def numba_xtrsm(cls, dtype) -> CPUDispatcher:
+        r"""
+        Solve a triangular matrix equation of the form :math:`op(A) X = \alpha B` (``side="L"``) or
+        :math:`X op(A) = \alpha B` (``side="R"``), overwriting ``B`` with the solution.
+        """
+
+        kind = get_blas_kind(dtype)
+        float_ptr = _get_nb_float_from_dtype(kind)
+        unique_func_name = f"scipy.blas.{kind}trsm"
+
+        @numba_basic.numba_njit
+        def get_trsm_pointer():
+            with numba.objmode(ptr=types.intp):
+                ptr = get_blas_ptr(dtype, "trsm")
+            return ptr
+
+        trsm_function_type = types.FunctionType(
+            types.void(
+                nb_i32p,  # SIDE
+                nb_i32p,  # UPLO
+                nb_i32p,  # TRANSA
+                nb_i32p,  # DIAG
+                nb_i32p,  # M
+                nb_i32p,  # N
+                float_ptr,  # ALPHA
+                float_ptr,  # A
+                nb_i32p,  # LDA
+                float_ptr,  # B
+                nb_i32p,  # LDB
+            )
+        )
+
+        @numba_basic.numba_njit
+        def trsm(SIDE, UPLO, TRANSA, DIAG, M, N, ALPHA, A, LDA, B, LDB):
+            fn = _call_cached_ptr(
+                get_ptr_func=get_trsm_pointer,
+                func_type_ref=trsm_function_type,
+                unique_func_name_lit=unique_func_name,
+            )
+            fn(SIDE, UPLO, TRANSA, DIAG, M, N, ALPHA, A, LDA, B, LDB)
+
+        return trsm

--- a/pytensor/link/numba/dispatch/linalg/_LAPACK.py
+++ b/pytensor/link/numba/dispatch/linalg/_LAPACK.py
@@ -139,50 +139,6 @@ class _LAPACK:
         ensure_lapack()
 
     @classmethod
-    def numba_xtrtrs(cls, dtype) -> CPUDispatcher:
-        """
-        Solve a triangular system of equations of the form A @ X = B or A.T @ X = B.
-
-        Called by scipy.linalg.solve_triangular
-        """
-
-        kind = get_blas_kind(dtype)
-        float_ptr = _get_nb_float_from_dtype(kind)
-        unique_func_name = f"scipy.lapack.{kind}trtrs"
-
-        @numba_basic.numba_njit
-        def get_trtrs_pointer():
-            with numba.objmode(ptr=types.intp):
-                ptr = get_lapack_ptr(dtype, "trtrs")
-            return ptr
-
-        trtrs_function_type = types.FunctionType(
-            types.void(
-                nb_i32p,  # UPLO
-                nb_i32p,  # TRANS
-                nb_i32p,  # DIAG
-                nb_i32p,  # N
-                nb_i32p,  # NRHS
-                float_ptr,  # A
-                nb_i32p,  # LDA
-                float_ptr,  # B
-                nb_i32p,  # LDB
-                nb_i32p,  # INFO
-            )
-        )
-
-        @numba_basic.numba_njit
-        def trtrs(UPLO, TRANS, DIAG, N, NRHS, A, LDA, B, LDB, INFO):
-            fn = _call_cached_ptr(
-                get_ptr_func=get_trtrs_pointer,
-                func_type_ref=trtrs_function_type,
-                unique_func_name_lit=unique_func_name,
-            )
-            fn(UPLO, TRANS, DIAG, N, NRHS, A, LDA, B, LDB, INFO)
-
-        return trtrs
-
-    @classmethod
     def numba_xpotrf(cls, dtype) -> CPUDispatcher:
         """
         Compute the Cholesky factorization of a real symmetric positive definite matrix.

--- a/pytensor/link/numba/dispatch/linalg/solvers/dispatch.py
+++ b/pytensor/link/numba/dispatch/linalg/solvers/dispatch.py
@@ -114,7 +114,7 @@ def numba_funcify_SolveTriangular(op, node, **kwargs):
             overwrite_b=overwrite_b,
         )
 
-    cache_version = 2
+    cache_version = 3
     return solve_triangular, cache_version
 
 

--- a/pytensor/link/numba/dispatch/linalg/solvers/dispatch.py
+++ b/pytensor/link/numba/dispatch/linalg/solvers/dispatch.py
@@ -114,7 +114,7 @@ def numba_funcify_SolveTriangular(op, node, **kwargs):
             overwrite_b=overwrite_b,
         )
 
-    cache_version = 3
+    cache_version = 4
     return solve_triangular, cache_version
 
 

--- a/pytensor/link/numba/dispatch/linalg/solvers/triangular.py
+++ b/pytensor/link/numba/dispatch/linalg/solvers/triangular.py
@@ -4,6 +4,8 @@ from numba.core.types import Complex, Float
 from numba.np.linalg import ensure_lapack
 from scipy import linalg
 
+from pytensor.link.numba.dispatch import basic as numba_basic
+from pytensor.link.numba.dispatch.linalg._BLAS import _BLAS
 from pytensor.link.numba.dispatch.linalg._LAPACK import (
     _LAPACK,
     int_ptr_to_val,
@@ -54,12 +56,12 @@ def solve_triangular_impl(A, B, trans, lower, unit_diagonal, overwrite_b):
     _check_dtypes_match((A, B), func_name="solve_triangular")
     dtype = A.dtype
     numba_trtrs = _LAPACK().numba_xtrtrs(dtype)
+    numba_trsm = _BLAS().numba_xtrsm(dtype)
+    B_is_1d = B.ndim == 1
 
     def impl(A, B, trans, lower, unit_diagonal, overwrite_b):
         _N = np.int32(A.shape[-1])
         _solve_check_input_shapes(A, B)
-
-        B_is_1d = B.ndim == 1
 
         if A.flags.f_contiguous or (A.flags.c_contiguous and trans in (0, 1)):
             A_f = A
@@ -71,6 +73,50 @@ def solve_triangular_impl(A, B, trans, lower, unit_diagonal, overwrite_b):
         else:
             A_f = np.asfortranarray(A)
 
+        UPLO = val_to_int_ptr(ord("L") if lower else ord("U"))
+        DIAG = val_to_int_ptr(ord("U") if unit_diagonal else ord("N"))
+
+        # A c_contiguous B reinterpreted as f_contiguous is B^T, so op(A) X = B can be solved as
+        # X^T op(A)^T = B^T, which is what trsm computes with side="R". That spares the transposing copy trtrs
+        # needs to consume B. op(A)^T is not expressible for trans=2, since trsm has no conjugate-only mode.
+        if (
+            not B_is_1d
+            and trans != 2
+            and B.flags.c_contiguous
+            and not B.flags.f_contiguous
+        ):
+            if not unit_diagonal and _has_zero_on_diagonal(A_f):
+                # trsm reports no INFO, so singular A has to be caught before the call
+                return np.full_like(B, np.nan)
+
+            B_work = B if overwrite_b else B.copy()
+            _NRHS = np.int32(B_work.shape[-1])
+            ALPHA = np.ones(1, dtype=dtype)
+
+            SIDE = val_to_int_ptr(ord("R"))
+            # op(A)^T is A^T for trans=0 and A for trans=1
+            TRANSA = val_to_int_ptr(ord("T") if trans == 0 else ord("N"))
+            M = val_to_int_ptr(_NRHS)
+            N = val_to_int_ptr(_N)
+            LDA = val_to_int_ptr(_N)
+            LDB = val_to_int_ptr(_NRHS)
+
+            numba_trsm(
+                SIDE,
+                UPLO,
+                TRANSA,
+                DIAG,
+                M,
+                N,
+                ALPHA.ctypes,
+                A_f.ctypes,
+                LDA,
+                B_work.ctypes,
+                LDB,
+            )
+
+            return B_work
+
         if overwrite_b and B.flags.f_contiguous:
             B_copy = B
         else:
@@ -81,9 +127,7 @@ def solve_triangular_impl(A, B, trans, lower, unit_diagonal, overwrite_b):
 
         NRHS = 1 if B_is_1d else int(B_copy.shape[-1])
 
-        UPLO = val_to_int_ptr(ord("L") if lower else ord("U"))
         TRANS = val_to_int_ptr(_trans_char_to_int(trans))
-        DIAG = val_to_int_ptr(ord("U") if unit_diagonal else ord("N"))
         N = val_to_int_ptr(_N)
         NRHS = val_to_int_ptr(NRHS)
         LDA = val_to_int_ptr(_N)
@@ -111,3 +155,11 @@ def solve_triangular_impl(A, B, trans, lower, unit_diagonal, overwrite_b):
         return B_copy
 
     return impl
+
+
+@numba_basic.numba_njit(inline="always")
+def _has_zero_on_diagonal(A):
+    for i in range(A.shape[0]):
+        if A[i, i] == 0:
+            return True
+    return False

--- a/pytensor/link/numba/dispatch/linalg/solvers/triangular.py
+++ b/pytensor/link/numba/dispatch/linalg/solvers/triangular.py
@@ -58,6 +58,12 @@ def solve_triangular_impl(A, B, trans, lower, unit_diagonal, overwrite_b):
         _N = np.int32(A.shape[-1])
         _solve_check_input_shapes(A, B)
 
+        # trsm reports no INFO, so a zero pivot has to be caught before the call. A is
+        # scanned as given, ahead of any copy: the diagonal does not depend on layout,
+        # and a singular system should not pay to be reordered first.
+        if not unit_diagonal and _has_zero_on_diagonal(A):
+            return np.full_like(B, np.nan)
+
         if A.flags.f_contiguous or (A.flags.c_contiguous and trans in (0, 1)):
             A_f = A
             if A.flags.c_contiguous:
@@ -67,10 +73,6 @@ def solve_triangular_impl(A, B, trans, lower, unit_diagonal, overwrite_b):
                 trans = 1 - trans
         else:
             A_f = np.asfortranarray(A)
-
-        if not unit_diagonal and _has_zero_on_diagonal(A_f):
-            # trsm reports no INFO, so a zero pivot has to be caught before the call
-            return np.full_like(B, np.nan)
 
         UPLO = val_to_int_ptr(ord("L") if lower else ord("U"))
         DIAG = val_to_int_ptr(ord("U") if unit_diagonal else ord("N"))

--- a/pytensor/link/numba/dispatch/linalg/solvers/triangular.py
+++ b/pytensor/link/numba/dispatch/linalg/solvers/triangular.py
@@ -28,9 +28,6 @@ def _solve_triangular(
 
     This function is overloaded instead of the original scipy function to avoid unexpected side-effects to users who
     import pytensor.
-
-    The signature must be the same as solve_triangular_impl, so b_ndim is included, although this argument is not
-    used by scipy.linalg.solve_triangular.
     """
     return linalg.solve_triangular(
         A,

--- a/pytensor/link/numba/dispatch/linalg/solvers/triangular.py
+++ b/pytensor/link/numba/dispatch/linalg/solvers/triangular.py
@@ -51,6 +51,7 @@ def solve_triangular_impl(A, B, trans, lower, unit_diagonal, overwrite_b):
     _check_dtypes_match((A, B), func_name="solve_triangular")
     dtype = A.dtype
     numba_trsm = _BLAS().numba_xtrsm(dtype)
+    ALPHA = np.ones(1, dtype=np.dtype(dtype.name))
     B_is_1d = B.ndim == 1
 
     def impl(A, B, trans, lower, unit_diagonal, overwrite_b):
@@ -71,7 +72,6 @@ def solve_triangular_impl(A, B, trans, lower, unit_diagonal, overwrite_b):
             # trsm reports no INFO, so a zero pivot has to be caught before the call
             return np.full_like(B, np.nan)
 
-        ALPHA = np.ones(1, dtype=dtype)
         UPLO = val_to_int_ptr(ord("L") if lower else ord("U"))
         DIAG = val_to_int_ptr(ord("U") if unit_diagonal else ord("N"))
         LDA = val_to_int_ptr(_N)

--- a/pytensor/link/numba/dispatch/linalg/solvers/triangular.py
+++ b/pytensor/link/numba/dispatch/linalg/solvers/triangular.py
@@ -36,6 +36,8 @@ def _solve_triangular(
     )
 
 
+# PyTensor always calls this with trans=0, transposing on the graph instead, so nothing
+# in the test suite reaches the trans=1 or trans=2 paths below.
 @overload(_solve_triangular)
 def solve_triangular_impl(A, B, trans, lower, unit_diagonal, overwrite_b):
     ensure_blas()

--- a/pytensor/link/numba/dispatch/linalg/solvers/triangular.py
+++ b/pytensor/link/numba/dispatch/linalg/solvers/triangular.py
@@ -1,16 +1,12 @@
 import numpy as np
 from numba.core.extending import overload
 from numba.core.types import Complex, Float
-from numba.np.linalg import ensure_lapack
+from numba.np.linalg import ensure_blas
 from scipy import linalg
 
 from pytensor.link.numba.dispatch import basic as numba_basic
 from pytensor.link.numba.dispatch.linalg._BLAS import _BLAS
-from pytensor.link.numba.dispatch.linalg._LAPACK import (
-    _LAPACK,
-    int_ptr_to_val,
-    val_to_int_ptr,
-)
+from pytensor.link.numba.dispatch.linalg._LAPACK import val_to_int_ptr
 from pytensor.link.numba.dispatch.linalg.solvers.utils import _solve_check_input_shapes
 from pytensor.link.numba.dispatch.linalg.utils import (
     _check_dtypes_match,
@@ -42,7 +38,7 @@ def _solve_triangular(
 
 @overload(_solve_triangular)
 def solve_triangular_impl(A, B, trans, lower, unit_diagonal, overwrite_b):
-    ensure_lapack()
+    ensure_blas()
 
     _check_linalg_matrix(
         A, ndim=2, dtype=(Float, Complex), func_name="solve_triangular"
@@ -52,7 +48,6 @@ def solve_triangular_impl(A, B, trans, lower, unit_diagonal, overwrite_b):
     )
     _check_dtypes_match((A, B), func_name="solve_triangular")
     dtype = A.dtype
-    numba_trtrs = _LAPACK().numba_xtrtrs(dtype)
     numba_trsm = _BLAS().numba_xtrsm(dtype)
     B_is_1d = B.ndim == 1
 
@@ -70,86 +65,59 @@ def solve_triangular_impl(A, B, trans, lower, unit_diagonal, overwrite_b):
         else:
             A_f = np.asfortranarray(A)
 
+        if not unit_diagonal and _has_zero_on_diagonal(A_f):
+            # trsm reports no INFO, so a zero pivot has to be caught before the call
+            return np.full_like(B, np.nan)
+
+        ALPHA = np.ones(1, dtype=dtype)
         UPLO = val_to_int_ptr(ord("L") if lower else ord("U"))
         DIAG = val_to_int_ptr(ord("U") if unit_diagonal else ord("N"))
+        LDA = val_to_int_ptr(_N)
 
         # A c_contiguous B reinterpreted as f_contiguous is B^T, so op(A) X = B can be solved as
-        # X^T op(A)^T = B^T, which is what trsm computes with side="R". That spares the transposing copy trtrs
-        # needs to consume B. op(A)^T is not expressible for trans=2, since trsm has no conjugate-only mode.
+        # X^T op(A)^T = B^T, which is what trsm computes with side="R", straight out of B's own buffer.
+        # op(A)^T is not expressible for trans=2, since trsm has no conjugate-only mode.
         if (
             not B_is_1d
             and trans != 2
             and B.flags.c_contiguous
             and not B.flags.f_contiguous
         ):
-            if not unit_diagonal and _has_zero_on_diagonal(A_f):
-                # trsm reports no INFO, so singular A has to be caught before the call
-                return np.full_like(B, np.nan)
-
             B_work = B if overwrite_b else B.copy()
             _NRHS = np.int32(B_work.shape[-1])
-            ALPHA = np.ones(1, dtype=dtype)
-
             SIDE = val_to_int_ptr(ord("R"))
             # op(A)^T is A^T for trans=0 and A for trans=1
             TRANSA = val_to_int_ptr(ord("T") if trans == 0 else ord("N"))
             M = val_to_int_ptr(_NRHS)
             N = val_to_int_ptr(_N)
-            LDA = val_to_int_ptr(_N)
             LDB = val_to_int_ptr(_NRHS)
-
-            numba_trsm(
-                SIDE,
-                UPLO,
-                TRANSA,
-                DIAG,
-                M,
-                N,
-                ALPHA.ctypes,
-                A_f.ctypes,
-                LDA,
-                B_work.ctypes,
-                LDB,
-            )
-
-            return B_work
-
-        if overwrite_b and B.flags.f_contiguous:
-            B_copy = B
         else:
-            B_copy = _copy_to_fortran_order_even_if_1d(B)
+            if overwrite_b and B.flags.f_contiguous:
+                B_work = B
+            else:
+                B_work = _copy_to_fortran_order_even_if_1d(B)
+            _NRHS = np.int32(1 if B_is_1d else B_work.shape[-1])
+            SIDE = val_to_int_ptr(ord("L"))
+            TRANSA = val_to_int_ptr(_trans_char_to_int(trans))
+            M = val_to_int_ptr(_N)
+            N = val_to_int_ptr(_NRHS)
+            LDB = val_to_int_ptr(_N)
 
-        if B_is_1d:
-            B_copy = np.expand_dims(B_copy, -1)
-
-        NRHS = 1 if B_is_1d else int(B_copy.shape[-1])
-
-        TRANS = val_to_int_ptr(_trans_char_to_int(trans))
-        N = val_to_int_ptr(_N)
-        NRHS = val_to_int_ptr(NRHS)
-        LDA = val_to_int_ptr(_N)
-        LDB = val_to_int_ptr(_N)
-        INFO = val_to_int_ptr(0)
-
-        numba_trtrs(
+        numba_trsm(
+            SIDE,
             UPLO,
-            TRANS,
+            TRANSA,
             DIAG,
+            M,
             N,
-            NRHS,
+            ALPHA.ctypes,
             A_f.ctypes,
             LDA,
-            B_copy.ctypes,
+            B_work.ctypes,
             LDB,
-            INFO,
         )
-        if int_ptr_to_val(INFO) != 0:
-            B_copy = np.full_like(B_copy, np.nan)
 
-        if B_is_1d:
-            return B_copy[..., 0]
-
-        return B_copy
+        return B_work
 
     return impl
 

--- a/tests/link/numba/linalg/test_decomposition.py
+++ b/tests/link/numba/linalg/test_decomposition.py
@@ -480,7 +480,7 @@ class TestDecompositions:
         compare_numba_and_py(
             [x],
             outs,
-            [np.zeros((0, 0))],
+            [np.zeros((0, 0), dtype=floatX)],
         )
 
     @pytest.mark.parametrize("output", ["real", "complex"], ids=lambda x: f"output_{x}")

--- a/tests/link/numba/linalg/test_solvers.py
+++ b/tests/link/numba/linalg/test_solvers.py
@@ -7,7 +7,6 @@ import scipy
 import pytensor
 import pytensor.tensor as pt
 from pytensor import In, config
-from pytensor.link.numba.dispatch.linalg.solvers.triangular import _solve_triangular
 from pytensor.tensor.linalg.decomposition.lu import lu_factor
 from pytensor.tensor.linalg.solvers.general import Solve, lu_solve, solve
 from pytensor.tensor.linalg.solvers.psd import CholeskySolve, cho_solve
@@ -17,14 +16,9 @@ from tests.link.numba.test_basic import compare_numba_and_py, numba_inplace_mode
 
 pytestmark = pytest.mark.filterwarnings("error")
 
-numba = pytest.importorskip("numba")
+pytest.importorskip("numba")
 
 floatX = config.floatX
-
-
-@numba.njit
-def njit_solve_triangular(A, B, trans, lower, unit_diagonal, overwrite_b):
-    return _solve_triangular(A, B, trans, lower, unit_diagonal, overwrite_b)
 
 
 class TestSolves:
@@ -249,84 +243,36 @@ class TestSolves:
         np.testing.assert_allclose(A_val_not_contig, A_val)
         np.testing.assert_allclose(b_val_not_contig, b_val)
 
-    @pytest.mark.parametrize("lower", [True, False], ids=lambda x: f"lower={x}")
-    @pytest.mark.parametrize("trans", [0, 1, 2], ids=lambda x: f"trans={x}")
-    @pytest.mark.parametrize("A_order", ["C", "F"], ids=lambda x: f"A_order={x}")
-    def test_solve_triangular_trans_with_c_contiguous_rhs(
-        self, lower: bool, trans: int, A_order: Literal["C", "F"]
-    ):
-        # test_solve_triangular covers trans=0 through the graph, which is all the op ever passes.
-        # The overload is called directly to reach trans=1 and 2, with a complex dtype so that a
-        # missing conjugation shows up.
-        dtype = "complex64" if floatX.endswith("32") else "complex128"
-        rtol = 1e-4 if np.dtype(dtype).char in "fF" else 1e-8
-
-        rng = np.random.default_rng(418)
-        A_base = rng.normal(size=(5, 5)) + 1j * rng.normal(size=(5, 5))
-        A_val = scipy.linalg.cholesky(A_base @ A_base.conj().T, lower=lower).astype(
-            dtype
-        )
-        A_val = np.copy(A_val, order=A_order)
-
-        b_val = (rng.normal(size=(5, 3)) + 1j * rng.normal(size=(5, 3))).astype(dtype)
-        b_val = np.copy(b_val, order="C")
-
-        expected = scipy.linalg.solve_triangular(A_val, b_val, trans=trans, lower=lower)
-        result = njit_solve_triangular(
-            A_val,
-            b_val,
-            trans=trans,
-            lower=lower,
-            unit_diagonal=False,
-            overwrite_b=True,
-        )
-
-        np.testing.assert_allclose(result, expected, rtol=rtol)
-        # A c-contiguous 2d rhs is solved in place by side="R". trans=2 has no side="R" form, so it
-        # falls back to side="L", which needs an f-contiguous copy.
-        assert np.shares_memory(result, b_val) == (trans != 2)
-
     def test_solve_triangular_unit_diagonal_ignores_zero_diagonal(self):
-        rtol = 1e-4 if np.dtype(floatX).char in "fF" else 1e-8
-
+        # The zero-pivot scan below has to defer to unit_diagonal, or a unit triangular
+        # matrix that happens to store a zero on its diagonal comes back all-nan.
         rng = np.random.default_rng(418)
         A_val = np.tril(rng.normal(size=(5, 5))).astype(floatX)
         A_val[2, 2] = 0.0
-        b_val = np.copy(rng.normal(size=(5, 3)).astype(floatX), order="C")
+        b_val = rng.normal(size=(5, 3)).astype(floatX)
 
-        expected = scipy.linalg.solve_triangular(
-            A_val, b_val, lower=True, unit_diagonal=True
-        )
-        result = njit_solve_triangular(
-            A_val,
-            b_val,
-            trans=0,
-            lower=True,
-            unit_diagonal=True,
-            overwrite_b=False,
-        )
+        A = pt.matrix("A", dtype=floatX)
+        b = pt.matrix("b", dtype=floatX)
+        X = pt.linalg.solve_triangular(A, b, lower=True, unit_diagonal=True)
 
-        np.testing.assert_allclose(result, expected, rtol=rtol)
+        compare_numba_and_py([A, b], X, [A_val, b_val])
 
     @pytest.mark.parametrize("b_shape", [(5, 3), (5,)], ids=["b_matrix", "b_vec"])
     def test_solve_triangular_singular_returns_nan(self, b_shape: tuple[int, ...]):
-        # trsm reports no INFO, so both sides depend on our own zero-pivot scan: a 2d rhs goes
-        # through side="R" and a vector through side="L".
+        # trsm reports no INFO, so a singular system depends on our own zero-pivot scan.
+        # Both sides of the scan matter: a 2d rhs is solved by side="R" and a vector by
+        # side="L". scipy raises here instead, so there is no reference to compare against.
         rng = np.random.default_rng(418)
         A_val = np.tril(rng.normal(size=(5, 5))).astype(floatX)
         A_val[2, 2] = 0.0
-        b_val = np.copy(rng.normal(size=b_shape).astype(floatX), order="C")
+        b_val = rng.normal(size=b_shape).astype(floatX)
 
-        result = njit_solve_triangular(
-            A_val,
-            b_val,
-            trans=0,
-            lower=True,
-            unit_diagonal=False,
-            overwrite_b=False,
-        )
+        A = pt.matrix("A", dtype=floatX)
+        b = pt.tensor("b", shape=b_shape, dtype=floatX)
+        X = pt.linalg.solve_triangular(A, b, lower=True, b_ndim=len(b_shape))
+        f = pytensor.function([A, b], X, mode="NUMBA")
 
-        assert np.isnan(result).all()
+        assert np.isnan(f(A_val, b_val)).all()
 
     @pytest.mark.parametrize("value", [np.nan, np.inf])
     def test_solve_triangular_does_not_raise_on_nan_inf(self, value):

--- a/tests/link/numba/linalg/test_solvers.py
+++ b/tests/link/numba/linalg/test_solvers.py
@@ -7,6 +7,7 @@ import scipy
 import pytensor
 import pytensor.tensor as pt
 from pytensor import In, config
+from pytensor.link.numba.dispatch.linalg.solvers.triangular import _solve_triangular
 from pytensor.tensor.linalg.decomposition.lu import lu_factor
 from pytensor.tensor.linalg.solvers.general import Solve, lu_solve, solve
 from pytensor.tensor.linalg.solvers.psd import CholeskySolve, cho_solve
@@ -19,6 +20,11 @@ pytestmark = pytest.mark.filterwarnings("error")
 numba = pytest.importorskip("numba")
 
 floatX = config.floatX
+
+
+@numba.njit
+def njit_solve_triangular(A, B, trans, lower, unit_diagonal, overwrite_b):
+    return _solve_triangular(A, B, trans, lower, unit_diagonal, overwrite_b)
 
 
 class TestSolves:
@@ -232,9 +238,9 @@ class TestSolves:
         res_c_contig = f(A_val_c_contig, b_val_c_contig)
         np.testing.assert_allclose(res_c_contig, res, rtol=rtol)
         np.testing.assert_allclose(A_val_c_contig, A_val)
-        assert np.allclose(b_val_c_contig, b_val) == (
-            not (overwrite_b and b_val_c_contig.flags.f_contiguous)
-        )
+        # A c-contiguous b is consumed in place as well: trtrs takes it when it is also f-contiguous
+        # (vectors and single-column matrices), trsm otherwise.
+        assert np.allclose(b_val_c_contig, b_val) == (not overwrite_b)
 
         A_val_not_contig = np.repeat(A_val, 2, axis=0)[::2]
         b_val_not_contig = np.repeat(b_val, 2, axis=0)[::2]
@@ -242,6 +248,85 @@ class TestSolves:
         np.testing.assert_allclose(res_not_contig, res, rtol=rtol)
         np.testing.assert_allclose(A_val_not_contig, A_val)
         np.testing.assert_allclose(b_val_not_contig, b_val)
+
+    @pytest.mark.parametrize("lower", [True, False], ids=lambda x: f"lower={x}")
+    @pytest.mark.parametrize("trans", [0, 1, 2], ids=lambda x: f"trans={x}")
+    @pytest.mark.parametrize("A_order", ["C", "F"], ids=lambda x: f"A_order={x}")
+    def test_solve_triangular_trans_with_c_contiguous_rhs(
+        self, lower: bool, trans: int, A_order: Literal["C", "F"]
+    ):
+        # test_solve_triangular covers trans=0 through the graph, which is all the op ever passes.
+        # The overload is called directly to reach trans=1 and 2, with a complex dtype so that a
+        # missing conjugation shows up.
+        dtype = "complex64" if floatX.endswith("32") else "complex128"
+        rtol = 1e-4 if np.dtype(dtype).char in "fF" else 1e-8
+
+        rng = np.random.default_rng(418)
+        A_base = rng.normal(size=(5, 5)) + 1j * rng.normal(size=(5, 5))
+        A_val = scipy.linalg.cholesky(A_base @ A_base.conj().T, lower=lower).astype(
+            dtype
+        )
+        A_val = np.copy(A_val, order=A_order)
+
+        b_val = (rng.normal(size=(5, 3)) + 1j * rng.normal(size=(5, 3))).astype(dtype)
+        b_val = np.copy(b_val, order="C")
+
+        expected = scipy.linalg.solve_triangular(A_val, b_val, trans=trans, lower=lower)
+        result = njit_solve_triangular(
+            A_val,
+            b_val,
+            trans=trans,
+            lower=lower,
+            unit_diagonal=False,
+            overwrite_b=True,
+        )
+
+        np.testing.assert_allclose(result, expected, rtol=rtol)
+        # A c-contiguous 2d rhs picks trsm, which solves into b itself. trans=2 has no trsm form,
+        # so it falls back to trtrs, which copies.
+        assert np.shares_memory(result, b_val) == (trans != 2)
+
+    def test_solve_triangular_unit_diagonal_ignores_zero_diagonal(self):
+        rtol = 1e-4 if np.dtype(floatX).char in "fF" else 1e-8
+
+        rng = np.random.default_rng(418)
+        A_val = np.tril(rng.normal(size=(5, 5))).astype(floatX)
+        A_val[2, 2] = 0.0
+        b_val = np.copy(rng.normal(size=(5, 3)).astype(floatX), order="C")
+
+        expected = scipy.linalg.solve_triangular(
+            A_val, b_val, lower=True, unit_diagonal=True
+        )
+        result = njit_solve_triangular(
+            A_val,
+            b_val,
+            trans=0,
+            lower=True,
+            unit_diagonal=True,
+            overwrite_b=False,
+        )
+
+        np.testing.assert_allclose(result, expected, rtol=rtol)
+
+    @pytest.mark.parametrize("b_shape", [(5, 3), (5,)], ids=["b_matrix", "b_vec"])
+    def test_solve_triangular_singular_returns_nan(self, b_shape: tuple[int, ...]):
+        # A 2d rhs takes trsm, which reports no INFO and needs its own singularity check; a vector
+        # takes trtrs, which reports it.
+        rng = np.random.default_rng(418)
+        A_val = np.tril(rng.normal(size=(5, 5))).astype(floatX)
+        A_val[2, 2] = 0.0
+        b_val = np.copy(rng.normal(size=b_shape).astype(floatX), order="C")
+
+        result = njit_solve_triangular(
+            A_val,
+            b_val,
+            trans=0,
+            lower=True,
+            unit_diagonal=False,
+            overwrite_b=False,
+        )
+
+        assert np.isnan(result).all()
 
     @pytest.mark.parametrize("value", [np.nan, np.inf])
     def test_solve_triangular_does_not_raise_on_nan_inf(self, value):
@@ -397,9 +482,7 @@ class TestSolves:
         np.testing.assert_allclose(res_c_contig, res)
         np.testing.assert_allclose(A_val_c_contig, A_val)
 
-        assert not (
-            should_destroy and b_val_c_contig.flags.f_contiguous
-        ) == np.allclose(b_val_c_contig, b_val)
+        assert np.allclose(b_val_c_contig, b_val) == (not should_destroy)
 
         A_val_not_contig = np.repeat(A_val, 2, axis=0)[::2]
         b_val_not_contig = np.repeat(b_val, 2, axis=0)[::2]

--- a/tests/link/numba/linalg/test_solvers.py
+++ b/tests/link/numba/linalg/test_solvers.py
@@ -238,8 +238,8 @@ class TestSolves:
         res_c_contig = f(A_val_c_contig, b_val_c_contig)
         np.testing.assert_allclose(res_c_contig, res, rtol=rtol)
         np.testing.assert_allclose(A_val_c_contig, A_val)
-        # A c-contiguous b is consumed in place as well: trtrs takes it when it is also f-contiguous
-        # (vectors and single-column matrices), trsm otherwise.
+        # A c-contiguous b is consumed in place as well: side="L" takes it when it is also
+        # f-contiguous (vectors and single-column matrices), side="R" otherwise.
         assert np.allclose(b_val_c_contig, b_val) == (not overwrite_b)
 
         A_val_not_contig = np.repeat(A_val, 2, axis=0)[::2]
@@ -282,8 +282,8 @@ class TestSolves:
         )
 
         np.testing.assert_allclose(result, expected, rtol=rtol)
-        # A c-contiguous 2d rhs picks trsm, which solves into b itself. trans=2 has no trsm form,
-        # so it falls back to trtrs, which copies.
+        # A c-contiguous 2d rhs is solved in place by side="R". trans=2 has no side="R" form, so it
+        # falls back to side="L", which needs an f-contiguous copy.
         assert np.shares_memory(result, b_val) == (trans != 2)
 
     def test_solve_triangular_unit_diagonal_ignores_zero_diagonal(self):
@@ -310,8 +310,8 @@ class TestSolves:
 
     @pytest.mark.parametrize("b_shape", [(5, 3), (5,)], ids=["b_matrix", "b_vec"])
     def test_solve_triangular_singular_returns_nan(self, b_shape: tuple[int, ...]):
-        # A 2d rhs takes trsm, which reports no INFO and needs its own singularity check; a vector
-        # takes trtrs, which reports it.
+        # trsm reports no INFO, so both sides depend on our own zero-pivot scan: a 2d rhs goes
+        # through side="R" and a vector through side="L".
         rng = np.random.default_rng(418)
         A_val = np.tril(rng.normal(size=(5, 5))).astype(floatX)
         A_val[2, 2] = 0.0

--- a/tests/link/numba/linalg/test_solvers.py
+++ b/tests/link/numba/linalg/test_solvers.py
@@ -51,6 +51,7 @@ class TestSolves:
 
         complex_dtype = "complex64" if floatX.endswith("32") else "complex128"
         dtype = complex_dtype if is_complex else floatX
+        rtol = 1e-4 if np.dtype(dtype).char in "fF" else 1e-8
 
         def A_func(x):
             if assume_a == "pos":
@@ -123,14 +124,14 @@ class TestSolves:
         A_val_f_contig = np.copy(A_val, order="F")
         b_val_f_contig = np.copy(b_val, order="F")
         res_f_contig = f(A_val_f_contig, b_val_f_contig)
-        np.testing.assert_allclose(res_f_contig, res)
+        np.testing.assert_allclose(res_f_contig, res, rtol=rtol)
         assert (A_val == A_val_f_contig).all() == (not overwrite_a)
         assert (b_val == b_val_f_contig).all() == (not overwrite_b)
 
         A_val_c_contig = np.copy(A_val, order="C")
         b_val_c_contig = np.copy(b_val, order="C")
         res_c_contig = f(A_val_c_contig, b_val_c_contig)
-        np.testing.assert_allclose(res_c_contig, res)
+        np.testing.assert_allclose(res_c_contig, res, rtol=rtol)
         can_destroy_c_contig_A = overwrite_a and not (
             is_complex and assume_a in ("pos", "her")
         )
@@ -142,7 +143,7 @@ class TestSolves:
         A_val_not_contig = np.repeat(A_val, 2, axis=0)[::2]
         b_val_not_contig = np.repeat(b_val, 2, axis=0)[::2]
         res_not_contig = f(A_val_not_contig, b_val_not_contig)
-        np.testing.assert_allclose(res_not_contig, res)
+        np.testing.assert_allclose(res_not_contig, res, rtol=rtol)
         np.testing.assert_allclose(A_val_not_contig, A_val)
         np.testing.assert_allclose(b_val_not_contig, b_val)
 
@@ -173,6 +174,7 @@ class TestSolves:
     ):
         complex_dtype = "complex64" if floatX.endswith("32") else "complex128"
         dtype = complex_dtype if is_complex else floatX
+        rtol = 1e-4 if np.dtype(dtype).char in "fF" else 1e-8
 
         def A_func(x):
             x = x @ x.conj().T
@@ -221,14 +223,14 @@ class TestSolves:
         A_val_f_contig = np.copy(A_val, order="F")
         b_val_f_contig = np.copy(b_val, order="F")
         res_f_contig = f(A_val_f_contig, b_val_f_contig)
-        np.testing.assert_allclose(res_f_contig, res)
+        np.testing.assert_allclose(res_f_contig, res, rtol=rtol)
         np.testing.assert_allclose(A_val, A_val_f_contig)
         assert (b_val == b_val_f_contig).all() == (not overwrite_b)
 
         A_val_c_contig = np.copy(A_val, order="C")
         b_val_c_contig = np.copy(b_val, order="C")
         res_c_contig = f(A_val_c_contig, b_val_c_contig)
-        np.testing.assert_allclose(res_c_contig, res)
+        np.testing.assert_allclose(res_c_contig, res, rtol=rtol)
         np.testing.assert_allclose(A_val_c_contig, A_val)
         assert np.allclose(b_val_c_contig, b_val) == (
             not (overwrite_b and b_val_c_contig.flags.f_contiguous)
@@ -237,7 +239,7 @@ class TestSolves:
         A_val_not_contig = np.repeat(A_val, 2, axis=0)[::2]
         b_val_not_contig = np.repeat(b_val, 2, axis=0)[::2]
         res_not_contig = f(A_val_not_contig, b_val_not_contig)
-        np.testing.assert_allclose(res_not_contig, res)
+        np.testing.assert_allclose(res_not_contig, res, rtol=rtol)
         np.testing.assert_allclose(A_val_not_contig, A_val)
         np.testing.assert_allclose(b_val_not_contig, b_val)
 

--- a/tests/link/numba/linalg/test_solvers.py
+++ b/tests/link/numba/linalg/test_solvers.py
@@ -426,6 +426,6 @@ class TestSolves:
         compare_numba_and_py(
             [a, b],
             [out],
-            [np.zeros((0, 0)), np.zeros(0)],
+            [np.zeros((0, 0), dtype=floatX), np.zeros(0, dtype=floatX)],
             eval_obj_mode=False,
         )

--- a/tests/link/numba/linalg/test_solvers.py
+++ b/tests/link/numba/linalg/test_solvers.py
@@ -243,20 +243,6 @@ class TestSolves:
         np.testing.assert_allclose(A_val_not_contig, A_val)
         np.testing.assert_allclose(b_val_not_contig, b_val)
 
-    def test_solve_triangular_unit_diagonal_ignores_zero_diagonal(self):
-        # The zero-pivot scan below has to defer to unit_diagonal, or a unit triangular
-        # matrix that happens to store a zero on its diagonal comes back all-nan.
-        rng = np.random.default_rng(418)
-        A_val = np.tril(rng.normal(size=(5, 5))).astype(floatX)
-        A_val[2, 2] = 0.0
-        b_val = rng.normal(size=(5, 3)).astype(floatX)
-
-        A = pt.matrix("A", dtype=floatX)
-        b = pt.matrix("b", dtype=floatX)
-        X = pt.linalg.solve_triangular(A, b, lower=True, unit_diagonal=True)
-
-        compare_numba_and_py([A, b], X, [A_val, b_val])
-
     @pytest.mark.parametrize("b_shape", [(5, 3), (5,)], ids=["b_matrix", "b_vec"])
     def test_solve_triangular_singular_returns_nan(self, b_shape: tuple[int, ...]):
         # trsm reports no INFO, so a singular system depends on our own zero-pivot scan.


### PR DESCRIPTION
Every rhs a graph produces is c-contiguous, so SolveTriangular always fell through to a transposing copy of B before calling trtrs. It now calls trsm with the side picked from the rhs layout: side="R" solves the transposed system straight out of a c-contiguous B, side="L" takes an f-contiguous one. That takes a (128, 100_000) solve from 39ms to 14ms.

trtrs drops out of the path entirely. Reference LAPACK's trtrs is a zero-pivot scan followed by a side="L" trsm, and the side="R" path already needed that scan in our own code, so calling trsm directly costs nothing; benchmarked equal within one sigma on an f-contiguous rhs across four shapes.

A c-contiguous rhs is now consumed in place under overwrite_b, where it previously survived because trtrs copied it.

numba_xtrtrs in _LAPACK is unused after this and left in place; happy to drop it here if you'd rather.

The first two commits are unrelated: the numba linalg tests only pass under floatX=float32 with them.

Closes #2358
