### PR TITLE
Add API docs for pytensor.graph.traversal

### DIFF
--- a/doc/library/graph/index.rst
+++ b/doc/library/graph/index.rst
@@ -17,5 +17,6 @@
     replace
     features
     op
+    traversal
     type
     utils

--- a/doc/library/graph/traversal.rst
+++ b/doc/library/graph/traversal.rst
@@ -1,0 +1,8 @@
+.. _libdoc_graph_traversal:
+
+================================================
+:mod:`traversal` -- Graph Traversal Utilities
+================================================
+
+.. automodule:: pytensor.graph.traversal
+   :members:

--- a/pytensor/graph/basic.py
+++ b/pytensor/graph/basic.py
@@ -45,13 +45,12 @@ _MOVED_FUNCTIONS = {
     "graph_inputs",
     "explicit_graph_inputs",
     "vars_between",
-    "orhpans_between",
+    "orphans_between",
     "applys_between",
     "apply_depends_on",
     "truncated_graph_inputs",
     "general_toposort",
     "io_toposort",
-    "list_of_nodes",
     "get_var_by_name",
 }
 


### PR DESCRIPTION
Functions like get_var_by_name, walk, ancestors, graph_inputs, toposort, etc. were moved from pytensor.graph.basic to pytensor.graph.traversal but the API reference page was never added.

Also:
- Fix orhpans_between typo to orphans_between
- Remove stale list_of_nodes from _MOVED_FUNCTIONS (does not exist)