### PR TITLE
Fix test incompatibilities with numpy 2.5

### DIFF
--- a/tests/link/numba/test_extra_ops.py
+++ b/tests/link/numba/test_extra_ops.py
@@ -391,7 +391,9 @@ def test_UnravelIndex(arr, shape, requires_obj_mode):
         pytest.param(
             (
                 pt.vector(),
-                np.array([0.29769574, 0.71649186, 0.20475563]).astype(config.floatX),
+                # Must be sorted: searchsorted on unsorted input is undefined
+                # behavior and numba/numpy implementations disagree there
+                np.array([0.20475563, 0.29769574, 0.71649186]).astype(config.floatX),
             ),
             (
                 pt.matrix(),

--- a/tests/tensor/signal/test_conv.py
+++ b/tests/tensor/signal/test_conv.py
@@ -146,7 +146,7 @@ def test_convolve2d(kernel_shape, data_shape, mode, boundary, boundary_kwargs):
 
     fn = function([data, kernel], conv_result)
 
-    rng = np.random.default_rng((172, kernel_shape, data_shape, sum(map(ord, mode))))
+    rng = np.random.default_rng((172, *kernel_shape, *data_shape, sum(map(ord, mode))))
     data_val = rng.normal(size=data_shape).astype(data.dtype)
     kernel_val = rng.normal(size=kernel_shape).astype(kernel.dtype)
 

--- a/tests/tensor/test_extra_ops.py
+++ b/tests/tensor/test_extra_ops.py
@@ -151,12 +151,13 @@ class TestSearchsortedOp(utt.InferShapeTester):
         )
 
     def test_searchsortedOp_on_right_side(self):
+        # searchsorted on unsorted input is undefined behavior, and numpy's
+        # results there depend on its binary search implementation details
+        sa = self.a[self.idx_sorted]
         f = pytensor.function(
             [self.x, self.v], searchsorted(self.x, self.v, side="right")
         )
-        assert np.allclose(
-            np.searchsorted(self.a, self.b, side="right"), f(self.a, self.b)
-        )
+        assert np.allclose(np.searchsorted(sa, self.b, side="right"), f(sa, self.b))
 
     def test_infer_shape(self):
         # Test using default parameters' value


### PR DESCRIPTION
## Description

CI on `main` has been failing since numpy 2.5 was picked up (e.g. [this run on main](https://github.com/pymc-devs/pytensor/actions/runs/32712791280)) — 8 jobs fail, all reducing to three test-side incompatibilities:

1. **`tests/tensor/signal/test_conv.py::test_convolve2d` (108 parametrizations, all `tensor scipy+blas+pad` jobs in every mode)**: the test seeded `np.random.default_rng((172, kernel_shape, data_shape, sum(map(ord, mode))))` — a tuple containing tuples. numpy 2.5's `SeedSequence` rejects nested sequences with `TypeError: SeedSequence does not accept nested sequences.` Fixed by flattening the entropy tuple (still deterministic per parametrization).

2. **`tests/tensor/test_extra_ops.py::TestSearchsortedOp::test_searchsortedOp_on_right_side` (NUMBA `tensor *rest` jobs)** and
3. **`tests/link/numba/test_extra_ops.py::test_Searchsorted[a1-v1-left-None-None]` (`numba link` job)**: both compared `np.searchsorted` against the pytensor/numba implementations on **unsorted** arrays. `searchsorted` on unsorted input is documented undefined behavior; numpy 2.5's reworked binary search now returns different (equally valid) results than numba's reimplementation, so the comparisons diverge. (CVM-mode jobs kept passing because the C implementation delegates to numpy's own routine.) Fixed by using sorted inputs — the same pattern `test_searchsortedOp_on_sorted_input` already uses.

Test-only changes; no library code touched. Verified locally with numpy 2.5.2: all 108 `test_convolve2d` params, the full `TestSearchsortedOp` suite, and all `test_Searchsorted` params pass (110 failed before).

These same failures currently show up on open PRs (e.g. #2375), where they are unrelated to the PR's changes.

## Related Issue
- [ ] Closes #
- [x] Related to failing CI on `main` (run [32712791280](https://github.com/pymc-devs/pytensor/actions/runs/32712791280)) and red checks on open PRs such as #2375

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):