### PR TITLE
Numba Join: better memory and runtime performance

### DIFF
--- a/pytensor/link/numba/dispatch/tensor_basic.py
+++ b/pytensor/link/numba/dispatch/tensor_basic.py
@@ -122,11 +122,13 @@ def numba_funcify_ARange(op, **kwargs):
 def numba_funcify_Join(op, node, **kwargs):
     """Copy each input into its slice of a preallocated output.
 
-    ``np.concatenate`` on a tuple of arrays compiles ~3x slower for the same result.
-    A whole-array slice write instead goes through Numba's fancy indexing, which
-    rebuilds the source as an ``A``-layout view and so copies it with gathers; the
-    dimensions ahead of the join axis are peeled with integer indexing so that the
-    destination slice stays contiguous. For ``join(1, x0, x1, x2)`` on matrices this
+    ``np.concatenate`` on a tuple of arrays compiles ~3x slower for the same
+    result. A whole-array slice write instead goes through Numba's fancy
+    indexing, which rebuilds the source as an ``A``-layout view and so copies it
+    with gathers; the dimensions ahead of the join axis are peeled with integer
+    indexing so that the destination slice stays contiguous.
+
+    For ``join(1, x0, x1, x2)`` on matrices (axis 1, the last one here) this
     emits::
 
         def join(*tensors):
@@ -141,12 +143,25 @@ def numba_funcify_Join(op, node, **kwargs):
             off = 0
             l = tensors[0].shape[1]
             for i0 in range(tensors[0].shape[0]):
-                dst = out[i0][off : off + l]
+                dst = out[i0, off : off + l]
                 src = tensors[0][i0]
                 for j0 in range(src.shape[0]):
                     dst[j0] = src[j0]
             off += l
-            ...
+            l = tensors[1].shape[1]
+            for i0 in range(tensors[1].shape[0]):
+                dst = out[i0, off : off + l]
+                src = tensors[1][i0]
+                for j0 in range(src.shape[0]):
+                    dst[j0] = src[j0]
+            off += l
+            l = tensors[2].shape[1]
+            for i0 in range(tensors[2].shape[0]):
+                dst = out[i0, off : off + l]
+                src = tensors[2][i0]
+                for j0 in range(src.shape[0]):
+                    dst[j0] = src[j0]
+            off += l
             return out
     """
     ndim = node.outputs[0].type.ndim
@@ -174,15 +189,14 @@ def numba_funcify_Join(op, node, **kwargs):
         f"out = np.empty({create_tuple_string(shape)}, dtype)",
         "off = 0",
     ]
-    # Dimensions before the join axis are peeled with integer indexing, so that the
-    # destination slice on the join axis stays contiguous whenever the input is.
     leading = "".join(f"[i{d}]" for d in range(ax))
+    leading_idx = "".join(f"i{d}, " for d in range(ax))
     trailing_idxs = ", ".join(f"j{k}" for k in range(ndim - ax))
     for name in names:
         code += [f"l = {name}.shape[{ax}]"]
         for d in range(ax):
             code += [f"for i{d} in range({name}.shape[{d}]):", CODE_TOKEN.INDENT]
-        code += [f"dst = out{leading}[off:off + l]", f"src = {name}{leading}"]
+        code += [f"dst = out[{leading_idx}off:off + l]", f"src = {name}{leading}"]
         for k in range(ndim - ax):
             code += [f"for j{k} in range(src.shape[{k}]):", CODE_TOKEN.INDENT]
         code += [f"dst[{trailing_idxs}] = src[{trailing_idxs}]"]

--- a/pytensor/link/numba/dispatch/tensor_basic.py
+++ b/pytensor/link/numba/dispatch/tensor_basic.py
@@ -9,7 +9,11 @@ from pytensor.link.numba.dispatch.basic import (
     register_funcify_and_cache_key,
     register_funcify_default_op_cache_key,
 )
