### PR TITLE
Convert MLX shared variable updates back to numpy arrays

### DIFF
--- a/pytensor/link/basic.py
+++ b/pytensor/link/basic.py
@@ -619,12 +619,12 @@ class JITLinker(PerformLinker):
         return inp
 
     def output_filter(self, var: Variable, out: Any) -> Any:
-        """Convert a value the JITed function produced into one `pytensor` can store.
+        """Convert a value the JITed function produced into one PyTensor can store.
 
-        Values returned to the caller keep whatever native type the backend produced,
-        but a value written back into a shared variable's container outlives the call
-        and may later be read by a function compiled for another backend. Backends whose
-        arrays are not `numpy` ones override this; the default passes the value through.
+        Only values written back into a shared variable's container pass through here.
+        Those outlive the call and may later be read by a function compiled for another
+        backend, so a backend whose arrays are not NumPy ones overrides this; the default
+        passes the value through.
         """
         return out
 
@@ -673,9 +673,11 @@ class JITLinker(PerformLinker):
 
         # Shared variable updates are the only outputs worth converting, and a backend
         # that leaves `output_filter` alone pays nothing for the hook.
-        filters_output = type(self).output_filter is not JITLinker.output_filter
+        overrides_output_filter = (
+            type(self).output_filter is not JITLinker.output_filter
+        )
         update_output_idxs = (
-            tuple(self.fgraph.update_mapping or ()) if filters_output else ()
+            tuple(self.fgraph.update_mapping or ()) if overrides_output_filter else ()
         )
 
         if thunk_outputs:
@@ -700,8 +702,10 @@ class JITLinker(PerformLinker):
                     o_storage[0] = o_val
 
                 for idx in update_output_idxs:
-                    o_storage = thunk_outputs[idx]
-                    o_storage[0] = output_filter(fgraph_outputs[idx], o_storage[0])
+                    update_storage = thunk_outputs[idx]
+                    update_storage[0] = output_filter(
+                        fgraph_outputs[idx], update_storage[0]
+                    )
 
         else:
             # Edge case - functions without outputs

--- a/pytensor/link/basic.py
+++ b/pytensor/link/basic.py
@@ -619,7 +619,13 @@ class JITLinker(PerformLinker):
         return inp
 
     def output_filter(self, var: Variable, out: Any) -> Any:
-        """Apply a filter to the data output by a JITed function call."""
+        """Convert a value the JITed function produced into one `pytensor` can store.
+
+        Values returned to the caller keep whatever native type the backend produced,
+        but a value written back into a shared variable's container outlives the call
+        and may later be read by a function compiled for another backend. Backends whose
+        arrays are not `numpy` ones override this; the default passes the value through.
+        """
         return out
 
     def create_jitable_thunk(
@@ -665,12 +671,22 @@ class JITLinker(PerformLinker):
         thunk_outputs = [storage_map[n] for n in self.fgraph.outputs]
         fgraph_jit = self.jit_compile(converted_fgraph)
 
+        # Shared variable updates are the only outputs worth converting, and a backend
+        # that leaves `output_filter` alone pays nothing for the hook.
+        filters_output = type(self).output_filter is not JITLinker.output_filter
+        update_output_idxs = (
+            tuple(self.fgraph.update_mapping or ()) if filters_output else ()
+        )
+
         if thunk_outputs:
 
             def thunk(
                 fgraph_jit=fgraph_jit,
                 thunk_inputs=thunk_inputs,
                 thunk_outputs=thunk_outputs,
+                update_output_idxs=update_output_idxs,
+                output_filter=self.output_filter,
+                fgraph_outputs=self.fgraph.outputs,
             ):
                 try:
                     outputs = fgraph_jit(*(x[0] for x in thunk_inputs))
@@ -682,6 +698,10 @@ class JITLinker(PerformLinker):
                 # zip strict not specified because we are in a hot loop
                 for o_storage, o_val in zip(thunk_outputs, outputs):
                     o_storage[0] = o_val
+
+                for idx in update_output_idxs:
+                    o_storage = thunk_outputs[idx]
+                    o_storage[0] = output_filter(fgraph_outputs[idx], o_storage[0])
 
         else:
             # Edge case - functions without outputs

--- a/pytensor/link/mlx/linker.py
+++ b/pytensor/link/mlx/linker.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from pytensor.link.basic import JITLinker
 
 
@@ -57,6 +59,11 @@ class MLXLinker(JITLinker):
             return inner_fn(*(mlx_typify(inp) for inp in inputs))
 
         return fn
+
+    def output_filter(self, var, out):
+        import mlx.core as mx
+
+        return np.asarray(out) if isinstance(out, mx.array) else out
 
     def create_thunk_inputs(self, storage_map):
         """Create inputs for the MLX thunk.

--- a/tests/link/mlx/test_basic.py
+++ b/tests/link/mlx/test_basic.py
@@ -405,9 +405,25 @@ def test_shared_updates_are_not_device_arrays():
     # The returned value stays an MLX array, but the one stored back in the shared
     # variable must not, or any other consumer of the container chokes on it.
     assert isinstance(mlx_res, mx.array)
-    assert isinstance(a.container.storage[0], np.ndarray)
     assert isinstance(a.get_value(borrow=True), np.ndarray)
