### PR TITLE
Fix docstrings that document parameters the functions do not have

### DIFF
--- a/pytensor/graph/replace.py
+++ b/pytensor/graph/replace.py
@@ -123,8 +123,6 @@ def graph_replace(
         Replace mapping
     strict: bool
         Raise an error if some replacements were not used
-    return_unused: bool
-        Return replacements that were not used
 
     Returns
     -------

--- a/pytensor/tensor/basic.py
+++ b/pytensor/tensor/basic.py
@@ -1265,11 +1265,11 @@ def tril_indices_from(
     k: int | ScalarVariable = 0,
 ) -> tuple[TensorVariable, TensorVariable]:
     """
-    Return the indices for the lower-triangle of arr.
+    Return the indices for the lower-triangle of `a`.
 
     Parameters
     ----------
-    arr : {array_like, TensorVariable}, shape(N, N)
+    a : {array_like, TensorVariable}, shape(N, N)
         The indices will be valid for square arrays.
     k : integer scalar, optional
         Diagonal offset to use when forming the indices. `k = 0` (the default)
@@ -1278,7 +1278,7 @@ def tril_indices_from(
     Returns
     -------
     tril_indices_from : tuple, shape(2) of TensorVariable, shape(N)
-        Indices for the lower-triangle of arr.
+        Indices for the lower-triangle of `a`.
 
     Raises
     ------
@@ -1323,11 +1323,11 @@ def triu_indices_from(
     k: int | ScalarVariable = 0,
 ) -> tuple[TensorVariable, TensorVariable]:
     """
-    Return the indices for the upper-triangle of arr.
+    Return the indices for the upper-triangle of `a`.
 
     Parameters
     ----------
-    arr : {array_like, TensorVariable}, shape(N, N)
+    a : {array_like, TensorVariable}, shape(N, N)
         The indices will be valid for square arrays.
     k : integer scalar, optional
         Diagonal offset to use when forming the indices. `k = 0` (the default)
@@ -1336,7 +1336,7 @@ def triu_indices_from(
     Returns
     -------
     triu_indices_from : tuple, shape(2) of TensorVariable, shape(N)
-        Indices for the upper-triangle of arr.
+        Indices for the upper-triangle of `a`.
 
     Raises
     ------


### PR DESCRIPTION
## Description

Three docstrings document parameters that the functions don't actually have.

**`tril_indices_from` / `triu_indices_from`** (`pytensor/tensor/basic.py`) are declared as:

```python
def tril_indices_from(
    a: np.ndarray | TensorVariable,
    k: int | ScalarVariable = 0,
) -> tuple[TensorVariable, TensorVariable]:
```

but the Parameters section documents `arr`:

```
    arr : {array_like, TensorVariable}, shape(N, N)
        The indices will be valid for square arrays.
```

`arr` is the name numpy uses (`np.tril_indices_from(arr, k=0)`), so the docstring looks like it was carried over with the numpy text while the parameter here was named `a`. Anyone following the rendered docs and calling `pt.tril_indices_from(arr=x)` gets a `TypeError`. I renamed the entries, plus the four surrounding references in the summary and Returns lines that also said `arr`.

**`graph_replace`** (`pytensor/graph/replace.py`) documents:

```
    return_unused: bool
        Return replacements that were not used
```

There's no such parameter, and no such behaviour — `return_unused` appears nowhere else in the repository, the docstring entry is its only occurrence:

```
$ grep -rn "return_unused" --include="*.py" .
./pytensor/graph/replace.py:126:    return_unused: bool
```

so I removed the entry.

Docs only — no code touched, no behaviour change.

## Related Issue

- [ ] Closes #
- [ ] Related to #

## Checklist

- [x] Checked that the pre-commit linting/style checks pass — `ruff check` and `ruff format --check` are clean on both changed files
- [ ] Included tests that prove the fix is effective — not applicable, this only changes docstring text
- [x] Added necessary documentation (docstrings and/or example notebooks)

## Type of change

- [x] Documentation

---

Two things I deliberately left out, happy to fold either in if you'd prefer:

1. The alternative fix for the `*_indices_from` pair is to rename the parameter `a` → `arr` so it matches numpy exactly, rather than changing the docs. That's a nicer API parity story but it would break anyone passing `a=` by keyword, so I went with the non-breaking option — let me know if you'd rather have the rename.

2. `toposort_with_orderings` in `pytensor/graph/traversal.py` has the same class of problem, but fixing it needs a call from you rather than a guess. Its signature is `(graphs, *, blockers, orderings)` and the Parameters section documents `graphs : ... Graph inputs.` and `outputs : ... Graph outputs.` — `outputs` isn't a parameter, and `blockers` is undocumented. The summary line ("between blocker (input) and graphs (output) variables") and the `# the inputs are used to decide where to stop expanding` comment both read as though `blockers` are the inputs and `graphs` are the outputs, which would make the `graphs` description wrong too. Is that reading right? If so I'll fix it the same way here or in a follow-up.