-from pytensor.link.numba.dispatch.string_codegen import create_tuple_string
+from pytensor.link.numba.dispatch.string_codegen import (
+    CODE_TOKEN,
+    build_source_code,
+    create_tuple_string,
+)
 from pytensor.tensor.basic import (
     Alloc,
     AllocEmpty,
@@ -115,14 +119,79 @@ def numba_funcify_ARange(op, **kwargs):
 
 
 @register_funcify_default_op_cache_key(Join)
-def numba_funcify_Join(op, **kwargs):
-    axis = op.axis
+def numba_funcify_Join(op, node, **kwargs):
+    """Write each input into its slice of a preallocated output.
 
-    @numba_basic.numba_njit
-    def join(*tensors):
-        return np.concatenate(tensors, axis)
+    ``np.concatenate`` on a tuple of arrays compiles ~3x slower for the same
+    result. For ``join(1, x0, x1, x2)`` on matrices this emits::
 
-    return join
+        def join(*tensors):
+            total = tensors[0].shape[1]
+            total += tensors[1].shape[1]
+            total += tensors[2].shape[1]
+            if tensors[1].shape[0] != tensors[0].shape[0]:
+                raise ValueError(_mismatch_msg)
+            if tensors[2].shape[0] != tensors[0].shape[0]:
+                raise ValueError(_mismatch_msg)
+            out = np.empty((tensors[0].shape[0], total), dtype)
+            off = 0
+            l = tensors[0].shape[1]
+            out[:, off : off + l] = tensors[0]
+            off += l
+            ...
+            return out
+    """
+    ndim = node.outputs[0].type.ndim
+    ax = op.axis % ndim
+    pre = ":, " * ax
+    post = ", :" * (ndim - ax - 1)
+    names = [f"tensors[{i}]" for i in range(len(node.inputs))]
+
+    shape = [f"tensors[0].shape[{d}]" for d in range(ndim)]
+    shape[ax] = "total"
+    code: list[str | CODE_TOKEN] = [
+        "def join(*tensors):",
+        CODE_TOKEN.INDENT,
+        f"total = tensors[0].shape[{ax}]",
+        *(f"total += {name}.shape[{ax}]" for name in names[1:]),
+    ]
+    for name in names[1:]:
+        for d in range(ndim):
+            if d != ax:
+                code += [
+                    f"if {name}.shape[{d}] != tensors[0].shape[{d}]:",
+                    CODE_TOKEN.INDENT,
+                    "raise ValueError(_mismatch_msg)",
+                    CODE_TOKEN.DEDENT,
+                ]
+    code += [
+        f"out = np.empty({create_tuple_string(shape)}, dtype)",
+        "off = 0",
+    ]
+    for name in names:
+        code += [
+            f"l = {name}.shape[{ax}]",
+            f"out[{pre}off:off + l{post}] = {name}",
+            "off += l",
+        ]
+    code += ["return out", CODE_TOKEN.DEDENT]
+
+    join_fn = compile_numba_function_src(
+        build_source_code(code),
+        "join",
+        globals()
+        | {
+            "np": np,
+            "dtype": np.dtype(node.outputs[0].type.dtype),
+            "_mismatch_msg": "all the input array dimensions except for the "
+            "concatenation axis must match exactly",
+        },
+    )
+
+    cache_version = 3
+    # The explicit slice writes cannot go out of bounds: the output is
+    # allocated from the validated input shapes
+    return numba_basic.numba_njit(join_fn, boundscheck=False), cache_version
 
 
 @register_funcify_default_op_cache_key(Split)

--- a/pytensor/link/numba/dispatch/tensor_basic.py
+++ b/pytensor/link/numba/dispatch/tensor_basic.py
@@ -120,10 +120,14 @@ def numba_funcify_ARange(op, **kwargs):
 
 @register_funcify_default_op_cache_key(Join)
 def numba_funcify_Join(op, node, **kwargs):
-    """Write each input into its slice of a preallocated output.
+    """Copy each input into its slice of a preallocated output.
 
-    ``np.concatenate`` on a tuple of arrays compiles ~3x slower for the same
-    result. For ``join(1, x0, x1, x2)`` on matrices this emits::
+    ``np.concatenate`` on a tuple of arrays compiles ~3x slower for the same result.
+    A whole-array slice write instead goes through Numba's fancy indexing, which
+    rebuilds the source as an ``A``-layout view and so copies it with gathers; the
+    dimensions ahead of the join axis are peeled with integer indexing so that the
+    destination slice stays contiguous. For ``join(1, x0, x1, x2)`` on matrices this
+    emits::
 
         def join(*tensors):
             total = tensors[0].shape[1]
@@ -136,15 +140,17 @@ def numba_funcify_Join(op, node, **kwargs):
             out = np.empty((tensors[0].shape[0], total), dtype)
             off = 0
             l = tensors[0].shape[1]
-            out[:, off : off + l] = tensors[0]
+            for i0 in range(tensors[0].shape[0]):
+                dst = out[i0][off : off + l]
+                src = tensors[0][i0]
+                for j0 in range(src.shape[0]):
+                    dst[j0] = src[j0]
             off += l
             ...
             return out
     """
     ndim = node.outputs[0].type.ndim
-    ax = op.axis % ndim
-    pre = ":, " * ax
-    post = ", :" * (ndim - ax - 1)
+    ax = op.axis
     names = [f"tensors[{i}]" for i in range(len(node.inputs))]
 
     shape = [f"tensors[0].shape[{d}]" for d in range(ndim)]
@@ -168,12 +174,21 @@ def numba_funcify_Join(op, node, **kwargs):
         f"out = np.empty({create_tuple_string(shape)}, dtype)",
         "off = 0",
     ]
+    # Dimensions before the join axis are peeled with integer indexing, so that the
+    # destination slice on the join axis stays contiguous whenever the input is.
+    leading = "".join(f"[i{d}]" for d in range(ax))
+    trailing_idxs = ", ".join(f"j{k}" for k in range(ndim - ax))
     for name in names:
-        code += [
-            f"l = {name}.shape[{ax}]",
-            f"out[{pre}off:off + l{post}] = {name}",
-            "off += l",
-        ]
+        code += [f"l = {name}.shape[{ax}]"]
+        for d in range(ax):
+            code += [f"for i{d} in range({name}.shape[{d}]):", CODE_TOKEN.INDENT]
+        code += [f"dst = out{leading}[off:off + l]", f"src = {name}{leading}"]
+        for k in range(ndim - ax):
+            code += [f"for j{k} in range(src.shape[{k}]):", CODE_TOKEN.INDENT]
+        code += [f"dst[{trailing_idxs}] = src[{trailing_idxs}]"]
+        code += [CODE_TOKEN.DEDENT] * (ndim - ax)
+        code += [CODE_TOKEN.DEDENT] * ax
+        code += ["off += l"]
     code += ["return out", CODE_TOKEN.DEDENT]
 
     join_fn = compile_numba_function_src(
@@ -188,9 +203,9 @@ def numba_funcify_Join(op, node, **kwargs):
         },
     )
 
-    cache_version = 3
-    # The explicit slice writes cannot go out of bounds: the output is
-    # allocated from the validated input shapes
+    cache_version = 4
+    # The loop nests cannot go out of bounds: the output is allocated from the
+    # validated input shapes
     return numba_basic.numba_njit(join_fn, boundscheck=False), cache_version
 
 

--- a/pytensor/link/numba/dispatch/tensor_basic.py
+++ b/pytensor/link/numba/dispatch/tensor_basic.py
@@ -118,18 +118,15 @@ def numba_funcify_ARange(op, **kwargs):
     return arange
 
 
-@register_funcify_default_op_cache_key(Join)
+@register_funcify_and_cache_key(Join)
 def numba_funcify_Join(op, node, **kwargs):
-    """Copy each input into its slice of a preallocated output.
+    """Copy each input into a preallocated output with a scalar loop nest.
 
-    ``np.concatenate`` on a tuple of arrays compiles ~3x slower for the same
-    result. A whole-array slice write instead goes through Numba's fancy
-    indexing, which rebuilds the source as an ``A``-layout view and so copies it
-    with gathers; the dimensions ahead of the join axis are peeled with integer
-    indexing so that the destination slice stays contiguous.
+    ``np.concatenate`` on a tuple of arrays compiles slower for the same result.
+    To let LLVM vectorize the inner copy loop, the join axis offset is unsigned
+    (provably non-negative) and broadcastable dimensions are indexed with zero.
 
-    For ``join(1, x0, x1, x2)`` on matrices (axis 1, the last one here) this
-    emits::
+    For ``join(1, x0, x1, x2)`` on matrices this emits::
 
         def join(*tensors):
             total = tensors[0].shape[1]
@@ -140,28 +137,19 @@ def numba_funcify_Join(op, node, **kwargs):
             if tensors[2].shape[0] != tensors[0].shape[0]:
                 raise ValueError(_mismatch_msg)
             out = np.empty((tensors[0].shape[0], total), dtype)
-            off = 0
-            l = tensors[0].shape[1]
-            for i0 in range(tensors[0].shape[0]):
-                dst = out[i0, off : off + l]
-                src = tensors[0][i0]
-                for j0 in range(src.shape[0]):
-                    dst[j0] = src[j0]
-            off += l
-            l = tensors[1].shape[1]
-            for i0 in range(tensors[1].shape[0]):
-                dst = out[i0, off : off + l]
-                src = tensors[1][i0]
-                for j0 in range(src.shape[0]):
-                    dst[j0] = src[j0]
-            off += l
-            l = tensors[2].shape[1]
-            for i0 in range(tensors[2].shape[0]):
-                dst = out[i0, off : off + l]
-                src = tensors[2][i0]
-                for j0 in range(src.shape[0]):
-                    dst[j0] = src[j0]
-            off += l
+            off = np.uint64(0)
+            for j0 in range(tensors[0].shape[0]):
+                for j1 in range(tensors[0].shape[1]):
+                    out[j0, np.uint64(j1) + off] = tensors[0][j0, j1]
+            off += np.uint64(tensors[0].shape[1])
+            for j0 in range(tensors[1].shape[0]):
+                for j1 in range(tensors[1].shape[1]):
+                    out[j0, np.uint64(j1) + off] = tensors[1][j0, j1]
+            off += np.uint64(tensors[1].shape[1])
+            for j0 in range(tensors[2].shape[0]):
+                for j1 in range(tensors[2].shape[1]):
+                    out[j0, np.uint64(j1) + off] = tensors[2][j0, j1]
+            off += np.uint64(tensors[2].shape[1])
             return out
     """
     ndim = node.outputs[0].type.ndim
@@ -187,22 +175,22 @@ def numba_funcify_Join(op, node, **kwargs):
                 ]
     code += [
         f"out = np.empty({create_tuple_string(shape)}, dtype)",
-        "off = 0",
+        "off = np.uint64(0)",
     ]
