### PR TITLE
Fix three more docstrings that name parameters the functions do not have

### DIFF
--- a/pytensor/d3viz/d3viz.py
+++ b/pytensor/d3viz/d3viz.py
@@ -18,7 +18,7 @@ def replace_patterns(x, replace):
 
     Parameters
     ----------
-    s : str
+    x : str
         String on which function is applied
     replace : dict
         `key`, `value` pairs where key is a regular expression and `value` a

--- a/pytensor/graph/fg.py
+++ b/pytensor/graph/fg.py
@@ -321,7 +321,7 @@ class FunctionGraph(AbstractFunctionGraph):
 
         Parameters
         ----------
-        variable : pytensor.graph.basic.Variable
+        var : pytensor.graph.basic.Variable
             The variable to be imported.
         reason : str
             The name of the optimization or operation in progress.

--- a/pytensor/graph/traversal.py
+++ b/pytensor/graph/traversal.py
@@ -666,9 +666,9 @@ def toposort_with_orderings(
     Parameters
     ----------
     graphs : list or tuple of Variable instances
-        Graph inputs.
-    outputs : list or tuple of Apply instances
         Graph outputs.
+    blockers : list or tuple of Variable instances
+        Graph inputs.
     orderings : dict
         Keys are `Apply` or `Variable` instances, values are lists of `Apply` or `Variable` instances.
 


### PR DESCRIPTION
## Description

Follow-up to #2408 — same class of mismatch, three more sites. Docs only, no code touched.

**`FunctionGraph.import_var`** takes `var` but documents `variable`:

```python
def import_var(
    self, var: Variable, reason: str | None = None, import_missing: bool = False
) -> None:
```

**`replace_patterns`** (`d3viz`) takes `x` but documents `s`. Its own summary line already refers to the argument correctly — "Replace `replace` in string `x`" — so the Parameters entry is the odd one out.

**`toposort_with_orderings`** is the one I asked about on #2408, and I think the evidence now settles it. The signature is:

```python
def toposort_with_orderings(
    graphs: Iterable[Variable],
    *,
    blockers: Iterable[Variable] | None = None,
    orderings: dict[Apply, list[Apply]] | None = None,
) -> Generator[Apply, None, None]:
```

but the Parameters section documents `graphs`, `outputs` and `orderings` — `outputs` isn't a parameter, and `blockers` is missing. The remaining `graphs` entry was also backwards, describing it as "Graph inputs". Two summary lines say the opposite:

- this function's own: *"Perform topological of nodes between blocker (input) and graphs (output) variables ..."*
- `toposort`, which it delegates to for the no-orderings branch: *"Topologically sort of Apply nodes between graphs (outputs) and blockers (inputs)."*

and the implementation agrees — the `# the inputs are used to decide where to stop expanding` comment sits directly above `if blockers:`. So `graphs` are the outputs and `blockers` are the inputs, and the entry that said `outputs` was describing `blockers` under the wrong name.

I've made it:

```
    graphs : list or tuple of Variable instances
        Graph outputs.
    blockers : list or tuple of Variable instances
        Graph inputs.
```

If you'd rather I'd left that one alone, or you read the roles differently, say so and I'll drop it from this PR — the other two stand on their own.

## Related Issue

- [ ] Closes #
- [x] Related to #2408

## Checklist

- [x] Checked that the pre-commit linting/style checks pass — `ruff check` clean on all three files
- [ ] Included tests that prove the fix is effective — not applicable, docstring text only
- [x] Added necessary documentation (docstrings and/or example notebooks)

## Type of change

- [x] Documentation
