### PR TITLE
Fix slogdet specialization for batched inputs

### DIFF
--- a/pytensor/tensor/rewriting/linalg/summary.py
+++ b/pytensor/tensor/rewriting/linalg/summary.py
@@ -245,7 +245,7 @@ def slogdet_specialization(fgraph, node):
         return None
 
     [x] = node.inputs
-    sign_det_x, log_abs_det_x = SLogDet()(x)
+    sign_det_x, log_abs_det_x = Blockwise(SLogDet())(x)
     log_det_x = pt.where(pt.eq(sign_det_x, -1), np.nan, log_abs_det_x)
     slogdet_specialization_map = {
         "sign": sign_det_x,

--- a/tests/tensor/rewriting/linalg/test_summary.py
+++ b/tests/tensor/rewriting/linalg/test_summary.py
@@ -274,6 +274,7 @@ def test_slogdet_specialization():
         rtol=1e-3 if config.floatX == "float32" else 1e-8,
     )
 
+
 @pytest.mark.parametrize(
     "original_fn, expected_fn",
     [

--- a/tests/tensor/rewriting/linalg/test_summary.py
+++ b/tests/tensor/rewriting/linalg/test_summary.py
@@ -225,6 +225,54 @@ def test_slogdet_specialization():
     nodes = f.maker.fgraph.apply_nodes
     assert not any(isinstance(node.op, SLogDet) for node in nodes)
 
+    # Batched input
+    x_batched = pt.tensor("x_batched", shape=(4, 3, 3), dtype=config.floatX)
+    det_x_batched = pt.linalg.det(x_batched)
+
+    sign_det_x_batched = pt.sign(det_x_batched)
+    log_abs_det_x_batched = pt.log(pt.abs(det_x_batched))
+    log_det_x_batched = pt.log(det_x_batched)
+
+    f = function(
+        [x_batched],
+        [sign_det_x_batched, log_abs_det_x_batched, log_det_x_batched],
+        mode="FAST_RUN",
+    )
+
+    slogdet_nodes = [
+        node
+        for node in f.maker.fgraph.apply_nodes
+        if hasattr(node.op, "core_op") and isinstance(node.op.core_op, SLogDet)
+    ]
+    assert len(slogdet_nodes) == 1
+    assert not any(isinstance(node.op, SLogDet) for node in f.maker.fgraph.apply_nodes)
+
+    x_batched_value = np.broadcast_to(
+        np.eye(3, dtype=config.floatX) * 2,
+        (4, 3, 3),
+    ).copy()
+    expected_det = np.linalg.det(x_batched_value)
+
+    rw_sign_det, rw_log_abs_det, rw_log_det = f(x_batched_value)
+
+    assert_allclose(
+        np.sign(expected_det),
+        rw_sign_det,
+        atol=1e-3 if config.floatX == "float32" else 1e-8,
+        rtol=1e-3 if config.floatX == "float32" else 1e-8,
+    )
+    assert_allclose(
+        np.log(np.abs(expected_det)),
+        rw_log_abs_det,
+        atol=1e-3 if config.floatX == "float32" else 1e-8,
+        rtol=1e-3 if config.floatX == "float32" else 1e-8,
+    )
+    assert_allclose(
+        np.log(expected_det),
+        rw_log_det,
+        atol=1e-3 if config.floatX == "float32" else 1e-8,
+        rtol=1e-3 if config.floatX == "float32" else 1e-8,
+    )
 
 @pytest.mark.parametrize(
     "original_fn, expected_fn",


### PR DESCRIPTION
## Description

Fix `slogdet_specialization` for batched inputs.

The `slogdet_specialization` rewrite currently replaces a batched
`Det` operation with a bare `SLogDet`. Since `SLogDet` only accepts
2D matrix inputs, this causes the rewrite to fail for batched inputs.

This change wraps `SLogDet` in `Blockwise`, preserving the batch
dimensions while applying `SLogDet` to each matrix in the batch.

Added regression coverage for batched:
- `sign(det(x))`
- `log(abs(det(x)))`
- `log(det(x))`

## Related Issue

- [x] Closes #2393
- [ ] Related to #

## Checklist

- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):