### PR TITLE
Numba: back-port compilation speedup for large tuple/ number of arguments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,11 @@ filterwarnings =[
 
 [tool.ruff]
 line-length = 88
-exclude = ["pytensor/_version.py"]
+# _patch_list_to_tuple.py is copied verbatim from numba; keep it diffable upstream
+exclude = [
+    "pytensor/_version.py",
+    "pytensor/link/numba/dispatch/_patch_list_to_tuple.py",
+]
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/pytensor/link/numba/dispatch/__init__.py
+++ b/pytensor/link/numba/dispatch/__init__.py
@@ -2,6 +2,9 @@
 # Patch numba's cgutils.pointer_add before any dispatch codegen runs
 import pytensor.link.numba.dispatch._patch_pointer_add
 
+# Patch numba's list_to_tuple peephole so >30-argument calls don't lower quadratically
+import pytensor.link.numba.dispatch._patch_list_to_tuple
+
 from pytensor.link.numba.dispatch.basic import numba_funcify, numba_typify
 
 # Load dispatch specializations

--- a/pytensor/link/numba/dispatch/_patch_list_to_tuple.py
+++ b/pytensor/link/numba/dispatch/_patch_list_to_tuple.py
@@ -1,0 +1,330 @@
+"""Backport of numba's fixed ``peep_hole_list_to_tuple`` (numba/numba#10782).
+
+CPython emits ``BUILD_LIST`` + ``LIST_APPEND`` per item + ``LIST_TO_TUPLE`` for
+any call or tuple display past 30 items (``STACK_USE_GUIDELINE``). Before the
+fix numba turned each appended item into a one-element tuple joined to an
+accumulator by a binary add, so the IR held a tuple of every prefix length and
+both it and the LLVM lowered from it were quadratic in the item count.
+Generated fgraph functions hit this for every wide node.
+
+``_peep_hole_list_to_tuple`` below is copied verbatim from numba ``master``
+(merged 2026-08-27, only the leading underscore added) so the behaviour matches
+what numba will ship, including runs of appends around starred unpacking. It is
+installed only on numba < 0.68, which is where the fix ships; delete this module
+once our minimum numba is at least that. The file is excluded from ruff in pyproject.toml
+so it stays diffable against upstream.
+"""
+
+import operator
+
+from numba import version_info as numba_version_info
+from numba.core import interpreter, ir
+
+
+def _peep_hole_list_to_tuple(func_ir):
+    """
+    This peephole rewrites a bytecode sequence new to Python 3.9 that looks
+    like e.g.:
+
+    def foo(a):
+        return (*a,)
+
+    41          0 BUILD_LIST               0
+                2 LOAD_FAST                0 (a)
+                4 LIST_EXTEND              1
+                6 LIST_TO_TUPLE
+                8 RETURN_VAL
+
+    essentially, the unpacking of tuples is written as a list which is appended
+    to/extended and then "magicked" into a tuple by the new LIST_TO_TUPLE
+    opcode.
+
+    This peephole repeatedly analyses the bytecode in a block looking for a
+    window between a `LIST_TO_TUPLE` and `BUILD_LIST` and...
+
+    1. Turns the BUILD_LIST into a BUILD_TUPLE
+    2. Sets an accumulator's initial value as the target of the BUILD_TUPLE
+    3. Searches for 'extend' on the original list and turns these into binary
+       additions on the accumulator.
+    4. Searches for 'append' on the original list, collecting runs of them
+       into a single `BUILD_TUPLE` which is then appended via binary addition
+       to the accumulator (an append-only window becomes the result itself).
+    5. Assigns the accumulator to the variable that exits the peephole and the
+       rest of the block/code refers to as the result of the unpack operation.
+    6. Patches up
+
+    Step 4 coalesces because CPython emits this bytecode for every call with
+    more than 30 arguments, and a `BUILD_TUPLE` per item leaves a tuple of
+    every prefix length, i.e. IR (and LLVM lowered from it) quadratic in the
+    item count. For `f(x[0], x[1], ..., x[30])` the emitted IR used to be::
+
+        $14build_list.2 = build_tuple(items=[])
+        $20binary_subscr.5 = getitem(value=x, index=$const18.4.1)
+        $24list_append.6_var = build_tuple(items=[$20binary_subscr.5])
+        $24list_append.7 = $14build_list.2 + $24list_append.6_var
+        $30binary_subscr.10 = getitem(value=x, index=$const28.9.2)
+        $34list_append.11_var = build_tuple(items=[$30binary_subscr.10])
+        $34list_append.12 = $24list_append.7 + $34list_append.11_var
+        ...                    # 29 more tuples, of widths 3, 4, ..., 31
+        $326call_intrinsic_1.158 = $324list_append.157
+        $328call_function_ex.159 = call $4load_global.0(
+            *$326call_intrinsic_1.158, vararg=$326call_intrinsic_1.158)
+
+    and is now a single tuple, built once and passed straight to the call::
+
+        $20binary_subscr.5 = getitem(value=x, index=$const18.4.1)
+        $30binary_subscr.10 = getitem(value=x, index=$const28.9.2)
+        ...
+        $326call_intrinsic_1.158 = build_tuple(items=[$20binary_subscr.5,
+            $30binary_subscr.10, ..., $320binary_subscr.155])
+        $328call_function_ex.159 = call $4load_global.0(
+            *$326call_intrinsic_1.158, vararg=$326call_intrinsic_1.158)
+    """
+    _DEBUG = False
+
+    # For all blocks
+    for offset, blk in func_ir.blocks.items():
+        # keep doing the peephole rewrite until nothing is left that matches
+        while True:
+            # first try and find a matching region
+            # i.e. BUILD_LIST...<stuff>...LIST_TO_TUPLE
+            def find_postive_region():
+                found = False
+                for idx in reversed(range(len(blk.body))):
+                    stmt = blk.body[idx]
+                    if isinstance(stmt, ir.Assign):
+                        value = stmt.value
+                        if (isinstance(value, ir.Expr) and
+                                value.op == 'list_to_tuple'):
+                            target_list = value.info[0]
+                            found = True
+                            bt = (idx, stmt)
+                    if found:
+                        if isinstance(stmt, ir.Assign):
+                            if stmt.target.name == target_list:
+                                region = (bt, (idx, stmt))
+                                return region
+
+            region = find_postive_region()
+            # if there's a peep hole region then do something with it
+            if region is not None:
+                peep_hole = blk.body[region[1][0] : region[0][0]]
+                if _DEBUG:
+                    print("\nWINDOW:")
+                    for x in peep_hole:
+                        print(x)
+                    print("")
+
+                appends = []
+                extends = []
+                init = region[1][1]
+                const_list = init.target.name
+                # Walk through the peep_hole and find things that are being
+                # "extend"ed and "append"ed to the BUILD_LIST
+                for x in peep_hole:
+                    if isinstance(x, ir.Assign):
+                        if isinstance(x.value, ir.Expr):
+                            expr = x.value
+                            if (expr.op == 'getattr' and
+                                    expr.value.name == const_list):
+                                # it's not strictly necessary to split out
+                                # extends and appends, but it helps with
+                                # debugging to do so!
+                                if expr.attr == 'extend':
+                                    extends.append(x.target.name)
+                                elif expr.attr == 'append':
+                                    appends.append(x.target.name)
+                                else:
+                                    assert 0
+                # go back through the peep hole build new IR based on it.
+                new_hole = []
+
+                def append_and_fix(x):
+                    """ Adds to the new_hole and fixes up definitions"""
+                    new_hole.append(x)
+                    if x.target.name in func_ir._definitions:
+                        # if there's already a definition, drop it, should only
+                        # be 1 as the way cpython emits the sequence for
+                        # `list_to_tuple` should ensure this.
+                        assert len(func_ir._definitions[x.target.name]) == 1
+                        func_ir._definitions[x.target.name].clear()
+                    func_ir._definitions[x.target.name].append(x.value)
+
+                the_build_list = init.target
+
+                # Buffer appended items and emit them as one build_tuple: a
+                # binary add per item makes the IR, and the LLVM lowered from
+                # it, quadratic in the number of items. Only an `extend` (which
+                # reads the accumulator) forces a flush; item values are
+                # computed by statements that stay in place, so buffering past
+                # them preserves evaluation order.
+                pending_appends = []
+
+                def flush_pending_appends(acc, loc, target=None):
+                    """Emit pending appends as one build_tuple. When `target`
+                    is given, an append-only window is written to it as a
+                    plain build_tuple (which the CALL_FUNCTION_EX peephole
+                    requires for calls with kwargs); any other shape keeps
+                    the assignment of the accumulator to `target`."""
+                    if pending_appends:
+                        items = list(pending_appends)
+                        pending_appends.clear()
+                        scope = items[0].scope
+                        tup = ir.Expr.build_tuple(items, loc)
+                        if acc is the_build_list and not init.value.items:
+                            # accumulator is still the empty initial list
+                            if target is not None:
+                                append_and_fix(ir.Assign(tup, target, loc))
+                                return target
+                            acc = scope.redefine("$_list_append_tuple",
+                                                 loc=loc)
+                            append_and_fix(ir.Assign(tup, acc, loc))
+                            return acc
+                        tup_var = scope.redefine("$_list_append_tuple",
+                                                 loc=loc)
+                        append_and_fix(ir.Assign(tup, tup_var, loc))
+                        acc_var = scope.redefine("$_list_append_acc", loc=loc)
+                        append_and_fix(
+                            ir.Assign(
+                                ir.Expr.binop(fn=operator.add, lhs=acc,
+                                              rhs=tup_var, loc=loc),
+                                acc_var, loc,
+                            )
+                        )
+                        acc = acc_var
+                    if target is not None:
+                        append_and_fix(ir.Assign(acc, target, loc))
+                        return target
+                    return acc
+
+                # Do the transform on the peep hole
+                if _DEBUG:
+                    print("\nBLOCK:")
+                    blk.dump()
+
+                # This section basically accumulates list appends and extends
+                # as binop(+) on tuples, it drops all the getattr() for extend
+                # and append as they are now dead and replaced with binop(+).
+                # It also switches out the build_list for a build_tuple and then
+                # ensures everything is wired up and defined ok.
+                t2l_agn = region[0][1]
+                acc = the_build_list
+                for x in peep_hole:
+                    if isinstance(x, ir.Assign):
+                        if isinstance(x.value, ir.Expr):
+                            expr = x.value
+                            if expr.op == 'getattr':
+                                if (x.target.name in extends or
+                                        x.target.name in appends):
+                                    # drop definition, it's being wholesale
+                                    # replaced.
+                                    func_ir._definitions.pop(x.target.name)
+                                    continue
+                                else:
+                                    # a getattr on something we're not
+                                    # interested in
+                                    new_hole.append(x)
+                            elif expr.op == 'call':
+                                fname = expr.func.name
+                                if fname in extends or fname in appends:
+                                    arg = expr.args[0]
+                                    if (fname in appends
+                                            and isinstance(arg, ir.Var)):
+                                        pending_appends.append(arg)
+                                        func_ir._definitions.pop(x.target.name,
+                                                                 None)
+                                        continue
+                                    acc = flush_pending_appends(acc, x.loc)
+                                    if isinstance(arg, ir.Var):
+                                        tmp_name = "%s_var_%s" % (fname,
+                                                                  arg.name)
+                                        if fname in appends:
+                                            bt = ir.Expr.build_tuple([arg,],
+                                                                     expr.loc)
+                                        else:
+                                            # Extend as tuple
+                                            gv_tuple = ir.Global(
+                                                name="tuple", value=tuple,
+                                                loc=expr.loc,
+                                            )
+                                            tuple_var = arg.scope.redefine(
+                                                "$_list_extend_gv_tuple",
+                                                loc=expr.loc,
+                                            )
+                                            new_hole.append(
+                                                ir.Assign(
+                                                    target=tuple_var,
+                                                    value=gv_tuple,
+                                                    loc=expr.loc,
+                                                ),
+                                            )
+                                            bt = ir.Expr.call(
+                                                tuple_var, (arg,), (),
+                                                loc=expr.loc,
+                                            )
+                                        var = ir.Var(arg.scope, tmp_name,
+                                                     expr.loc)
+                                        asgn = ir.Assign(bt, var, expr.loc)
+                                        append_and_fix(asgn)
+                                        arg = var
+
+                                    # this needs to be a binary add
+                                    new = ir.Expr.binop(fn=operator.add,
+                                                        lhs=acc,
+                                                        rhs=arg,
+                                                        loc=x.loc)
+                                    asgn = ir.Assign(new, x.target, expr.loc)
+                                    append_and_fix(asgn)
+                                    acc = asgn.target
+                                else:
+                                    # there could be a call in the unpack, like
+                                    # *(a, x.append(y))
+                                    new_hole.append(x)
+                            elif (expr.op == 'build_list' and
+                                    x.target.name == const_list):
+                                new = ir.Expr.build_tuple(expr.items, expr.loc)
+                                asgn = ir.Assign(new, x.target, expr.loc)
+                                # Not a temporary any more
+                                append_and_fix(asgn)
+                            else:
+                                new_hole.append(x)
+                        else:
+                            new_hole.append(x)
+
+                    else:
+                        # stick everything else in as-is
+                        new_hole.append(x)
+                # Finally write the result back into the original build list
+                # as everything refers to it. Flushing straight into it keeps
+                # an all-append window a plain build_tuple, which the
+                # CALL_FUNCTION_EX peephole requires for calls with kwargs.
+                flush_pending_appends(acc, the_build_list.loc,
+                                      target=t2l_agn.target)
+                if _DEBUG:
+                    print("\nNEW HOLE:")
+                    for x in new_hole:
+                        print(x)
+
+                # and then update the block body with the modified region
+                cpy = blk.body[:]
+                head = cpy[:region[1][0]]
+                tail = blk.body[region[0][0] + 1:]
+                tmp = head + new_hole + tail
+                blk.body.clear()
+                blk.body.extend(tmp)
+
+                if _DEBUG:
+                    print("\nDUMP post hole:")
+                    blk.dump()
+
+            else:
+                # else escape
+                break
+
+    return func_ir
+
+
+# Merged after 0.67.0 was tagged, so it ships in 0.68
+if numba_version_info.short < (0, 68):
+    # ``Interpreter.interpret`` resolves the peephole through the module at call time
+    interpreter.peep_hole_list_to_tuple = _peep_hole_list_to_tuple

--- a/pytensor/link/numba/dispatch/_patch_pointer_add.py
+++ b/pytensor/link/numba/dispatch/_patch_pointer_add.py
@@ -13,11 +13,12 @@ object the pointer points into (see the audit in `numba#10696
 <https://github.com/numba/numba/pull/10696>`_), so forming the result with a
 byte-wise ``getelementptr`` -- which preserves provenance -- is always valid.
 
-Imported for its side effect from ``pytensor.link.numba.dispatch``; drop this
-module once the numba-side fix is released.
+Imported for its side effect from ``pytensor.link.numba.dispatch``; applied only
+on numba < 0.67, where the fix landed. Drop this module once that is our minimum.
 """
 
 from llvmlite import ir
+from numba import version_info as numba_version_info
 from numba.core import cgutils
 
 
@@ -32,6 +33,8 @@ def _pointer_add_gep(builder, ptr, offset, return_type=None):
     return builder.bitcast(addr, return_type or ptr.type)
 
 
-# Every numba caller resolves ``pointer_add`` through the module at call time,
-# so reassigning the attribute reaches them all (including ``get_item_pointer2``).
-cgutils.pointer_add = _pointer_add_gep
+# Fixed upstream in numba 0.67.0 (numba/numba#10696)
+if numba_version_info.short < (0, 67):
+    # Every numba caller resolves ``pointer_add`` through the module at call time,
+    # so reassigning the attribute reaches them all (including ``get_item_pointer2``).
+    cgutils.pointer_add = _pointer_add_gep

--- a/tests/link/numba/test_patch_list_to_tuple.py
+++ b/tests/link/numba/test_patch_list_to_tuple.py
@@ -1,0 +1,125 @@
+import operator
+
+import pytest
+
+
+numba = pytest.importorskip("numba")
+
+import pytensor.link.numba.dispatch  # noqa: F401  (installs the patch)
+
+
+def _interpret(fn):
+    from numba.core import bytecode, interpreter
+
+    func_id = bytecode.FunctionIdentity.from_function(fn)
+    interp = interpreter.Interpreter(func_id)
+    return interp.interpret(bytecode.ByteCode(func_id))
+
+
+def _make_wide_caller(n_args):
+    args_sig = ", ".join(f"a{i}" for i in range(n_args))
+    src = f"def caller(callee, {args_sig}):\n    return callee({args_sig})\n"
+    glb: dict = {}
+    exec(src, glb)
+    return glb["caller"]
+
+
+def test_wide_call_collapses_to_single_build_tuple():
+    """A >30-argument call leaves one build_tuple, not a chain of prefix tuples."""
+    from numba.core import ir
+
+    func_ir = _interpret(_make_wide_caller(40))
+    tuple_adds = [
+        stmt
+        for blk in func_ir.blocks.values()
+        for stmt in blk.body
+        if isinstance(stmt, ir.Assign)
+        and isinstance(stmt.value, ir.Expr)
+        and stmt.value.op == "binop"
+        and stmt.value.fn is operator.add
+    ]
+    assert not tuple_adds
+    # the empty list the peephole starts from may survive as dead code
+    widths = [
+        len(stmt.value.items)
+        for blk in func_ir.blocks.values()
+        for stmt in blk.body
+        if isinstance(stmt, ir.Assign)
+        and isinstance(stmt.value, ir.Expr)
+        and stmt.value.op == "build_tuple"
+        and stmt.value.items
+    ]
+    assert widths == [40]
+
+
+def test_wide_call_computes_correctly():
+    @numba.njit
+    def callee(*args):
+        total = 0.0
+        for a in args:
+            total += a
+        return total
+
+    caller = numba.njit(_make_wide_caller(35))
+    vals = [float(i) for i in range(35)]
+    assert caller(callee, *vals) == sum(vals)
+
+
+def test_wide_call_with_kwarg():
+    """>30 positional args plus a keyword argument: the collapsed tuple must
+    reach the call's vararg directly or numba's kwargs peephole rejects it."""
+    n_args = 40
+    params = ", ".join(f"a{i}" for i in range(n_args))
+    glb: dict = {}
+    exec(
+        f"def callee({params}, k):\n"
+        f"    return a0 + k\n"
+        f"def caller({params}):\n"
+        f"    return jitted_callee({params}, k=1.0)\n",
+        glb,
+    )
+    glb["jitted_callee"] = numba.njit(glb["callee"])
+    caller = numba.njit(glb["caller"])
+    assert caller(*[float(i) for i in range(n_args)]) == 1.0
+
+
+def test_tuple_unpacking_still_works():
+    """Chains interleaved with genuine unpacking still compute correctly."""
+
+    @numba.njit
+    def spread(a, b):
+        t = (*a, 1.0, *b, 2.0)
+        return len(t), t[len(a)], t[-1]
+
+    n, mid, last = spread((3.0, 4.0), (5.0,))
+    assert (n, mid, last) == (5, 1.0, 2.0)
+
+
+def test_wide_call_with_starred_unpacking():
+    """Runs of appends around a starred unpack each coalesce, so the chain is
+    bounded by the number of extends rather than the argument count."""
+    from numba.core import ir
+
+    n = 35
+    params = ", ".join(f"a{i}" for i in range(n))
+    glb: dict = {}
+    exec(f"def caller(callee, t, {params}):\n    return callee({params}, *t)\n", glb)
+    func_ir = _interpret(glb["caller"])
+    adds = [
+        stmt
+        for blk in func_ir.blocks.values()
+        for stmt in blk.body
+        if isinstance(stmt, ir.Assign)
+        and isinstance(stmt.value, ir.Expr)
+        and stmt.value.op == "binop"
+        and stmt.value.fn is operator.add
+    ]
+    assert len(adds) <= 2
+
+    @numba.njit
+    def callee(*args):
+        return args[0] + args[-1]
+
+    cfunc = numba.njit(glb["caller"])
+    vals = [float(i) for i in range(n)]
+    assert cfunc(callee, (99.0, 7.0), *vals) == 7.0


### PR DESCRIPTION
## Problem

Numba's `peep_hole_list_to_tuple` rewrites the bytecode CPython emits for >30-item calls and tuple displays (`STACK_USE_GUIDELINE`) into incremental tuple concatenation — an IR tuple of every prefix length — which types and lowers as O(n²) LLVM IR plus NRT refcount churn, with a hard cliff at 31 items (21× module-size jump). Generated fgraph functions make such calls for every >30-input node (`MakeVector`, `Scan`, wide fused kernels), so compile time and memory blow up quadratically in node arity.

## Fix

`_patch_list_to_tuple` wraps the peephole, collapses the concatenation chain into a single `build_tuple`, and inlines that tuple back into direct call arguments (so no aggregate forms at either side of a wide call boundary) — the same patch-until-upstream-releases mold as `_patch_pointer_add`. The bug is fixed upstream in numba/numba#10782, but numba releases roughly twice a year and pytensor supports already-released versions, so the workaround is warranted until the minimum supported numba ships the fix; the module then just gets deleted.

## Results

Interleaved with `main` in one session on an otherwise-idle 8-core/16-thread box (Ryzen 7 PRO 4750U, BLAS/OMP threads pinned to 1), cold caches (absolute times here are load-sensitive, so only same-session comparisons are quoted): on the n=80 additive repro this patch alone takes 364.9 s / 2696 MB to 323.3 s / 1689 MB — most of the win is memory, because the caller-side bytecode chain is only one of the two quadratics. Combined with #2362, which removes the wide-tuple *callee* in `Join`: 105.9 s / 933 MB. The two are complementary — this PR carries the memory win, #2362 the compile-time one. Pure-numba: a 160-argument jitted call compiles ~3x faster and its caller module is 34x smaller.