-    leading = "".join(f"[i{d}]" for d in range(ax))
-    leading_idx = "".join(f"i{d}, " for d in range(ax))
-    trailing_idxs = ", ".join(f"j{k}" for k in range(ndim - ax))
+    # The join axis is never broadcastable here: its static length is the sum.
+    static_shape = node.outputs[0].type.shape
+    looped = [d for d in range(ndim) if d == ax or static_shape[d] != 1]
+    src_idx = ", ".join(f"j{d}" if d in looped else "0" for d in range(ndim))
+    dst_idx = ", ".join(
+        f"np.uint64(j{d}) + off" if d == ax else (f"j{d}" if d in looped else "0")
+        for d in range(ndim)
+    )
     for name in names:
-        code += [f"l = {name}.shape[{ax}]"]
-        for d in range(ax):
-            code += [f"for i{d} in range({name}.shape[{d}]):", CODE_TOKEN.INDENT]
-        code += [f"dst = out[{leading_idx}off:off + l]", f"src = {name}{leading}"]
-        for k in range(ndim - ax):
-            code += [f"for j{k} in range(src.shape[{k}]):", CODE_TOKEN.INDENT]
-        code += [f"dst[{trailing_idxs}] = src[{trailing_idxs}]"]
-        code += [CODE_TOKEN.DEDENT] * (ndim - ax)
-        code += [CODE_TOKEN.DEDENT] * ax
-        code += ["off += l"]
+        for d in looped:
+            code += [f"for j{d} in range({name}.shape[{d}]):", CODE_TOKEN.INDENT]
+        code += [f"out[{dst_idx}] = {name}[{src_idx}]"]
+        code += [CODE_TOKEN.DEDENT] * len(looped)
+        code += [f"off += np.uint64({name}.shape[{ax}])"]
     code += ["return out", CODE_TOKEN.DEDENT]
 
     join_fn = compile_numba_function_src(
@@ -217,10 +205,13 @@ def numba_funcify_Join(op, node, **kwargs):
         },
     )
 