+    assert isinstance(a.get_value(borrow=False), np.ndarray)
     np.testing.assert_allclose(a.get_value(), np.array([2, 3, 4], dtype=config.floatX))
+
+
+def test_multiple_shared_updates():
+    a = shared(np.array([1, 2, 3], dtype=config.floatX))
+    b = shared(np.array([10, 20, 30], dtype=config.floatX))
+    x = pt.vector("x", dtype=config.floatX)
+
+    pytensor_mlx_fn = function([x], x * 2, updates={a: a + 1, b: b * 2}, mode=mlx_mode)
+    mlx_res = pytensor_mlx_fn(np.array([1, 1, 1], dtype=config.floatX))
+
+    assert isinstance(mlx_res, mx.array)
+    for shared_var, expected in ((a, [2, 3, 4]), (b, [20, 40, 60])):
+        assert isinstance(shared_var.get_value(borrow=True), np.ndarray)
+        np.testing.assert_allclose(
+            shared_var.get_value(), np.array(expected, dtype=config.floatX)
+        )
 
 
 def test_shared_updates_readable_by_other_backend():

--- a/tests/link/mlx/test_basic.py
+++ b/tests/link/mlx/test_basic.py
@@ -394,3 +394,27 @@ def test_shared_updates():
     assert res1 == 5
     assert res2 == 6
     assert a.get_value() == 7
+
+
+def test_shared_updates_are_not_device_arrays():
+    a = shared(np.array([1, 2, 3], dtype=config.floatX))
+
+    pytensor_mlx_fn = function([], a, updates={a: a + 1}, mode=mlx_mode)
+    mlx_res = pytensor_mlx_fn()
+
+    # The returned value stays an MLX array, but the one stored back in the shared
+    # variable must not, or any other consumer of the container chokes on it.
+    assert isinstance(mlx_res, mx.array)
+    assert isinstance(a.container.storage[0], np.ndarray)
+    assert isinstance(a.get_value(borrow=True), np.ndarray)
+    np.testing.assert_allclose(a.get_value(), np.array([2, 3, 4], dtype=config.floatX))
+
+
+def test_shared_updates_readable_by_other_backend():
+    a = shared(np.array([1, 2, 3], dtype=config.floatX))
+
+    mlx_fn = function([], a, updates={a: a + 1}, mode=mlx_mode)
+    other_fn = function([], a * 2)
+
+    mlx_fn()
+    np.testing.assert_allclose(other_fn(), np.array([4, 6, 8], dtype=config.floatX))

--- a/tests/link/mlx/test_basic.py
+++ b/tests/link/mlx/test_basic.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 
 import pytensor
-from pytensor import config
+from pytensor import config, shared
 from pytensor import tensor as pt
 from pytensor.compile.maker import function
 from pytensor.compile.mode import MLX, Mode
@@ -355,3 +355,42 @@ def test_nan_array_constant():
     compare_mlx_and_py(
         [x], [x + c], [np.array([10.0, 20.0, 30.0], dtype=config.floatX)]
     )
+
+
+def test_shared():
+    a = shared(np.array([1, 2, 3], dtype=config.floatX))
+
+    pytensor_mlx_fn = function([], a, mode=mlx_mode)
+    mlx_res = pytensor_mlx_fn()
+
+    assert isinstance(mlx_res, mx.array)
+    np.testing.assert_allclose(np.asarray(mlx_res), a.get_value())
+
+    pytensor_mlx_fn = function([], a * 2, mode=mlx_mode)
+    mlx_res = pytensor_mlx_fn()
+
+    assert isinstance(mlx_res, mx.array)
+    np.testing.assert_allclose(np.asarray(mlx_res), a.get_value() * 2)
+
+    new_a_value = np.array([3, 4, 5], dtype=config.floatX)
+    a.set_value(new_a_value)
+
+    mlx_res = pytensor_mlx_fn()
+    assert isinstance(mlx_res, mx.array)
+    np.testing.assert_allclose(np.asarray(mlx_res), new_a_value * 2)
+
+
+def test_shared_updates():
+    a = shared(0)
+
+    pytensor_mlx_fn = function([], a, updates={a: a + 1}, mode=mlx_mode)
+    res1, res2 = pytensor_mlx_fn(), pytensor_mlx_fn()
+    assert res1 == 0
+    assert res2 == 1
+    assert a.get_value() == 2
+
+    a.set_value(5)
+    res1, res2 = pytensor_mlx_fn(), pytensor_mlx_fn()
+    assert res1 == 5
+    assert res2 == 6
+    assert a.get_value() == 7


### PR DESCRIPTION
`Function.__call__` writes an update straight into the shared variable's storage slot, bypassing the container's filter, so after one MLX call the shared variable holds an `mx.array` instead of an ndarray. `get_value()` then returns a device array even with `borrow=False`, and passing that shared variable to a function compiled for another backend fails outright - a plain numba graph raises a `TypingError` on it.

`JITLinker.output_filter` already existed for this and was dead code, called by nothing. It's now applied to the outputs named in `fgraph.update_mapping`, and `MLXLinker` overrides it. Values returned to the caller still come back as `mx.array`; only what gets stored back in a container is converted. Backends that don't override the hook run the same thunk as before.