-    cache_version = 4
+    cache_version = 5
+    cache_key = numba_basic.default_hash_key_from_props(
+        op, looped=tuple(looped), cache_version=cache_version
+    )
     # The loop nests cannot go out of bounds: the output is allocated from the
     # validated input shapes
-    return numba_basic.numba_njit(join_fn, boundscheck=False), cache_version
+    return numba_basic.numba_njit(join_fn, boundscheck=False), cache_key
 
 
 @register_funcify_default_op_cache_key(Split)

--- a/tests/link/numba/test_tensor_basic.py
+++ b/tests/link/numba/test_tensor_basic.py
@@ -159,6 +159,24 @@ def test_ARange():
             ),
             1,
         ),
+        # More than two inputs, ragged along the join axis, with dimensions both
+        # ahead of and behind it
+        (
+            (
+                (pt.tensor3(), rng.normal(size=(2, 1, 3)).astype(config.floatX)),
+                (pt.tensor3(), rng.normal(size=(2, 2, 3)).astype(config.floatX)),
+                (pt.tensor3(), rng.normal(size=(2, 3, 3)).astype(config.floatX)),
+            ),
+            1,
+        ),
+        (
+            (
+                (pt.tensor3(), rng.normal(size=(2, 3, 1)).astype(config.floatX)),
+                (pt.tensor3(), rng.normal(size=(2, 3, 2)).astype(config.floatX)),
+                (pt.tensor3(), rng.normal(size=(2, 3, 3)).astype(config.floatX)),
+            ),
+            2,
+        ),
     ],
 )
 def test_Join(vals, axis):

--- a/tests/link/numba/test_tensor_basic.py
+++ b/tests/link/numba/test_tensor_basic.py
@@ -172,6 +172,14 @@ def test_Join(vals, axis):
     )
 
 
+def test_Join_mismatched_shape_raises():
+    xs = [pt.matrix("x0"), pt.matrix("x1")]
+    fn = function(xs, pt.join(0, *xs), mode=get_mode("NUMBA"))
+    rng = np.random.default_rng(0)
+    with pytest.raises(ValueError, match="dimensions except for the concatenation"):
+        fn(rng.normal(size=(2, 3)), rng.normal(size=(2, 4)))
+
+
 @pytest.mark.parametrize(
     "n_splits, axis, values, sizes",
     [

--- a/tests/link/numba/test_tensor_basic.py
+++ b/tests/link/numba/test_tensor_basic.py
@@ -177,6 +177,20 @@ def test_ARange():
             ),
             2,
         ),
+        # A broadcastable dimension is indexed with a constant rather than looped over
+        (
+            (
+                (
+                    pt.tensor("x0", shape=(None, None, 1)),
+                    rng.normal(size=(2, 1, 1)).astype(config.floatX),
+                ),
+                (
+                    pt.tensor("x1", shape=(None, None, 1)),
+                    rng.normal(size=(2, 3, 1)).astype(config.floatX),
+                ),
+            ),
+            1,
+        ),
     ],
 )
 def test_Join(vals, axis):


### PR DESCRIPTION
`Join`'s numba implementation was `np.concatenate` on a `*tensors` tuple; numba types and lowers an implementation that receives its inputs as one wide tuple quadratically in the input count, and >30-input joins are routine (gradient assembly concatenates one piece per parameter).

The generated implementation takes one named parameter per input and writes each into its slice of a preallocated output — linear codegen, same single copy per input. Split off from #2354 per review there (a dispatch-level Join fix instead of a graph rewrite).


## Results

Interleaved with `main` in one session on an otherwise-idle 8-core/16-thread box (Ryzen 7 PRO 4750U, BLAS/OMP threads pinned to 1), cold caches (absolute times here are load-sensitive, so only same-session comparisons are quoted), n=80 additive repro whose gradient assembly is a 60-tensor join:

| | compile | peak RSS |
|---|---|---|
| main | 364.9 s | 2696 MB |
| this PR alone | 151.5 s | 2660 MB |
| with #2361 | 105.9 s | 933 MB |

The two are complementary: this one removes the wide-tuple *callee* (`np.concatenate` typed with a 60-tuple) and carries the compile-time win, while #2361 removes the caller-side bytecode chain and carries the memory win.

